### PR TITLE
chore: Attempt to use `rumdl` in the SDK

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,9 @@
 <!-- description of the changes in this PR -->
 
-- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
+- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md`
+      files.
 - [ ] This PR was made with the help of AI.
 
 <!-- Sign-off, if not part of the commits -->
 <!-- See CONTRIBUTING.md if you don't know what this is -->
-Signed-off-by: 
+Signed-off-by:

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,91 @@
+[global]
+# Use the GitHub Markdown flavour, https://github.com/rvben/rumdl/blob/main/docs/flavors/gfm.md.
+flavor = "gfm"
+disable = [
+  # `commands-show-output`, https://github.com/rvben/rumdl/blob/main/docs/md014.md.
+  # Not necessary to show the shell commands output every time.
+  "MD014",
+
+  # `first-line-heading`, https://github.com/rvben/rumdl/blob/main/docs/md041.md.
+  # Some documents are fragments, the first heading is defined somewhere else.
+  "MD041",
+]
+
+# `heading-style`, https://github.com/rvben/rumdl/blob/main/docs/md003.md.
+[MD003]
+style = "atx"
+
+# `ul-style`, https://github.com/rvben/rumdl/blob/main/docs/md004.md.
+[MD004]
+style = "dash"
+
+# `line-length`, https://github.com/rvben/rumdl/blob/main/docs/md013.md.
+[MD013]
+line-length = 80
+code-blocks = false
+reflow = true
+
+# `no-trailing-punctuation`, https://github.com/rvben/rumdl/blob/main/docs/md026.md.
+[MD026]
+punctuation = ".,;:"
+
+# `ol-prefix`, https://github.com/rvben/rumdl/blob/main/docs/md029.md.
+[MD029]
+style = "ordered"
+
+# `no-inline-html`, https://github.com/rvben/rumdl/blob/main/docs/md033.md.
+[MD033]
+allowed-elements = [
+  "i",
+  "q",
+  "cite",
+  "a",
+  "time",
+  "sub",
+  "sup",
+  "figure", "figcaption",
+  "table",
+  "summary", "details",
+  "math", "mo", "mn", "mi", "semantics", "annotation",
+]
+disallowed-elements = ["gfm"]
+fix = true
+fix-mode = "relaxed"
+
+# `code-block-style`, https://github.com/rvben/rumdl/blob/main/docs/md046.md.
+[MD046]
+style = "fenced"
+
+# `code-fence-style`, https://github.com/rvben/rumdl/blob/main/docs/md048.md.
+[MD048]
+style = "backtick"
+
+# `emphasis-style`, https://github.com/rvben/rumdl/blob/main/docs/md049.md.
+[MD049]
+style = "underscore"
+
+# `strong-style`, https://github.com/rvben/rumdl/blob/main/docs/md050.md.
+[MD050]
+style = "asterisk"
+
+# `link-image-style`, https://github.com/rvben/rumdl/blob/main/docs/md054.md.
+[MD054]
+autolink = false
+collapsed = false
+preferred-style = "full"
+
+# `table-format`, https://github.com/rvben/rumdl/blob/main/docs/md060.md.
+[MD060]
+enabled = true
+
+# `heading-capitalization`, https://github.com/rvben/rumdl/blob/main/docs/md063.md.
+[MD063]
+enabled = true
+style = "sentence-case"
+max-level = 3
+ignore-words = ["Matrix", "Rust", "Swift", "Android", "Java"]
+
+# `list-item-spacing`, https://github.com/rvben/rumdl/blob/main/docs/md076.md.
+[MD076]
+style = "tight"
+allow-loose-continuation = true

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 The SDK is split into multiple layers:
 
-```
+```text
     WASM (external crate matrix-rust-sdk-crypto-wasm)
       /
      /     uniffi
@@ -23,35 +23,39 @@ crypto    /
       common (matrix-sdk-common)
 ```
 
-Where the store implementations are `matrix-sdk-sqlite` and `matrix-sdk-indexeddb` as well as
-`MemoryStore` which is defined in `matrix-sdk-base`.
+Where the store implementations are `matrix-sdk-sqlite` and
+`matrix-sdk-indexeddb` as well as `MemoryStore` which is defined in
+`matrix-sdk-base`.
 
 ## `crates/matrix-sdk`
 
-This is the main crate, and one that is expected to be used by most consumers. Notable data types
-include:
+This is the main crate, and one that is expected to be used by most consumers.
+Notable data types include:
 
-- the `Client`, which can run room-independent requests: logging in/out, creating rooms, running
-  sync, etc.
-- the `Room`, which represents a room and its state (notably via the observable `RoomInfo`), and
-  allows running queries that are room-specific, notably sending events.
+- the `Client`, which can run room-independent requests: logging in/out,
+  creating rooms, running sync, etc.
+- the `Room`, which represents a room and its state (notably via the observable
+  `RoomInfo`), and allows running queries that are room-specific, notably
+  sending events.
 
 ## `crates/matrix-sdk-base`
 
-A *sans I/O* crate to represent the base data types persisted in the SDK. No network or storage I/O
-happens in this crate, although it defines traits (`StateStore` and `EventCacheStore`) representing
-storage backends, as well as dummy in-memory implementations of these traits.
+A _sans I/O_ crate to represent the base data types persisted in the SDK. No
+network or storage I/O happens in this crate, although it defines traits
+(`StateStore` and `EventCacheStore`) representing storage backends, as well as
+dummy in-memory implementations of these traits.
 
 ## `crates/matrix-sdk-common`
 
-Common helpers used by most of the other crates; almost a leaf in the dependency tree of our own
-crates (the only crate it's using is test helpers).
+Common helpers used by most of the other crates; almost a leaf in the dependency
+tree of our own crates (the only crate it's using is test helpers).
 
 ## `crates/matrix-sdk-crypto`
 
-A *sans I/O* implementation of a state machine that handles end-to-end encryption for Matrix
-clients. It defines a `CryptoStore` trait representing storage backends that will perform the
-actual storage I/O later, as well as a dummy in-memory implementation of this trait.
+A _sans I/O_ implementation of a state machine that handles end-to-end
+encryption for Matrix clients. It defines a `CryptoStore` trait representing
+storage backends that will perform the actual storage I/O later, as well as a
+dummy in-memory implementation of this trait.
 
 ## `crates/matrix-sdk-indexeddb`
 
@@ -60,7 +64,8 @@ indexeddb backend (for use in Web browsers, via WebAssembly).
 
 ## `crates/matrix-sdk-qrcode`
 
-Implementation of QR codes for interactive verifications, used in the crypto crate.
+Implementation of QR codes for interactive verifications, used in the crypto
+crate.
 
 ## `crates/matrix-sdk-sqlite`
 
@@ -69,33 +74,35 @@ SQLite backend.
 
 ## `crates/matrix-sdk-store-encryption`
 
-Low-level primitives for encrypting/decrypting/hashing values. Store implementations that
-implement encryption at rest can use those primitives.
+Low-level primitives for encrypting/decrypting/hashing values. Store
+implementations that implement encryption at rest can use those primitives.
 
 ## `crates/matrix-sdk-ui`
 
-Very high-level primitives implementing the best practices and cutting-edge Matrix tech:
+Very high-level primitives implementing the best practices and cutting-edge
+Matrix tech:
 
-- `EncryptionSyncService`: a specialized service running simplified sliding sync (MSC4186) for
-  everything related to crypto and E2EE for the current `Client`.
-- `RoomListService`: a specialized service running simplified sliding sync (MSC4186) for
-  retrieving the list of current rooms, and exposing its entries.
-- `SyncService`: a wrapper for the two previous services, coordinating their running and shutting
-  down.
-- `Timeline`: a high-level view for a `Room`'s timeline of events, grouping related events
-  (aggregations) into single timeline items.
+- `EncryptionSyncService`: a specialized service running simplified sliding sync
+  (MSC4186) for everything related to crypto and E2EE for the current `Client`.
+- `RoomListService`: a specialized service running simplified sliding sync
+  (MSC4186) for retrieving the list of current rooms, and exposing its entries.
+- `SyncService`: a wrapper for the two previous services, coordinating their
+  running and shutting down.
+- `Timeline`: a high-level view for a `Room`'s timeline of events, grouping
+  related events (aggregations) into single timeline items.
 
 ## `bindings/matrix-sdk-crypto-ffi/`
 
-FFI bindings for the crypto crate, used in a Web browser context via WebAssembly. These use
-`wasm-bindgen` to generate the bindings. These bindings are used in Element Web and the legacy
-Element apps, as of 2024-11-07.
+FFI bindings for the crypto crate, used in a Web browser context via
+WebAssembly. These use `wasm-bindgen` to generate the bindings. These bindings
+are used in Element Web and the legacy Element apps, as of 2024-11-07.
 
 ## `bindings/matrix-sdk-ffi/`
 
-FFI bindings for important concepts in `matrix-sdk-ui` and `matrix-sdk`, generated with
-[UniFFI](https://github.com/mozilla/uniffi-rs) and to be used from other languages like
-Swift/Go/Kotlin. These bindings are used in the ElementX apps, as of 2024-11-07.
+FFI bindings for important concepts in `matrix-sdk-ui` and `matrix-sdk`,
+generated with [UniFFI](https://github.com/mozilla/uniffi-rs) and to be used
+from other languages like Swift/Go/Kotlin. These bindings are used in the
+ElementX apps, as of 2024-11-07.
 
 ## `bindings/matrix-sdk-ffi-macros/`
 
@@ -111,9 +118,11 @@ Implementation of the `#[async_test]` test macro.
 
 ## `testing/matrix-sdk-integration-testing/`
 
-Fully-fledged integration tests that require spawning a Synapse instance to run. A docker-compose
-setup is provided to ease running the tests, and it is compatible for running with Podman too.
+Fully-fledged integration tests that require spawning a Synapse instance to run.
+A docker-compose setup is provided to ease running the tests, and it is
+compatible for running with Podman too.
 
-# Inspiration
+## Inspiration
 
-This document has been inspired by the reading of this [blog post](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html).
+This document has been inspired by the reading of this
+[blog post](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ integration tests that need a running synapse instance. These tests reside in
 [README](./testing/matrix-sdk-integration-testing/README.md) to easily set up a
 synapse for testing purposes.
 
-### Snapshot Testing
+### Snapshot testing
 
 You can add/review snapshot tests using [insta.rs](https://insta.rs)
 
@@ -97,20 +97,20 @@ that is, just the branch name.)
 We use towncrier to generate changelogs from individual fragment files. Each
 change must be documented as a changelog fragment in the appropriate crate:
 
-```
+```text
 /crates/<crate-name>/changelog.d/
 ```
 
 Each changelog fragment must include **both the pull request number and the
 fragment type** in its filename:
 
-```
+```text
 <PR number>.<fragment type>.md
 ```
 
 For example:
 
-```
+```text
 4357.added.md
 4357.fixed.md
 4357.changed.md
@@ -119,14 +119,15 @@ For example:
 The pull request link is automatically added during changelog generation, so it
 must not be included manually.
 
-We use standard towncrier fragment types to categorize changes. Common types include:
+We use standard towncrier fragment types to categorize changes. Common types
+include:
 
-* `added` – new features or functionality
-* `changed` – changes in existing behavior
-* `fixed` – bug fixes
-* `removed` – removed features or APIs
-* `security` – security-related fixes
-* `internal` – changes that do not affect users (refactoring, CI, tooling)
+- `added` – new features or functionality
+- `changed` – changes in existing behavior
+- `fixed` – bug fixes
+- `removed` – removed features or APIs
+- `security` – security-related fixes
+- `internal` – changes that do not affect users (refactoring, CI, tooling)
 
 Choose the type that best matches the nature of the change.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
 <div align="center">
 
-The Matrix Rust SDK is a collection of libraries that make it easier to build [Matrix] clients in [Rust].
+The Matrix Rust SDK is a collection of libraries that make it easier to build
+[Matrix] clients in [Rust].
 <br />
 <br />
 
@@ -33,9 +34,14 @@ The Matrix Rust SDK is a collection of libraries that make it easier to build [M
 <br />
 <br />
 
-Development of the SDK is proudly sponsored and maintained by [Element](https://element.io). Element uses the SDK in their next-generation mobile apps Element X on [iOS](https://github.com/element-hq/element-x-ios) and [Android](https://github.com/element-hq/element-x-android) and has plans to introduce it to the web and desktop clients as well.
+Development of the SDK is proudly sponsored and maintained by
+[Element](https://element.io). Element uses the SDK in their next-generation
+mobile apps Element X on [iOS](https://github.com/element-hq/element-x-ios) and
+[Android](https://github.com/element-hq/element-x-android) and has plans to
+introduce it to the web and desktop clients as well.
 
-The SDK is also the basis for multiple Matrix projects and we welcome contributions from all.
+The SDK is also the basis for multiple Matrix projects and we welcome
+contributions from all.
 
 </div>
 
@@ -51,19 +57,24 @@ is designed to be flexible, async-friendly, and ready to use out of the box.
 The Matrix Rust SDK is made up of several crates that build on top of each
 other. The following crates are expected to be usable as direct dependencies:
 
-- [matrix-sdk-ui](https://docs.rs/matrix-sdk-ui/latest/matrix_sdk_ui/) – A high-level client library that makes it easy to build
-  full-featured UI clients with minimal setup. Check out our reference client,
-  [multiverse](https://github.com/matrix-org/matrix-rust-sdk/tree/main/labs/multiverse), for an example.
-- [matrix-sdk](https://docs.rs/matrix-sdk/latest/matrix_sdk/) – A mid-level client library, ideal for building bots, custom
-  clients, or higher-level abstractions. You can find example usage in the
+- [matrix-sdk-ui](https://docs.rs/matrix-sdk-ui/latest/matrix_sdk_ui/) – A
+  high-level client library that makes it easy to build full-featured UI clients
+  with minimal setup. Check out our reference client,
+  [multiverse](https://github.com/matrix-org/matrix-rust-sdk/tree/main/labs/multiverse),
+  for an example.
+- [matrix-sdk](https://docs.rs/matrix-sdk/latest/matrix_sdk/) – A mid-level
+  client library, ideal for building bots, custom clients, or higher-level
+  abstractions. You can find example usage in the
   [examples directory](https://github.com/matrix-org/matrix-rust-sdk/tree/main/examples).
-- [matrix-sdk-crypto](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/) – A standalone encryption state machine with no network I/O,
-  providing end-to-end encryption support for Matrix clients and libraries.
-  See the [crypto tutorial](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/tutorial/index.html)
+- [matrix-sdk-crypto](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/)
+  – A standalone encryption state machine with no network I/O, providing
+  end-to-end encryption support for Matrix clients and libraries. See the
+  [crypto tutorial](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/tutorial/index.html)
   for a step-by-step introduction.
 
-All other crates are effectively internal-only and only structured as crates
-for organizational purposes and to improve compilation times. Direct usage of them is discouraged.
+All other crates are effectively internal-only and only structured as crates for
+organizational purposes and to improve compilation times. Direct usage of them
+is discouraged.
 
 ## Status
 
@@ -71,8 +82,9 @@ The library is considered production ready and backs multiple client
 implementations such as Element X
 [[1]](https://github.com/element-hq/element-x-ios)
 [[2]](https://github.com/element-hq/element-x-android),
-[Fractal](https://gitlab.gnome.org/World/fractal) and [iamb](https://github.com/ulyssa/iamb). Client developers should feel
-confident to build upon it.
+[Fractal](https://gitlab.gnome.org/World/fractal) and
+[iamb](https://github.com/ulyssa/iamb). Client developers should feel confident
+to build upon it.
 
 ## Bindings
 
@@ -84,7 +96,6 @@ into your language of choice.
 ## License
 
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)
-
 
 [Matrix]: https://matrix.org/
 [Rust]: https://www.rust-lang.org/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,15 +24,14 @@ The procedure is as follows:
    cargo xtask release prepare --execute minor|patch|rc
    ```
 
-3. Double-check and edit the `CHANGELOG.md` and `README.md` if necessary. Once you are
-   satisfied, push the branch and open a PR.
+3. Double-check and edit the `CHANGELOG.md` and `README.md` if necessary. Once
+   you are satisfied, push the branch and open a PR.
 
    ```bash
    git push --set-upstream origin/release-x.y.z
    ```
 
 4. Pass the review and merge the branch as you would with any other branch.
-
 5. Create tags for your new release, publish the release on crates.io and push
    the tags:
 
@@ -45,4 +44,7 @@ The procedure is as follows:
    cargo xtask release publish --execute
    ```
 
-   For more information on cargo-release: https://github.com/crate-ci/cargo-release
+   For more information on cargo-release:
+   [https://github.com/crate-ci/cargo-release][https-github-com-crate-ci-cargo-release]
+
+[https-github-com-crate-ci-cargo-release]: https://github.com/crate-ci/cargo-release

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,9 +3,8 @@
 This directory contains various benchmarks that test critical functionality in
 the crypto layer in the rust-sdk.
 
-We're using [Criterion] for the benchmarks, the full documentation for Criterion
-can be found
-[here](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
+We're using [Criterion] for the benchmarks,
+[the full documentation for Criterion can be found here](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
 
 ## Running the benchmarks
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,8 @@ This directory contains various benchmarks that test critical functionality in
 the crypto layer in the rust-sdk.
 
 We're using [Criterion] for the benchmarks, the full documentation for Criterion
-can be found [here](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
+can be found
+[here](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
 
 ## Running the benchmarks
 
@@ -16,15 +17,16 @@ $ cargo bench
 
 This will work from the workspace directory of the rust-sdk.
 
-To lower compile times, you might be interested in using the `profiling` profile, that's optimized
-for a fair tradeoff between compile times and runtime performance:
+To lower compile times, you might be interested in using the `profiling`
+profile, that's optimized for a fair tradeoff between compile times and runtime
+performance:
 
 ```bash
 $ cargo bench --profile profiling
 ```
 
-If you want to pass options to the benchmark [you'll need to specify the name of
-the benchmark](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options):
+If you want to pass options to the benchmark
+[you'll need to specify the name of the benchmark](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options):
 
 ```bash
 $ cargo bench --bench crypto_bench -- # Your options go here
@@ -37,7 +39,8 @@ benchmark as an argument:
 $ cargo bench --bench crypto_bench "Room key sharing/"
 ```
 
-After the benchmarks are done, a HTML report can be found in `target/criterion/report/index.html`.
+After the benchmarks are done, a HTML report can be found in
+`target/criterion/report/index.html`.
 
 ### Using a baseline for the benchmark
 
@@ -59,7 +62,7 @@ so:
 $ cargo bench --bench crypto_bench -- --baseline libolm
 ```
 
-### Generating Flame Graphs for the benchmarks
+### Generating flame graphs for the benchmarks
 
 The benchmarks support profiling and generating [Flame Graphs] while they run in
 profiling mode using [pprof].
@@ -79,8 +82,8 @@ To generate flame graphs feature, enable the profiling mode using the
 $ cargo bench --bench crypto_bench -- --profile-time=5
 ```
 
-After the benchmarks are done, a flame graph for each individual benchmark can be
-found in `target/criterion/<name-of-benchmark>/profile/flamegraph.svg`.
+After the benchmarks are done, a flame graph for each individual benchmark can
+be found in `target/criterion/<name-of-benchmark>/profile/flamegraph.svg`.
 
 [pprof]: https://docs.rs/pprof/0.5.0/pprof/index.html#
 [Criterion]: https://docs.rs/criterion/0.3.5/criterion/

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -1,41 +1,81 @@
 ## Introduction
-**matrix-rust-sdk** leverages [UniFFI](https://mozilla.github.io/uniffi-rs/) to generate bindings for host languages (eg. Swift and Kotlin).
 
-Rust code related with bindings live in the [matrix-rust-sdk/bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings) folder.
+**matrix-rust-sdk** leverages [UniFFI](https://mozilla.github.io/uniffi-rs/) to
+generate bindings for host languages (eg. Swift and Kotlin).
+
+Rust code related with bindings live in the
+[matrix-rust-sdk/bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings)
+folder.
 
 Developers can expose Rust code to UniFFI using two different approaches:
-- Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
-- Add UniFFI directivies as Rust attributes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). Attributes are preferred, where applicable.
- 
+
+- Using an `.udl` file. When a crate has one, you find it under the `src` folder
+  (an example is
+  [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
+- Add UniFFI directivies as Rust attributes. In this case Rust source files
+  (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`).
+  Attributes are preferred, where applicable.
 
 ## Expose Rust definitions to UniFFI
 
 ### Check if the API is already on UniFFI
 
-First of all check if the Rust definition you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
-This crate contains mainly small Rust wrappers around the actual Rust SDK (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
+First of all check if the Rust definition you are looking for exists on UniFFI
+already. Most of exposed matrix definitions are collected in the crate
+[matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
+This crate contains mainly small Rust wrappers around the actual Rust SDK (e.g.
+the crate
+[matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
 If the Rust definition is on UniFFI already, you either:
-- find it in a `.udl` file like [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)
-- see it marked with a proper UniFFI Rust attribute like this `#[uniffi::export]`
 
+- find it in a `.udl` file like
+  [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)
+- see it marked with a proper UniFFI Rust attribute like this
+  `#[uniffi::export]`
 
 ### Adding a missing matrix API
 
-1. Unless you want to contribute on the crypto side, you probably need to add some code in the [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to understand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs)
+1. Unless you want to contribute on the crypto side, you probably need to add
+   some code in the
+   [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi)
+   crate. After you find the crate you need to understand which file is best to
+   contain the new Rust definition. When exposing new matrix API often (but not
+   always) you need to touch the file
+   [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs)
 
-2. Identify the API to expose in the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find it, you probably need to touch the actual Rust SDK as well. In this case you typically just need to write some code around [ruma](https://github.com/ruma/ruma) (a Rust SDK’s dependency) which already implements most of the matrix protocol
+2. Identify the API to expose in the target Rust crate (typically in
+   [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk).
+   If you can’t find it, you probably need to touch the actual Rust SDK as well.
+   In this case you typically just need to write some code around
+   [ruma](https://github.com/ruma/ruma) (a Rust SDK’s dependency) which already
+   implements most of the matrix protocol
 
-3. After you got (by finding or writing) the required Rust code, you need to expose to UniFFI. To do that just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**) you found on step 1.
+3. After you got (by finding or writing) the required Rust code, you need to
+   expose to UniFFI. To do that just write a small Rust wrapper in the related
+   UniFFI crate (most of the time is **matrix-sdk-ffi**) you found on step 1.
 
-4. When your new (wrapping) Rust definition is ready, remember to expose it to UniFFI.
-It’s best to do it using UniFFI Rust attributes (e.g. `#[uniffi::export]`). Otherwise add the new definition in the crate’s `.udl` file. For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). **Remember**: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html)
+4. When your new (wrapping) Rust definition is ready, remember to expose it to
+   UniFFI.
+It’s best to do it using UniFFI Rust attributes (e.g. `#[uniffi::export]`).
+Otherwise add the new definition in the crate’s `.udl` file. For the
+**matrix-sdk-ffi** crate the definition file is
+[api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl).
+**Remember**: the language inside a `.udl` file isn’t Rust. To learn more about
+how map Rust into UDL read
+[here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html)
 
 ## FAQ
 
-**Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the compiler is happy?\
-**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
+**Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the
+compiler is happy?\
+**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The
+compiler will complain if the Rust code and/or the `.udl` is wrong.
 
-
-**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?\
-**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong and fix it accordingly.
+**Q**: The compiler is happy with my code but the CI is failing on GitHub. How
+can I fix it?\
+**A**: The CI may fail for different reasons, you need to have a look on the
+failing GitHub workflow. One common reason though is that the linter
+([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code.
+If this is the case, you can run `cargo clippy` in the crate you touched to see
+what’s wrong and fix it accordingly.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -10,8 +10,7 @@ folder.
 Developers can expose Rust code to UniFFI using two different approaches:
 
 - Using an `.udl` file. When a crate has one, you find it under the `src` folder
-  (an example is
-  [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
+  ([an example is here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
 - Add UniFFI directivies as Rust attributes. In this case Rust source files
   (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`).
   Attributes are preferred, where applicable.
@@ -61,9 +60,8 @@ It’s best to do it using UniFFI Rust attributes (e.g. `#[uniffi::export]`).
 Otherwise add the new definition in the crate’s `.udl` file. For the
 **matrix-sdk-ffi** crate the definition file is
 [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl).
-**Remember**: the language inside a `.udl` file isn’t Rust. To learn more about
-how map Rust into UDL read
-[here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html)
+**Remember**: the language inside a `.udl` file isn’t Rust. To
+[learn more about how map Rust into UDL read here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html)
 
 ## FAQ
 

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -3,17 +3,17 @@
 In this directory, one can find bindings to the Rust SDK that are
 maintained by the owners of the Matrix Rust SDK project.
 
-* [`apple`] or `matrix-rust-components-swift`, Swift bindings of the
+- [`apple`] or `matrix-rust-components-swift`, Swift bindings of the
   [`matrix-sdk`] crate via [`matrix-sdk-ffi`],
-* [`matrix-sdk-crypto-ffi`], UniFFI (Kotlin, Swift, Python, Ruby) bindings of the [`matrix-sdk-crypto`]
-  crate,
-* [`matrix-sdk-ffi`], UniFFI bindings of the [`matrix-sdk`] crate.
+- [`matrix-sdk-crypto-ffi`], UniFFI (Kotlin, Swift, Python, Ruby) bindings of
+  the [`matrix-sdk-crypto`] crate,
+- [`matrix-sdk-ffi`], UniFFI bindings of the [`matrix-sdk`] crate.
 
 There are also external bindings in other repositories:
 
-* [`matrix-sdk-crypto-wasm`], JavaScript / WebAssembly bindings of the
+- [`matrix-sdk-crypto-wasm`], JavaScript / WebAssembly bindings of the
   [`matrix-sdk-crypto`] crate,
-* [`matrix-sdk-crypto-nodejs`], Node.js bindings of the
+- [`matrix-sdk-crypto-nodejs`], Node.js bindings of the
   [`matrix-sdk-crypto`] crate
 
 [`apple`]: ./apple

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -1,73 +1,115 @@
 # Apple platforms support
 
-This project and build script demonstrate how to create an XCFramework that can be imported into an Xcode project and run on Apple platforms. It can compile and bundle an [entire SDK](#Building-the-SDK), or only a smaller [Crypto module](#Building-only-the-Crypto-SDK) that provides end-to-end encryption for clients that already depend on an SDK (e.g. [Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk))
+This project and build script demonstrate how to create an XCFramework that can
+be imported into an Xcode project and run on Apple platforms. It can compile and
+bundle an [entire SDK](#Building-the-SDK), or only a smaller
+[Crypto module](#Building-only-the-Crypto-SDK) that provides end-to-end
+encryption for clients that already depend on an SDK (e.g.
+[Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk))
 
 ## Building
 
 ### Prerequisites for building universal frameworks
 
 - the Rust toolchain
-- Apple targets (e.g. `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`)
-- `xcodebuild` command line tool from [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
+- Apple targets (e.g.
+  `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`)
+- `xcodebuild` command line tool from
+  [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
 - `lipo` for creating the fat static libs
 
 ### Building the SDK
 
-```
+```text
 cargo xtask swift build-framework
 ```
 
-The `build-framework` task will go through all the steps required to generate a fully usable `.xcframework`:
+The `build-framework` task will go through all the steps required to generate a
+fully usable `.xcframework`:
 
-1. compile `matrix-sdk-ffi` libraries for iOS, the iOS simulator and macOS under `/target`. Some targets are not part of the standard library and they will be built using the nightly toolchain.
+1. compile `matrix-sdk-ffi` libraries for iOS, the iOS simulator and macOS under
+   `/target`. Some targets are not part of the standard library and they will be
+   built using the nightly toolchain.
 2. `lipo` together the libraries for the same platform under `/generated`
 3. run `uniffi` and generate the C header, module map and swift files
-4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKFFI.xcframework`
-5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
+4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS
+   one, and add the header and module map to it under
+   `generated/MatrixSDKFFI.xcframework`
+5. cleanup and delete the generated files except the .xcframework and the swift
+   sources (that aren't part of the framework)
 
-For development purposes, it will additionally generate a `Package.swift` file in the root of the repo that can be used to add the framework to your project and enable debugging through the use of [rust-xcode-plugin](https://github.com/BrainiumLLC/rust-xcode-plugin) (make sure to run the task with the argument `--profile=reldbg`).
+For development purposes, it will additionally generate a `Package.swift` file
+in the root of the repo that can be used to add the framework to your project
+and enable debugging through the use of
+[rust-xcode-plugin](https://github.com/BrainiumLLC/rust-xcode-plugin) (make sure
+to run the task with the argument `--profile=reldbg`).
 
-When building the SDK for release you should pass the `--release` argument to the task, which will strip away any symbols and optimise the created binary.
+When building the SDK for release you should pass the `--release` argument to
+the task, which will strip away any symbols and optimise the created binary.
 
-### Building only the Crypto SDK
+### Building only the crypto SDK
 
-```
+```text
 build_crypto_xcframework.sh
 ```
 
-The `build_crypto_xcframework.sh` script will go through all the steps required to generate a fully usable `.xcframework`:
+The `build_crypto_xcframework.sh` script will go through all the steps required
+to generate a fully usable `.xcframework`:
 
-1. compile `matrix-sdk-crypto-ffi` libraries for iOS and the iOS simulator under `/target`
+1. compile `matrix-sdk-crypto-ffi` libraries for iOS and the iOS simulator under
+   `/target`
 2. `lipo` together the libraries for the same platform under `/generated`
 3. run `uniffi` and generate the C header, module map and swift files
-4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKCryptoFFI.xcframework`
-5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
+4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS
+   one, and add the header and module map to it under
+   `generated/MatrixSDKCryptoFFI.xcframework`
+5. cleanup and delete the generated files except the .xcframework and the swift
+   sources (that aren't part of the framework)
 
 ### Building & testing the Swift package
 
-The `Package.swift` file in this directory provides a simple example on how to integrate everything together but also a place to run unit and integration tests from.
+The `Package.swift` file in this directory provides a simple example on how to
+integrate everything together but also a place to run unit and integration tests
+from.
 
-It's pre-configured to link to the generated static lib and .swift files so successfully running `cargo xtask swift build-library` first is necessary for it to compile. Afterwards you can execute the tests with `swift test`. Note that for the moment this only works on macOS but we're planning to add Linux support in the future.
+It's pre-configured to link to the generated static lib and .swift files so
+successfully running `cargo xtask swift build-library` first is necessary for it
+to compile. Afterwards you can execute the tests with `swift test`. Note that
+for the moment this only works on macOS but we're planning to add Linux support
+in the future.
 
 ## Distribution
 
-The generated framework and Swift code can be distributed and integrated directly but in order to make things simpler we bundle them together as a [Swift package](https://github.com/matrix-org/matrix-rust-components-swift/) in the case of SDK, and as a CocoaPods podspec in the case of Crypto SDK.
+The generated framework and Swift code can be distributed and integrated
+directly but in order to make things simpler we bundle them together as a
+[Swift package](https://github.com/matrix-org/matrix-rust-components-swift/) in
+the case of SDK, and as a CocoaPods podspec in the case of Crypto SDK.
 
 ### Publishing MatrixSDKCrypto
 
-1. Navigate into `bindings/apple` and run [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which generates a .zip file with the framework in `./generated` folder
+1. Navigate into `bindings/apple` and run
+   [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which
+   generates a .zip file with the framework in `./generated` folder
 
-   Note that whilst you can run this command from any git branch, if you want to make a public release, ensure you are building from latest `main`
+   Note that whilst you can run this command from any git branch, if you want to
+   make a public release, ensure you are building from latest `main`
 
 2. Tag the commit you just used to build the release and push the tag to GitHub
 
    Use `matrix-sdk-crypto-ffi-<major>.<minor>.<patch>` tag name
 
-3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) using this tag (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.3.4))
+3. Create a new
+   [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases)
+   using this tag (see
+   [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.3.4))
 4. Upload the previously generated .zip file to this release
-5. Increment the version in [`MatrixSDKCrypto.podspec`](./MatrixSDKCrypto.podspec)
+5. Increment the version in
+   [`MatrixSDKCrypto.podspec`](./MatrixSDKCrypto.podspec)
 
-   Note that this is not automated and is a local-only change. To determine the most recent published version, run `pod repo update && pod search MatrixSDKCrypto`
-   or check git tags via `git tag | grep matrix-sdk-crypto-ffi`
+   Note that this is not automated and is a local-only change. To determine the
+   most recent published version, run
+   `pod repo update && pod search MatrixSDKCrypto` or check git tags via
+   `git tag | grep matrix-sdk-crypto-ffi`
 
-6. Push new Podspec version to Cocoapods via `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`
+6. Push new Podspec version to Cocoapods via
+   `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -13,7 +13,7 @@ encryption for clients that already depend on an SDK (e.g.
 
 - the Rust toolchain
 - Apple targets (e.g.
-  `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`)
+  `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`) <!-- rumdl-disable-line MD013 -->
 - `xcodebuild` command line tool from
   [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
 - `lipo` for creating the fat static libs
@@ -85,7 +85,7 @@ directly but in order to make things simpler we bundle them together as a
 [Swift package](https://github.com/matrix-org/matrix-rust-components-swift/) in
 the case of SDK, and as a CocoaPods podspec in the case of Crypto SDK.
 
-### Publishing MatrixSDKCrypto
+### Publishing `MatrixSDKCrypto`
 
 1. Navigate into `bindings/apple` and run
    [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which

--- a/bindings/matrix-sdk-crypto-ffi/README.md
+++ b/bindings/matrix-sdk-crypto-ffi/README.md
@@ -97,4 +97,3 @@ $ cp ../../target/aarch64-linux-android/debug/libmatrix_sdk_crypto_ffi.so \
 [installer]: https://rustup.rs/
 [targets]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [Cargo]: https://doc.rust-lang.org/cargo/
-[uniffi]: https://github.com/mozilla/uniffi-rs/

--- a/bindings/matrix-sdk-crypto-ffi/README.md
+++ b/bindings/matrix-sdk-crypto-ffi/README.md
@@ -1,30 +1,33 @@
-# Uniffi based bindings for the Rust SDK crypto crate.
+# Uniffi based bindings for the Rust SDK crypto crate
 
 This crate contains Uniffi based bindings for the `matrix-sdk-crypto` crate. The
 README mainly describes how to build and integrate the bindings into a Kotlin
 based Android project, but the Android specific bits can be skipped if you are
 targeting an x86 Linux project.
 
-To build and distribute bindings for iOS projects, see a [dedicated page](../apple/README.md)
+To build and distribute bindings for iOS projects, see a
+[dedicated page](../apple/README.md)
 
 ## Prerequisites
 
 ### Rust
 
 To build the bindings [Rust] will be needed it can be either installed using an
-OS specific package manager or directly with the provided [installer](https://rustup.rs/).
+OS specific package manager or directly with the provided
+[installer](https://rustup.rs/).
 
 ### Android NDK
 
 The Android NDK will be required as well, it can be installed either through
-Android Studio or directly using an [installer](https://developer.android.com/ndk/downloads).
+Android Studio or directly using an
+[installer](https://developer.android.com/ndk/downloads).
 
 ### Configuring Rust for cross compilation
 
-First we'll need to install the Rust target for our desired Android architecture,
-for example:
+First we'll need to install the Rust target for our desired Android
+architecture, for example:
 
-```
+```text
 # rustup target add aarch64-linux-android
 ```
 
@@ -39,14 +42,14 @@ with a value of the path to an appropriate linker in your NDK installation.
 
 This may be set through an environment variable:
 
-```
+```text
 $ export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="<path-to-ndk-installation>/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang"
 ```
 
-Alternatively, it may be set in the `.cargo/config.toml` file in the current directory,
-any parent directory, or your home directory:
+Alternatively, it may be set in the `.cargo/config.toml` file in the current
+directory, any parent directory, or your home directory:
 
-```
+```text
 [target.aarch64-linux-android]
 linker = "<path-to-ndk-installation>/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang"
 ```
@@ -57,13 +60,13 @@ To enable cross compilation for `olm-sys` which builds our `libolm` C library
 we'll need to set the `ANDROID_NDK` environment variable to the location of our
 Android NDK installation.
 
-```
+```text
 $ export ANDROID_NDK=$HOME/Android/Sdk/ndk/<some-installed-version>
 ```
 
 Also, include the NDK tools directory in your `PATH`:
 
-```
+```text
 $ export PATH="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
 ```
 
@@ -71,16 +74,17 @@ $ export PATH="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
 
 The bindings can built for the `aarch64` target with:
 
-```
+```text
 $ cargo build --target aarch64-linux-android
 ```
 
-After that, a dynamic library can be found in the `target/aarch64-linux-android/debug` directory,
-under the repository root directory.
-The library will be called `libmatrix_sdk_crypto_ffi.so` and needs to be renamed and
-copied into the `jniLibs` directory of your Android project, for Element Android:
+After that, a dynamic library can be found in the
+`target/aarch64-linux-android/debug` directory, under the repository root
+directory. The library will be called `libmatrix_sdk_crypto_ffi.so` and needs to
+be renamed and copied into the `jniLibs` directory of your Android project, for
+Element Android:
 
-```
+```text
 $ cp ../../target/aarch64-linux-android/debug/libmatrix_sdk_crypto_ffi.so \
      /home/example/matrix-sdk-android/src/main/jniLibs/aarch64/libuniffi_olm.so
 ```

--- a/bindings/matrix-sdk-ffi-macros/README.md
+++ b/bindings/matrix-sdk-ffi-macros/README.md
@@ -10,6 +10,3 @@ Internal macros used for the FFI layer (bindings) of the Rust Matrix SDK.
 **NOTE:** These are just macros that help build the matrix-rust-sdk bindings,
 you're probably interested in the main
 [rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/) crate.
-
-[Matrix]: https://matrix.org/
-[Rust]: https://www.rust-lang.org/

--- a/bindings/matrix-sdk-ffi-macros/README.md
+++ b/bindings/matrix-sdk-ffi-macros/README.md
@@ -3,12 +3,13 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![#matrix-rust-sdk](https://img.shields.io/badge/matrix-%23matrix--rust--sdk-blue?style=flat-square)](https://matrix.to/#/#matrix-rust-sdk:matrix.org)
 
-# matrix-sdk-ffi-macros
+# `matrix-sdk-ffi-macros`
 
 Internal macros used for the FFI layer (bindings) of the Rust Matrix SDK.
 
-**NOTE:** These are just macros that help build the matrix-rust-sdk bindings, you're probably
-interested in the main [rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/) crate.
+**NOTE:** These are just macros that help build the matrix-rust-sdk bindings,
+you're probably interested in the main
+[rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/) crate.
 
 [Matrix]: https://matrix.org/
 [Rust]: https://www.rust-lang.org/

--- a/bindings/matrix-sdk-ffi/CHANGELOG.md
+++ b/bindings/matrix-sdk-ffi/CHANGELOG.md
@@ -6,33 +6,39 @@ All notable changes to this project will be documented in this file.
 
 ## [0.17.0] - 2026-05-08
 
-### Bug Fixes
+### Bug fixes
 
-- Add `Client::set_avatar_url` to manually set the avatar URL of the user to a provided MXC one.
-- Allow setting a custom Sliding Sync connection ID and timeline limit on `RoomListService`.
+- Add `Client::set_avatar_url` to manually set the avatar URL of the user to a
+  provided MXC one.
+- Allow setting a custom Sliding Sync connection ID and timeline limit on
+  `RoomListService`.
   ([#6289](https://github.com/matrix-org/matrix-rust-sdk/pull/6289))
-- Fix devices on Android 11 crashing because the SDK could not be initialized using `libloading` 
-  to get a reference to the JVM. Replaced `libloading` with `jvm-getter`, which works like a 
-  compatibility layer. ([#6370](https://github.com/matrix-org/matrix-rust-sdk/pull/6370))
-- Added `android_platform.rs` for fixing the `rustls` integration on Android, which was broken. 
-  ([#6306](https://github.com/matrix-org/matrix-rust-sdk/pull/6306)) 
-- [**breaking**] `OtherState` properly supports redacted events that still have fields in the
-  content. The following fields are no longer optional:
+- Fix devices on Android 11 crashing because the SDK could not be initialized
+  using `libloading` to get a reference to the JVM. Replaced `libloading` with
+  `jvm-getter`, which works like a compatibility layer.
+  ([#6370](https://github.com/matrix-org/matrix-rust-sdk/pull/6370))
+- Added `android_platform.rs` for fixing the `rustls` integration on Android,
+  which was broken.
+  ([#6306](https://github.com/matrix-org/matrix-rust-sdk/pull/6306))
+- [**breaking**] `OtherState` properly supports redacted events that still have
+  fields in the content. The following fields are no longer optional:
   - `federate` in `OtherState::RoomCreate`.
   - `history_visibility` in `OtherState::RoomHistoryVisibility`.
   - `thresholds` in `OtherState::RoomPowerLevels`.
-- `omit_checksums` option is now enabled for the Kotlin bindings in all FFI-exporting crates.
-  We enabled them because with JNA direct mapping enabled they result in invalid checks in
-  ARM 32bit devices, preventing the SDK from working altogether (see
+- `omit_checksums` option is now enabled for the Kotlin bindings in all
+  FFI-exporting crates. We enabled them because with JNA direct mapping enabled
+  they result in invalid checks in ARM 32bit devices, preventing the SDK from
+  working altogether (see
 [this issue](https://github.com/mozilla/uniffi-rs/issues/2740)).
 ([#6069](https://github.com/matrix-org/matrix-rust-sdk/pull/6069),
 [#6112](https://github.com/matrix-org/matrix-rust-sdk/pull/6112),
 [#6115](https://github.com/matrix-org/matrix-rust-sdk/pull/6115),
 [#6116](https://github.com/matrix-org/matrix-rust-sdk/pull/6116)).
-- `Client::create_room` now uses `RoomPowerLevelsContentOverride` under the hood instead of
-  `RoomPowerLevelsEventContent` to be able to explicitly set values which would previously be
-  ignored if they matched the default power level values specified by the spec: these may not be
-  the same in the homeserver and result in rooms with incorrect power levels being created.
+- `Client::create_room` now uses `RoomPowerLevelsContentOverride` under the hood
+  instead of `RoomPowerLevelsEventContent` to be able to explicitly set values
+  which would previously be ignored if they matched the default power level
+  values specified by the spec: these may not be the same in the homeserver and
+  result in rooms with incorrect power levels being created.
   ([#6034](https://github.com/matrix-org/matrix-rust-sdk/pull/6034))
 - Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not
   accounting for the membership state.
@@ -44,33 +50,39 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- `RoomNotificationInfo`, `NotificationItem` and `SpaceRoom` now have `is_dm` fields. 
-  ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
-- Expose `RoomMember::is_service_member` field. ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
-- Expose `beacon` and `beacon_info` fields in `RoomPowerLevelsValues` and `RoomPowerLevelChanges`,
-  allowing clients to read and update the power levels required to send beacon (live location)
-  message events and beacon info state events respectively.
+- `RoomNotificationInfo`, `NotificationItem` and `SpaceRoom` now have `is_dm`
+  fields. ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
+- Expose `RoomMember::is_service_member` field.
+  ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
+- Expose `beacon` and `beacon_info` fields in `RoomPowerLevelsValues` and
+  `RoomPowerLevelChanges`, allowing clients to read and update the power levels
+  required to send beacon (live location) message events and beacon info state
+  events respectively.
   ([#6540](https://github.com/matrix-org/matrix-rust-sdk/pull/6540))
-- Expose `ClientBuilder::dm_room_definition` to customize the DM room definition used by the `Client`, 
-  added `RoomInfo::is_dm` field based on it. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
+- Expose `ClientBuilder::dm_room_definition` to customize the DM room definition
+  used by the `Client`, added `RoomInfo::is_dm` field based on it.
+  ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Expose `HumanQrGrantLoginError::Unknown` reason in error message.
   ([#6514](https://github.com/matrix-org/matrix-rust-sdk/pull/6514))
-- Add a list of `declined_by: Vec<String>` to the `TimelineItemContent::RtcNotification`, this will contain the list
-  of users that have declined the call.
+- Add a list of `declined_by: Vec<String>` to the
+  `TimelineItemContent::RtcNotification`, this will contain the list of users
+  that have declined the call.
   ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
-- Add `RoomInfo::active_service_members_count` and `NotificationRoomInfo::active_service_members_count`,
-  returning the amount of service members that are part of the room.
+- Add `RoomInfo::active_service_members_count` and
+  `NotificationRoomInfo::active_service_members_count`, returning the amount of
+  service members that are part of the room.
   ([#6483](https://github.com/matrix-org/matrix-rust-sdk/pull/6483))
-- Add `Client::get_dm_rooms` function to get a list with the DMs for the provided user id.
+- Add `Client::get_dm_rooms` function to get a list with the DMs for the
+  provided user id.
   ([#6487](https://github.com/matrix-org/matrix-rust-sdk/pull/6487))
-- Expose `ffi::NotificationRoomInfo::service_members` so clients can use the list of service
-  members to calculate if a room is a DM from the notification info.
-  ([#6474](https://github.com/matrix-org/matrix-rust-sdk/pull/6474))
-- Enable `experimental-push-secrets` feature by default. 
+- Expose `ffi::NotificationRoomInfo::service_members` so clients can use the
+  list of service members to calculate if a room is a DM from the notification
+  info. ([#6474](https://github.com/matrix-org/matrix-rust-sdk/pull/6474))
+- Enable `experimental-push-secrets` feature by default.
   ([#6473](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))
-- Add new high-level search helpers `RoomSearchIterator` and `GlobalSearchIterator` to perform
-  searches for messages in a room or across all rooms.
-  ([6394](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))
+- Add new high-level search helpers `RoomSearchIterator` and
+  `GlobalSearchIterator` to perform searches for messages in a room or across
+  all rooms. ([6394](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))
 - Added the `Client.request_openid_token()` method.
   ([#6458](https://github.com/matrix-org/matrix-rust-sdk/pull/6458))
 - Added the `Client::import_secrets_bundle` method.
@@ -90,73 +102,89 @@ All notable changes to this project will be documented in this file.
   accepts a `SyncListenerV2` callback that receives a `SyncResponseV2`
   after each successful sync.
   ([#6359](https://github.com/matrix-org/matrix-rust-sdk/pull/6359))
-- Added `HomeserverCapabilities` and `Client::homeserver_capabilities()` to get the capabilities
-  of the homeserver. ([#6371](https://github.com/matrix-org/matrix-rust-sdk/pull/6371))
+- Added `HomeserverCapabilities` and `Client::homeserver_capabilities()` to get
+  the capabilities of the homeserver.
+  ([#6371](https://github.com/matrix-org/matrix-rust-sdk/pull/6371))
 - Expose `Room.send_state_event_raw()` for sending arbitrary state events
   through the FFI layer.
   ([#6350](https://github.com/matrix-org/matrix-rust-sdk/pull/6350))
 - Introduce a `ThreadListService` which offers reactive interfaces for rendering
   and managing the list of threads from a particular room.
   ([6311](https://github.com/matrix-org/matrix-rust-sdk/pull/6311))
-- [**breaking**] Move `LiveLocation` out of `TimelineItemContent` and into `MsgLikeKind`
-  so it has access to `MsgLikeContent` `reactions`.
+- [**breaking**] Move `LiveLocation` out of `TimelineItemContent` and into
+  `MsgLikeKind` so it has access to `MsgLikeContent` `reactions`.
   ([#6286](https://github.com/matrix-org/matrix-rust-sdk/pull/6286))
-- Add `HumanQrLoginError::UnsupportedQrCodeType` for when a QR is parseable but cannot be used to
-  complete a login.
+- Add `HumanQrLoginError::UnsupportedQrCodeType` for when a QR is parseable but
+  cannot be used to complete a login.
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6285)
-- Add `HumanQrGrantLoginError::UnsupportedQrCodeType` for when a QR is parseable but cannot be used
-  to grant a login.
+- Add `HumanQrGrantLoginError::UnsupportedQrCodeType` for when a QR is parseable
+  but cannot be used to grant a login.
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6285)
 - Add the `QrCodeData::base_url` and `QrCodeData::intent` methods.
   ([#6283](https://github.com/matrix-org/matrix-rust-sdk/pull/6283))
-- Add `Encryption::recover_and_fix_backup` to automatically fix key storage backup if the
-  private backup decryption key is missing, invalid or inconsistent with the public key.
+- Add `Encryption::recover_and_fix_backup` to automatically fix key storage
+  backup if the private backup decryption key is missing, invalid or
+  inconsistent with the public key.
   ([#6252](https://github.com/matrix-org/matrix-rust-sdk/pull/6252))
-- Add support for [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489)  
-  live location sharing through a new `TimelineItemContent::LiveLocation` variant.
-  ([#6232](https://github.com/matrix-org/matrix-rust-sdk/pull/6232))
-- Add `HumanQrGrantLoginError::ConnectionInsecure` for errors establishing the secure channel
+- Add support for
+  [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489)  
+  live location sharing through a new `TimelineItemContent::LiveLocation`
+  variant. ([#6232](https://github.com/matrix-org/matrix-rust-sdk/pull/6232))
+- Add `HumanQrGrantLoginError::ConnectionInsecure` for errors establishing the
+  secure channel
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `HumanQrGrantLoginError::Expired` for when a timeout is encountered during the grant
-  ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
+- Add `HumanQrGrantLoginError::Expired` for when a timeout is encountered during
+  the grant ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
 - Add `HumanQrGrantLoginError::Cancelled` for when the grant is cancelled
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `HumanQrGrantLoginError::OtherDeviceAlreadySignedIn` for when the other device is already signed in
+- Add `HumanQrGrantLoginError::OtherDeviceAlreadySignedIn` for when the other
+  device is already signed in
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `HumanQrGrantLoginError::DeviceNotFound` for when the requested device was not returned by the homeserver
+- Add `HumanQrGrantLoginError::DeviceNotFound` for when the requested device was
+  not returned by the homeserver
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `RoomInfo::is_low_priority` for getting the room's `m.lowpriority` tag state
-  ([#6183](https://github.com/matrix-org/matrix-rust-sdk/pull/6183))
-- Add `Client::subscribe_to_duplicate_key_upload_errors` for listening to duplicate key
-  upload errors from `/keys/upload`.
+- Add `RoomInfo::is_low_priority` for getting the room's `m.lowpriority` tag
+  state ([#6183](https://github.com/matrix-org/matrix-rust-sdk/pull/6183))
+- Add `Client::subscribe_to_duplicate_key_upload_errors` for listening to
+  duplicate key upload errors from `/keys/upload`.
   ([#6135](https://github.com/matrix-org/matrix-rust-sdk/pull/6135/))
-- Add `NotificationItem::raw_event` to get the raw event content of the event that triggered the notification, which can be useful for debugging and to support clients that want to implement custom handling for certain notifications. ([#6122](https://github.com/matrix-org/matrix-rust-sdk/pull/6122))
+- Add `NotificationItem::raw_event` to get the raw event content of the event
+  that triggered the notification, which can be useful for debugging and to
+  support clients that want to implement custom handling for certain
+  notifications.
+  ([#6122](https://github.com/matrix-org/matrix-rust-sdk/pull/6122))
 - [**breaking**] Extend `TimelineFocus::Event` to allow marking the target
   event as the root of a thread.
   [#6050](https://github.com/matrix-org/matrix-rust-sdk/pull/6050)
-- [**breaking**] Remove `TimelineFilter::EventTypeFilter` which has been replaced by
-  the more generic `TimelineFilter::EventFilter`. Users of `TimelineEventTypeFilter::include`
-  and `TimelineEventTypeFilter::exclude` can switch to `TimelineEventFilter::include_event_types`
-  and `TimelineEventFilter::exclude_event_types`.
+- [**breaking**] Remove `TimelineFilter::EventTypeFilter` which has been
+  replaced by the more generic `TimelineFilter::EventFilter`. Users of
+  `TimelineEventTypeFilter::include` and `TimelineEventTypeFilter::exclude` can
+  switch to `TimelineEventFilter::include_event_types` and
+  `TimelineEventFilter::exclude_event_types`.
   ([#6070](https://github.com/matrix-org/matrix-rust-sdk/pull/6070/))
 - Add `TimelineFilter::EventFilter` for filtering events based on their type or
   content. For content filtering, only membership and profile change filters
   are available as of now.
   ([#6048](https://github.com/matrix-org/matrix-rust-sdk/pull/6048/))
 - Introduce `SpaceFilter`s as a mechanism for narrowing down what's displayed in
-  the room list ([#6025](https://github.com/matrix-org/matrix-rust-sdk/pull/6025))
-- Expose room power level thresholds in `OtherState::RoomPowerLevels` (ban, kick, invite, redact, state &
-  events defaults, per-event overrides, notifications), so clients can compute the required power level
-  for actions and compare with previous values. ([#5931](https://github.com/matrix-org/matrix-rust-sdk/pull/5931))
-- Add `RoomCreationParameters::is_space` parameter to be able to create spaces. ([#6010](https://github.com/matrix-org/matrix-rust-sdk/pull/6010/))
-- [**breaking**] `LazyTimelineItemProvider::get_shields` no longer returns an
-  an `Option`: the `ShieldState` type contains a `None` variant, so the
-  `Option` was redundant. The `message` field has also been removed: since there
-  was no way to localise the returned string, applications should not be using it.
+  the room list
+  ([#6025](https://github.com/matrix-org/matrix-rust-sdk/pull/6025))
+- Expose room power level thresholds in `OtherState::RoomPowerLevels` (ban,
+  kick, invite, redact, state & events defaults, per-event overrides,
+  notifications), so clients can compute the required power level for actions
+  and compare with previous values.
+  ([#5931](https://github.com/matrix-org/matrix-rust-sdk/pull/5931))
+- Add `RoomCreationParameters::is_space` parameter to be able to create spaces.
+  ([#6010](https://github.com/matrix-org/matrix-rust-sdk/pull/6010/))
+- [**breaking**] `LazyTimelineItemProvider::get_shields` no longer returns an an
+  `Option`: the `ShieldState` type contains a `None` variant, so the `Option`
+  was redundant. The `message` field has also been removed: since there was no
+  way to localise the returned string, applications should not be using it.
   ([#5959](https://github.com/matrix-org/matrix-rust-sdk/pull/5959))
 - Add `Room::list_threads` to list all the threads in a room.
   ([#5953](https://github.com/matrix-org/matrix-rust-sdk/pull/5953))
-- Add `SpaceService::get_space_room` to get a space given its id from the space graph if available.
+- Add `SpaceService::get_space_room` to get a space given its id from the space
+  graph if available.
 [#5944](https://github.com/matrix-org/matrix-rust-sdk/pull/5944)
 - Add `QrCodeData::to_bytes()` to allow generation of a QR code.
   ([#5939](https://github.com/matrix-org/matrix-rust-sdk/pull/5939))
@@ -164,76 +192,95 @@ All notable changes to this project will be documented in this file.
   `Room::new_latest_event` overwrites the `Room::latest_event` method. See the
   documentation of `matrix_sdk::latest_event` to learn about the new API.
   [#5624](https://github.com/matrix-org/matrix-rust-sdk/pull/5624/)
-- Created `RoomPowerLevels::events` function which returns a `HashMap<TimelineEventType, i64>` with all the power
-  levels per event type. ([#5937](https://github.com/matrix-org/matrix-rust-sdk/pull/5937))
-- Expose `EventTimelineItem::forwarder` and `forwarder_profile`, which, if present, provide the ID and profile of
-  the user who forwarded the keys used to decrypt the event as part of an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)
-  key bundle.
-  ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
-- Add `NonFavorite` filter to the Room List API. ([#5991](https://github.com/matrix-org/matrix-rust-sdk/pull/5991)
-- Add `call_intent` (either `RtcCallIntent::Audio` or `RtcCallIntent::Video`) field to `RtcNotification` event content. ([#6207](https://github.com/matrix-org/matrix-rust-sdk/pull/6207))
-- Add `RoomInfo::active_room_call_consensus_intent` method to get the call intent for the current call,
-  based on what members are advertising.
+- Created `RoomPowerLevels::events` function which returns a
+  `HashMap<TimelineEventType, i64>` with all the power levels per event type.
+  ([#5937](https://github.com/matrix-org/matrix-rust-sdk/pull/5937))
+- Expose `EventTimelineItem::forwarder` and `forwarder_profile`, which, if
+  present, provide the ID and profile of the user who forwarded the keys used to
+  decrypt the event as part of an
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) key
+  bundle. ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
+- Add `NonFavorite` filter to the Room List API.
+  ([#5991](https://github.com/matrix-org/matrix-rust-sdk/pull/5991)
+- Add `call_intent` (either `RtcCallIntent::Audio` or `RtcCallIntent::Video`)
+  field to `RtcNotification` event content.
+  ([#6207](https://github.com/matrix-org/matrix-rust-sdk/pull/6207))
+- Add `RoomInfo::active_room_call_consensus_intent` method to get the call
+  intent for the current call, based on what members are advertising.
   ([#6274](https://github.com/matrix-org/matrix-rust-sdk/pull/6274))
 
 ### Refactor
 
-- [**breaking**] All OIDC related types and functions have been renamed from `Oidc`/`oidc` to `OAuth`/`oauth` to align
-  with the finalised naming in the spec.
-  ([#6500](https://github.com/matrix-org/matrix-rust-sdk/pull/6500))
-- [**breaking**] `LiveLocationShares` has been renamed to `LiveLocationsObserver` and
-  `Room::live_location_shares` to `Room::live_locations_observer`.
+- [**breaking**] All OIDC related types and functions have been renamed from
+  `Oidc`/`oidc` to `OAuth`/`oauth` to align with the finalised naming in the
+  spec. ([#6500](https://github.com/matrix-org/matrix-rust-sdk/pull/6500))
+- [**breaking**] `LiveLocationShares` has been renamed to
+  `LiveLocationsObserver` and `Room::live_location_shares` to
+  `Room::live_locations_observer`.
   ([#6446](https://github.com/matrix-org/matrix-rust-sdk/pull/6446))
 - [**breaking**] `Room::observe_live_location_shares` has been replaced by
-  `Room::live_locations_observer`. Call [`LiveLocationsObserver::subscribe`] on it to
-  receive an initial snapshot and a stream of incremental updates.The stream is seeded from the event cache
-  on creation and includes the own user's shares (previously excluded). `LiveLocationShare.is_live`
-  has been removed; instead `ts` (start timestamp) and `timeout` (duration in milliseconds) are now
-  exposed so clients can compute liveness themselves via `current_time < ts + timeout`. Non-live
-  shares are automatically removed from the list. A new `LiveLocationShareListener` callback
-  interface must be implemented and passed to the method.
+  `Room::live_locations_observer`. Call [`LiveLocationsObserver::subscribe`] on
+  it to receive an initial snapshot and a stream of incremental updates.The
+  stream is seeded from the event cache on creation and includes the own user's
+  shares (previously excluded). `LiveLocationShare.is_live` has been removed;
+  instead `ts` (start timestamp) and `timeout` (duration in milliseconds) are
+  now exposed so clients can compute liveness themselves via
+  `current_time < ts + timeout`. Non-live shares are automatically removed from
+  the list. A new `LiveLocationShareListener` callback interface must be
+  implemented and passed to the method.
   ([#6385](https://github.com/matrix-org/matrix-rust-sdk/pull/6385))
-- [**breaking**] The `RoomAliases` variants of `StateEventContent`, `StateEventType` and
-  `OtherState` was removed. This state event type was removed from the Matrix specification a while
-  ago, and support for it has been removed in Ruma.
+- [**breaking**] The `RoomAliases` variants of `StateEventContent`,
+  `StateEventType` and `OtherState` was removed. This state event type was
+  removed from the Matrix specification a while ago, and support for it has been
+  removed in Ruma.
   ([#6414](https://github.com/matrix-org/matrix-rust-sdk/pull/6414))
-- `Client::new` no longer unnecessarily instantiates an `OAuth` component if `CrossProcessLockConfig::SingleProcess` 
-  is used. ([#6293](https://github.com/matrix-org/matrix-rust-sdk/pull/6293))
-- [**breaking**] `Room::report_content()` no longer takes a `score` argument, because it was
-  removed from the Matrix specification.
+- `Client::new` no longer unnecessarily instantiates an `OAuth` component if
+  `CrossProcessLockConfig::SingleProcess` is used.
+  ([#6293](https://github.com/matrix-org/matrix-rust-sdk/pull/6293))
+- [**breaking**] `Room::report_content()` no longer takes a `score` argument,
+  because it was removed from the Matrix specification.
   ([#6256](https://github.com/matrix-org/matrix-rust-sdk/pull/6256))
-- [**breaking**] The `current_version` field of `ErrorKind::WrongRoomKeysVersion`
-  is no longer optional.
+- [**breaking**] The `current_version` field of
+  `ErrorKind::WrongRoomKeysVersion` is no longer optional.
   ([#6241](https://github.com/matrix-org/matrix-rust-sdk/pull/6241))
 - [**breaking**] The following variants of `AccountManagementAction` were
-  renamed to match their new names after being merge in the Matrix specification:
+  renamed to match their new names after being merge in the Matrix
+  specification:
   - `SessionsList` is renamed to `DevicesList`
   - `SessionView` is renamed to `DeviceView`
   - `SessionEnd` is renamed to `DeviceDelete`
   ([#6217](https://github.com/matrix-org/matrix-rust-sdk/pull/6217))
 - [**breaking**] `HumanQrGrantLoginError::UnableToCreateDevice` has been removed
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- [**breaking**] Removed `ClientBuilder::enable_oidc_refresh_lock` in favour of using `ClientBuilder::cross_process_lock_config`
-  to configure that lock when a `MultiProcess` configuration is supplied. ([#6204](https://github.com/matrix-org/matrix-rust-sdk/pull/6204))
+- [**breaking**] Removed `ClientBuilder::enable_oidc_refresh_lock` in favour of
+  using `ClientBuilder::cross_process_lock_config` to configure that lock when a
+  `MultiProcess` configuration is supplied.
+  ([#6204](https://github.com/matrix-org/matrix-rust-sdk/pull/6204))
 - `RoomPaginationStatus` is renamed to `PaginationStatus`.
   ([#6174](https://github.com/matrix-org/matrix-rust-sdk/pull/6174/))
-- [**breaking**] Replaced `ClientBuilder::cross_process_store_locks_holder_name` with `ClientBuilder::cross_process_lock_config`, 
-  which accepts a `CrossProcessLockConfig` value to specify whether the resulting `Client` will be used in a single 
-  process or multiple processes. ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
-- [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will now
-  account also for v12 rooms, where creators and users with PL 150 matter.
+- [**breaking**] Replaced `ClientBuilder::cross_process_store_locks_holder_name`
+  with `ClientBuilder::cross_process_lock_config`, which accepts a
+  `CrossProcessLockConfig` value to specify whether the resulting `Client` will
+  be used in a single process or multiple processes.
+  ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
+- [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will
+  now account also for v12 rooms, where creators and users with PL 150 matter.
   ([#6036](https://github.com/matrix-org/matrix-rust-sdk/pull/6036))
-- [**breaking**] The existing `TimelineEventType` was renamed to `TimelineEventContent`, because it contained the
-  actual contents of the event. Then, we created a new `TimelineEventType` enum that actually contains *just* the
-  event type. ([#5937](https://github.com/matrix-org/matrix-rust-sdk/pull/5937))
-- [**breaking**] The function `TimelineEvent::event_type` is now `TimelineEvent::content`.
+- [**breaking**] The existing `TimelineEventType` was renamed to
+  `TimelineEventContent`, because it contained the actual contents of the event.
+  Then, we created a new `TimelineEventType` enum that actually contains _just_
+  the event type.
+  ([#5937](https://github.com/matrix-org/matrix-rust-sdk/pull/5937))
+- [**breaking**] The function `TimelineEvent::event_type` is now
+  `TimelineEvent::content`.
   ([#5937](https://github.com/matrix-org/matrix-rust-sdk/pull/5937))
 - [**breaking**] The `SpaceService` will no longer auto-subscribe to required
   client events when invoking the `subscribe_to_joined_spaces` but instead do it
   through its, now async, constructor.
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 - [**breaking**] The `SpaceService`'s `joined_spaces` method has been renamed
-  `top_level_joined_spaces` and `subscribe_to_joined_spaces` to `space_service.subscribe_to_top_level_joined_spaces`
+  `top_level_joined_spaces` and `subscribe_to_joined_spaces` to
+  `space_service.subscribe_to_top_level_joined_spaces`
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 
 ## [0.16.1] - 2026-05-08
@@ -244,16 +291,17 @@ No notable changes in this release.
 
 ### Breaking changes
 
-- `TimelineConfiguration::track_read_receipts`'s type is now an enum to allow tracking to be enabled for all events
-  (like before) or only for message-like events (which prevents read receipts from being placed on state events).
+- `TimelineConfiguration::track_read_receipts`'s type is now an enum to allow
+  tracking to be enabled for all events (like before) or only for message-like
+  events (which prevents read receipts from being placed on state events).
   ([#5900](https://github.com/matrix-org/matrix-rust-sdk/pull/5900))
 - `Client::reset_server_info()` has been split into `reset_supported_versions()`
   and `reset_well_known()`.
   ([#5910](https://github.com/matrix-org/matrix-rust-sdk/pull/5910))
-- Add `HumanQrLoginError::NotFound` for non-existing / expired rendezvous sessions
-  ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
-- Add `HumanQrGrantLoginError::NotFound` for non-existing / expired rendezvous sessions
-  ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
+- Add `HumanQrLoginError::NotFound` for non-existing / expired rendezvous
+  sessions ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
+- Add `HumanQrGrantLoginError::NotFound` for non-existing / expired rendezvous
+  sessions ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
 - The `LatestEventValue::Local` type gains 2 new fields: `sender` and `profile`.
   ([#5885](https://github.com/matrix-org/matrix-rust-sdk/pull/5885))
 - The `Encryption::user_identity()` method has received a new argument. The
@@ -262,7 +310,8 @@ No notable changes in this release.
   ([#5870](https://github.com/matrix-org/matrix-rust-sdk/pull/5870))
 - Expose the power level required to modify `m.space.child` on
   `room::power_levels::RoomPowerLevelsValues`.
-- Rename `Client::login_with_qr_code` to `Client::new_login_with_qr_code_handler`.
+- Rename `Client::login_with_qr_code` to
+  `Client::new_login_with_qr_code_handler`.
   ([#5836](https://github.com/matrix-org/matrix-rust-sdk/pull/5836))
 - Add the `sqlite` feature, along with the `indexeddb` feature, to enable either
   the SQLite or IndexedDB store. The `session_paths`, `session_passphrase`,
@@ -292,134 +341,179 @@ No notable changes in this release.
       )
   ```
 
-- UniFFI was upgraded to `v0.30.0` ([#5808](https://github.com/matrix-org/matrix-rust-sdk/pull/5808)).
-- The `waveform` parameter in `Timeline::send_voice_message` format changed to a list of `f32`
-  between 0 and 1.
+- UniFFI was upgraded to `v0.30.0`
+  ([#5808](https://github.com/matrix-org/matrix-rust-sdk/pull/5808)).
+- The `waveform` parameter in `Timeline::send_voice_message` format changed to a
+  list of `f32` between 0 and 1.
   ([#5732](https://github.com/matrix-org/matrix-rust-sdk/pull/5732))
 - The `normalized_power_level` field has been removed from the `RoomMember`
   struct.
   ([#5635](https://github.com/matrix-org/matrix-rust-sdk/pull/5635))
-- Remove the deprecated `CallNotify` event (`org.matrix.msc4075.call.notify`) in favor of the new
-  `RtcNotification` event (`org.matrix.msc4075.rtc.notification`).
+- Remove the deprecated `CallNotify` event (`org.matrix.msc4075.call.notify`) in
+  favor of the new `RtcNotification` event
+  (`org.matrix.msc4075.rtc.notification`).
   ([#5668](https://github.com/matrix-org/matrix-rust-sdk/pull/5668))
-- Add `QrLoginProgress::SyncingSecrets` to indicate that secrets are being synced between the two
-  devices.
+- Add `QrLoginProgress::SyncingSecrets` to indicate that secrets are being
+  synced between the two devices.
   ([#5760](https://github.com/matrix-org/matrix-rust-sdk/pull/5760))
-- Add `Room::subscribe_to_send_queue_updates` to observe room send queue updates.
-  ([#5761](https://github.com/matrix-org/matrix-rust-sdk/pull/5761))
-- `Client::login_with_qr_code` now returns a handler that allows performing the flow with either the
-  current device scanning or generating the QR code. Additionally, new errors `HumanQrLoginError::CheckCodeAlreadySent`
-  and `HumanQrLoginError::CheckCodeCannotBeSent` were added.
+- Add `Room::subscribe_to_send_queue_updates` to observe room send queue
+  updates. ([#5761](https://github.com/matrix-org/matrix-rust-sdk/pull/5761))
+- `Client::login_with_qr_code` now returns a handler that allows performing the
+  flow with either the current device scanning or generating the QR code.
+  Additionally, new errors `HumanQrLoginError::CheckCodeAlreadySent` and
+  `HumanQrLoginError::CheckCodeCannotBeSent` were added.
   ([#5786](https://github.com/matrix-org/matrix-rust-sdk/pull/5786))
 - `ComposerDraft` now includes attachments alongside the text message.
   ([#5794](https://github.com/matrix-org/matrix-rust-sdk/pull/5794))
-- Add `Client::subscribe_to_send_queue_updates` to observe global send queue updates.
-  ([#5784](https://github.com/matrix-org/matrix-rust-sdk/pull/5784))
+- Add `Client::subscribe_to_send_queue_updates` to observe global send queue
+  updates. ([#5784](https://github.com/matrix-org/matrix-rust-sdk/pull/5784))
 
 ### Features
 
-- Add `Client::get_store_sizes()` so to query the size of the existing stores, if available. ([#5911](https://github.com/matrix-org/matrix-rust-sdk/pull/5911))
-- Expose `is_space` in `NotificationRoomInfo`, allowing clients to determine if the room that triggered the notification is a space.
-- Add push actions to `NotificationItem` and replace `SyncNotification` with `NotificationItem`.
+- Add `Client::get_store_sizes()` so to query the size of the existing stores,
+  if available.
+  ([#5911](https://github.com/matrix-org/matrix-rust-sdk/pull/5911))
+- Expose `is_space` in `NotificationRoomInfo`, allowing clients to determine if
+  the room that triggered the notification is a space.
+- Add push actions to `NotificationItem` and replace `SyncNotification` with
+  `NotificationItem`.
   ([#5835](https://github.com/matrix-org/matrix-rust-sdk/pull/5835))
-- Add `Client::new_grant_login_with_qr_code_handler` for granting login to a new device by way of
-  a QR code.
+- Add `Client::new_grant_login_with_qr_code_handler` for granting login to a new
+  device by way of a QR code.
   ([#5836](https://github.com/matrix-org/matrix-rust-sdk/pull/5836))
-- Add `Client::register_notification_handler` for observing notifications generated from sync responses.
+- Add `Client::register_notification_handler` for observing notifications
+  generated from sync responses.
   ([#5831](https://github.com/matrix-org/matrix-rust-sdk/pull/5831))
-- Add `Room::mark_as_fully_read_unchecked` so clients can mark a room as read without needing a `Timeline` instance. Note this method is not recommended as it can potentially cause incorrect read receipts, but it can needed in certain cases.
-- Add `Timeline::latest_event_id` to be able to fetch the event id of the latest event of the timeline.
-- Add `Room::load_or_fetch_event` so we can get a `TimelineEvent` given its event id ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
-- Add `TimelineEvent::thread_root_event_id` to expose the thread root event id for this type too ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
-- Add `NotificationSettings::get_raw_push_rules` so clients can fetch the raw JSON content of the push rules of the current user and include it in bug reports ([#5706](https://github.com/matrix-org/matrix-rust-sdk/pull/5706)).
-- Add new API to decline calls ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)): `Room::decline_call` and `Room::subscribe_to_call_decline_events`
+- Add `Room::mark_as_fully_read_unchecked` so clients can mark a room as read
+  without needing a `Timeline` instance. Note this method is not recommended as
+  it can potentially cause incorrect read receipts, but it can needed in certain
+  cases.
+- Add `Timeline::latest_event_id` to be able to fetch the event id of the latest
+  event of the timeline.
+- Add `Room::load_or_fetch_event` so we can get a `TimelineEvent` given its
+  event id ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
+- Add `TimelineEvent::thread_root_event_id` to expose the thread root event id
+  for this type too
+  ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
+- Add `NotificationSettings::get_raw_push_rules` so clients can fetch the raw
+  JSON content of the push rules of the current user and include it in bug
+  reports ([#5706](https://github.com/matrix-org/matrix-rust-sdk/pull/5706)).
+- Add new API to decline calls
+  ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)):
+  `Room::decline_call` and `Room::subscribe_to_call_decline_events`
   ([#5614](https://github.com/matrix-org/matrix-rust-sdk/pull/5614))
-- Expose `m.federate` in `OtherState::RoomCreate` and `history_visibility` in `OtherState::RoomHistoryVisibility`, allowing clients to know whether a room federates and how its history is shared in the appropriate timeline events.
-- Expose `join_rule` in `OtherState::RoomJoinRules`, allowing clients to know the join rules of a room from the appropriate timeline events.
+- Expose `m.federate` in `OtherState::RoomCreate` and `history_visibility` in
+  `OtherState::RoomHistoryVisibility`, allowing clients to know whether a room
+  federates and how its history is shared in the appropriate timeline events.
+- Expose `join_rule` in `OtherState::RoomJoinRules`, allowing clients to know
+  the join rules of a room from the appropriate timeline events.
 
 ### Changes
 
-- `Timeline::latest_event_id` now uses its `ui::Timeline::latest_event_id` counterpart, instead of getting the latest event from the timeline and then its id.([#5864](https://github.com/matrix-org/matrix-rust-sdk/pull/5864))
-- Build Android ARM64 bindings using better default RUSTFLAGS (the same used for iOS ARM64). This should improve performance. [(#5854)](https://github.com/matrix-org/matrix-rust-sdk/pull/5854)
+- `Timeline::latest_event_id` now uses its `ui::Timeline::latest_event_id`
+  counterpart, instead of getting the latest event from the timeline and then
+  its id.([#5864](https://github.com/matrix-org/matrix-rust-sdk/pull/5864))
+- Build Android ARM64 bindings using better default RUSTFLAGS (the same used for
+  iOS ARM64). This should improve performance.
+  [(#5854)](https://github.com/matrix-org/matrix-rust-sdk/pull/5854)
 
 ## [0.14.0] - 2025-09-04
 
-### Features:
+### Features
 
-- Add `LowPriority` and `NonLowPriority` variants to `RoomListEntriesDynamicFilterKind` for filtering
-  rooms based on their low priority status. These filters allow clients to show only low priority rooms
+- Add `LowPriority` and `NonLowPriority` variants to
+  `RoomListEntriesDynamicFilterKind` for filtering rooms based on their low
+  priority status. These filters allow clients to show only low priority rooms
   or exclude low priority rooms from the room list.
   ([#5508](https://github.com/matrix-org/matrix-rust-sdk/pull/5508))
-- Add `room_version` and `privileged_creators_role` to `RoomInfo` ([#5449](https://github.com/matrix-org/matrix-rust-sdk/pull/5449)).
-- The [`unstable-hydra`] feature has been enabled, which enables room v12 changes in the SDK.
+- Add `room_version` and `privileged_creators_role` to `RoomInfo`
+  ([#5449](https://github.com/matrix-org/matrix-rust-sdk/pull/5449)).
+- The [`unstable-hydra`] feature has been enabled, which enables room v12
+  changes in the SDK.
   ([#5450](https://github.com/matrix-org/matrix-rust-sdk/pull/5450)).
 - Add experimental support for
-  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
-  `Room::fetch_thread_subscription()` and `Room::set_thread_subscription()` methods.
-  ([#5442](https://github.com/matrix-org/matrix-rust-sdk/pull/5442))
-- [**breaking**] [`GalleryUploadParameters::reply`] and [`UploadParameters::reply`] have been both
-  replaced with a new optional `in_reply_to` field, that's a string which will be parsed into an
-  `OwnedEventId` when sending the event. The thread relationship will be automatically filled in,
-  based on the timeline focus.
+  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with
+  the `Room::fetch_thread_subscription()` and `Room::set_thread_subscription()`
+  methods. ([#5442](https://github.com/matrix-org/matrix-rust-sdk/pull/5442))
+- [**breaking**] [`GalleryUploadParameters::reply`] and
+  [`UploadParameters::reply`] have been both replaced with a new optional
+  `in_reply_to` field, that's a string which will be parsed into an
+  `OwnedEventId` when sending the event. The thread relationship will be
+  automatically filled in, based on the timeline focus.
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
-- [**breaking**] [`Timeline::send_reply()`] now automatically fills in the thread relationship,
-  based on the timeline focus. As a result, it only takes an `OwnedEventId` parameter, instead of
-  the `Reply` type. The proper way to start a thread is now thus to create a threaded-focused
-  timeline, and then use `Timeline::send()`.
+- [**breaking**] [`Timeline::send_reply()`] now automatically fills in the
+  thread relationship, based on the timeline focus. As a result, it only takes
+  an `OwnedEventId` parameter, instead of the `Reply` type. The proper way to
+  start a thread is now thus to create a threaded-focused timeline, and then use
+  `Timeline::send()`.
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
-- Add `HomeserverLoginDetails::supports_sso_login` for legacy SSO support information.
-  This is primarily for Element X to give a dedicated error message in case
-  it connects a homeserver with only this method available.
+- Add `HomeserverLoginDetails::supports_sso_login` for legacy SSO support
+  information. This is primarily for Element X to give a dedicated error message
+  in case it connects a homeserver with only this method available.
   ([#5222](https://github.com/matrix-org/matrix-rust-sdk/pull/5222))
 
-### Breaking changes:
+### Breaking changes
 
 - The timeline will now always use the send queue to upload medias, so the
-  `UploadParameters::use_send_queue` bool has been removed. Make sure to listen to the send queue's
-  error updates, and to handle send queue restarts.
+  `UploadParameters::use_send_queue` bool has been removed. Make sure to listen
+  to the send queue's error updates, and to handle send queue restarts.
   ([#5525](https://github.com/matrix-org/matrix-rust-sdk/pull/5525))
-- Support for the legacy media upload progress has been disabled. Media upload progress is
-  available through the send queue, and can be enabled thanks to
+- Support for the legacy media upload progress has been disabled. Media upload
+  progress is available through the send queue, and can be enabled thanks to
   `Client::enable_send_queue_upload_progress()`.
   ([#5525](https://github.com/matrix-org/matrix-rust-sdk/pull/5525))
-- `TimelineDiff` is now exported as a true `uniffi::Enum` instead of the weird `uniffi::Object` hybrid. This matches
-  both `RoomDirectorySearchEntryUpdate` and `RoomListEntriesUpdate` and can be used in the same way.
+- `TimelineDiff` is now exported as a true `uniffi::Enum` instead of the weird
+  `uniffi::Object` hybrid. This matches both `RoomDirectorySearchEntryUpdate`
+  and `RoomListEntriesUpdate` and can be used in the same way.
   ([#5474](https://github.com/matrix-org/matrix-rust-sdk/pull/5474))
-- The `creator` field of `RoomInfo` has been renamed to `creators` and can now contain a list of
-  user IDs, to reflect that a room can now have several creators, as introduced in room version 12.
+- The `creator` field of `RoomInfo` has been renamed to `creators` and can now
+  contain a list of user IDs, to reflect that a room can now have several
+  creators, as introduced in room version 12.
   ([#5436](https://github.com/matrix-org/matrix-rust-sdk/pull/5436))
-- The `PowerLevel` type was introduced to represent power levels instead of `i64` to differentiate
-  the infinite power level of creators, as introduced in room version 12. It is used in
-  `suggested_role_for_power_level`, `suggested_power_level_for_role` and `RoomMember`.
+- The `PowerLevel` type was introduced to represent power levels instead of
+  `i64` to differentiate the infinite power level of creators, as introduced in
+  room version 12. It is used in `suggested_role_for_power_level`,
+  `suggested_power_level_for_role` and `RoomMember`.
   ([#5436](https://github.com/matrix-org/matrix-rust-sdk/pull/5436))
-- `Client::get_url` now returns a `Vec<u8>` instead of a `String`. It also throws an error when the
-  response isn't status code 200 OK, instead of providing the error in the response body.
+- `Client::get_url` now returns a `Vec<u8>` instead of a `String`. It also
+  throws an error when the response isn't status code 200 OK, instead of
+  providing the error in the response body.
   ([#5438](https://github.com/matrix-org/matrix-rust-sdk/pull/5438))
-- `RoomPreview::info()` doesn't return a result anymore. All unknown join rules are handled in the
-  `JoinRule::Custom` variant.
+- `RoomPreview::info()` doesn't return a result anymore. All unknown join rules
+  are handled in the `JoinRule::Custom` variant.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
-- The `reason` argument of `Room::report_room` is now required, do to a clarification in the spec.
+- The `reason` argument of `Room::report_room` is now required, do to a
+  clarification in the spec.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
-- `PublicRoomJoinRule` has more variants, supporting all the known values from the spec.
+- `PublicRoomJoinRule` has more variants, supporting all the known values from
+  the spec. ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
+- The fields of `MediaPreviewConfig` are both optional, allowing to use the type
+  for room account data as well as global account data.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
-- The fields of `MediaPreviewConfig` are both optional, allowing to use the type for room account
-  data as well as global account data.
-  ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
-- The `event_id` field of `PredecessorRoom` was removed, due to its removal in the Matrix
-  specification with MSC4291.
+- The `event_id` field of `PredecessorRoom` was removed, due to its removal in
+  the Matrix specification with MSC4291.
   ([#5419](https://github.com/matrix-org/matrix-rust-sdk/pull/5419))
-- `Client::url_for_oidc` now allows requesting additional scopes for the OAuth2 authorization code grant.
+- `Client::url_for_oidc` now allows requesting additional scopes for the OAuth2
+  authorization code grant.
   ([#5395](https://github.com/matrix-org/matrix-rust-sdk/pull/5395))
-- `Client::url_for_oidc` now allows passing an optional existing device id from a previous login call.
+- `Client::url_for_oidc` now allows passing an optional existing device id from
+  a previous login call.
   ([#5394](https://github.com/matrix-org/matrix-rust-sdk/pull/5394))
-- `ClientBuilder::build_with_qr_code` has been removed. Instead, the Client should be built by passing
-  `QrCodeData::server_name` to `ClientBuilder::server_name_or_homeserver_url`, after which QR login can be performed by
-  calling `Client::login_with_qr_code`. ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
+- `ClientBuilder::build_with_qr_code` has been removed. Instead, the Client
+  should be built by passing `QrCodeData::server_name` to
+  `ClientBuilder::server_name_or_homeserver_url`, after which QR login can be
+  performed by calling `Client::login_with_qr_code`.
+  ([#5388](https://github.com/matrix-org/matrix-rust-sdk/pull/5388))
 - The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
-- `Room::send_call_notification` and `Room::send_call_notification_if_needed` have been removed, since the event type they send is outdated, and `Client` is not actually supposed to be able to join MatrixRTC sessions (yet). In practice, users of these methods probably already rely on another MatrixRTC implementation to participate in sessions, and such an implementation should be capable of sending notifications itself.
-- The `GalleryItemInfo` variants now take an `UploadSource` rather than a `String` path to enable uploading
-  from bytes directly.
+- `Room::send_call_notification` and `Room::send_call_notification_if_needed`
+  have been removed, since the event type they send is outdated, and `Client` is
+  not actually supposed to be able to join MatrixRTC sessions (yet). In
+  practice, users of these methods probably already rely on another MatrixRTC
+  implementation to participate in sessions, and such an implementation should
+  be capable of sending notifications itself.
+- The `GalleryItemInfo` variants now take an `UploadSource` rather than a
+  `String` path to enable uploading from bytes directly.
   ([#5529](https://github.com/matrix-org/matrix-rust-sdk/pull/5529))
 - Media and gallery uploads now use `UploadSource` to specify the thumbnail.
   ([#5530](https://github.com/matrix-org/matrix-rust-sdk/pull/5530))
@@ -430,9 +524,11 @@ No notable changes in this release.
 
 - Add `NotificationRoomInfo::topic` to the `NotificationRoomInfo` struct, which
   contains the topic of the room. This is useful for displaying the room topic
-  in notifications. ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))
-- Add `EmbeddedEventDetails::timestamp` and `EmbeddedEventDetails::event_or_transaction_id`
-  which are already available in regular timeline items.
+  in notifications.
+  ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))
+- Add `EmbeddedEventDetails::timestamp` and
+  `EmbeddedEventDetails::event_or_transaction_id` which are already available in
+  regular timeline items.
   ([#5331](https://github.com/matrix-org/matrix-rust-sdk/pull/5331))
 - `RoomListService::subscribe_to_rooms` becomes `async` and automatically calls
   `matrix_sdk::latest_events::LatestEvents::listen_to_room`
@@ -440,29 +536,32 @@ No notable changes in this release.
 
 ### Refactor
 
-- Adjust features in the `matrix-sdk-ffi` crate to expose more platform-specific knobs.
-  Previously the `matrix-sdk-ffi` was configured primarily by target configs, choosing
-  between the tls flavor (`rustls-tls` or `native-tls`) and features like `sentry` based
-  purely on the target. As we work to add an additional Wasm target to this crate,
-  the cross product of target specific features has become somewhat chaotic, and we
-  have shifted to externalize these choices as feature flags.
+- Adjust features in the `matrix-sdk-ffi` crate to expose more platform-specific
+  knobs. Previously the `matrix-sdk-ffi` was configured primarily by target
+  configs, choosing between the tls flavor (`rustls-tls` or `native-tls`) and
+  features like `sentry` based purely on the target. As we work to add an
+  additional Wasm target to this crate, the cross product of target specific
+  features has become somewhat chaotic, and we have shifted to externalize these
+  choices as feature flags.
 
-  To maintain existing compatibility on the major platforms, these features should be used:
-  Android: `"bundled-sqlite,unstable-msc4274,rustls-tls,sentry"`
-  iOS: `"bundled-sqlite,unstable-msc4274,native-tls,sentry"`
-  Javascript/Wasm: `"unstable-msc4274,native-tls"`
+  To maintain existing compatibility on the major platforms, these features
+  should be used: Android: `"bundled-sqlite,unstable-msc4274,rustls-tls,sentry"`
+  iOS: `"bundled-sqlite,unstable-msc4274,native-tls,sentry"` Javascript/Wasm:
+  `"unstable-msc4274,native-tls"`
 
-  In the future additional choices (such as session storage, `sqlite` and `indexeddb`)
-  will likely be added as well.
+  In the future additional choices (such as session storage, `sqlite` and
+  `indexeddb`) will likely be added as well.
 
 Breaking changes:
 
-- `Client::reset_server_capabilities` has been renamed to `Client::reset_server_info`.
+- `Client::reset_server_capabilities` has been renamed to
+  `Client::reset_server_info`.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
-- `RoomPreview::join_rule`, `NotificationItem::join_rule`, `RoomInfo::is_public`, and
-  `Room::is_public()` return values are now optional. They will be set to `None` if the join rule
-  state event is missing for a given room. `NotificationRoomInfo::is_public` has been removed;
-  callers can inspect the value of `NotificationItem::join_rule` to determine if the room is public
+- `RoomPreview::join_rule`, `NotificationItem::join_rule`,
+  `RoomInfo::is_public`, and `Room::is_public()` return values are now optional.
+  They will be set to `None` if the join rule state event is missing for a given
+  room. `NotificationRoomInfo::is_public` has been removed; callers can inspect
+  the value of `NotificationItem::join_rule` to determine if the room is public
   (i.e. if the join rule is `Public`).
   ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
@@ -470,60 +569,73 @@ Breaking changes:
 
 Breaking changes:
 
-- `Client::send_call_notification_if_needed` now returns `Result<bool>` instead of `Result<()>` so we can check if
-  the event was sent.
-- `Client::upload_avatar` and `Timeline::send_attachment` now may fail if a file too large for the homeserver media
-  config is uploaded.
-- `UploadParameters` replaces field `filename: String` with `source: UploadSource`.
-  `UploadSource` is an enum which may take a filename or a filename and bytes, which
-  allows a foreign language to read file contents natively and then pass those contents to
-  the foreign function when uploading a file through the `Timeline`.
+- `Client::send_call_notification_if_needed` now returns `Result<bool>` instead
+  of `Result<()>` so we can check if the event was sent.
+- `Client::upload_avatar` and `Timeline::send_attachment` now may fail if a file
+  too large for the homeserver media config is uploaded.
+- `UploadParameters` replaces field `filename: String` with
+  `source: UploadSource`. `UploadSource` is an enum which may take a filename or
+  a filename and bytes, which allows a foreign language to read file contents
+  natively and then pass those contents to the foreign function when uploading a
+  file through the `Timeline`.
   ([#4948](https://github.com/matrix-org/matrix-rust-sdk/pull/4948))
-- `RoomInfo` replaces its field `is_tombstoned: bool` with `tombstone: Option<RoomTombstoneInfo>`,
-  containing the data needed to implement the room migration UI, a message and the replacement room id.
+- `RoomInfo` replaces its field `is_tombstoned: bool` with
+  `tombstone: Option<RoomTombstoneInfo>`, containing the data needed to
+  implement the room migration UI, a message and the replacement room id.
   ([#5027](https://github.com/matrix-org/matrix-rust-sdk/pull/5027))
 
 Additions:
 
-- `Client::subscribe_to_room_info` allows clients to subscribe to room info updates in rooms which may not be known yet.
-  This is useful when displaying a room preview for an unknown room, so when we receive any membership change for it,
-  we can automatically update the UI.
-- `Client::get_max_media_upload_size` to get the max size of a request sent to the homeserver so we can tweak our media
-  uploads by compressing/transcoding the media.
-- Add `ClientBuilder::enable_share_history_on_invite` to enable experimental support for sharing encrypted room history
-  on invite, per [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
+- `Client::subscribe_to_room_info` allows clients to subscribe to room info
+  updates in rooms which may not be known yet. This is useful when displaying a
+  room preview for an unknown room, so when we receive any membership change for
+  it, we can automatically update the UI.
+- `Client::get_max_media_upload_size` to get the max size of a request sent to
+  the homeserver so we can tweak our media uploads by compressing/transcoding
+  the media.
+- Add `ClientBuilder::enable_share_history_on_invite` to enable experimental
+  support for sharing encrypted room history on invite, per
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5141](https://github.com/matrix-org/matrix-rust-sdk/pull/5141))
-- Support for adding a Sentry layer to the FFI bindings has been added. Only `tracing` statements with
-  the field `sentry=true` will be forwarded to Sentry, in addition to default Sentry filters.
+- Support for adding a Sentry layer to the FFI bindings has been added. Only
+  `tracing` statements with the field `sentry=true` will be forwarded to Sentry,
+  in addition to default Sentry filters.
 - Add room topic string to `StateEventContent`
-- Add `UploadSource` for representing upload data - this is analogous to `matrix_sdk_ui::timeline::AttachmentSource`
-- Add `Client::observe_account_data_event` and `Client::observe_room_account_data_event` to
-  subscribe to global and room account data changes.
+- Add `UploadSource` for representing upload data - this is analogous to
+  `matrix_sdk_ui::timeline::AttachmentSource`
+- Add `Client::observe_account_data_event` and
+  `Client::observe_room_account_data_event` to subscribe to global and room
+  account data changes.
   ([#4994](https://github.com/matrix-org/matrix-rust-sdk/pull/4994))
 - Add `Timeline::send_gallery` to send MSC4274-style galleries.
   ([#5163](https://github.com/matrix-org/matrix-rust-sdk/pull/5163))
-- Add `reply_params` to `GalleryUploadParameters` to allow sending galleries as (threaded) replies.
+- Add `reply_params` to `GalleryUploadParameters` to allow sending galleries as
+  (threaded) replies.
   ([#5173](https://github.com/matrix-org/matrix-rust-sdk/pull/5173))
 
 Breaking changes:
 
-- `contacts` has been removed from `OidcConfiguration` (it was unused since the switch to OAuth).
+- `contacts` has been removed from `OidcConfiguration` (it was unused since the
+  switch to OAuth).
 
 ## [0.11.0] - 2025-04-11
 
 Breaking changes:
 
-- `TracingConfiguration` now includes a new field `trace_log_packs`, which gives a convenient way
-  to set the TRACE log level for multiple targets related to a given feature.
+- `TracingConfiguration` now includes a new field `trace_log_packs`, which gives
+  a convenient way to set the TRACE log level for multiple targets related to a
+  given feature.
   ([#4824](https://github.com/matrix-org/matrix-rust-sdk/pull/4824))
 
-- `setup_tracing` has been renamed `init_platform`; in addition to the `TracingConfiguration`
-  parameter it also now takes a boolean indicating whether to spawn a minimal tokio runtime for the
-  application; in general for main app processes this can be set to `false`, and memory-constrained
-  programs can set it to `true`.
+- `setup_tracing` has been renamed `init_platform`; in addition to the
+  `TracingConfiguration` parameter it also now takes a boolean indicating
+  whether to spawn a minimal tokio runtime for the application; in general for
+  main app processes this can be set to `false`, and memory-constrained programs
+  can set it to `true`.
 
-- Matrix client API errors coming from API responses will now be mapped to `ClientError::MatrixApi`, containing both the
-  original message and the associated error code and kind.
+- Matrix client API errors coming from API responses will now be mapped to
+  `ClientError::MatrixApi`, containing both the original message and the
+  associated error code and kind.
 
 - `EventSendState` now has two additional variants: `CrossSigningNotSetup` and
   `SendingFromUnverifiedDevice`. These indicate that your own device is not
@@ -535,27 +647,28 @@ Breaking changes:
   identity-based strategy, in addition to when using the device-based strategy
   with `error_on_verified_user_problem` is set.
 
-- `EventSendState` now has two additional variants: `VerifiedUserHasUnsignedDevice` and
-  `VerifiedUserChangedIdentity`. These reflect problems with verified users in the room
-  and as such can only be returned when the room key recipient strategy has
+- `EventSendState` now has two additional variants:
+  `VerifiedUserHasUnsignedDevice` and `VerifiedUserChangedIdentity`. These
+  reflect problems with verified users in the room and as such can only be
+  returned when the room key recipient strategy has
   `error_on_verified_user_problem` set.
 
 - The `AuthenticationService` has been removed:
-    - Instead of calling `configure_homeserver`, build your own client with the `serverNameOrHomeserverUrl` builder
-      method to keep the same behaviour.
-        - The parts of `AuthenticationError` related to discovery will be represented in the `ClientBuildError` returned
-          when calling `build()`.
-    - The remaining methods can be found on the built `Client`.
-        - There is a new `abortOidcLogin` method that should be called if the webview is dismissed without a callback (
-          or fails to present).
-        - The rest of `AuthenticationError` is now found in the OidcError type.
-
+  - Instead of calling `configure_homeserver`, build your own client with the
+    `serverNameOrHomeserverUrl` builder method to keep the same behaviour.
+    - The parts of `AuthenticationError` related to discovery will be
+      represented in the `ClientBuildError` returned
+      when calling `build()`.
+  - The remaining methods can be found on the built `Client`.
+    - There is a new `abortOidcLogin` method that should be called if the
+      webview is dismissed without a callback (
+      or fails to present).
+    - The rest of `AuthenticationError` is now found in the OidcError type.
 - `OidcAuthenticationData` is now called `OidcAuthorizationData`.
-
-- The `get_element_call_required_permissions` function now requires the device_id.
+- The `get_element_call_required_permissions` function now requires the
+  device_id.
 
 - Some `OidcPrompt` cases have been removed (`None`, `SelectAccount`).
-
 - `Room::is_encrypted` is replaced by `Room::latest_encryption_state`
   which returns a value of the new `EncryptionState` enum; another
   `Room::encryption_state` non-async and infallible method is added to get the
@@ -584,7 +697,8 @@ Breaking changes:
 - The `dynamic_registrations_file` field of `OidcConfiguration` was removed.
   Clients are supposed to re-register with the homeserver for every login.
 
-- `RoomPreview::own_membership_details` is now `RoomPreview::member_with_sender_info`, takes any user id and returns an
+- `RoomPreview::own_membership_details` is now
+  `RoomPreview::member_with_sender_info`, takes any user id and returns an
   `Option<RoomMemberWithSenderInfo>`.
 
 Additions:
@@ -600,11 +714,12 @@ Additions:
 - Add `Timeline::send_thread_reply` for clients that need to start threads
   themselves.
   ([4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
-- Add `ClientBuilder::session_pool_max_size`, `::session_cache_size` and `::session_journal_size_limit` to control the
-  stores configuration, especially their memory consumption
+- Add `ClientBuilder::session_pool_max_size`, `::session_cache_size` and
+  `::session_journal_size_limit` to control the stores configuration, especially
+  their memory consumption
   ([#4870](https://github.com/matrix-org/matrix-rust-sdk/pull/4870/))
 - Add `ClientBuilder::system_is_memory_constrained` to indicate that the system
   has less memory available than the current standard
   ([#4894](https://github.com/matrix-org/matrix-rust-sdk/pull/4894))
-- Add `Room::member_with_sender_info` to get both a room member's info and for the user who sent the `m.room.member`
-  event the `RoomMember` is based on.
+- Add `Room::member_with_sender_info` to get both a room member's info and for
+  the user who sent the `m.room.member` event the `RoomMember` is based on.

--- a/bindings/matrix-sdk-ffi/README.md
+++ b/bindings/matrix-sdk-ffi/README.md
@@ -1,6 +1,9 @@
 # FFI bindings for the rust matrix SDK
 
-This uses [`uniffi`](https://mozilla.github.io/uniffi-rs/Overview.html) to build the matrix bindings for native support and wasm-bindgen for web-browser assembly support. Please refer to the specific section to figure out how to build and use the bindings for your platform.
+This uses [`uniffi`](https://mozilla.github.io/uniffi-rs/Overview.html) to build
+the matrix bindings for native support and wasm-bindgen for web-browser assembly
+support. Please refer to the specific section to figure out how to build and use
+the bindings for your platform.
 
 ## Features
 
@@ -8,18 +11,22 @@ Given the number of platforms targeted, we have broken out a number of features
 
 ### Functionality
 
-- `sentry`: Enable error monitoring using Sentry, not supports on Wasm platforms.
+- `sentry`: Enable error monitoring using Sentry, not supports on Wasm
+  platforms.
 - `sqlite`: Use SQLite for the session storage.
-- `bundled-sqlite`: Use an embedded version of SQLite instead of the system provided one.
+- `bundled-sqlite`: Use an embedded version of SQLite instead of the system
+  provided one.
 - `indexeddb`: Use IndexedDB for the session storage.
 
 ### Unstable specs
 
-- `unstable-msc4274`: Adds support for gallery message types, which contain multiple media elements.
+- `unstable-msc4274`: Adds support for gallery message types, which contain
+  multiple media elements.
 
 ## Platforms
 
-Each supported target should use features to build the relevant system. Here are some suggested feature flags for the major platforms:
+Each supported target should use features to build the relevant system. Here are
+some suggested feature flags for the major platforms:
 
 - Android: `"bundled-sqlite,unstable-msc4274,sentry"`
 - iOS: `"bundled-sqlite,unstable-msc4274,sentry"`

--- a/bindings/matrix-sdk-ffi/changelog.d/6561.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6561.changed.md
@@ -1,1 +1,2 @@
-[**breaking**] `SpaceRoomList::rooms` and `SpaceRoomList::subscribe_to_room_updates` are now asynchronous.
+[**breaking**] `SpaceRoomList::rooms` and
+`SpaceRoomList::subscribe_to_room_updates` are now asynchronous.

--- a/contrib/key-forwarding-algorithm/README.md
+++ b/contrib/key-forwarding-algorithm/README.md
@@ -3,9 +3,15 @@ tooling to render it as a PDF or PNG.
 
 # Usage
 
-    make  # Render the decision tree both as a PDF and PNG
+```text
+make  # Render the decision tree both as a PDF and PNG
+```
 
-    make pdf  # Renders the decision tree as a PDF
-    make png  # Renders the decision tree as a PNG
+```text
+make pdf  # Renders the decision tree as a PDF
+make png  # Renders the decision tree as a PNG
+```
 
-    make clean  # Remove rendered artifacts
+```text
+make clean  # Remove rendered artifacts
+```

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -6,21 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ## [0.17.0] - 2026-05-08
 
-### Bug Fixes
+### Bug fixes
 
-- Filter out service members from `Room::heroes`. This *should* be done by the homeservers, but some don't. 
+- Filter out service members from `Room::heroes`. This _should_ be done by the
+  homeservers, but some don't.
   ([#6535](https://github.com/matrix-org/matrix-rust-sdk/pull/6535))
-- Room keys are now rotated whenever the client fully reloads the member list by making a
-  request to `/members`, which prevents clients using keys that may have been shared under
-  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) even if a gappy
-  sync occurs.
+- Room keys are now rotated whenever the client fully reloads the member list by
+  making a request to `/members`, which prevents clients using keys that may
+  have been shared under
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) even
+  if a gappy sync occurs.
   ([#6339](https://github.com/matrix-org/matrix-rust-sdk/pull/6339))
 
 - Fix invited/knocked rooms disappearing from the room list after
   join → leave/kick → re-invite when using Sliding Sync. The SDK now always
   emits a room update so the room is surfaced correctly again.
   ([#6126](https://github.com/matrix-org/matrix-rust-sdk/pull/6126))
-
 
 - [**breaking**] `BaseClient::room_info_notable_update_sender` has
   moved into `BaseStateStore`. `BaseStateStore::derive_from_other`
@@ -33,28 +34,31 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] Add `RoomSummary::active_service_members` field to act as a cached value that will be computed 
-  when we sync members. Rename `Room::is_dm` to `Room::compute_is_dm` since it will now also store the computed 
-  active service members count in the new cached field. `Room::active_service_members` is now 
-  `Room::update_active_service_members` for the same reason.
+- [**breaking**] Add `RoomSummary::active_service_members` field to act as a
+  cached value that will be computed when we sync members. Rename `Room::is_dm`
+  to `Room::compute_is_dm` since it will now also store the computed active
+  service members count in the new cached field. `Room::active_service_members`
+  is now `Room::update_active_service_members` for the same reason.
   ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
-- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
-  `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
-  with an atomic version, `Room::update_room_info`, which is also synchronized by
-  the state store lock.
+- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires
+  `StateStore::save_changes` to acquire state store lock and replaces
+  `Room::set_room_info` with an atomic version, `Room::update_room_info`, which
+  is also synchronized by the state store lock.
   ([#6478](https://github.com/matrix-org/matrix-rust-sdk/pull/6478))
-- Add `RoomMember::is_service_member` that automatically checks the room info and retrieves this info. 
+- Add `RoomMember::is_service_member` that automatically checks the room info
+  and retrieves this info.
   ([#6536](https://github.com/matrix-org/matrix-rust-sdk/pull/6536))
-- [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a DM 
-  room should look like. A `Room::is_dm` method was added to check if a room is a DM room too, 
-  using this definition. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
-- Add `Room::active_room_members`, returning a list of all the service room members 
-  that are active in the room. 
+- [**breaking**] Add `DmRoomDefinition` enum, allowing clients to specify what a
+  DM room should look like. A `Room::is_dm` method was added to check if a room
+  is a DM room too, using this definition.
+  ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
+- Add `Room::active_room_members`, returning a list of all the service room
+  members that are active in the room.
   ([#6843](https://github.com/matrix-org/matrix-rust-sdk/pull/6483))
-- Add support in the `MemoryStore`'s implementation of `EventCacheStore` for 
-  having duplicate events in a room, where each duplicate is in a different 
-  `LinkedChunk`. This is useful, e.g., when an event is in a room and a 
-  thread in that room. 
+- Add support in the `MemoryStore`'s implementation of `EventCacheStore` for
+  having duplicate events in a room, where each duplicate is in a different
+  `LinkedChunk`. This is useful, e.g., when an event is in a room and a
+  thread in that room.
   (#[6200](https://github.com/matrix-org/matrix-rust-sdk/pull/6200))
 - Add `StateStore::upsert_thread_subscriptions()` method for bulk upserts.
   ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
@@ -62,21 +66,22 @@ All notable changes to this project will be documented in this file.
   OwnedEventId` field.
   ([#5977](https://github.com/matrix-org/matrix-rust-sdk/pull/5977))
 - [**breaking**] `RelationalLinkedChunk::apply_updates` returns an error rather
-  than panicking. This is necessary in order to ensure certain behaviors are disallowed.
-  ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
-- Add `RoomInfo::active_room_call_consensus_intent()` method to get the call intent for the current call,
-  based on what members are advertising.
+  than panicking. This is necessary in order to ensure certain behaviors are
+  disallowed. ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
+- Add `RoomInfo::active_room_call_consensus_intent()` method to get the call
+  intent for the current call, based on what members are advertising.
   ([#6274](https://github.com/matrix-org/matrix-rust-sdk/pull/6274))
 - Add `Room::is_call` to check for Call rooms (MSC3417)
   ([#6315](https://github.com/matrix-org/matrix-rust-sdk/pull/6315))
 
 ### Refactor
 
-- [**breaking**] `TtlStoreValue` was moved and renamed to `matrix_sdk_common::ttl::TtlValue`.
+- [**breaking**] `TtlStoreValue` was moved and renamed to
+  `matrix_sdk_common::ttl::TtlValue`.
   ([#6463](https://github.com/matrix-org/matrix-rust-sdk/pull/6463),
   [#6484](https://github.com/matrix-org/matrix-rust-sdk/pull/6484))
-- [**breaking**] `Gap::prev_token` has been renamed to `Gap::token` since it's now used for both
-  the previous batch token and the next batch token.
+- [**breaking**] `Gap::prev_token` has been renamed to `Gap::token` since it's
+  now used for both the previous batch token and the next batch token.
   ([#6236](https://github.com/matrix-org/matrix-rust-sdk/pull/6236))
 - [**breaking**] Invite acceptance details are no longer stored in `RoomInfo`,
   and the accessors `RoomInfo.invite_acceptance_details()` and
@@ -85,18 +90,18 @@ All notable changes to this project will be documented in this file.
   feature is enabled, are accessible via
   `BaseClient::get_pending_key_bundle_details_for_room`.
   ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199))
-- [**breaking**] `once_cell` is no longer reexported from this crate. The types that were stabilized
-  in the Rust standard library can be used instead in most cases.
-  ([#6194](https://github.com/matrix-org/matrix-rust-sdk/pull/6194))
-- [**breaking**] All the `*StoreLock` structs use a `CrossProcessLockConfig` now instead of the previous `holder` value
-  and so does `StoreConfig` and `BaseClient::clone_with_in_memory_state_store. Passing a 
-  `CrossProcessLockConfig::MultiProcess` will keep the same behaviour we had where the client uses the cross process 
-  lock and using `CrossProcessLockConfig::SingleProcess` will disable the cross process lock.
+- [**breaking**] `once_cell` is no longer reexported from this crate. The types
+  that were stabilized in the Rust standard library can be used instead in most
+  cases. ([#6194](https://github.com/matrix-org/matrix-rust-sdk/pull/6194))
+- [**breaking**] All the `*StoreLock` structs use a `CrossProcessLockConfig` now
+  instead of the previous `holder` value and so does `StoreConfig` and
+  `BaseClient::clone_with_in_memory_state_store. Passing a `CrossProcessLockConfig::MultiProcess` will keep the same behaviour we had where the client uses the cross process lock and using `CrossProcessLockConfig::SingleProcess`
+  will disable the cross process lock.
   ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
-- [**breaking**] The `StateStore::upsert_thread_subscription` method has been removed in favor of a
-  bulk method `StateStore::upsert_thread_subscriptions`.
-- [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
-  been eliminated entirely.
+- [**breaking**] The `StateStore::upsert_thread_subscription` method has been
+  removed in favor of a bulk method `StateStore::upsert_thread_subscriptions`.
+- [**breaking**] The `message-ids` feature has been removed. It was already a
+  no-op and has now been eliminated entirely.
   ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))
 
 ## [0.16.1] - 2026-05-08
@@ -105,11 +110,13 @@ No notable changes in this release.
 
 ## [0.16.0] - 2025-12-04
 
-### Security Fixes
+### Security fixes
 
 - Skip the serialization of custom join rules in the `RoomInfo` which prevented
   the processing of sync responses containing events with custom join rules.
-  ([#5924](https://github.com/matrix-org/matrix-rust-sdk/pull/5924), Low, [CVE-2025-66622](https://www.cve.org/CVERecord?id=CVE-2025-66622), [GHSA-jj6p-3m75-g2p3](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-jj6p-3m75-g2p3)).
+  ([#5924](https://github.com/matrix-org/matrix-rust-sdk/pull/5924), Low,
+  [CVE-2025-66622](https://www.cve.org/CVERecord?id=CVE-2025-66622),
+  [GHSA-jj6p-3m75-g2p3](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-jj6p-3m75-g2p3)).
 
 ### Refactor
 
@@ -119,8 +126,8 @@ No notable changes in this release.
   `maybe_decode()`. Its constructor has been removed since all its fields are
   now public.
   ([#5910](https://github.com/matrix-org/matrix-rust-sdk/pull/5910))
-    - `StateStoreData(Key/Value)::ServerInfo` has been split into the
-      `SupportedVersions` and `WellKnown` variants.
+  - `StateStoreData(Key/Value)::ServerInfo` has been split into the
+    `SupportedVersions` and `WellKnown` variants.
 - [**breaking**] Upgrade Ruma to version 0.14.0.
   ([#5882](https://github.com/matrix-org/matrix-rust-sdk/pull/5882))
 - `Client::sync_lock` has been renamed `Client::state_store_lock`.
@@ -138,18 +145,19 @@ No notable changes in this release.
 
 ## [0.14.1] - 2025-09-10
 
-### Security Fixes
+### Security fixes
 
 - Fix a panic in the `RoomMember::normalized_power_level` method.
-  ([#5635](https://github.com/matrix-org/matrix-rust-sdk/pull/5635)) (
-  Low, [CVE-2025-59047](https://www.cve.org/CVERecord?id=CVE-2025-59047), [GHSA-qhj8-q5r6-8q6j](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-qhj8-q5r6-8q6j)).
+  ([#5635](https://github.com/matrix-org/matrix-rust-sdk/pull/5635)) ( Low,
+  [CVE-2025-59047](https://www.cve.org/CVERecord?id=CVE-2025-59047),
+  [GHSA-qhj8-q5r6-8q6j](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-qhj8-q5r6-8q6j)).
 
 ## [0.14.0] - 2025-09-04
 
 ### Features
 
-- Add `SyncResponse::RoomUpdates::is_empty` to check if there were any room updates.
-  ([#5593](https://github.com/matrix-org/matrix-rust-sdk/pull/5593))
+- Add `SyncResponse::RoomUpdates::is_empty` to check if there were any room
+  updates. ([#5593](https://github.com/matrix-org/matrix-rust-sdk/pull/5593))
 - Add `EncryptionState::StateEncrypted` to represent rooms supporting encrypted
   state events. Feature-gated behind `experimental-encrypted-state-events`.
   ([#5523](https://github.com/matrix-org/matrix-rust-sdk/pull/5523))
@@ -164,7 +172,7 @@ No notable changes in this release.
 - [**breaking**] The `RoomInfo` method now remembers the inviter at the time
   when the `BaseClient::room_joined()` method was called. The caller is
   responsible to remember the inviter before a server request to join the room
-  is made. The  `RoomInfo::invite_accepted_at` method was removed, the
+  is made. The `RoomInfo::invite_accepted_at` method was removed, the
   `RoomInfo::invite_details` method returns both the timestamp and the
   inviter.
   ([#5390](https://github.com/matrix-org/matrix-rust-sdk/pull/5390))
@@ -178,8 +186,8 @@ No notable changes in this release.
 - [**breaking**] The `stripped_state` field of `StateChanges` uses
   `StrippedState` instead of `AnyStrippedStateEvent`.
   ([#5473](https://github.com/matrix-org/matrix-rust-sdk/pull/5473))
-- [**breaking**] `RelationalLinkedChunk::items` now takes a `RoomId` instead of an
-  `&OwnedLinkedChunkId` parameter.
+- [**breaking**] `RelationalLinkedChunk::items` now takes a `RoomId` instead of
+  an `&OwnedLinkedChunkId` parameter.
   ([#5445](https://github.com/matrix-org/matrix-rust-sdk/pull/5445))
 - [**breaking**] Add an `IsPrefix = False` bound to the
   `get_state_event_static()`, `get_state_event_static_for_key()` and
@@ -189,8 +197,9 @@ No notable changes in this release.
   is now enforced at compile-time. The matching non-`static` methods of
   `StateStore` can be used instead for event types with a variable suffix.
   ([#5444](https://github.com/matrix-org/matrix-rust-sdk/pull/5444))
-- [**breaking**] `SyncOrStrippedState<RoomPowerLevelsEventContent>::power_levels()`
-  takes `AuthorizationRules` and a list of creators, because creators can have
+- [**breaking**]
+  `SyncOrStrippedState<RoomPowerLevelsEventContent>::power_levels()` takes
+  `AuthorizationRules` and a list of creators, because creators can have
   infinite power levels, as introduced in room version 12.
   ([#5436](https://github.com/matrix-org/matrix-rust-sdk/pull/5436))
 - [**breaking**] `RoomMember::power_level()` and
@@ -223,21 +232,22 @@ No notable changes in this release.
   timestamp exists, the `RoomInfo::invite_accepted_at()` method returns this
   timestamp.
   ([#5333](https://github.com/matrix-org/matrix-rust-sdk/pull/5333))
-- [**breaking**] The `BaseClient::new()` method now takes an additional `ThreadingSupport`
-  parameter controlling whether the client is supposed to do extra processing for threads. Right
-  now, it controls whether to exclude in-thread events from the room unread counts, but it may be
-  expanded in the future to support more threading-related features.
+- [**breaking**] The `BaseClient::new()` method now takes an additional
+  `ThreadingSupport` parameter controlling whether the client is supposed to do
+  extra processing for threads. Right now, it controls whether to exclude
+  in-thread events from the room unread counts, but it may be expanded in the
+  future to support more threading-related features.
   ([#5325](https://github.com/matrix-org/matrix-rust-sdk/pull/5325))
 
 ### Refactor
 
 - The cached `ServerCapabilities` has been renamed to `ServerInfo` and
-  additionally contains the well-known response alongside the existing server versions.
-  Despite the old name, it does not contain the server capabilities.
+  additionally contains the well-known response alongside the existing server
+  versions. Despite the old name, it does not contain the server capabilities.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
-- `Room::join_rule` and `Room::is_public` now return an `Option` to reflect that the join rule
-  state event might be missing, in which case they will return `None`.
-  ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
+- `Room::join_rule` and `Room::is_public` now return an `Option` to reflect that
+  the join rule state event might be missing, in which case they will return
+  `None`. ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ## [0.12.0] - 2025-06-10
 
@@ -255,9 +265,9 @@ No notable changes in this release.
 - [**breaking**] The `MediaRetentionPolicy` can now trigger regular cleanups
   with its new `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
-    - `Clone` is a supertrait of `EventCacheStoreMedia`.
-    - `EventCacheStoreMedia` has a new method `last_media_cleanup_time_inner`
-    - There are new `'static` bounds in `MediaService` for the media cache stores
+  - `Clone` is a supertrait of `EventCacheStoreMedia`.
+  - `EventCacheStoreMedia` has a new method `last_media_cleanup_time_inner`
+  - There are new `'static` bounds in `MediaService` for the media cache stores
 - `event_cache::store::MemoryStore` implements `Clone`.
 - `BaseClient` now has a `handle_verification_events` field which is `true` by
   default and can be negated so the `NotificationClient` won't handle received
@@ -277,11 +287,11 @@ No notable changes in this release.
 - [**breaking**] `BaseClient::set_session_metadata` is renamed
   `activate`, and `BaseClient::logged_in` is renamed `is_activated`
   ([#4850](https://github.com/matrix-org/matrix-rust-sdk/pull/4850))
-- [**breaking] `DependentQueuedRequestKind::UploadFileWithThumbnail`
-  was renamed to `DependentQueuedRequestKind::UploadFileOrThumbnail`.
-  Under the `unstable-msc4274` feature, `DependentQueuedRequestKind::UploadFileOrThumbnail`
-  and `SentMediaInfo` were generalized to allow chaining multiple dependent
-  file / thumbnail uploads.
+- [**breaking] `DependentQueuedRequestKind::UploadFileWithThumbnail` was renamed
+  to `DependentQueuedRequestKind::UploadFileOrThumbnail`. Under the
+  `unstable-msc4274` feature,
+  `DependentQueuedRequestKind::UploadFileOrThumbnail` and `SentMediaInfo` were
+  generalized to allow chaining multiple dependent file / thumbnail uploads.
   ([#4897](https://github.com/matrix-org/matrix-rust-sdk/pull/4897))
 - [**breaking**] `RoomInfo::prev_state` has been removed due to being useless.
   ([#5054](https://github.com/matrix-org/matrix-rust-sdk/pull/5054))
@@ -293,17 +303,18 @@ No notable changes in this release.
 - [**breaking**] `EventCacheStore` allows to control which media content is
   allowed in the media cache, and how long it should be kept, with a
   `MediaRetentionPolicy`:
-    - `EventCacheStore::add_media_content()` has an extra argument,
-      `ignore_policy`, which decides whether a media content should ignore the
-      `MediaRetentionPolicy`. It should be stored alongside the media content.
-    - `EventCacheStore` has four new methods: `media_retention_policy()`,
-      `set_media_retention_policy()`, `set_ignore_media_retention_policy()` and
-      `clean_up_media_cache()`.
-    - `EventCacheStore` implementations should delegate media cache methods to the
-      methods of the same name of `MediaService` to use the `MediaRetentionPolicy`.
-      They need to implement the `EventCacheStoreMedia` trait that can be tested
-      with the `event_cache_store_media_integration_tests!` macro.
-      ([#4571](https://github.com/matrix-org/matrix-rust-sdk/pull/4571))
+  - `EventCacheStore::add_media_content()` has an extra argument,
+    `ignore_policy`, which decides whether a media content should ignore the
+    `MediaRetentionPolicy`. It should be stored alongside the media content.
+  - `EventCacheStore` has four new methods: `media_retention_policy()`,
+    `set_media_retention_policy()`, `set_ignore_media_retention_policy()` and
+    `clean_up_media_cache()`.
+  - `EventCacheStore` implementations should delegate media cache methods to the
+    methods of the same name of `MediaService` to use the
+    `MediaRetentionPolicy`. They need to implement the `EventCacheStoreMedia`
+    trait that can be tested with the
+    `event_cache_store_media_integration_tests!` macro.
+    ([#4571](https://github.com/matrix-org/matrix-rust-sdk/pull/4571))
 
 ### Refactor
 
@@ -328,7 +339,7 @@ No notable changes in this release.
   excluded from the room display name calculation.
   ([#4335](https://github.com/matrix-org/matrix-rust-sdk/pull/4335))
 
-### Bug Fixes
+### Bug fixes
 
 - Fix an off-by-one error in the `ObservableMap` when the `remove()` method is
   called. Previously, items following the removed item were not shifted left by
@@ -337,18 +348,15 @@ No notable changes in this release.
 
 ## [0.8.0] - 2024-11-19
 
-### Bug Fixes
+### Bug fixes
 
 - Add more invalid characters for room aliases.
-
 - Use the `DisplayName` struct to protect against homoglyph attacks.
 
 ### Features
 
 - Add `BaseClient::room_key_recipient_strategy` field
-
 - `AmbiguityCache` contains the room member's user ID.
-
 - [**breaking**] `Media::get_thumbnail` and `MediaFormat::Thumbnail` allow to
   request an animated thumbnail They both take a `MediaThumbnailSettings`
   instead of `MediaThumbnailSize`.
@@ -370,9 +378,7 @@ No notable changes in this release.
   `IndexedDb`.
 
 - Make `ObservableMap::stream` works on `wasm32-unknown-unknown`.
-
 - Allow aborting media uploads.
-
 - Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges`
   by a custom one.
 
@@ -382,70 +388,67 @@ No notable changes in this release.
 ### Refactor
 
 - [**breaking**] Rename `DisplayName` to `RoomDisplayName`.
-
 - Rename `AmbiguityMap` to `DisplayNameUsers`.
-
 - Move `event_cache_store/` to `event_cache/store/` in `matrix-sdk-base`.
-
 - Move `linked_chunk` from `matrix-sdk` to `matrix-sdk-common`.
-
 - Move `Event` and `Gap` into `matrix_sdk_base::event_cache`.
-
 - The ambiguity maps in `SyncResponse` are moved to `JoinedRoom` and `LeftRoom`.
-
 - `Store::get_rooms` and `Store::get_rooms_filtered` are way faster because they
   don't acquire the lock for every room they read.
 
 - `Store::get_rooms`, `Store::get_rooms_filtered` and `Store::get_room` are
   renamed `Store::rooms`, `Store::rooms_filtered` and `Store::room`.
 
-- [**breaking**] `Client::get_rooms` and `Client::get_rooms_filtered` are renamed
-  `Client::rooms` and `Client::rooms_filtered`.
+- [**breaking**] `Client::get_rooms` and `Client::get_rooms_filtered` are
+  renamed `Client::rooms` and `Client::rooms_filtered`.
 
 - [**breaking**] `Client::get_stripped_rooms` has finally been removed.
-
 - [**breaking**] The `StateStore` methods to access data in the media cache
   where moved to a separate `EventCacheStore` trait.
 
-- [**breaking**] The `instant` module was removed, use the `ruma::time` module instead.
+- [**breaking**] The `instant` module was removed, use the `ruma::time` module
+  instead.
 
-# 0.7.0
+## 0.7.0
 
 - Rename `RoomType` to `RoomState`
 - Add `RoomInfo::state` accessor
-- Remove `members` and `stripped_members` fields in `StateChanges`. Room member events are now with
-  other state events in `state` and `stripped_state`.
-- `StateStore::get_user_ids` takes a `RoomMemberships` to be able to filter the results by any
-  membership state.
-    - `StateStore::get_joined_user_ids` and `StateStore::get_invited_user_ids` are deprecated.
-- `Room::members` takes a `RoomMemberships` to be able to filter the results by any membership
-  state.
-    - `Room::active_members` and `Room::joined_members` are deprecated.
+- Remove `members` and `stripped_members` fields in `StateChanges`. Room member
+  events are now with other state events in `state` and `stripped_state`.
+- `StateStore::get_user_ids` takes a `RoomMemberships` to be able to filter the
+  results by any membership state.
+  - `StateStore::get_joined_user_ids` and `StateStore::get_invited_user_ids` are
+    deprecated.
+- `Room::members` takes a `RoomMemberships` to be able to filter the results by
+  any membership state.
+  - `Room::active_members` and `Room::joined_members` are deprecated.
 - `RoomMember` has new methods:
-    - `can_ban`
-    - `can_invite`
-    - `can_kick`
-    - `can_redact`
-    - `can_send_message`
-    - `can_send_state`
-    - `can_trigger_room_notification`
+  - `can_ban`
+  - `can_invite`
+  - `can_kick`
+  - `can_redact`
+  - `can_send_message`
+  - `can_send_state`
+  - `can_trigger_room_notification`
 - Move `StateStore::get_member_event` to `StateStoreExt`
-- `StateStore::get_stripped_room_infos` is deprecated. All room infos should now be returned by
-  `get_room_infos`.
+- `StateStore::get_stripped_room_infos` is deprecated. All room infos should now
+  be returned by `get_room_infos`.
 - `BaseClient::get_stripped_rooms` is deprecated. Use `get_rooms_filtered` with
   `RoomStateFilter::INVITED` instead.
 - Add methods to `StateStore` to be able to retrieve data in batch
-    - `get_state_events_for_keys`
-    - `get_profiles`
-    - `get_presence_events`
-    - `get_users_with_display_names`
-- Move `Session`, `SessionTokens` and associated methods to the `matrix-sdk` crate.
+  - `get_state_events_for_keys`
+  - `get_profiles`
+  - `get_presence_events`
+  - `get_users_with_display_names`
+- Move `Session`, `SessionTokens` and associated methods to the `matrix-sdk`
+  crate.
 - Add `Room::subscribe_info`
 
-# 0.5.1
+## 0.5.1
 
-## Bug Fixes
+### Bug fixes
 
-- #664: Fix regression with push rules being applied to the own user_id only instead of all but the own user_id
+- #664: Fix regression with push rules being applied to the own user_id only
+  instead of all but the own user_id
 
-# 0.5.0
+## 0.5.0

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -93,10 +93,11 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] `once_cell` is no longer reexported from this crate. The types
   that were stabilized in the Rust standard library can be used instead in most
   cases. ([#6194](https://github.com/matrix-org/matrix-rust-sdk/pull/6194))
-- [**breaking**] All the `*StoreLock` structs use a `CrossProcessLockConfig` now
+- [**breaking**] All the `*StoreLock` structs use a `CrossProcessLockConfig` now <!-- rumdl-disable-line MD013 -->
   instead of the previous `holder` value and so does `StoreConfig` and
-  `BaseClient::clone_with_in_memory_state_store. Passing a `CrossProcessLockConfig::MultiProcess` will keep the same behaviour we had where the client uses the cross process lock and using `CrossProcessLockConfig::SingleProcess`
-  will disable the cross process lock.
+  `BaseClient::clone_with_in_memory_state_store. Passing a `CrossProcessLockConfig::MultiProcess`
+  will keep the same behaviour we had where the client uses the cross process
+  lock and using `CrossProcessLockConfig::SingleProcess` will disable the cross process lock.
   ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
 - [**breaking**] The `StateStore::upsert_thread_subscription` method has been
   removed in favor of a bulk method `StateStore::upsert_thread_subscriptions`.

--- a/crates/matrix-sdk-base/README.md
+++ b/crates/matrix-sdk-base/README.md
@@ -1,10 +1,15 @@
 This crate implements the base to build a [Matrix](https://matrix.org/) client
 library.
 
-## Crate Feature Flags
+## Crate feature flags
 
 The following crate feature flags are available:
 
-* `encryption`: Enables end-to-end encryption support in the library.
-* `qrcode`: Enables QRcode generation and reading code.
-* `testing`: Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.
+- `encryption`: Enables end-to-end encryption support in the library.
+- `qrcode`: Enables QRcode generation and reading code.
+- `testing`: Provides facilities and functions for tests, in particular for
+  integration testing store implementations. ATTENTION: do not ever use outside
+  of tests, we do not provide any stability warantees on these, these are merely
+  helpers. If you find you _need_ any function provided here outside of tests,
+  please open a Github Issue and inform us about your use case for us to
+  consider.

--- a/crates/matrix-sdk-common/CHANGELOG.md
+++ b/crates/matrix-sdk-common/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to this project will be documented in this file.
   ([#6467](https://github.com/matrix-org/matrix-rust-sdk/pull/6467))
 - Add a method to check the validity of edits.
   ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
-- A background task monitor has been added, that can spawn background tasks and monitor their
-  execution on a separate channel. Such tasks can run forever, or they can run for one-shot jobs.
+- A background task monitor has been added, that can spawn background tasks and
+  monitor their execution on a separate channel. Such tasks can run forever, or
+  they can run for one-shot jobs.
   ([#6075](https://github.com/matrix-org/matrix-rust-sdk/pull/6075) &&
   [#6421](https://github.com/matrix-org/matrix-rust-sdk/pull/6421))
 - Add `AcquireCrossProcessLockResult` and `AcquireCrossProcessLockFn`
@@ -22,31 +23,41 @@ All notable changes to this project will be documented in this file.
   ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
 - Add support in the `MemoryStore`'s implementation of `EventCacheStore` for
   having duplicate events in a room, where each duplicate is in a different
-  `LinkedChunk`. This is useful, e.g., when an event is in a room and a 
+  `LinkedChunk`. This is useful, e.g., when an event is in a room and a
   thread in that room.
-- [**breaking**] In order to support having duplicate events in the same room (in different `LinkedChunk`'s) a few
-  functions were changed in `RelationalLinkedChunk`. The items in the `Iterator` returned by `RelationalLinkedChunk::items`
-  now also include the `LinkedChunkId` in which the `Item` was found. Additionally, `RelationalLinkedChunk::save_item`
-  now requires the `Item` to be `Clone` as it may be stored in multiple `LinkedChunk`s. 
+- [**breaking**] In order to support having duplicate events in the same room
+  (in different `LinkedChunk`'s) a few functions were changed in
+  `RelationalLinkedChunk`. The items in the `Iterator` returned by
+  `RelationalLinkedChunk::items` now also include the `LinkedChunkId` in which
+  the `Item` was found. Additionally, `RelationalLinkedChunk::save_item` now
+  requires the `Item` to be `Clone` as it may be stored in multiple
+  `LinkedChunk`s.
   (#[6200](https://github.com/matrix-org/matrix-rust-sdk/pull/6200))
-- [**breaking**] Added `CrossProcessLockConfig`, which can be used to configure the behavior of the cross-process lock.
-  `CrossProcessLock` now takes a `CrossProcessLockConfig` as an argument to its constructor instead of a `lock_holder` 
-  value. ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
+- [**breaking**] Added `CrossProcessLockConfig`, which can be used to configure
+  the behavior of the cross-process lock. `CrossProcessLock` now takes a
+  `CrossProcessLockConfig` as an argument to its constructor instead of a
+  `lock_holder` value.
+  ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 - [**breaking**] `ShieldStateCode` no longer includes
   `SentInClear`. `VerificationState::to_shield_state_{lax,strict}` never
   returned that code, and so having it in the enum was somewhat misleading.
   ([#5959](https://github.com/matrix-org/matrix-rust-sdk/pull/5959))
 - Add field `forwarder` of type `ForwarderInfo` to `EncryptionInfo`, which
   exposes information about the forwarder of the keys with which an event was
-  encrypted if they were shared as part of an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)
-  room key bundle.
+  encrypted if they were shared as part of an
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) room
+  key bundle.
   ([#5945](https://github.com/matrix-org/matrix-rust-sdk/pull/5945)).
 
-### Bug Fixes
+### Bug fixes
 
-- Fix an off-by-one check for `Error:InvalidItemIndex` in `LinkedChunk::remove_item_at`.
+- Fix an off-by-one check for `Error:InvalidItemIndex` in
+  `LinkedChunk::remove_item_at`.
   ([#6057](https://github.com/matrix-org/matrix-rust-sdk/pull/6057))
-- Fix `TimelineEvent::from_bundled_latest_event` sometimes removing the `session_id` of UTDs. This broken event could later be saved to the event cache and become an unresolvable UTD. ([#5970](https://github.com/matrix-org/matrix-rust-sdk/pull/5970)).
+- Fix `TimelineEvent::from_bundled_latest_event` sometimes removing the
+  `session_id` of UTDs. This broken event could later be saved to the event
+  cache and become an unresolvable UTD.
+  ([#5970](https://github.com/matrix-org/matrix-rust-sdk/pull/5970)).
 
 ### Refactor
 
@@ -64,21 +75,30 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] Cross-process lock can be dirty. The `CrossProcess::try_lock_once` now returns a new type `CrossProcessResult`, which is an enum with `Clean`, `Dirty` or `Unobtained` variants. When the lock is dirty it means it's been acquired once, then acquired another time from another holder, so the current holder may want to refresh its internal state.
+- [**breaking**] Cross-process lock can be dirty. The
+  `CrossProcess::try_lock_once` now returns a new type `CrossProcessResult`,
+  which is an enum with `Clean`, `Dirty` or `Unobtained` variants. When the lock
+  is dirty it means it's been acquired once, then acquired another time from
+  another holder, so the current holder may want to refresh its internal state.
   ([#5672](https://github.com/matrix-org/matrix-rust-sdk/pull/5672)).
 
 ## [0.14.0] - 2025-09-04
 
 ### Features
 
-- Tracing subscribers created via [`matrix_sdk_common::js_tracing::MakeJsLogWriter`] or [`make_tracing_subscriber`] will now drop log events at the `TRACE` level. Previously `TRACE` logs were treated the same as `DEBUG` logs. ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590)).
+- Tracing subscribers created via
+  [`matrix_sdk_common::js_tracing::MakeJsLogWriter`] or
+  [`make_tracing_subscriber`] will now drop log events at the `TRACE` level.
+  Previously `TRACE` logs were treated the same as `DEBUG` logs.
+  ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590)).
 
-- [**breaking**] Use `Raw<AnyTimelineEvent>` in place of `Raw<AnyMessageLikeEvent>`
-  in `DecryptedRoomEvent::event`.
-  ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512)).
-  Affects the following functions:
-  - `OlmMachine::decrypt_room_event` - existing matches on the result's event field
-     should be updated to `AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::...)`
+- [**breaking**] Use `Raw<AnyTimelineEvent>` in place of
+  `Raw<AnyMessageLikeEvent>` in `DecryptedRoomEvent::event`.
+  ([#5512](https://github.com/matrix-org/matrix-rust-sdk/pull/5512)). Affects
+  the following functions:
+  - `OlmMachine::decrypt_room_event` - existing matches on the result's event
+    field should be updated to
+    `AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::...)`
 
 ## [0.13.0] - 2025-07-10
 
@@ -120,7 +140,7 @@ No notable changes in this release.
 
 ## [0.9.0] - 2024-12-18
 
-### Bug Fixes
+### Bug fixes
 
 - Change the behavior of `LinkedChunk::new_with_update_history()` to emit an
   `Update::NewItemsChunk` when a new, initial empty, chunk is created.

--- a/crates/matrix-sdk-common/README.md
+++ b/crates/matrix-sdk-common/README.md
@@ -5,5 +5,3 @@ you're probably interested in the main
 [matrix-sdk](https://docs.rs/matrix-sdk/) crate.
 
 [matrix-sdk]: https://github.com/matrix-org/matrix-rust-sdk/
-[Matrix]: https://matrix.org/
-[Rust]: https://www.rust-lang.org/

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.17.0] - 2026-05-08
 
-### Bug Fixes
+### Bug fixes
 
 - Check the user ID in the `sender_device_keys` property of Olm-encrypted
 to-device events to prevent sender spoofing by homeserver owners.
@@ -28,23 +28,26 @@ to-device events to prevent sender spoofing by homeserver owners.
   `CryptoStore::get_all_rooms_pending_key_bundle`, which can be used by
   applications to track whether they are expecting an
   [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) key
-  bundle.
-  ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)), ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233)),
+  bundle. ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)),
+  ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233)),
 - Add MSC4388 support to the QrcodeData struct.
   ([#6089](https://github.com/matrix-org/matrix-rust-sdk/pull/6089))
 - Improved logging when we are sending secrets in `GossipMachine`.
   ([#6074](https://github.com/matrix-org/matrix-rust-sdk/pull/6074))
   ([#6083](https://github.com/matrix-org/matrix-rust-sdk/pull/6083))
-- Added a new field `forwarder` to `InboundGroupSession` of type `ForwarderData`, which stores information about the forwarder of a session shared in a room key bundle under [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
-  ([#5980])(https://github.com/matrix-org/matrix-rust-sdk/pull/5980)
+- Added a new field `forwarder` to `InboundGroupSession` of type
+  `ForwarderData`, which stores information about the forwarder of a session
+  shared in a room key bundle under
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
+  ([#5980])([https://github.com/matrix-org/matrix-rust-sdk/pull/5980][https-github-com-matrix-org-matrix-rust-sdk-pull-5980])
 - The `OutboundGroupSession` and `OlmMachine` now return the `EncryptionInfo`
   used when encrypting raw events.
   ([#5936](https://github.com/matrix-org/matrix-rust-sdk/pull/5936))
-- Expose a new method `CryptoStore::has_downloaded_all_room_keys`, used to track whether the
-  client has previously downloaded historical room keys for a given room from key backup prior
-  to building an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) room
-  key bundle.
-  ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
+- Expose a new method `CryptoStore::has_downloaded_all_room_keys`, used to track
+  whether the client has previously downloaded historical room keys for a given
+  room from key backup prior to building an
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) room
+  key bundle. ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
   ([#6044](https://github.com/matrix-org/matrix-rust-sdk/pull/6044))
 
 ### Refactor
@@ -62,16 +65,19 @@ to-device events to prevent sender spoofing by homeserver owners.
 - **breaking** The `BackupDecryptionKey::new` and `DehydratedDeviceKey::new`
   methods became infallible, they don't return a `Result` anymore.
   ([#5502](https://github.com/matrix-org/matrix-rust-sdk/pull/5502))
-- [**breaking**] Remove cross-process lock generation logic from `OlmMachine`, which is now
-  implemented more generally in `matrix_sdk_common::cross_process_lock::CrossProcessLock`.
+- [**breaking**] Remove cross-process lock generation logic from `OlmMachine`,
+  which is now implemented more generally in
+  `matrix_sdk_common::cross_process_lock::CrossProcessLock`.
   ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
-- [**breaking**] The `MediaEncryptionInfo` fields changed to match the new fields of `EncryptedFile`
-  from Ruma. The serialized JSON format did not change and still matches the format of
-  `EncryptedFile` defined in the spec, without the `url` field. The `DecryptorError::KeyNonceLength`
-  variant was removed because the length of the key and nonce are now enforced in
+- [**breaking**] The `MediaEncryptionInfo` fields changed to match the new
+  fields of `EncryptedFile` from Ruma. The serialized JSON format did not change
+  and still matches the format of `EncryptedFile` defined in the spec, without
+  the `url` field. The `DecryptorError::KeyNonceLength` variant was removed
+  because the length of the key and nonce are now enforced in
   `MediaEncryptionInfo`.
   ([#6346](https://github.com/matrix-org/matrix-rust-sdk/pull/6346))
-- [**breaking**] Removed `WithLocking` from `EncryptionSyncService` and replaced it with `CrossProcessLockConfig`.
+- [**breaking**] Removed `WithLocking` from `EncryptionSyncService` and replaced
+  it with `CrossProcessLockConfig`.
   ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 - [**breaking**] The QrcodeData struct has been reworked in preparation to
   support MSC4388. The fields of the QrcodeData struct are not anymore publicly
@@ -79,13 +85,13 @@ to-device events to prevent sender spoofing by homeserver owners.
   returns an MSC-specific struct now. The `rendezvous_url()` method has been
   removed.
   ([#6081](https://github.com/matrix-org/matrix-rust-sdk/pull/6081))
-- [**breaking**] The `message-ids` feature has been removed. It was already a no-op and has now
-  been eliminated entirely.
+- [**breaking**] The `message-ids` feature has been removed. It was already a
+  no-op and has now been eliminated entirely.
   ([#5963](https://github.com/matrix-org/matrix-rust-sdk/pull/5963))
 
 ## [0.16.1] - 2026-05-08
 
-### Bug Fixes
+### Bug fixes
 
 - Check the user ID in the `sender_device_keys` property of Olm-encrypted
 to-device events to prevent sender spoofing by homeserver owners.
@@ -95,43 +101,57 @@ to-device events to prevent sender spoofing by homeserver owners.
 
 ### Features
 
-- When we receive an inbound Megolm session from two different sources, merge the two copies together to get the best of both.
+- When we receive an inbound Megolm session from two different sources, merge
+  the two copies together to get the best of both.
   ([#5865](https://github.com/matrix-org/matrix-rust-sdk/pull/5865)
-- When constructing a key bundle for history sharing, if we had received a key bundle ourselves, in which one or more sessions was marked as "history not shared", pass that on to the new user.
+- When constructing a key bundle for history sharing, if we had received a key
+  bundle ourselves, in which one or more sessions was marked as "history not
+  shared", pass that on to the new user.
   ([#5820](https://github.com/matrix-org/matrix-rust-sdk/pull/5820)
 - Expose new method `CryptoStore::get_withheld_sessions_by_room_id`.
   ([#5819](https://github.com/matrix-org/matrix-rust-sdk/pull/5819))
 - Use new withheld code in key bundles for sessions not marked as
   `shared_history`.
-  ([#5807](https://github.com/matrix-org/matrix-rust-sdk/pull/5807), ([#5834](https://github.com/matrix-org/matrix-rust-sdk/pull/5834))
+  ([#5807](https://github.com/matrix-org/matrix-rust-sdk/pull/5807),
+  ([#5834](https://github.com/matrix-org/matrix-rust-sdk/pull/5834))
 - Improve feedback support for shared history when downloading room key
   bundles.
   ([#5737](https://github.com/matrix-org/matrix-rust-sdk/pull/5737))
-  - Add `RoomKeyWithheldEntry` enum, wrapping either a received to-device `m.room_key.withheld` event or
-    its content, if derived from a downloaded room key bundle.
-  - `OlmMachine::receive_room_key_bundle` now appends withheld key information to the store.
-  - [**breaking**] `Changes::withheld_session_info` now stores a `RoomKeyWithheldEntry` in each `room-id`-`session-id` entry.
-  - [**breaking**] `CryptoStore::get_withheld_info` now returns `Result<Option<RoomKeyWithheldEntry>>`. This change also affects `MemoryStore`.
+  - Add `RoomKeyWithheldEntry` enum, wrapping either a received to-device
+    `m.room_key.withheld` event or its content, if derived from a downloaded
+    room key bundle.
+  - `OlmMachine::receive_room_key_bundle` now appends withheld key information
+    to the store.
+  - [**breaking**] `Changes::withheld_session_info` now stores a
+    `RoomKeyWithheldEntry` in each `room-id`-`session-id` entry.
+  - [**breaking**] `CryptoStore::get_withheld_info` now returns
+    `Result<Option<RoomKeyWithheldEntry>>`. This change also affects
+    `MemoryStore`.
 - [**breaking**] Add `name` fields to some of the variants of
   `store::SecretImportError` to indicate what secret was being imported when the
   error occurred.
   ([#5647](https://github.com/matrix-org/matrix-rust-sdk/pull/5647))
 
-### Bug Fixes
+### Bug fixes
 
-- Fix a bug which caused encrypted to-device messages from unknown devices to be ignored.
+- Fix a bug which caused encrypted to-device messages from unknown devices to be
+  ignored. ([#5763](https://github.com/matrix-org/matrix-rust-sdk/pull/5763))
+- Fix a bug which caused history shared on invite to be ignored when "exclude
+  insecure devices" was enabled.
   ([#5763](https://github.com/matrix-org/matrix-rust-sdk/pull/5763))
-- Fix a bug which caused history shared on invite to be ignored when "exclude insecure devices" was enabled.
-  ([#5763](https://github.com/matrix-org/matrix-rust-sdk/pull/5763))
-- Fix a bug introduced in 0.14.0 which meant that the serialization of the value returned by `OtherUserIdentity::verification_request_content` did not include a `msgtype` field.
+- Fix a bug introduced in 0.14.0 which meant that the serialization of the value
+  returned by `OtherUserIdentity::verification_request_content` did not include
+  a `msgtype` field.
   ([#5642](https://github.com/matrix-org/matrix-rust-sdk/pull/5642))
 
 ## [0.14.0] - 2025-09-04
 
 ### Features
 
-- Log message index for Megolm sessions received over encrypted to-device messages. ([#5599](https://github.com/matrix-org/matrix-rust-sdk/pull/5599))
-- Add `RoomSettings::encrypt_state_events` flag. ([#5511](https://github.com/matrix-org/matrix-rust-sdk/pull/5511))
+- Log message index for Megolm sessions received over encrypted to-device
+  messages. ([#5599](https://github.com/matrix-org/matrix-rust-sdk/pull/5599))
+- Add `RoomSettings::encrypt_state_events` flag.
+  ([#5511](https://github.com/matrix-org/matrix-rust-sdk/pull/5511))
 - Make sure to accept historic room key bundles only if the sender is trusted
   enough.
   ([#5510](https://github.com/matrix-org/matrix-rust-sdk/pull/5510))
@@ -164,7 +184,8 @@ to-device events to prevent sender spoofing by homeserver owners.
 
 ### Features
 
-- [**breaking**] Add a new `VerificationLevel::MismatchedSender` to indicate that the sender of an event appears to have been tampered with.
+- [**breaking**] Add a new `VerificationLevel::MismatchedSender` to indicate
+  that the sender of an event appears to have been tampered with.
   ([#5219](https://github.com/matrix-org/matrix-rust-sdk/pull/5219))
 
 ### Refactor
@@ -181,52 +202,65 @@ to-device events to prevent sender spoofing by homeserver owners.
 
 ### Features
 
-- [**breaking**] The `ProcessedToDeviceEvent::Decrypted` variant now also have an `EncryptionInfo` field.
-  Format changed from `Decrypted(Raw<AnyToDeviceEvent>)` to `Decrypted { raw: Raw<AnyToDeviceEvent>, encryption_info: EncryptionInfo) }`
+- [**breaking**] The `ProcessedToDeviceEvent::Decrypted` variant now also have
+  an `EncryptionInfo` field. Format changed from
+  `Decrypted(Raw<AnyToDeviceEvent>)` to
+  `Decrypted { raw: Raw<AnyToDeviceEvent>, encryption_info: EncryptionInfo) }`
   ([#5074](https://github.com/matrix-org/matrix-rust-sdk/pull/5074))
 
-- [**breaking**] Move `session_id` from `EncryptionInfo` to `AlgorithmInfo` as it is megolm specific.
-  Use `EncryptionInfo::session_id()` helper for quick access.
-  ([#4981](https://github.com/matrix-org/matrix-rust-sdk/pull/4981))
+- [**breaking**] Move `session_id` from `EncryptionInfo` to `AlgorithmInfo` as
+  it is megolm specific. Use `EncryptionInfo::session_id()` helper for quick
+  access. ([#4981](https://github.com/matrix-org/matrix-rust-sdk/pull/4981))
 
 - Send stable identifier `sender_device_keys` for MSC4147 (Including device
   keys with Olm-encrypted events).
   ([#4964](https://github.com/matrix-org/matrix-rust-sdk/pull/4964))
 
-- Add experimental APIs for sharing encrypted room key history with new members, `Store::build_room_key_bundle` and `OlmMachine::share_room_key_bundle_data`.
-  ([#4775](https://github.com/matrix-org/matrix-rust-sdk/pull/4775), [#4864](https://github.com/matrix-org/matrix-rust-sdk/pull/4864))
+- Add experimental APIs for sharing encrypted room key history with new members,
+  `Store::build_room_key_bundle` and `OlmMachine::share_room_key_bundle_data`.
+  ([#4775](https://github.com/matrix-org/matrix-rust-sdk/pull/4775),
+  [#4864](https://github.com/matrix-org/matrix-rust-sdk/pull/4864))
 
-- Check the `sender_device_keys` field on *all* incoming Olm-encrypted to-device messages
-  and ignore any to-device messages which include the field but whose data is invalid
-  (as per [MSC4147](https://github.com/matrix-org/matrix-spec-proposals/pull/4147)).
+- Check the `sender_device_keys` field on _all_ incoming Olm-encrypted to-device
+  messages and ignore any to-device messages which include the field but whose
+  data is invalid (as per
+  [MSC4147](https://github.com/matrix-org/matrix-spec-proposals/pull/4147)).
   ([#4922](https://github.com/matrix-org/matrix-rust-sdk/pull/4922))
 
-- Fix bug which caused room keys to be unnecessarily rotated on every send in the
-  presence of blacklisted/withheld devices in the room.
+- Fix bug which caused room keys to be unnecessarily rotated on every send in
+  the presence of blacklisted/withheld devices in the room.
   ([#4954](https://github.com/matrix-org/matrix-rust-sdk/pull/4954))
 
-- Fix [#2729](https://github.com/matrix-org/matrix-rust-sdk/issues/2729) which in rare
-  cases can cause room key oversharing.
+- Fix [#2729](https://github.com/matrix-org/matrix-rust-sdk/issues/2729) which
+  in rare cases can cause room key oversharing.
   ([#4975](https://github.com/matrix-org/matrix-rust-sdk/pull/4975))
 
-- [**breaking**] `OlmMachine.receive_sync_changes` returns now a list of `ProcessedToDeviceEvent`
-  instead of a list of `Raw<AnyToDeviceEvent>`. With variants like `Decrypted`|`UnableToDecrypt`|`PlainText`|`NotProcessed`.
-  This allows for example to make the difference between an event sent in clear and an event successfully decrypted.
-  For quick compatibility a helper `ProcessedToDeviceEvent::to_raw` allows to map back to the previous behaviour.
+- [**breaking**] `OlmMachine.receive_sync_changes` returns now a list of
+  `ProcessedToDeviceEvent` instead of a list of `Raw<AnyToDeviceEvent>`. With
+  variants like `Decrypted`|`UnableToDecrypt`|`PlainText`|`NotProcessed`. This
+  allows for example to make the difference between an event sent in clear and
+  an event successfully decrypted. For quick compatibility a helper
+  `ProcessedToDeviceEvent::to_raw` allows to map back to the previous behaviour.
   ([#4935](https://github.com/matrix-org/matrix-rust-sdk/pull/4935))
 
 ## [0.11.1] - 2025-06-10
 
-### Security Fixes
+### Security fixes
+
 - Check the sender of an event matches owner of session, preventing sender
   spoofing by homeserver owners.
-  [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55) (High, [CVE-2025-48937](https://www.cve.org/CVERecord?id=CVE-2025-48937), [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
+  [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55)
+  (High, [CVE-2025-48937](https://www.cve.org/CVERecord?id=CVE-2025-48937),
+  [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
 
-### Bug Fixes
+### Bug fixes
+
 - Remove a wildcard enum variant import which breaks compilation if used with
   `tracing-attributes` version `0.1.29`. This is a workaround for a bug in
   `tracing-attributes`.
-  ([#5190](https://github.com/matrix-org/matrix-rust-sdk/issues/5190)) ([#5191](https://github.com/matrix-org/matrix-rust-sdk/issues/5191)) ([#5193](https://github.com/matrix-org/matrix-rust-sdk/issues/5193))
+  ([#5190](https://github.com/matrix-org/matrix-rust-sdk/issues/5190))
+  ([#5191](https://github.com/matrix-org/matrix-rust-sdk/issues/5191))
+  ([#5193](https://github.com/matrix-org/matrix-rust-sdk/issues/5193))
 
 ## [0.11.0] - 2025-04-11
 
@@ -242,8 +276,8 @@ to-device events to prevent sender spoofing by homeserver owners.
   `shared_history` field that defaults to `false.`
   ([#4700](https://github.com/matrix-org/matrix-rust-sdk/pull/4700))
 
-- Have the `RoomIdentityProvider` return processing changes when identities transition
-  to `IdentityState::Verified` too.
+- Have the `RoomIdentityProvider` return processing changes when identities
+  transition to `IdentityState::Verified` too.
   ([#4670](https://github.com/matrix-org/matrix-rust-sdk/pull/4670))
 
 ## [0.10.0] - 2025-02-04
@@ -282,16 +316,17 @@ to-device events to prevent sender spoofing by homeserver owners.
   `OtherUserIdentity::withdraw_verification`.
   ([#4415](https://github.com/matrix-org/matrix-rust-sdk/pull/4415))
 
-- Added new `UtdCause` variants `WithheldForUnverifiedOrInsecureDevice` and `WithheldBySender`.
-  These variants provide clearer categorization for expected Unable-To-Decrypt (UTD) errors
-  when the sender either did not wish to share or was unable to share the room_key.
+- Added new `UtdCause` variants `WithheldForUnverifiedOrInsecureDevice` and
+  `WithheldBySender`. These variants provide clearer categorization for expected
+  Unable-To-Decrypt (UTD) errors when the sender either did not wish to share or
+  was unable to share the room_key.
   ([#4305](https://github.com/matrix-org/matrix-rust-sdk/pull/4305))
 
 - `UtdCause` has two new variants that replace the existing `HistoricalMessage`:
-  `HistoricalMessageAndBackupIsDisabled` and `HistoricalMessageAndDeviceIsUnverified`.
-  These give more detail about what went wrong and allow us to suggest to users
-  what actions they can take to fix the problem. See the doc comments on these
-  variants for suggested wording.
+  `HistoricalMessageAndBackupIsDisabled` and
+  `HistoricalMessageAndDeviceIsUnverified`. These give more detail about what
+  went wrong and allow us to suggest to users what actions they can take to fix
+  the problem. See the doc comments on these variants for suggested wording.
   ([#4384](https://github.com/matrix-org/matrix-rust-sdk/pull/4384))
 
 ## [0.8.0] - 2024-11-19
@@ -299,7 +334,6 @@ to-device events to prevent sender spoofing by homeserver owners.
 ### Features
 
 - Pin identity when we withdraw verification.
-
 - Expose new method `OlmMachine::room_keys_withheld_received_stream`, to allow
   applications to receive notifications about received `m.room_key.withheld`
   events.
@@ -355,7 +389,6 @@ to-device events to prevent sender spoofing by homeserver owners.
 - Include event timestamps on logs from event decryption.
   ([#3194](https://github.com/matrix-org/matrix-rust-sdk/pull/3194))
 
-
 ### Refactor
 
 - Fix [#4424](https://github.com/matrix-org/matrix-rust-sdk/issues/4424) Failed
@@ -367,10 +400,12 @@ to-device events to prevent sender spoofing by homeserver owners.
 - Add new method `OlmMachine::try_decrypt_room_event`.
   ([#4116](https://github.com/matrix-org/matrix-rust-sdk/pull/4116))
 
-- Add reason code to `matrix_sdk_common::deserialized_responses::UnableToDecryptInfo`.
+- Add reason code to
+  `matrix_sdk_common::deserialized_responses::UnableToDecryptInfo`.
   ([#4116](https://github.com/matrix-org/matrix-rust-sdk/pull/4116))
 
-- [**breaking**] The `UserIdentity` struct has been renamed to `OtherUserIdentity`.
+- [**breaking**] The `UserIdentity` struct has been renamed to
+  `OtherUserIdentity`.
   ([#4036](https://github.com/matrix-org/matrix-rust-sdk/pull/4036]))
 
 - [**breaking**] The `UserIdentities` enum has been renamed to `UserIdentity`.
@@ -421,23 +456,24 @@ to-device events to prevent sender spoofing by homeserver owners.
 
 Breaking changes:
 
-- [**breaking**] `VerificationRequestState::Transitioned` now includes a new field
-  `other_device_data` of type `DeviceData`.
+- [**breaking**] `VerificationRequestState::Transitioned` now includes a new
+  field `other_device_data` of type `DeviceData`.
   ([#4153](https://github.com/matrix-org/matrix-rust-sdk/pull/4153))
 
-- [**breaking**] `OlmMachine::decrypt_room_event` now returns a `DecryptedRoomEvent` type,
-  instead of the more generic `TimelineEvent` type.
+- [**breaking**] `OlmMachine::decrypt_room_event` now returns a
+  `DecryptedRoomEvent` type, instead of the more generic `TimelineEvent` type.
 
-- [**breaking**] **NOTE**: this version causes changes to the format of the serialised data in
-  the CryptoStore, meaning that, once upgraded, it will not be possible to roll
-  back applications to earlier versions without breaking user sessions.
+- [**breaking**] **NOTE**: this version causes changes to the format of the
+  serialised data in the CryptoStore, meaning that, once upgraded, it will not
+  be possible to roll back applications to earlier versions without breaking
+  user sessions.
 
 - [**breaking**] Renamed `VerificationLevel::PreviouslyVerified` to
   `VerificationLevel::VerificationViolation`.
 
 - [**breaking**] `OlmMachine::decrypt_room_event` now takes a
   `DecryptionSettings` argument, which includes a `TrustRequirement` indicating
-  the required trust level for the sending device.  When it is called with
+  the required trust level for the sending device. When it is called with
   `TrustRequirement` other than `TrustRequirement::Unverified`, it may return
   the new `MegolmError::SenderIdentityNotTrusted` variant if the sending device
   does not satisfy the required trust level.
@@ -493,45 +529,51 @@ Breaking changes:
 - [**breaking**] Rename the `OlmMachine::invalidate_group_session` method to
   `OlmMachine::discard_room_key`.
 
-- [**breaking**] Move `OlmMachine::export_room_keys` to `matrix_sdk_crypto::store::Store`.
-  (Call it with `olm_machine.store().export_room_keys(...)`.)
+- [**breaking**] Move `OlmMachine::export_room_keys` to
+  `matrix_sdk_crypto::store::Store`. (Call it with
+  `olm_machine.store().export_room_keys(...)`.)
 
-- [**breaking**] Add new `dehydrated` property to `olm::account::PickledAccount`.
+- [**breaking**] Add new `dehydrated` property to
+  `olm::account::PickledAccount`.
   ([#3164](https://github.com/matrix-org/matrix-rust-sdk/pull/3164))
 
 - [**breaking**] Remove deprecated `OlmMachine::import_room_keys`.
   ([#3448](https://github.com/matrix-org/matrix-rust-sdk/pull/3448))
 
-- [**breaking**] Add the `SasState::Created` variant to differentiate the state between the
-  party that sent the verification start and the party that received it.
+- [**breaking**] Add the `SasState::Created` variant to differentiate the state
+  between the party that sent the verification start and the party that received
+  it.
 
 - [**breaking**] Deprecate `BackupMachine::import_backed_up_room_keys`.
   ([#3448](https://github.com/matrix-org/matrix-rust-sdk/pull/3448))
 
+## 0.7.2
 
-# 0.7.2
-
-### Security Fixes
+### Security fixes
 
 - Fix `UserIdentity::is_verified` to take into account our own identity
-  [#d8d9dae](https://github.com/matrix-org/matrix-rust-sdk/commit/d8d9dae9d77bee48a2591b9aad9bd2fa466354cc) (Moderate, [GHSA-4qg4-cvh2-crgg](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-4qg4-cvh2-crgg)).
+  [#d8d9dae](https://github.com/matrix-org/matrix-rust-sdk/commit/d8d9dae9d77bee48a2591b9aad9bd2fa466354cc)
+  (Moderate,
+  [GHSA-4qg4-cvh2-crgg](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-4qg4-cvh2-crgg)).
 
-# 0.7.1
-### Security Fixes
+## 0.7.1
 
-- Don't log the private part of the backup key, introduced in [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
+### Security fixes
 
-# 0.7.0
+- Don't log the private part of the backup key, introduced in
+  [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
+
+## 0.7.0
 
 - Add method to mark a list of inbound group sessions as backed up:
   `CryptoStore::mark_inbound_group_sessions_as_backed_up`
 
 - `OlmMachine::toggle_room_key_forwarding` is replaced by two separate methods:
 
-  * `OlmMachine::set_room_key_requests_enabled`, which controls whether
+  - `OlmMachine::set_room_key_requests_enabled`, which controls whether
     outgoing room key requests are enabled, and:
 
-  * `OlmMachine::set_room_key_forwarding_enabled`, which controls whether we
+  - `OlmMachine::set_room_key_forwarding_enabled`, which controls whether we
     automatically reply to incoming room key requests.
 
   `OlmMachine::is_room_key_forwarding_enabled` is updated to return the setting
@@ -569,7 +611,6 @@ Breaking changes:
   signatures to a `RoomKeyBackupInfo`.
 
 - Remove the `backups_v1` feature, backups support is now enabled by default.
-
 - Use the `Signatures` type as the return value for the
   `MegolmV1BackupKey::signatures()` method.
 
@@ -584,7 +625,7 @@ Breaking changes:
     to `&Raw<AnyMessageLikeEventContent>`
 
 - Change the return value of `bootstrap_cross_signing` so it returns an extra
-  keys upload request.  The three requests must be sent in the order they
+  keys upload request. The three requests must be sent in the order they
   appear in the return tuple.
 
 - Stop logging large quantities of data about the `Store` during olm
@@ -594,13 +635,9 @@ Breaking changes:
   for every outgoing secret request.
 
 - Clean up the logging of to-device messages in `share_room_key`.
-
 - Expose new `OlmMachine::get_room_event_encryption_info` method.
-
 - Add support for secret storage.
-
 - Add initial support for MSC3814 - dehydrated devices.
-
 - Mark our `OwnUserIdentity` as verified if we successfully import the matching
   private keys.
 
@@ -608,7 +645,6 @@ Breaking changes:
   This removes an `unwrap()` from the codebase.
 
 - Add support for the `hkdf-hmac-sha256.v2` SAS message authentication code.
-
 - Ensure that the correct short authentication strings are used when accepting a
   SAS verification with the `Sas::accept()` method.
 
@@ -616,7 +652,6 @@ Breaking changes:
   of `m.room.encrypted` event contents which get sent out.
 
 - Disable the automatic-key-forwarding feature by default.
-
 - Add a new variant to the `VerificationRequestState` enum called
   `Transitioned`. This enum variant is used when a `VerificationRequest`
   transitions into a concrete `Verification` object. The concrete `Verification`
@@ -637,14 +672,11 @@ Breaking changes:
   broadcasting to all devices.
 
 - Expose `VerificationRequest::time_remaining`.
-
 - For verification-via-emojis, return the word "Aeroplane" rather than
   "Airplane", for consistency with the Matrix spec.
 
 - Fix handling of SAS verification start events once we have shown a QR code.
-
 - Fix a bug which could cause generated one-time-keys not to be persisted.
-
 - Fix parsing error for `POST /_matrix/client/v3/keys/signatures/upload`
   responses generated by Synapse.
 
@@ -660,3 +692,5 @@ Breaking changes:
 
 - Change the returned success value type of `BackupMachine::backup` from
   `OutgoingRequest` to `(OwnedTransactionId, KeysBackupRequest)`.
+
+[https-github-com-matrix-org-matrix-rust-sdk-pull-5980]: https://github.com/matrix-org/matrix-rust-sdk/pull/5980

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -163,7 +163,7 @@ to-device events to prevent sender spoofing by homeserver owners.
   the sender's device is not verified. Also, several methods now take a
   `DecryptionSettings` argument to allow controlling the processing of to-device
   events based on those settings. To recreate the previous behaviour pass in:
-  `DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted }`.
+  `DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted }`. <!-- rumdl-disable-line MD013 -->
   Affected methods are `OlmMachine::receive_sync_changes`,
   `RehydratedDevice::receive_events`, and several internal methods.
   ([#5319](https://github.com/matrix-org/matrix-rust-sdk/pull/5319))

--- a/crates/matrix-sdk-crypto/README.md
+++ b/crates/matrix-sdk-crypto/README.md
@@ -57,6 +57,7 @@ async fn main() -> Result<(), OlmError> {
     Ok(())
 }
 ```
+
 It is recommended to use the [tutorial] to understand how end-to-end encryption
 works in Matrix and how to add end-to-end encryption support in your Matrix
 client library.
@@ -64,20 +65,27 @@ client library.
 [Matrix]: https://matrix.org/
 [matrix-sdk]: https://github.com/matrix-org/matrix-rust-sdk/
 
-# Crate Feature Flags
+# Crate feature flags
 
 The following crate feature flags are available:
 
-| Feature             | Default | Description                                                                                                                |
-| ------------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------- |
-| `qrcode`            |   No    | Enables QR code based interactive verification                                                                             |
-| `js`                |   No    | Enables JavaScript API usage for things like the current system time on WASM (does nothing on other targets)               |
-| `testing`           |   No    | Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider. |
+| Feature   | Default | Description                                                                                                                                                                                                                                                                                                                                                                               |
+| --------- | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `qrcode`  |   No    | Enables QR code based interactive verification                                                                                                                                                                                                                                                                                                                                            |
+| `js`      |   No    | Enables JavaScript API usage for things like the current system time on WASM (does nothing on other targets)                                                                                                                                                                                                                                                                              |
+| `testing` |   No    | Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider. |
 
-* `testing`: Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.
+- `testing`: Provides facilities and functions for tests, in particular for
+  integration testing store implementations. ATTENTION: do not ever use outside
+  of tests, we do not provide any stability warantees on these, these are merely
+  helpers. If you find you _need_ any function provided here outside of tests,
+  please open a Github Issue and inform us about your use case for us to
+  consider.
 
-* `_disable-minimum-rotation-period-ms`: Do not use except for testing. Disables the floor on the rotation period of room keys.
-# Enabling logging
+- `_disable-minimum-rotation-period-ms`: Do not use except for testing. Disables
+  the floor on the rotation period of room keys.
+
+## Enabling logging
 
 Users of the `matrix-sdk-crypto` crate can enable log output by depending on the
 `tracing-subscriber` crate and including the following line in their

--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this project will be documented in this file.
 - Implement `CryptoStore::get_pending_key_bundle_details_for_room` and
   `CryptoStore::get_all_rooms_pending_key_bundle`, and process
   `rooms_pending_key_bundle` field in `Changes`.
-  ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)), ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233))
+  ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)),
+  ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233))
 - Expose implementations of `EventCacheStore` and `MediaStore` and add a
   composite type for initializing all stores with a single function - i.e.,
   `IndexeddbStores::open`. Additionally, allow feature flags for each of the
@@ -28,20 +29,23 @@ All notable changes to this project will be documented in this file.
   `room_key_backups_fully_downloaded` field in `Changes`.
   ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
   ([#6044](https://github.com/matrix-org/matrix-rust-sdk/pull/6044))
-- [**breaking**] In `EventCacheStore::handle_linked_chunk_updates`, new chunks may no longer
-  reference chunk identifiers which do not yet exist in the store
+- [**breaking**] In `EventCacheStore::handle_linked_chunk_updates`, new chunks
+  may no longer reference chunk identifiers which do not yet exist in the store
   ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
 
-### Bug Fixes
+### Bug fixes
 
-- Ensure that encrypted tests are run with a `StoreCipher`. This happened to reveal tests which fail in an
-  encrypted `EventCacheStore`, which required fixing queries for all events in a room. ([#5933](https://github.com/matrix-org/matrix-rust-sdk/pull/5933))
+- Ensure that encrypted tests are run with a `StoreCipher`. This happened to
+  reveal tests which fail in an encrypted `EventCacheStore`, which required
+  fixing queries for all events in a room.
+  ([#5933](https://github.com/matrix-org/matrix-rust-sdk/pull/5933))
 
 ### Refactor
 
-- Add migration to `IndexeddbCryptoStore` that removes cross-process lock generation key from 
-  `CORE` object store, as this is tracked in `LEASE_LOCKS` object store.
-  ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326)) 
+- Add migration to `IndexeddbCryptoStore` that removes cross-process lock
+  generation key from `CORE` object store, as this is tracked in `LEASE_LOCKS`
+  object store.
+  ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
 
 ## [0.16.1] - 2026-05-08
 
@@ -53,15 +57,18 @@ No notable changes in this release.
 
 - Implement new method `CryptoStore::get_withheld_sessions_by_room_id`.
   ([#5819](https://github.com/matrix-org/matrix-rust-sdk/pull/5819))
-- [**breaking**] `IndexeddbCryptoStore::get_withheld_info` now returns `Result<Option<RoomKeyWithheldEntry>, ...>`.
+- [**breaking**] `IndexeddbCryptoStore::get_withheld_info` now returns
+  `Result<Option<RoomKeyWithheldEntry>, ...>`.
   ([#5737](https://github.com/matrix-org/matrix-rust-sdk/pull/5737))
 - Implement `StateStore::upsert_thread_subscriptions()` method for bulk upserts.
   ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
 
 ### Performance
 
-- Improve performance of certain media queries in `MediaStore` implementation by storing media content and media metadata
-  in separate object stores in IndexedDB (see [#5795](https://github.com/matrix-org/matrix-rust-sdk/pull/5795)).
+- Improve performance of certain media queries in `MediaStore` implementation by
+  storing media content and media metadata in separate object stores in
+  IndexedDB (see
+  [#5795](https://github.com/matrix-org/matrix-rust-sdk/pull/5795)).
 
 ## [0.14.0] - 2025-09-04
 
@@ -71,7 +78,10 @@ No notable changes in this release.
 
 ### Features
 
-- Add support for received room key bundle data, as required by encrypted history sharing ((MSC4268)[https://github.com/matrix-org/matrix-spec-proposals/pull/4268)). ([#5276](https://github.com/matrix-org/matrix-rust-sdk/pull/5276))
+- Add support for received room key bundle data, as required by encrypted
+  history sharing
+  ((MSC4268)[[https://github.com/matrix-org/matrix-spec-proposals/pull/4268][https-github-com-matrix-org-matrix-spec-proposals-pull-4268])).
+  ([#5276](https://github.com/matrix-org/matrix-rust-sdk/pull/5276))
 
 ## [0.12.0] - 2025-06-10
 
@@ -94,13 +104,17 @@ No notable changes in this release.
 ### Features
 
 - Improve the efficiency of objects stored in the crypto store.
-  ([#3645](https://github.com/matrix-org/matrix-rust-sdk/pull/3645), [#3651](https://github.com/matrix-org/matrix-rust-sdk/pull/3651))
+  ([#3645](https://github.com/matrix-org/matrix-rust-sdk/pull/3645),
+  [#3651](https://github.com/matrix-org/matrix-rust-sdk/pull/3651))
 
-- Add new method `IndexeddbCryptoStore::open_with_key`. ([#3423](https://github.com/matrix-org/matrix-rust-sdk/pull/3423))
+- Add new method `IndexeddbCryptoStore::open_with_key`.
+  ([#3423](https://github.com/matrix-org/matrix-rust-sdk/pull/3423))
 
 - `save_change` performance improvement, all encryption and serialization
   is done now outside of the db transaction.
 
-### Bug Fixes
+### Bug fixes
 
 - Use the `DisplayName` struct to protect against homoglyph attacks.
+
+[https-github-com-matrix-org-matrix-spec-proposals-pull-4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268

--- a/crates/matrix-sdk-indexeddb/README.md
+++ b/crates/matrix-sdk-indexeddb/README.md
@@ -1,4 +1,4 @@
-# Matrix-sdk-indexedddb
+# `matrix-sdk-indexedddb`
 
 This crate implements a storage backend on IndexedDB for web environments using
 the matrix-sdk-base primitives.

--- a/crates/matrix-sdk-indexeddb/README.md
+++ b/crates/matrix-sdk-indexeddb/README.md
@@ -1,21 +1,23 @@
-# matrix-sdk-indexedddb
+# Matrix-sdk-indexedddb
 
-This crate implements a storage backend on IndexedDB for web environments using the matrix-sdk-base primitives. 
+This crate implements a storage backend on IndexedDB for web environments using
+the matrix-sdk-base primitives.
 
 ## Usage
 
-The most common usage pattern would be to have this included via `matrix-sdk` in your `Cargo.toml` and leave
-instantiation to it.
+The most common usage pattern would be to have this included via `matrix-sdk` in
+your `Cargo.toml` and leave instantiation to it.
 
 ```toml,no_test
 [target.'cfg(target_family = "wasm")'.dependencies]
 matrix-sdk = { version = "0.5, default-features = false, features = ["indexeddb", "e2e-encryption"] }
 ```
 
-
-## Crate Feature Flags
+## Crate feature flags
 
 The following crate feature flags are available:
 
-* `e2e-encryption`: (on by default) Enables the store for end-to-end encrypted data (`IndexeddbCryptoStore`).
-* `state-store`: (on by default) Enables the `StateStore` implementation (`IndexeddbStateStore`).
+- `e2e-encryption`: (on by default) Enables the store for end-to-end encrypted
+  data (`IndexeddbCryptoStore`).
+- `state-store`: (on by default) Enables the `StateStore` implementation
+  (`IndexeddbStateStore`).

--- a/crates/matrix-sdk-search/README.md
+++ b/crates/matrix-sdk-search/README.md
@@ -1,4 +1,4 @@
-# Matrix-sdk-search
+# `matrix-sdk-search`
 
 This crate implements a searchable index for messages in a Matrix client.
 

--- a/crates/matrix-sdk-search/README.md
+++ b/crates/matrix-sdk-search/README.md
@@ -1,15 +1,16 @@
-# matrix-sdk-search
+# Matrix-sdk-search
 
 This crate implements a searchable index for messages in a Matrix client.
 
 ## Usage
 
-The recommended way to use this crate is to include `matrix-sdk` as a dependency 
+The recommended way to use this crate is to include `matrix-sdk` as a dependency
 in your `Cargo.toml` file with the `experimental-search` feature flag turned on.
 
 ## Stand-alone usage
 
-Constructing a `matrix_sdk_search::index::RoomIndex` is done with the `matrix_sdk_search::index::builder::RoomIndexBuilder`.
+Constructing a `matrix_sdk_search::index::RoomIndex` is done with the
+`matrix_sdk_search::index::builder::RoomIndexBuilder`.
 
 ```rust
 use std::path::PathBuf;
@@ -27,8 +28,9 @@ fn create_index(path: PathBuf, room_id: &RoomId) -> Result<RoomIndex, IndexError
 }
 ```
 
-The search crate accepts index operations through `matrix_sdk_search::index::RoomIndex::execute()`
-which takes a `matrix_sdk_search::index::RoomIndexOperation`. 
+The search crate accepts index operations through
+`matrix_sdk_search::index::RoomIndex::execute()` which takes a
+`matrix_sdk_search::index::RoomIndexOperation`.
 
 ```rust
 use matrix_sdk_search::index::{
@@ -42,6 +44,6 @@ async fn add_event(index: &mut RoomIndex, event: OriginalSyncRoomMessageEvent) {
 }
 ```
 
-Some method(s) for creating these operations will need to be implemented. There is an example of
-handling `ruma::events::AnySyncTimelineEvents` in `matrix-sdk::search_index`.
-
+Some method(s) for creating these operations will need to be implemented. There
+is an example of handling `ruma::events::AnySyncTimelineEvents` in
+`matrix-sdk::search_index`.

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -11,24 +11,25 @@ All notable changes to this project will be documented in this file.
 - Implement `CryptoStore::get_pending_key_bundle_details_for_room` and
   `CryptoStore::get_all_rooms_pending_key_bundle`, and process
   `rooms_pending_key_bundle` field in `Changes`.
-  ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)), ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233))
+  ([#6199](https://github.com/matrix-org/matrix-rust-sdk/pull/6199)),
+  ([#6233](https://github.com/matrix-org/matrix-rust-sdk/pull/6233))
 - Implement new method `CryptoStore::has_downloaded_all_room_keys`, and process
   `room_key_backups_fully_downloaded` field in `Changes`.
   ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
   ([#6044](https://github.com/matrix-org/matrix-rust-sdk/pull/6044))
-- [**breaking**] In `EventCacheStore::handle_linked_chunk_updates`, new chunks may no longer
-  reference chunk identifiers which do not yet exist in the store
+- [**breaking**] In `EventCacheStore::handle_linked_chunk_updates`, new chunks
+  may no longer reference chunk identifiers which do not yet exist in the store
   ([#6061](https://github.com/matrix-org/matrix-rust-sdk/pull/6061))
 
-### Bug Fixes
+### Bug fixes
 
 - Fix a panic when the SQLite connection is aborted.
   ([#6091](https://github.com/matrix-org/matrix-rust-sdk/pull/6091))
 
 ### Refactor
 
-- Add migration to `SqliteCryptoStore` that removes cross-process lock generation key from
-  `kv` table, as this is tracked in `lease_locks` table.
+- Add migration to `SqliteCryptoStore` that removes cross-process lock
+  generation key from `kv` table, as this is tracked in `lease_locks` table.
   ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
 
 ## [0.16.1] - 2026-05-08
@@ -41,15 +42,19 @@ No notable changes in this release.
 
 - Implement new method `CryptoStore::get_withheld_sessions_by_room_id`.
   ([#5819](https://github.com/matrix-org/matrix-rust-sdk/pull/5819))
-- [**breaking**] `SqliteCryptoStore::get_withheld_info` now returns `Result<Option<RoomKeyWithheldEntry>>`.
+- [**breaking**] `SqliteCryptoStore::get_withheld_info` now returns
+  `Result<Option<RoomKeyWithheldEntry>>`.
   ([#5737](https://github.com/matrix-org/matrix-rust-sdk/pull/5737))
-- Implement a new constructor that allows to open `SqliteCryptoStore` with a cryptographic key
+- Implement a new constructor that allows to open `SqliteCryptoStore` with a
+  cryptographic key
   ([#5472](https://github.com/matrix-org/matrix-rust-sdk/pull/5472))
 - Implement `StateStore::upsert_thread_subscriptions()` method for bulk upserts.
   ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
 
 ### Refactor
-- [breaking] Change the logic for opening a store so as to use a `Secret` enum in the function `open_with_pool` instead of a `passphrase`
+
+- [breaking] Change the logic for opening a store so as to use a `Secret` enum
+  in the function `open_with_pool` instead of a `passphrase`
   ([#5472](https://github.com/matrix-org/matrix-rust-sdk/pull/5472))
 
 ## [0.14.0] - 2025-09-04
@@ -58,14 +63,16 @@ No notable changes in this release.
 
 ## [0.13.0] - 2025-07-10
 
-### Security Fixes
+### Security fixes
 
 - Fix SQL injection vulnerability in `find_event_relations()`.
-  ([d0c0100](https://github.com/matrix-org/matrix-rust-sdk/commit/d0c01006e4808db5eb96ad5c496416f284d8bd3c), Moderate, [CVE-2025-53549](https://www.cve.org/CVERecord?id=CVE-2025-53549), [GHSA-275g-g844-73jh](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-275g-g844-73jh))
+  ([d0c0100](https://github.com/matrix-org/matrix-rust-sdk/commit/d0c01006e4808db5eb96ad5c496416f284d8bd3c),
+  Moderate, [CVE-2025-53549](https://www.cve.org/CVERecord?id=CVE-2025-53549),
+  [GHSA-275g-g844-73jh](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-275g-g844-73jh))
 
 ## [0.12.0] - 2025-06-10
 
-### Bug Fixes
+### Bug fixes
 
 - Fix a `UNIQUE` constraint violation in the event cache store
   ([#5001](https://github.com/matrix-org/matrix-rust-sdk/pull/5001))
@@ -74,7 +81,8 @@ No notable changes in this release.
 
 ### Features
 
-- Implement the new method of `EventCacheStoreMedia` for `SqliteEventCacheStore`.
+- Implement the new method of `EventCacheStoreMedia` for
+  `SqliteEventCacheStore`.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
 - Defragment an sqlite state store after removing a room.
   ([#4651](https://github.com/matrix-org/matrix-rust-sdk/pull/4651))
@@ -110,15 +118,14 @@ No notable changes in this release.
 
 - Add support for persisting LinkedChunks in the SQLite store. This is a step
   towards implementing event cache support, enabling a persisted cache of
-  events.
-  ([#4340](https://github.com/matrix-org/matrix-rust-sdk/pull/4340)) ([#4362](https://github.com/matrix-org/matrix-rust-sdk/pull/4362))
+  events. ([#4340](https://github.com/matrix-org/matrix-rust-sdk/pull/4340))
+  ([#4362](https://github.com/matrix-org/matrix-rust-sdk/pull/4362))
 
 ## [0.8.0] - 2024-11-19
 
-### Bug Fixes
+### Bug fixes
 
 - Use the `DisplayName` struct to protect against homoglyph attacks.
-
 
 ### Refactor
 

--- a/crates/matrix-sdk-store-encryption/CHANGELOG.md
+++ b/crates/matrix-sdk-store-encryption/CHANGELOG.md
@@ -38,7 +38,7 @@ No notable changes in this release.
 
 ## [0.10.0] - 2025-02-04
 
-### Bug Fixes
+### Bug fixes
 
 - Remove the usage of an unwrap in the `StoreCipher::import_with_key` method.
   This could have lead to panics if the second argument was an invalid

--- a/crates/matrix-sdk-store-encryption/README.md
+++ b/crates/matrix-sdk-store-encryption/README.md
@@ -36,7 +36,7 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
-## ⚠️ security warning: hazmat!
+## Security warning: hazmat! ⚠️
 
 This crate only implements the low-level block cipher function, to be used
 _only_ as a building block for higher-level constructions. It is NOT intended

--- a/crates/matrix-sdk-store-encryption/README.md
+++ b/crates/matrix-sdk-store-encryption/README.md
@@ -36,15 +36,15 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
-# ⚠️ Security Warning: Hazmat!
+## ⚠️ security warning: hazmat!
 
 This crate only implements the low-level block cipher function, to be used
-*only* as a building block for higher-level constructions. It is NOT intended
+_only_ as a building block for higher-level constructions. It is NOT intended
 for direct use in applications.
 
 USE AT YOUR OWN RISK!
 
-# Encryption scheme
+## Encryption scheme
 
 The central component of the encryption scheme is the `StoreCipher` type, used
 for both obfuscating keys and encrypting values of the key/value store.
@@ -65,19 +65,19 @@ we use blake3 as the keyed hash construction.
                 └───────────────────────────────────────┘
 ```
 
-The `StoreCipher` has some Matrix-specific assumptions built in, which ensure that
-the limits of the cryptographic primitives are not exceeded. If this crate is
-used for non-Matrix data, users need to ensure:
+The `StoreCipher` has some Matrix-specific assumptions built in, which ensure
+that the limits of the cryptographic primitives are not exceeded. If this crate
+is used for non-Matrix data, users need to ensure:
 
 1. That individual values are chunked, otherwise decryption might be susceptible
    to a DOS attack.
 2. The `StoreCipher` is periodically rotated/rekeyed.
 
-# WASM support
+## WASM support
 
 This crate relies on the `random` and `getrandom` crates which don't support
 WASM automatically.
 
 Either turn the `js` feature on directly on this crate or depend on `getrandom`
-with the `js` feature turned on. More info can be found in the [`getrandom`
-docs](https://docs.rs/getrandom/latest/getrandom/index.html#webassembly-support).
+with the `js` feature turned on. More info can be found in the
+[`getrandom` docs](https://docs.rs/getrandom/latest/getrandom/index.html#webassembly-support).

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.17.0] - 2026-05-08
 
-### Bug Fixes
+### Bug fixes
 
 - Fix a possible panic in `RoomList::entries_with_dynamic_adapters`.
   ([#6459](https://github.com/matrix-org/matrix-rust-sdk/pull/6459))
@@ -14,15 +14,16 @@ All notable changes to this project will be documented in this file.
   `Room::latest_event()`, so room summaries still show the last live location
   sharing session after it ends.
   ([#6437](https://github.com/matrix-org/matrix-rust-sdk/pull/6437))
-- Allow setting a custom Sliding Sync connection ID and timeline limit on `RoomListService`.
+- Allow setting a custom Sliding Sync connection ID and timeline limit on
+  `RoomListService`.
   ([#6289](https://github.com/matrix-org/matrix-rust-sdk/pull/6289))
 - Don't show a "sent in clear" shield on live location timeline items in
   encrypted rooms, since `beacon_info` is a state event that cannot be
   encrypted by design.
   ([#6308](https://github.com/matrix-org/matrix-rust-sdk/pull/6308))
-- Include secondary relations when re-initializing a threaded timeline after a lag.
-  ([#6209](https://github.com/matrix-org/matrix-rust-sdk/pull/6209))
-- Ensure that the display name of a `Room` in a `NotificationStatus` coming 
+- Include secondary relations when re-initializing a threaded timeline after a
+  lag. ([#6209](https://github.com/matrix-org/matrix-rust-sdk/pull/6209))
+- Ensure that the display name of a `Room` in a `NotificationStatus` coming
   from a `NotificationClient` excludes service members.
   ([#6136](https://github.com/matrix-org/matrix-rust-sdk/pull/6136))
 - Fix the `is_last_admin` check in `LeaveSpaceRoom` since it was not
@@ -38,14 +39,17 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- `SpaceRoom` and `NotificationItem` now have an `is_dm` field to indicate whether the room is a DM room. 
+- `SpaceRoom` and `NotificationItem` now have an `is_dm` field to indicate
+  whether the room is a DM room.
   ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
-- Add a list of `declined_by: Vec<OwnedUserId>` to the `TimelineItemContent::RtcNotification`, this will contain the list
-  of users that have declined the call.
+- Add a list of `declined_by: Vec<OwnedUserId>` to the
+  `TimelineItemContent::RtcNotification`, this will contain the list of users
+  that have declined the call.
   ([#6494](https://github.com/matrix-org/matrix-rust-sdk/pull/6494))
-- [**breaking**] Add the `suggested` field to the `SpaceRoom` struct,
-  which indicates whether a space's admins have marked that sub-space/room
-  as a "suggested" one to join. ([6417](https://github.com/matrix-org/matrix-rust-sdk/pull/6417))
+- [**breaking**] Add the `suggested` field to the `SpaceRoom` struct, which
+  indicates whether a space's admins have marked that sub-space/room as a
+  "suggested" one to join.
+  ([6417](https://github.com/matrix-org/matrix-rust-sdk/pull/6417))
 - Handle local echoes of redactions in the timeline.
   ([#6250](https://github.com/matrix-org/matrix-rust-sdk/pull/6250))
 - [**breaking**] Remove support for `native-tls` and remove all feature
@@ -57,15 +61,18 @@ All notable changes to this project will be documented in this file.
 - Introduce a `ThreadListService` which offers reactive interfaces for rendering
   and managing the list of threads from a particular room.
   ([#6311](https://github.com/matrix-org/matrix-rust-sdk/pull/6311))
-- [**breaking**] Remove the `Room::load_thread_list` in favor of the new `ThreadListService`
+- [**breaking**] Remove the `Room::load_thread_list` in favor of the new
+  `ThreadListService`
   ([#6311](https://github.com/matrix-org/matrix-rust-sdk/pull/6311))
-- Add support for [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489)
-  live location sharing through a new `TimelineItemContent::LiveLocation` variant.
-- The internal timeline unique ID may be recycled when an event is deduplicated from the timeline,
-  so that embedders can notice that it's the same item and avoid unnecessary re-rendering.
+- Add support for
+  [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) live
+  location sharing through a new `TimelineItemContent::LiveLocation` variant.
+- The internal timeline unique ID may be recycled when an event is deduplicated
+  from the timeline, so that embedders can notice that it's the same item and
+  avoid unnecessary re-rendering.
   ([#6228](https://github.com/matrix-org/matrix-rust-sdk/pull/6228))
-- [**breaking**] Add `NotificationState.EventRedacted` enum value, to handle the case
-  where a notification resolves to a redacted event.
+- [**breaking**] Add `NotificationState.EventRedacted` enum value, to handle the
+  case where a notification resolves to a redacted event.
   ([#6203](https://github.com/matrix-org/matrix-rust-sdk/pull/6203))
 - [**breaking**] Extend `TimelineFocus::Event` to allow marking the target
   event as the root of a thread.
@@ -78,9 +85,10 @@ All notable changes to this project will be documented in this file.
   are available as of now.
   ([#6048](https://github.com/matrix-org/matrix-rust-sdk/pull/6048/))
 - Introduce `SpaceFilter`s as a mechanism for narrowing down what's displayed in
-  the room list ([#6025](https://github.com/matrix-org/matrix-rust-sdk/pull/6025))
-- Utilize the cache and include common relations when focusing a timeline on an event without
-  requestion context.
+  the room list
+  ([#6025](https://github.com/matrix-org/matrix-rust-sdk/pull/6025))
+- Utilize the cache and include common relations when focusing a timeline on an
+  event without requestion context.
   ([#5858](https://github.com/matrix-org/matrix-rust-sdk/pull/5858))
 - [**breaking**] `EventTimelineItem::get_shield` now returns a new type,
   `TimelineEventShieldState`, which extends the old `ShieldState` with a code
@@ -94,42 +102,48 @@ All notable changes to this project will be documented in this file.
   `EventTimelineItem::from_latest_event`, and `Timeline::latest_event`. See the
   documentation of `matrix_sdk::latest_event` to learn about the new API.
   ([#5624](https://github.com/matrix-org/matrix-rust-sdk/pull/5624/))
-- `Room::load_event_with_relations` now also calls `/relations` to fetch related events when falling back
-  to network mode after a cache miss.
+- `Room::load_event_with_relations` now also calls `/relations` to fetch related
+  events when falling back to network mode after a cache miss.
   ([#5930](https://github.com/matrix-org/matrix-rust-sdk/pull/5930))
-- Expose `EventTimelineItem::forwarder` and `forwarder_profile`, which, if present, provide the ID and profile of
-  the user who forwarded the keys used to decrypt the event as part of an [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268)
-  key bundle.
-  ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
-  
+- Expose `EventTimelineItem::forwarder` and `forwarder_profile`, which, if
+  present, provide the ID and profile of the user who forwarded the keys used to
+  decrypt the event as part of an
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) key
+  bundle. ([#6000](https://github.com/matrix-org/matrix-rust-sdk/pull/6000))
+
 ### Refactor
 
-- Use `DmRoomDefinition` to check if a room should be considered part of the `RoomCategory::People` or 
-  `RoomCategory::Room` when using room list filters. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
-- [**breaking**] `AnyOtherStateEventContentChange::RoomAliases` was removed. This state event type
-  was removed from the Matrix specification a while ago, and support for it has been removed in Ruma.
+- Use `DmRoomDefinition` to check if a room should be considered part of the
+  `RoomCategory::People` or `RoomCategory::Room` when using room list filters.
+  ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
+- [**breaking**] `AnyOtherStateEventContentChange::RoomAliases` was removed.
+  This state event type was removed from the Matrix specification a while ago,
+  and support for it has been removed in Ruma.
   ([#6414](https://github.com/matrix-org/matrix-rust-sdk/pull/6414))
-- [**breaking**] Move `LiveLocation` out of `TimelineItemContent` and into `MsgLikeKind`
-  so it has access to `MsgLikeContent` `reactions`.
+- [**breaking**] Move `LiveLocation` out of `TimelineItemContent` and into
+  `MsgLikeKind` so it has access to `MsgLikeContent` `reactions`.
   ([#6286](https://github.com/matrix-org/matrix-rust-sdk/pull/6286))
-- [**breaking**] Rename `AnyOtherFullStateEventContent` to `AnyOtherStateEventContentChange`
-  to match the name change in the upstream types.
-  ([#6218](https://github.com/matrix-org/matrix-rust-sdk/pull/6218))
-- [**breaking**] Remove `WithLocking` from `EncryptionSyncService`, the locking mechanism will be taken from the parent 
-  `Client` with `Client::cross_process_store_config`. ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
-- [**breaking**] The [`Timeline::pin_event`] and [`Timeline::unpin_event`] methods have been
-  moved to the SDK crate, in the `Room` object. Users can replace previous uses with
-  `timeline.room().pin_event()` etc.
+- [**breaking**] Rename `AnyOtherFullStateEventContent` to
+  `AnyOtherStateEventContentChange` to match the name change in the upstream
+  types. ([#6218](https://github.com/matrix-org/matrix-rust-sdk/pull/6218))
+- [**breaking**] Remove `WithLocking` from `EncryptionSyncService`, the locking
+  mechanism will be taken from the parent `Client` with
+  `Client::cross_process_store_config`.
+  ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
+- [**breaking**] The [`Timeline::pin_event`] and [`Timeline::unpin_event`]
+  methods have been moved to the SDK crate, in the `Room` object. Users can
+  replace previous uses with `timeline.room().pin_event()` etc.
   ([#6106](https://github.com/matrix-org/matrix-rust-sdk/pull/6106))
-- [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will now
-  account also for v12 rooms, where creators and users with PL 150 matter.
+- [**breaking**] Refactored `is_last_admin` to `is_last_owner` the check will
+  now account also for v12 rooms, where creators and users with PL 150 matter.
   ([#6036](https://github.com/matrix-org/matrix-rust-sdk/pull/6036))
 - [**breaking**] The `SpaceService` will no longer auto-subscribe to required
   client events when invoking the `subscribe_to_joined_spaces` but instead do it
   through its, now async, constructor.
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 - [**breaking**] The `SpaceService`'s `joined_spaces` method has been renamed
-  `top_level_joined_spaces` and `subscribe_to_joined_spaces` to `space_service.subscribe_to_top_level_joined_spaces`
+  `top_level_joined_spaces` and `subscribe_to_joined_spaces` to
+  `space_service.subscribe_to_top_level_joined_spaces`
   ([#5972](https://github.com/matrix-org/matrix-rust-sdk/pull/5972))
 - `RoomListService::subscribe_to_rooms` now forgets previous subscriptions.
   ([#6012](https://github.com/matrix-org/matrix-rust-sdk/pull/6012))
@@ -142,37 +156,46 @@ No notable changes in this release.
 
 ### Features
 
-- [**breaking**] `TimelineBuilder::track_read_marker_and_receipts` now takes a parameter to allow tracking to be enabled
-  for all events (like before) or only for message-like events (which prevents read receipts from being placed on state
-  events).
+- [**breaking**] `TimelineBuilder::track_read_marker_and_receipts` now takes a
+  parameter to allow tracking to be enabled for all events (like before) or only
+  for message-like events (which prevents read receipts from being placed on
+  state events).
   ([#5900](https://github.com/matrix-org/matrix-rust-sdk/pull/5900))
 
 ## [0.15.0] - 2025-11-27
 
 ### Features
 
-- Expose `is_space` in `NotificationItem`, allowing clients to determine if the room that triggered the notification is a space.
+- Expose `is_space` in `NotificationItem`, allowing clients to determine if the
+  room that triggered the notification is a space.
 - [**breaking**] The `LatestEventValue::Local` type gains 2 new fields: `sender`
   and `profile`.
   ([#5885](https://github.com/matrix-org/matrix-rust-sdk/pull/5885))
 - Add push actions to `NotificationItem`.
   ([#5835](https://github.com/matrix-org/matrix-rust-sdk/pull/5835))
-- Add support for top level space ordering through [MSC3230](https://github.com/matrix-org/matrix-spec-proposals/pull/3230)
-  and `m.space_order` room account data fields ([#5799](https://github.com/matrix-org/matrix-rust-sdk/pull/5799))
+- Add support for top level space ordering through
+  [MSC3230](https://github.com/matrix-org/matrix-spec-proposals/pull/3230) and
+  `m.space_order` room account data fields
+  ([#5799](https://github.com/matrix-org/matrix-rust-sdk/pull/5799))
 
 ### Refactor
 
-- `Timeline::latest_event` will return the latest event in the timeline, not the latest item of the timeline if it's
-  an event.
-- `TimelineFocusKind::Event` can now handle both the existing event pagination and thread pagination if the focused 
-  event is part of a thread ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
+- `Timeline::latest_event` will return the latest event in the timeline, not the
+  latest item of the timeline if it's an event.
+- `TimelineFocusKind::Event` can now handle both the existing event pagination
+  and thread pagination if the focused event is part of a thread
+  ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678)).
 - [**breaking**] The `Room` type in `room_list_service` is renamed to
   `RoomListItem`.
   ([#5684](https://github.com/matrix-org/matrix-rust-sdk/pull/5684))
 
-### Bug Fixes
+### Bug fixes
 
-- `Timeline::latest_event_id` won't take threaded events into account on live/event focused timelines if `hide_threaded_events` is enabled. This fixes a bug in `Timeline::mark_as_read` that incorrectly tried to send a read receipt for threaded events that aren't really part of those timelines. ([#5864](https://github.com/matrix-org/matrix-rust-sdk/pull/5864/))
+- `Timeline::latest_event_id` won't take threaded events into account on
+  live/event focused timelines if `hide_threaded_events` is enabled. This fixes
+  a bug in `Timeline::mark_as_read` that incorrectly tried to send a read
+  receipt for threaded events that aren't really part of those timelines.
+  ([#5864](https://github.com/matrix-org/matrix-rust-sdk/pull/5864/))
 - Avoid replacing timeline items when the encryption info is unchanged.
   ([#5660](https://github.com/matrix-org/matrix-rust-sdk/pull/5660))
 - Improvement performance of `RoomList` by introducing a new `RoomListItem` type
@@ -182,48 +205,56 @@ No notable changes in this release.
 ## [0.14.0] - 2025-09-04
 
 ### Features
-- Add a new [`SpaceService`] that provides high level reactive interfaces for listing 
-  the user's joined top level spaces as long as their children.
+
+- Add a new [`SpaceService`] that provides high level reactive interfaces for
+  listing the user's joined top level spaces as long as their children.
   ([#5509](https://github.com/matrix-org/matrix-rust-sdk/pull/5509))
-- Add `new_filter_low_priority` and `new_filter_non_low_priority` filters to the room list filtering system,
-  allowing clients to filter rooms based on their low priority status. The filters use the `Room::is_low_priority()` 
-  method which checks for the `m.lowpriority` room tag.
+- Add `new_filter_low_priority` and `new_filter_non_low_priority` filters to the
+  room list filtering system, allowing clients to filter rooms based on their
+  low priority status. The filters use the `Room::is_low_priority()` method
+  which checks for the `m.lowpriority` room tag.
   ([#5508](https://github.com/matrix-org/matrix-rust-sdk/pull/5508))
-- [**breaking**] Refactor the `non_space` filter into a `space` filter, favouring its use in combination with the
-  `not` filter. ([#5508](https://github.com/matrix-org/matrix-rust-sdk/pull/5508))
-- [**breaking**] Space rooms are now being retrieved through sliding sync and the newly introduced 
-  [`room_list_service::filters::new_filter_non_space`] filter should be used to exclude them from any room list.
+- [**breaking**] Refactor the `non_space` filter into a `space` filter,
+  favouring its use in combination with the `not` filter.
+  ([#5508](https://github.com/matrix-org/matrix-rust-sdk/pull/5508))
+- [**breaking**] Space rooms are now being retrieved through sliding sync and
+  the newly introduced [`room_list_service::filters::new_filter_non_space`]
+  filter should be used to exclude them from any room list.
   ([5479](https://github.com/matrix-org/matrix-rust-sdk/pull/5479))
-- [**breaking**] [`Timeline::send_gallery()`] now automatically fills in the thread relationship,
-  based on the timeline focus. As a result, the `GalleryConfig::reply()` builder method has been
-  replaced with `GalleryConfig::in_reply_to`, and only takes an optional event id (the event that is
-  effectively replied to) instead of the `Reply` type. The proper way to start a thread with a
-  gallery event is now thus to create a threaded-focused timeline, and then use
-  `Timeline::send_gallery()`.
+- [**breaking**] [`Timeline::send_gallery()`] now automatically fills in the
+  thread relationship, based on the timeline focus. As a result, the
+  `GalleryConfig::reply()` builder method has been replaced with
+  `GalleryConfig::in_reply_to`, and only takes an optional event id (the event
+  that is effectively replied to) instead of the `Reply` type. The proper way to
+  start a thread with a gallery event is now thus to create a threaded-focused
+  timeline, and then use `Timeline::send_gallery()`.
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
-- [**breaking**] [`Timeline::send_attachment()`] now automatically fills in the thread
-  relationship, based on the timeline focus. As a result, there's a new
-  `matrix_sdk_ui::timeline::AttachmentConfig` type in town, that has a simplified optional parameter
-  `replied_to` of type `OwnedEventId` instead of the `Reply` type and that must be used in place of
-  `matrix_sdk::attachment::AttachmentConfig`. The proper way to start a thread with a media
-  attachment is now thus to create a threaded-focused timeline, and then use
-  `Timeline::send_attachment()`.
+- [**breaking**] [`Timeline::send_attachment()`] now automatically fills in the
+  thread relationship, based on the timeline focus. As a result, there's a new
+  `matrix_sdk_ui::timeline::AttachmentConfig` type in town, that has a
+  simplified optional parameter `replied_to` of type `OwnedEventId` instead of
+  the `Reply` type and that must be used in place of
+  `matrix_sdk::attachment::AttachmentConfig`. The proper way to start a thread
+  with a media attachment is now thus to create a threaded-focused timeline, and
+  then use `Timeline::send_attachment()`.
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
-- [**breaking**] [`Timeline::send_reply()`] now automatically fills in the thread relationship,
-  based on the timeline focus. As a result, it only takes an `OwnedEventId` parameter, instead of
-  the `Reply` type. The proper way to start a thread is now thus to create a threaded-focused
-  timeline, and then use `Timeline::send()`.
+- [**breaking**] [`Timeline::send_reply()`] now automatically fills in the
+  thread relationship, based on the timeline focus. As a result, it only takes
+  an `OwnedEventId` parameter, instead of the `Reply` type. The proper way to
+  start a thread is now thus to create a threaded-focused timeline, and then use
+  `Timeline::send()`.
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
-- `Timeline::send()` will now automatically fill the thread relationship, if the timeline has a
-  thread focus, and the sent event doesn't have a prefilled `relates_to` field (i.e. a relationship).
+- `Timeline::send()` will now automatically fill the thread relationship, if the
+  timeline has a thread focus, and the sent event doesn't have a prefilled
+  `relates_to` field (i.e. a relationship).
   ([5427](https://github.com/matrix-org/matrix-rust-sdk/pull/5427))
 
 ### Refactor
 
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
-  ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431)) 
+  ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
 
-### Bug Fixes
+### Bug fixes
 
 - Correctly remove unable-to-decrypt items that have been decrypted but contain
   unsupported event types.
@@ -240,8 +271,8 @@ No notable changes in this release.
   contains the topic of the room. This is useful for displaying the room topic
   in notifications.
   ([#5300](https://github.com/matrix-org/matrix-rust-sdk/pull/5300))
-- Add `EmbeddedEvent::timestamp` and `EmbeddedEvent::identifier` which are already
-  available in regular timeline items.
+- Add `EmbeddedEvent::timestamp` and `EmbeddedEvent::identifier` which are
+  already available in regular timeline items.
   ([#5331](https://github.com/matrix-org/matrix-rust-sdk/pull/5331))
 - `RoomListService::subscribe_to_rooms` becomes `async` and automatically calls
   `matrix_sdk::latest_events::LatestEvents::listen_to_room`
@@ -258,26 +289,29 @@ No notable changes in this release.
 
 ### Refactor
 
-- [**breaking**] [`TimelineItemContent::reactions()`] returns an `Option<&ReactionsByKeyBySender>`
-  instead of `ReactionsByKeyBySender`. This reflects the fact that some timeline items cannot hold
-  reactions at all.
-- `NotificationItem::room_join_rule` is now optional to reflect that the join rule
-  state event might be missing, in which case it will be set to `None`. The
-  `NotificationItem::is_public` field has been replaced with a method that returns an `Option<bool>`, based on the same logic.
+- [**breaking**] [`TimelineItemContent::reactions()`] returns an
+  `Option<&ReactionsByKeyBySender>` instead of `ReactionsByKeyBySender`. This
+  reflects the fact that some timeline items cannot hold reactions at all.
+- `NotificationItem::room_join_rule` is now optional to reflect that the join
+  rule state event might be missing, in which case it will be set to `None`. The
+  `NotificationItem::is_public` field has been replaced with a method that
+  returns an `Option<bool>`, based on the same logic.
   ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
-### Bug Fixes
+### Bug fixes
 
 - Introduce `Timeline` regions, which helps to remove a class of bugs in the
   `Timeline` where items could be inserted in the wrong _regions_, such as
   a remote timeline item before the `TimelineStart` virtual timeline item.
   ([#5000](https://github.com/matrix-org/matrix-rust-sdk/pull/5000))
-- `NotificationClient` will filter out events sent by ignored users on `get_notification` and `get_notifications`. ([#5081](https://github.com/matrix-org/matrix-rust-sdk/pull/5081))
+- `NotificationClient` will filter out events sent by ignored users on
+  `get_notification` and `get_notifications`.
+  ([#5081](https://github.com/matrix-org/matrix-rust-sdk/pull/5081))
 
 ### Features
 
-- `Timeline::send_single_receipt()` and `Timeline::send_multiple_receipts()` now also unset the
-  unread flag of the room if an unthreaded read receipt is sent.
+- `Timeline::send_single_receipt()` and `Timeline::send_multiple_receipts()` now
+  also unset the unread flag of the room if an unthreaded read receipt is sent.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
 - `Timeline::mark_as_read()` unsets the unread flag of the room if it was set.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
@@ -287,7 +321,7 @@ No notable changes in this release.
 
 ## [0.11.0] - 2025-04-11
 
-### Bug Fixes
+### Bug fixes
 
 ### Features
 
@@ -295,8 +329,9 @@ No notable changes in this release.
   ([#4819](https://github.com/matrix-org/matrix-rust-sdk/pull/4819))
 - [**breaking**] Push `RepliedToInfo`, `ReplyContent`, `EnforceThread` and
   `UnsupportedReplyItem` (becoming `ReplyError`) down into matrix_sdk.
-  [`Timeline::send_reply()`] now takes an event ID rather than a `RepliedToInfo`.
-  `Timeline::replied_to_info_from_event_id` has been made private in `matrix_sdk`.
+  [`Timeline::send_reply()`] now takes an event ID rather than a
+  `RepliedToInfo`. `Timeline::replied_to_info_from_event_id` has been made
+  private in `matrix_sdk`.
   ([#4842](https://github.com/matrix-org/matrix-rust-sdk/pull/4842))
 - Allow sending media as (thread) replies. The reply behaviour can be configured
   through new fields on [`AttachmentConfig`].
@@ -305,17 +340,18 @@ No notable changes in this release.
 ### Refactor
 
 - [**breaking**] Reactions on a given timeline item have been moved from
-  [`EventTimelineItem::reactions()`] to [`TimelineItemContent::reactions()`]; they're thus available
-  from an [`EventTimelineItem`] by calling `.content().reactions()`. They're also returned by
-  ownership (cloned) instead of by reference.
+  [`EventTimelineItem::reactions()`] to [`TimelineItemContent::reactions()`];
+  they're thus available from an [`EventTimelineItem`] by calling
+  `.content().reactions()`. They're also returned by ownership (cloned) instead
+  of by reference.
   ([#4576](https://github.com/matrix-org/matrix-rust-sdk/pull/4576))
-- [**breaking**] The parameters `event_id` and `enforce_thread` on [`Timeline::send_reply()`]
-  have been wrapped in a `reply` struct parameter.
+- [**breaking**] The parameters `event_id` and `enforce_thread` on
+  [`Timeline::send_reply()`] have been wrapped in a `reply` struct parameter.
   ([#4880](https://github.com/matrix-org/matrix-rust-sdk/pull/4880/))
 
 ## [0.10.0] - 2025-02-04
 
-### Bug Fixes
+### Bug fixes
 
 - Don't consider rooms in the banned state to be non-left rooms. This bug was
   introduced due to the introduction of the banned state for rooms, and the
@@ -352,10 +388,11 @@ No notable changes in this release.
   [#4608](https://github.com/matrix-org/matrix-rust-sdk/pull/4608),
   [#4612](https://github.com/matrix-org/matrix-rust-sdk/pull/4612))
 
-- [**breaking**] `Timeline::paginate_forwards` and `Timeline::paginate_backwards`
-  are unified to work on a live or focused timeline.
-  `Timeline::live_paginate_*` and `Timeline::focused_paginate_*` have been
-  removed ([#4584](https://github.com/matrix-org/matrix-rust-sdk/pull/4584)).
+- [**breaking**] `Timeline::paginate_forwards` and
+  `Timeline::paginate_backwards` are unified to work on a live or focused
+  timeline. `Timeline::live_paginate_*` and `Timeline::focused_paginate_*` have
+  been removed
+  ([#4584](https://github.com/matrix-org/matrix-rust-sdk/pull/4584)).
 
 - [**breaking**] `Timeline::subscribe_batched` replaces
   `Timeline::subscribe`. `subscribe` has been removed in
@@ -365,7 +402,7 @@ No notable changes in this release.
 
 ## [0.9.0] - 2024-12-18
 
-### Bug Fixes
+### Bug fixes
 
 - Add the `m.room.create` and the `m.room.history_visibility` state events to
   the required state for the sync. These two state events are required to
@@ -381,10 +418,9 @@ No notable changes in this release.
 
 ## [0.8.0] - 2024-11-19
 
-### Bug Fixes
+### Bug fixes
 
 - Disable `share_pos()` inside `RoomListService`.
-
 - `UtdHookManager` no longer re-reports UTD events as late decryptions.
   ([#3480](https://github.com/matrix-org/matrix-rust-sdk/pull/3480))
 
@@ -398,13 +434,13 @@ No notable changes in this release.
 ### Features
 
 - Add `m.room.join_rules` to the required state.
-
 - `EncryptionSyncService` and `Notification` are using
   `Client::cross_process_store_locks_holder_name`.
 
 ### Refactor
 
-- [**breaking**] `Timeline::edit` now takes a `RoomMessageEventContentWithoutRelation`.
+- [**breaking**] `Timeline::edit` now takes a
+  `RoomMessageEventContentWithoutRelation`.
 
 - [**breaking**] `Timeline::send_attachment` now takes an `impl Into<PathBuf>`
   for the path of the file to send.
@@ -412,7 +448,6 @@ No notable changes in this release.
 - [**breaking**] `Timeline::item_by_transaction_id` has been renamed to
   `Timeline::local_item_by_transaction_id` (always returns local echoes).
 
-
-# 0.7.0
+## 0.7.0
 
 Initial release

--- a/crates/matrix-sdk-ui/changelog.d/6561.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6561.changed.md
@@ -1,3 +1,4 @@
-[**breaking**] `SpaceRoom::new_from_known`  and `SpaceRoom::new_from_summary` are now asynchronous so we can
-properly check if they are DMs on demand instead of trusting the pre-computed value. Some other related functions
-are now `async` too.
+[**breaking**] `SpaceRoom::new_from_known` and `SpaceRoom::new_from_summary` are
+now asynchronous so we can properly check if they are DMs on demand instead of
+trusting the pre-computed value. Some other related functions are now `async`
+too.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -8,34 +8,39 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- [**breaking**] `Room::is_dm` was renamed to `Room::compute_is_dm` to match its behavior, since it'll now compute 
-  and cache the result. A new *synchronous* `Room::is_dm` function was added which centralizes the logic of 
-  checking if something is a DM based on that cached value and the provided `DmRoomDefinition`. `Room::sync_members` 
-  will also now compute active service members. ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
-- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires 
-  `StateStore::save_changes` to acquire state store lock and replaces `Room::set_room_info` 
-  with an atomic version, `Room::update_room_info`, which is also synchronized by
-  the state store lock.
+- [**breaking**] `Room::is_dm` was renamed to `Room::compute_is_dm` to match its
+  behavior, since it'll now compute and cache the result. A new _synchronous_
+  `Room::is_dm` function was added which centralizes the logic of checking if
+  something is a DM based on that cached value and the provided
+  `DmRoomDefinition`. `Room::sync_members` will also now compute active service
+  members. ([#6537](https://github.com/matrix-org/matrix-rust-sdk/pull/6537))
+- [**breaking**] Enforce atomic and synchronized updates to `RoomInfo`. Requires
+  `StateStore::save_changes` to acquire state store lock and replaces
+  `Room::set_room_info` with an atomic version, `Room::update_room_info`, which
+  is also synchronized by the state store lock.
   ([#6478](https://github.com/matrix-org/matrix-rust-sdk/pull/6478))
-- Added `beacon` and `beacon_info` fields to `RoomPowerLevelChanges`, allowing callers to read
-  and update the power levels required to send beacon (live location) message events and beacon
-  info state events respectively.
+- Added `beacon` and `beacon_info` fields to `RoomPowerLevelChanges`, allowing
+  callers to read and update the power levels required to send beacon (live
+  location) message events and beacon info state events respectively.
   ([#6540](https://github.com/matrix-org/matrix-rust-sdk/pull/6540))
-- Added `DmRoomDefinition` as a parameter of `ClientBuilder` so we can specify it when creating a Client. 
-  Also added a `Room::is_dm` method and added some logic to use the new DM definitions in `Client::get_dm_rooms` 
-  and when using message search. ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
+- Added `DmRoomDefinition` as a parameter of `ClientBuilder` so we can specify
+  it when creating a Client. Also added a `Room::is_dm` method and added some
+  logic to use the new DM definitions in `Client::get_dm_rooms` and when using
+  message search.
+  ([#6490](https://github.com/matrix-org/matrix-rust-sdk/pull/6490))
 - Sharing encrypted history on room invite, per
   [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) is
   now enabled by default (though can still be disabled via
   `ClientBuilder::with_enable_share_history_on_invite`).
   ([#6497](https://github.com/matrix-org/matrix-rust-sdk/pull/6497))
-- Add `Client::get_dm_rooms` function to get an iterator with the DMs for the provided user id.
+- Add `Client::get_dm_rooms` function to get an iterator with the DMs for the
+  provided user id.
   ([#6487](https://github.com/matrix-org/matrix-rust-sdk/pull/6487))
 - Support the stable `m.key_backup` prefix for MSC4287: Sharing key backup
   preference between clients.
   ([#6410](https://github.com/matrix-org/matrix-rust-sdk/pull/6410))
-- Add new high-level search helpers in `matrix_sdk_ui::search` to perform searches for messages in
-  a room or across all rooms.
+- Add new high-level search helpers in `matrix_sdk_ui::search` to perform
+  searches for messages in a room or across all rooms.
   ([#6394](https://github.com/matrix-org/matrix-rust-sdk/pull/6394))
 - Latest Event does not emit an update when it computes the same value as the
   previous Latest Event.
@@ -47,38 +52,43 @@ All notable changes to this project will be documented in this file.
   ([#6432](https://github.com/matrix-org/matrix-rust-sdk/pull/6432))
 - Add `room_versions()` & `account_moderation()` to `HomeserverCapabilities`.
   ([#6413](https://github.com/matrix-org/matrix-rust-sdk/pull/6413))
-- Enable sending redaction events through the send queue via `RoomSendQueue::redact`.
-  This includes local echoes for redaction events through the new `LocalEchoContent::Redaction`
-  variant.
+- Enable sending redaction events through the send queue via
+  `RoomSendQueue::redact`. This includes local echoes for redaction events
+  through the new `LocalEchoContent::Redaction` variant.
   ([#6250](https://github.com/matrix-org/matrix-rust-sdk/pull/6250))
 - [**breaking**] Remove support for `native-tls` and remove all feature
   flags for selecting TLS backend, as `rustls` is the now the only supported
   TLS backend.
   ([#6409](https://github.com/matrix-org/matrix-rust-sdk/pull/6409))
-- [**breaking**] Added `HomeserverCapabilities` and `Client::homeserver_capabilities()` to get the capabilities
-  of the homeserver. This replaces `Client::get_capabilities()`.
+- [**breaking**] Added `HomeserverCapabilities` and
+  `Client::homeserver_capabilities()` to get the capabilities of the homeserver.
+  This replaces `Client::get_capabilities()`.
   ([#6371](https://github.com/matrix-org/matrix-rust-sdk/pull/6371))
-- [**breaking**] `matrix_sdk::error::Error` has a new variant `Timeout` which occurs when
-  a cross-signing reset does not succeed after some period of time.
+- [**breaking**] `matrix_sdk::error::Error` has a new variant `Timeout` which
+  occurs when a cross-signing reset does not succeed after some period of time.
   ([#6325](https://github.com/matrix-org/matrix-rust-sdk/pull/6325))
-- The `beacon_info` start event ([MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672))
-  is now included when computing the latest event for a room, so live location sharing
-  sessions can be surfaced as a room's most recent activity.
+- The `beacon_info` start event
+  ([MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672)) is
+  now included when computing the latest event for a room, so live location
+  sharing sessions can be surfaced as a room's most recent activity.
   ([#6295](https://github.com/matrix-org/matrix-rust-sdk/pull/6295))
-- [**breaking**] The `EventCacheError` is now `Clone`able, which implied marking a few other error
-  types as `Clone`able, and wrapping a few other error variants with `Arc`.
+- [**breaking**] The `EventCacheError` is now `Clone`able, which implied marking
+  a few other error types as `Clone`able, and wrapping a few other error
+  variants with `Arc`.
   ([#6305](https://github.com/matrix-org/matrix-rust-sdk/pull/6305))
-- [**breaking**]: The unread count computation has now moved from the sliding sync processing, to
-  the event cache. As a result, it is necessary to enable the event cache if you want to keep a
-  precise unread counts, using `Client::event_cache().subscribe()`. The unread counts will now also
-  be available even if you used a previous version of sync (v2), as long as you've enabled the
-  event cache beforehand.
+- [**breaking**]: The unread count computation has now moved from the sliding
+  sync processing, to the event cache. As a result, it is necessary to enable
+  the event cache if you want to keep a precise unread counts, using
+  `Client::event_cache().subscribe()`. The unread counts will now also be
+  available even if you used a previous version of sync (v2), as long as you've
+  enabled the event cache beforehand.
   ([#6253](https://github.com/matrix-org/matrix-rust-sdk/pull/6253))
-- [**breaking**] `room::reply::Event` has a new field `add_mentions` which is passed forward in
-  `room::reply::make_reply_event`.
+- [**breaking**] `room::reply::Event` has a new field `add_mentions` which is
+  passed forward in `room::reply::make_reply_event`.
   ([#6270](https://github.com/matrix-org/matrix-rust-sdk/pull/6270))
-- Add `Recovery::recover_and_fix_backup` to automatically fix key storage backup if the
-  private backup decryption key is missing, invalid or inconsistent with the public key.
+- Add `Recovery::recover_and_fix_backup` to automatically fix key storage backup
+  if the private backup decryption key is missing, invalid or inconsistent with
+  the public key.
   ([#6252](https://github.com/matrix-org/matrix-rust-sdk/pull/6252))
 - Attempt to import stored room key bundles for rooms awaiting bundles at
   client startup.
@@ -90,18 +100,21 @@ All notable changes to this project will be documented in this file.
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
 - Add `QRCodeGrantLoginError::UnexpectedMessage` for protocol message errors
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `QRCodeGrantLoginError::LoginFailure` for login failure errors received from the other device
+- Add `QRCodeGrantLoginError::LoginFailure` for login failure errors received
+  from the other device
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `QRCodeGrantLoginError::DeviceNotFound` for when the requested device was not returned by the homeserver
+- Add `QRCodeGrantLoginError::DeviceNotFound` for when the requested device was
+  not returned by the homeserver
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Add `Client::subscribe_to_duplicate_key_upload_errors` for listening to duplicate key
-  upload errors from `/keys/upload`.
+- Add `Client::subscribe_to_duplicate_key_upload_errors` for listening to
+  duplicate key upload errors from `/keys/upload`.
   ([#6135](https://github.com/matrix-org/matrix-rust-sdk/pull/6135/))
-- Add `Room::pin_event` and `Room::unpin_event`, which allow pinning and unpinning events from a
-  room. These were extracted from the `matrix_sdk_ui` crate, with no changes in functionality.
+- Add `Room::pin_event` and `Room::unpin_event`, which allow pinning and
+  unpinning events from a room. These were extracted from the `matrix_sdk_ui`
+  crate, with no changes in functionality.
   ([#6106](https://github.com/matrix-org/matrix-rust-sdk/pull/6106))
-- `LatestEventValue::RemoteInvite` is added to handle a Latest Event for invite room.
-  ([#6056](https://github.com/matrix-org/matrix-rust-sdk/pull/6056))
+- `LatestEventValue::RemoteInvite` is added to handle a Latest Event for invite
+  room. ([#6056](https://github.com/matrix-org/matrix-rust-sdk/pull/6056))
 - Add `Room::set_own_member_display_name` to set the current user's display name
   within only the one single room (can be used for /myroomnick functionality).
   [#5981](https://github.com/matrix-org/matrix-rust-sdk/pull/5981)
@@ -123,8 +136,8 @@ All notable changes to this project will be documented in this file.
 - Replace in-memory stores with IndexedDB implementations when initializing
   `Client` with `BuilderStoreConfig::IndexedDb`.
   ([#5946](https://github.com/matrix-org/matrix-rust-sdk/pull/5946))
-- Call: Add support for the new Intents for voice only calls `Intent.StartCallDmVoice`
-  and `Intent.JoinExistingDmVoice`.
+- Call: Add support for the new Intents for voice only calls
+  `Intent.StartCallDmVoice` and `Intent.JoinExistingDmVoice`.
   ([#6003](https://github.com/matrix-org/matrix-rust-sdk/pull/6003))
 - Add `SlidingSync::unsubscribe_to_rooms` and
   `SlidingSync::clear_and_subscribe_to_rooms`.
@@ -136,110 +149,135 @@ All notable changes to this project will be documented in this file.
   to true will now trigger a download of all historical keys for the room in
   question from the client's key backup.
   ([#6017](https://github.com/matrix-org/matrix-rust-sdk/pull/6017))
-- Add widget partial support for MSC4039. Allows widgets to download non-encrypted files from the
-  content repository (like avatars).
+- Add widget partial support for MSC4039. Allows widgets to download
+  non-encrypted files from the content repository (like avatars).
   ([#6354](https://github.com/matrix-org/matrix-rust-sdk/pull/6354))
 
-### Breaking Changes
+### Breaking changes
 
-- [**breaking**] `LiveLocationShares` has been renamed to `LiveLocationsObserver` and
-  `Room::live_location_shares` to `Room::live_locations_observer`.
+- [**breaking**] `LiveLocationShares` has been renamed to
+  `LiveLocationsObserver` and `Room::live_location_shares` to
+  `Room::live_locations_observer`.
   ([#6446](https://github.com/matrix-org/matrix-rust-sdk/pull/6446))
 
-- `Room::observe_live_location_shares` has been replaced by `Room::live_locations_observer`.
-  The new API returns a `LiveLocationsObserver` struct with a `subscribe()` method that provides an initial
-  snapshot (`Vector<LiveLocationShare>`) and a batched stream of `VectorDiff` updates, instead of
-  emitting individual `LiveLocationShare` items as beacon events arrive. The initial snapshot is loaded
-  from the event cache on creation, includes the own user's shares (previously excluded), and properly
-  handles share start/stop by listening to beacon_info state events.
+- `Room::observe_live_location_shares` has been replaced by
+  `Room::live_locations_observer`. The new API returns a `LiveLocationsObserver`
+  struct with a `subscribe()` method that provides an initial snapshot
+  (`Vector<LiveLocationShare>`) and a batched stream of `VectorDiff` updates,
+  instead of emitting individual `LiveLocationShare` items as beacon events
+  arrive. The initial snapshot is loaded from the event cache on creation,
+  includes the own user's shares (previously excluded), and properly handles
+  share start/stop by listening to beacon_info state events.
   ([#6385](https://github.com/matrix-org/matrix-rust-sdk/pull/6385))
 
 ### Bugfix
 
-- Add the `session` key in `OAuthCrossSigningResetInfo`, allowing to provide `AuthData::OAuth` in
-  `CrossSigningResetHandle::auth()`, to match the behavior described in the Matrix spec.
+- Add the `session` key in `OAuthCrossSigningResetInfo`, allowing to provide
+  `AuthData::OAuth` in `CrossSigningResetHandle::auth()`, to match the behavior
+  described in the Matrix spec.
   ([#6525](https://github.com/matrix-org/matrix-rust-sdk/pull/6525))
-- When threads are enabled, a focused event timeline is used and the focused event is not part of a thread, 
-  hide other threaded events by default like it happens on the live focus timeline. 
+- When threads are enabled, a focused event timeline is used and the focused
+  event is not part of a thread, hide other threaded events by default like it
+  happens on the live focus timeline.
   ([#6519](https://github.com/matrix-org/matrix-rust-sdk/pull/6519))
-- Add a recursion limit attribute that raises it from the default value of 128 to 256.
-  ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
+- Add a recursion limit attribute that raises it from the default value of 128
+  to 256. ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
 - Reject invalid edits as candidates for the latest event.
   ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 - Fix an infinite loop when loading pinned events from the storage.
   ([#6453](https://github.com/matrix-org/matrix-rust-sdk/pull/6453))
-- `beacon_info` stop events (`live: false`, [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672))
-  are now also eligible as the latest event for a room, preventing the live location sharing item
-  from disappearing from the room list summary once the session ends.
-  ([#6373](https://github.com/matrix-org/matrix-rust-sdk/pull/6373))
-- Android: add back custom certificates and disabling SSL verification options in `ClientBuilder` using
-  the previous `webkpi` verifier instead of platform verifier, otherwise these features will fail.
+- `beacon_info` stop events (`live: false`,
+  [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672)) are
+  now also eligible as the latest event for a room, preventing the live location
+  sharing item from disappearing from the room list summary once the session
+  ends. ([#6373](https://github.com/matrix-org/matrix-rust-sdk/pull/6373))
+- Android: add back custom certificates and disabling SSL verification options
+  in `ClientBuilder` using the previous `webkpi` verifier instead of platform
+  verifier, otherwise these features will fail.
   ([#6328](https://github.com/matrix-org/matrix-rust-sdk/pull/6328))
-- Room keys are now rotated whenever the client receives an `m.room.member` event not belonging
-  to the current user with non-`join` membership in order to prevent
-  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) from leaking room keys
-  in an unintuitive manner.
+- Room keys are now rotated whenever the client receives an `m.room.member`
+  event not belonging to the current user with non-`join` membership in order to
+  prevent
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268) from
+  leaking room keys in an unintuitive manner.
   ([#6292](https://github.com/matrix-org/matrix-rust-sdk/pull/6292))
   ([#6457](https://github.com/matrix-org/matrix-rust-sdk/pull/6457))
 - Only share historic room keys on invite if the current room history is shared.
   ([#6275](https://github.com/matrix-org/matrix-rust-sdk/pull/6275))
-- The event cache's thread subscriptions background task won't enable if the server doesn't
-  advertise support for the experimental thread subscription feature. In the past, this would result
-  in sending spurious requests that aren't supported by the user's homeserver.
+- The event cache's thread subscriptions background task won't enable if the
+  server doesn't advertise support for the experimental thread subscription
+  feature. In the past, this would result in sending spurious requests that
+  aren't supported by the user's homeserver.
   ([#6245](https://github.com/matrix-org/matrix-rust-sdk/pull/6245))
-- Handle race between send queue update and remote echo in latest event computation.
+- Handle race between send queue update and remote echo in latest event
+  computation.
   ([#6220](https://github.com/matrix-org/matrix-rust-sdk/pull/6220))
-- Return `QRCodeGrantLoginError::DeviceNotFound` instead of `QRCodeGrantLoginError::DeviceIDAlreadyInUse` for when
-  the new device is not returned by the homeserver.
+- Return `QRCodeGrantLoginError::DeviceNotFound` instead of
+  `QRCodeGrantLoginError::DeviceIDAlreadyInUse` for when the new device is not
+  returned by the homeserver.
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- Latest Event is correctly computed when multiple edits exist for the same event candidate.
+- Latest Event is correctly computed when multiple edits exist for the same
+  event candidate.
   ([#6096](https://github.com/matrix-org/matrix-rust-sdk/pull/6096))
-- Restrict which `m.room.member` can be a `LatestEventValue` candidate by relying on `MembershipChange` for more control.
+- Restrict which `m.room.member` can be a `LatestEventValue` candidate by
+  relying on `MembershipChange` for more control.
   ([#6143](https://github.com/matrix-org/matrix-rust-sdk/pull/6143))
-- Add manual WAL checkpoints when opening Sqlite DBs and when vacuuming them, since the WAL files aren't automatically shrinking. ([#6004](https://github.com/matrix-org/matrix-rust-sdk/pull/6004))
-- Use the server name extracted from the user id in `Client::fetch_client_well_known` as a fallback value. Otherwise, sometimes the server name is not available and we can't reload the well-known contents. ([#5996](https://github.com/matrix-org/matrix-rust-sdk/pull/5996))
+- Add manual WAL checkpoints when opening Sqlite DBs and when vacuuming them,
+  since the WAL files aren't automatically shrinking.
+  ([#6004](https://github.com/matrix-org/matrix-rust-sdk/pull/6004))
+- Use the server name extracted from the user id in
+  `Client::fetch_client_well_known` as a fallback value. Otherwise, sometimes
+  the server name is not available and we can't reload the well-known contents.
+  ([#5996](https://github.com/matrix-org/matrix-rust-sdk/pull/5996))
 - Latest Event is lazier: a `RoomLatestEvents` can be registered even if its
   associated `RoomEventCache` isn't created yet.
   ([#5947](https://github.com/matrix-org/matrix-rust-sdk/pull/5947))
 - Allow granting of QR login to a new client whose device ID is not a base64
   encoded Curve25519 public key.
   ([#5940](https://github.com/matrix-org/matrix-rust-sdk/pull/5940))
-- Remove an unwrap in `SlidingSync::send_sync_request` when an asynchronous task panics or is cancelled.
+- Remove an unwrap in `SlidingSync::send_sync_request` when an asynchronous task
+  panics or is cancelled.
   ([#6316](https://github.com/matrix-org/matrix-rust-sdk/pull/6316))
 
 ### Refactor
 
 - [**breaking**] Upgrade Ruma to 0.15.1.
   ([#6503](https://github.com/matrix-org/matrix-rust-sdk/pull/6503))
-- Revert back to to determining lock dirtiness in `Encryption::{spin_lock_store, try_lock_once_store}`
-  through logic defined in `OlmMachine`, rather than `CrossProcessLock`.
+- Revert back to to determining lock dirtiness in
+  `Encryption::{spin_lock_store, try_lock_once_store}` through logic defined in
+  `OlmMachine`, rather than `CrossProcessLock`.
   ([#6496](https://github.com/matrix-org/matrix-rust-sdk/pull/6496))
-- [**breaking**] Update `Encryption::{spin_lock_store, try_lock_once_store}` so that lock dirtiness
-  is determined entirely by `CrossProcessLock`, rather than logic defined by `OlmMachine`. Also enforce
-  that lock generation is opaque by removing `CrossProcessLockStoreGuardWithGeneration`.
+- [**breaking**] Update `Encryption::{spin_lock_store, try_lock_once_store}` so
+  that lock dirtiness is determined entirely by `CrossProcessLock`, rather than
+  logic defined by `OlmMachine`. Also enforce that lock generation is opaque by
+  removing `CrossProcessLockStoreGuardWithGeneration`.
   ([#6326](https://github.com/matrix-org/matrix-rust-sdk/pull/6326))
-- [**breaking**] The `EventCache` now owns pagination tasks, and will run them to completion, even
-  if a manual caller stopped polling the called future.
+- [**breaking**] The `EventCache` now owns pagination tasks, and will run them
+  to completion, even if a manual caller stopped polling the called future.
   ([#6304](https://github.com/matrix-org/matrix-rust-sdk/pull/6304))
 - [**breaking**] `RoomEventCache::thread_pagination` is now async and fallible.
   ([#6280](https://github.com/matrix-org/matrix-rust-sdk/pull/6280))
-- [**breaking**] The `UrlOrQuery` enum was moved from the `authentication::oauth`
-  module to the `utils` module. It can also be converted from a `QueryString`.
+- [**breaking**] The `UrlOrQuery` enum was moved from the
+  `authentication::oauth` module to the `utils` module. It can also be converted
+  from a `QueryString`.
   ([#6224](https://github.com/matrix-org/matrix-rust-sdk/pull/6224))
 - [**breaking**] `MatrixAuth::login_with_sso_callback()` takes a `UrlOrQuery`
   instead of a `Url`, to make it more convenient to use with
   `LocalServerBuilder` / `LocalServerRedirectHandle`.
   ([#6224](https://github.com/matrix-org/matrix-rust-sdk/pull/6224))
-- [**breaking**] `Room::report_content()` no longer takes a `score` argument, because it was
-  removed from the Matrix specification. The `ReportedContentScore` type was removed too.
+- [**breaking**] `Room::report_content()` no longer takes a `score` argument,
+  because it was removed from the Matrix specification. The
+  `ReportedContentScore` type was removed too.
   ([#6256](https://github.com/matrix-org/matrix-rust-sdk/pull/6256))
-- [**breaking**] `Client::enabled_thread_subscriptions()` is now async and fallible, as it will
-  check for both static enablement of the thread subscription feature as well as dynamically
-  checking that the user's homeserver supports it.
+- [**breaking**] `Client::enabled_thread_subscriptions()` is now async and
+  fallible, as it will check for both static enablement of the thread
+  subscription feature as well as dynamically checking that the user's
+  homeserver supports it.
 - [**breaking**] `SessionChange::UnknownToken` is now a tuple variant containing
   an `UnknownTokenErrorData`.
   ([#6241](https://github.com/matrix-org/matrix-rust-sdk/pull/6241))
-- [**breaking**] `EventCacheError::BackPaginationError` has been renamed `PaginationError`.
+- [**breaking**] `EventCacheError::BackPaginationError` has been renamed
+  `PaginationError`.
   ([#6239](https://github.com/matrix-org/matrix-rust-sdk/pull/6239))
 - [**breaking**] The functions on the `OAuth` API to access the account
   management URL and its actions were removed. The methods available on the
@@ -247,7 +285,9 @@ All notable changes to this project will be documented in this file.
   ([#6217](https://github.com/matrix-org/matrix-rust-sdk/pull/6217))
 - [**breaking**] `QRCodeGrantLoginError::UnableToCreateDevice` has been removed
   ([#6141](https://github.com/matrix-org/matrix-rust-sdk/pull/6141)
-- The `RoomEventCache::paginate_thread_backwards` method is replaced by `RoomEventCache::thread_pagination` which returns a new `ThreadPagination` type, similar to `RoomPagination`.
+- The `RoomEventCache::paginate_thread_backwards` method is replaced by
+  `RoomEventCache::thread_pagination` which returns a new `ThreadPagination`
+  type, similar to `RoomPagination`.
   ([#6174](https://github.com/matrix-org/matrix-rust-sdk/pull/6174))
 
   Before:
@@ -261,17 +301,20 @@ All notable changes to this project will be documented in this file.
   ```rust
   room_event_cache.thread_pagination(thread_id).run_backwards_once(42).await
   ```
+
 - `RoomPaginationStatus` is renamed to `PaginationStatus`.
   ([#6174](https://github.com/matrix-org/matrix-rust-sdk/pull/6174/))
-- [**breaking**] Replaced `ClientBuilder::cross_process_store_locks_holder_name` with
-  `ClientBuilder::cross_process_store_config` to allow specifying the configuration for the cross-process lock and
-  whether it should act as a no-op (client used in a single process) or we should keep the previous behavior (client
-  used in multiple processes). ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
+- [**breaking**] Replaced `ClientBuilder::cross_process_store_locks_holder_name`
+  with `ClientBuilder::cross_process_store_config` to allow specifying the
+  configuration for the cross-process lock and whether it should act as a no-op
+  (client used in a single process) or we should keep the previous behavior
+  (client used in multiple processes).
+  ([#6160](https://github.com/matrix-org/matrix-rust-sdk/pull/6160))
 
 ## [0.16.1] - 2026-05-08
 
-- Add a recursion limit attribute that raises it from the default value of 128 to 256.
-  ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
+- Add a recursion limit attribute that raises it from the default value of 128
+  to 256. ([#6489](https://github.com/matrix-org/matrix-rust-sdk/pull/6489))
 - Reject invalid edits as candidates for the latest event.
   ([#6454](https://github.com/matrix-org/matrix-rust-sdk/pull/6454))
 
@@ -279,11 +322,13 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add `Client::get_store_sizes()` so to query the size of the existing stores, if available. ([#5911](https://github.com/matrix-org/matrix-rust-sdk/pull/5911))
-- Add `QRCodeLoginError::NotFound` for non-existing / expired rendezvous sessions
-  ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
-- Add `QRCodeGrantLoginError::NotFound` for non-existing / expired rendezvous sessions
-  ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
+- Add `Client::get_store_sizes()` so to query the size of the existing stores,
+  if available.
+  ([#5911](https://github.com/matrix-org/matrix-rust-sdk/pull/5911))
+- Add `QRCodeLoginError::NotFound` for non-existing / expired rendezvous
+  sessions ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
+- Add `QRCodeGrantLoginError::NotFound` for non-existing / expired rendezvous
+  sessions ([#5898](https://github.com/matrix-org/matrix-rust-sdk/pull/5898))
 - Improve logging around key history bundles when joining a room.
   ([#5866](https://github.com/matrix-org/matrix-rust-sdk/pull/5866))
 - Expose the power level required to modify `m.space.child` on
@@ -291,41 +336,50 @@ All notable changes to this project will be documented in this file.
   ([#5857](https://github.com/matrix-org/matrix-rust-sdk/pull/5857))
 - Add the `Client::server_versions_cached()` method.
   ([#5853](https://github.com/matrix-org/matrix-rust-sdk/pull/5853))
-- Extend `authentication::oauth::OAuth::grant_login_with_qr_code` to support granting
-  login by scanning a QR code on the existing device.
+- Extend `authentication::oauth::OAuth::grant_login_with_qr_code` to support
+  granting login by scanning a QR code on the existing device.
   ([#5818](https://github.com/matrix-org/matrix-rust-sdk/pull/5818))
 - Add a new `RequestConfig::skip_auth()` option. This is useful to ensure that
   certain request won't ever include an authorization header.
   ([#5822](https://github.com/matrix-org/matrix-rust-sdk/pull/5822))
-- Add support for extended profile fields with `Account::fetch_profile_field_of()`,
+- Add support for extended profile fields with
+  `Account::fetch_profile_field_of()`,
   `Account::fetch_profile_field_of_static()`, `Account::set_profile_field()` and
   `Account::delete_profile_field()`.
   ([#5771](https://github.com/matrix-org/matrix-rust-sdk/pull/5771))
 - [**breaking**] Remove the `matrix-sdk-crypto` re-export.
   ([#5769](https://github.com/matrix-org/matrix-rust-sdk/pull/5769))
-- Allow `Client::get_dm_room()` to be called without the `e2e-encryption` crate feature.
-  ([#5787](https://github.com/matrix-org/matrix-rust-sdk/pull/5787))
-- [**breaking**] Add `encryption::secret_storage::SecretStorageError::ImportError` to indicate
-  an error that occurred when importing a secret from secret storage.
+- Allow `Client::get_dm_room()` to be called without the `e2e-encryption` crate
+  feature. ([#5787](https://github.com/matrix-org/matrix-rust-sdk/pull/5787))
+- [**breaking**] Add
+  `encryption::secret_storage::SecretStorageError::ImportError` to indicate an
+  error that occurred when importing a secret from secret storage.
   ([#5647](https://github.com/matrix-org/matrix-rust-sdk/pull/5647))
-- [**breaking**] Add `authentication::oauth::qrcode::login::LoginProgress::SyncingSecrets` to
+- [**breaking**] Add
+  `authentication::oauth::qrcode::login::LoginProgress::SyncingSecrets` to
   indicate that secrets are being synced between the two devices.
   ([#5760](https://github.com/matrix-org/matrix-rust-sdk/pull/5760))
-- Add `authentication::oauth::OAuth::grant_login_with_qr_code` to reciprocate a login by
-  generating a QR code on the existing device.
+- Add `authentication::oauth::OAuth::grant_login_with_qr_code` to reciprocate a
+  login by generating a QR code on the existing device.
   ([#5801](https://github.com/matrix-org/matrix-rust-sdk/pull/5801))
-- [**breaking**] `OAuth::login_with_qr_code` now returns a builder that allows performing the flow with either the
-  current device scanning or generating the QR code. Additionally, new errors `SecureChannelError::CannotReceiveCheckCode`
+- [**breaking**] `OAuth::login_with_qr_code` now returns a builder that allows
+  performing the flow with either the current device scanning or generating the
+  QR code. Additionally, new errors `SecureChannelError::CannotReceiveCheckCode`
   and `QRCodeLoginError::ServerReset` were added.
   ([#5711](https://github.com/matrix-org/matrix-rust-sdk/pull/5711))
-- [**breaking**] `ThreadedEventsLoader::new` now takes optional `tokens` parameter to customise where the pagination
-  begins ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678).
-- Make `PaginationTokens` `pub`, as well as its `previous` and `next` tokens so they can be assigned from other files
+- [**breaking**] `ThreadedEventsLoader::new` now takes optional `tokens`
+  parameter to customise where the pagination begins
   ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678).
-- Add new API to decline calls ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)): `Room::make_decline_call_event` and `Room::subscribe_to_call_decline_events`
+- Make `PaginationTokens` `pub`, as well as its `previous` and `next` tokens so
+  they can be assigned from other files
+  ([#5678](https://github.com/matrix-org/matrix-rust-sdk/pull/5678).
+- Add new API to decline calls
+  ([MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)):
+  `Room::make_decline_call_event` and `Room::subscribe_to_call_decline_events`
   ([#5614](https://github.com/matrix-org/matrix-rust-sdk/pull/5614))
-- Use `StateStore::upsert_thread_subscriptions()` to bulk process thread subscription updates received
-  via the sync response or from the MSC4308 companion endpoint.
+- Use `StateStore::upsert_thread_subscriptions()` to bulk process thread
+  subscription updates received via the sync response or from the MSC4308
+  companion endpoint.
   ([#5848](https://github.com/matrix-org/matrix-rust-sdk/pull/5848))
 
 ### Refactor
@@ -338,30 +392,32 @@ All notable changes to this project will be documented in this file.
   ([#5910](https://github.com/matrix-org/matrix-rust-sdk/pull/5910))
 - [**breaking**]: `Client::send()` has extra bounds where
   `Request::Authentication: AuthScheme<Input<'a> = SendAccessToken<'a>>` and
-  `Request::PathBuilder: SupportedPathBuilder`. This method should still work for any request to the
-  Client-Server API. This allows to drop the `HttpError::NotClientRequest` error in favor of a
-  compile-time error.
+  `Request::PathBuilder: SupportedPathBuilder`. This method should still work
+  for any request to the Client-Server API. This allows to drop the
+  `HttpError::NotClientRequest` error in favor of a compile-time error.
   ([#5781](https://github.com/matrix-org/matrix-rust-sdk/pull/5781),
-   [#5789](https://github.com/matrix-org/matrix-rust-sdk/pull/5789),
-   [#5815](https://github.com/matrix-org/matrix-rust-sdk/pull/5815))
-- [**breaking**]: The `waveform` field was moved from `AttachmentInfo::Voice` to `BaseAudioInfo`,
-  allowing to set it for any audio message. Its format also changed, and it is now a list of `f32`
-  between 0 and 1.
+  [#5789](https://github.com/matrix-org/matrix-rust-sdk/pull/5789),
+  [#5815](https://github.com/matrix-org/matrix-rust-sdk/pull/5815))
+- [**breaking**]: The `waveform` field was moved from `AttachmentInfo::Voice` to
+  `BaseAudioInfo`, allowing to set it for any audio message. Its format also
+  changed, and it is now a list of `f32` between 0 and 1.
   ([#5732](https://github.com/matrix-org/matrix-rust-sdk/pull/5732))
-- [**breaking**] The `caption` and `formatted_caption` fields and methods of `AttachmentConfig`,
-  `GalleryConfig` and `GalleryItemInfo` have been merged into a single field that uses
-  `TextMessageEventContent`.
+- [**breaking**] The `caption` and `formatted_caption` fields and methods of
+  `AttachmentConfig`, `GalleryConfig` and `GalleryItemInfo` have been merged
+  into a single field that uses `TextMessageEventContent`.
   ([#5733](https://github.com/matrix-org/matrix-rust-sdk/pull/5733))
 - The Matrix SDK crate now uses the 2024 edition of Rust.
   ([#5677](https://github.com/matrix-org/matrix-rust-sdk/pull/5677))
-- [**breaking**] Make `LoginProgress::EstablishingSecureChannel` generic in order to reuse it
-  for the currently missing QR login flow.
+- [**breaking**] Make `LoginProgress::EstablishingSecureChannel` generic in
+  order to reuse it for the currently missing QR login flow.
   ([#5750](https://github.com/matrix-org/matrix-rust-sdk/pull/5750))
-- [**breaking**] The `new_virtual_element_call_widget` now uses a `props` and a `config` parameter instead of only `props`.
-  This splits the configuration of the widget into required properties ("widget_id", "parent_url"...) so the widget can work
-  and optional config parameters ("skip_lobby", "header", "...").
-  The config option should in most cases only provide the `"intent"` property.
-  All other config options will then be chosen by EC based on platform + `intent`.
+- [**breaking**] The `new_virtual_element_call_widget` now uses a `props` and a
+  `config` parameter instead of only `props`. This splits the configuration of
+  the widget into required properties ("widget_id", "parent_url"...) so the
+  widget can work and optional config parameters ("skip_lobby", "header",
+  "..."). The config option should in most cases only provide the `"intent"`
+  property. All other config options will then be chosen by EC based on platform
+  - `intent`.
 
   Before:
 
@@ -391,6 +447,7 @@ All notable changes to this project will be documented in this file.
     }
   )
   ```
+
   ([#5560](https://github.com/matrix-org/matrix-rust-sdk/pull/5560))
 
 ### Bugfix
@@ -399,39 +456,42 @@ All notable changes to this project will be documented in this file.
   must be created as `LocalCannotBeSent` if a previous local `LatestEventValue`
   exists and is `LocalCannotBeSent`.
   ([#5908](https://github.com/matrix-org/matrix-rust-sdk/pull/5908))
-- Switch QR login implementation from `std::time::Instant` to `ruma::time::Instant` which
-  is compatible with Wasm.
+- Switch QR login implementation from `std::time::Instant` to
+  `ruma::time::Instant` which is compatible with Wasm.
   ([#5889](https://github.com/matrix-org/matrix-rust-sdk/pull/5889))
 
 ## [0.14.0] - 2025-09-04
 
 ### Features
 
-- `Client::fetch_thread_subscriptions` implements support for the companion endpoint of the
-  experimental MSC4308, allowing to fetch thread subscriptions for a given range, as specified by
-  the MSC.
+- `Client::fetch_thread_subscriptions` implements support for the companion
+  endpoint of the experimental MSC4308, allowing to fetch thread subscriptions
+  for a given range, as specified by the MSC.
   ([#5590](https://github.com/matrix-org/matrix-rust-sdk/pull/5590))
-- Add a `Client::joined_space_rooms` method that allows retrieving the list of joined spaces.
+- Add a `Client::joined_space_rooms` method that allows retrieving the list of
+  joined spaces.
   ([#5592](https://github.com/matrix-org/matrix-rust-sdk/pull/5592))
-- `Room::enable_encryption` and `Room::enable_encryption_with_state_event_encryption` will poll
-  the encryption state for up to 3 seconds, rather than checking once after a single sync has
-  completed.
-  ([#5559](https://github.com/matrix-org/matrix-rust-sdk/pull/5559))
-- Add `Room::enable_encryption_with_state` to enable E2E encryption with encrypted state event
-  support, gated behind the `experimental-encrypted-state-events` feature.
+- `Room::enable_encryption` and
+  `Room::enable_encryption_with_state_event_encryption` will poll the encryption
+  state for up to 3 seconds, rather than checking once after a single sync has
+  completed. ([#5559](https://github.com/matrix-org/matrix-rust-sdk/pull/5559))
+- Add `Room::enable_encryption_with_state` to enable E2E encryption with
+  encrypted state event support, gated behind the
+  `experimental-encrypted-state-events` feature.
   ([#5557](https://github.com/matrix-org/matrix-rust-sdk/pull/5557))
-- Add `ignore_timeout_on_first_sync` to the `SyncSettings`, which should allow to have a quicker
-  first response when using one of the `sync`, `sync_with_callback`, `sync_with_result_callback`
-  or `sync_stream` methods on `Client`, if the response is empty.
+- Add `ignore_timeout_on_first_sync` to the `SyncSettings`, which should allow
+  to have a quicker first response when using one of the `sync`,
+  `sync_with_callback`, `sync_with_result_callback` or `sync_stream` methods on
+  `Client`, if the response is empty.
   ([#5481](https://github.com/matrix-org/matrix-rust-sdk/pull/5481))
 - The methods to use the `/v3/sync` endpoint set the `use_state_after` field,
   which means that, if the server supports it, the response will contain the
   state changes between the last sync and the end of the timeline.
   ([#5488](https://github.com/matrix-org/matrix-rust-sdk/pull/5488))
 - Add experimental support for
-  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with the
-  `Room::fetch_thread_subscription()`, `Room::subscribe_thread()` and `Room::unsubscribe_thread()`
-  methods.
+  [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306), with
+  the `Room::fetch_thread_subscription()`, `Room::subscribe_thread()` and
+  `Room::unsubscribe_thread()` methods.
   ([#5439](https://github.com/matrix-org/matrix-rust-sdk/pull/5439))
 - [**breaking**] `RoomMemberRole` has a new `Creator` variant, that
   differentiates room creators with infinite power levels, as introduced in room
@@ -444,17 +504,23 @@ All notable changes to this project will be documented in this file.
 - Add support to accept historic room key bundles that arrive out of order, i.e.
   the bundle arrives after the invite has already been accepted.
   ([#5322](https://github.com/matrix-org/matrix-rust-sdk/pull/5322))
-- [**breaking**] `OAuth::login` now allows requesting additional scopes for the authorization code grant.
+- [**breaking**] `OAuth::login` now allows requesting additional scopes for the
+  authorization code grant.
   ([#5395](https://github.com/matrix-org/matrix-rust-sdk/pull/5395))
 
 ### Refactor
 
 - [**breaking**] Upgrade ruma to 0.13.0
   ([#5623](https://github.com/matrix-org/matrix-rust-sdk/pull/5623))
-- [**breaking**] `SyncSettings` token is now `SyncToken` enum type which has default behaviour of `SyncToken::ReusePrevious` token. This breaks `Client::sync_once`.
-  For old behaviour, set the token to `SyncToken::NoToken` with the usual `SyncSettings::token` setter.
+- [**breaking**] `SyncSettings` token is now `SyncToken` enum type which has
+  default behaviour of `SyncToken::ReusePrevious` token. This breaks
+  `Client::sync_once`. For old behaviour, set the token to `SyncToken::NoToken`
+  with the usual `SyncSettings::token` setter.
   ([#5522](https://github.com/matrix-org/matrix-rust-sdk/pull/5522))
-- [**breaking**] Change the upload_encrypted_file and make it clone the client instead of owning it. The lifetime of the `UploadEncryptedFile` request returned by `Client::upload_encrypted_file()` only depends on the request lifetime now.
+- [**breaking**] Change the upload_encrypted_file and make it clone the client
+  instead of owning it. The lifetime of the `UploadEncryptedFile` request
+  returned by `Client::upload_encrypted_file()` only depends on the request
+  lifetime now.
   ([#5470](https://github.com/matrix-org/matrix-rust-sdk/pull/5470))
 - [**breaking**] Add an `IsPrefix = False` bound to the `account_data()` and
   `fetch_account_data_static()` methods of `Account`. These methods only worked
@@ -463,9 +529,9 @@ All notable changes to this project will be documented in this file.
   respectively can be used instead for event types with a variable suffix.
   ([#5444](https://github.com/matrix-org/matrix-rust-sdk/pull/5444))
 - [**breaking**] `RoomMemberRole::suggested_role_for_power_level()` and
-  `RoomMemberRole::suggested_power_level()` now use `UserPowerLevel` to represent
-  power levels instead of `i64` to differentiate the infinite power level of
-  creators, as introduced in room version 12.
+  `RoomMemberRole::suggested_power_level()` now use `UserPowerLevel` to
+  represent power levels instead of `i64` to differentiate the infinite power
+  level of creators, as introduced in room version 12.
   ([#5436](https://github.com/matrix-org/matrix-rust-sdk/pull/5436))
 - [**breaking**] The `reason` argument of `Room::report_room()` is now required,
   due to a clarification in the spec.
@@ -476,7 +542,12 @@ All notable changes to this project will be documented in this file.
   ([#5337](https://github.com/matrix-org/matrix-rust-sdk/pull/5337))
 - [**breaking**] The MSRV has been bumped to Rust 1.88.
   ([#5431](https://github.com/matrix-org/matrix-rust-sdk/pull/5431))
-- [**breaking**] `Room::send_call_notification` and `Room::send_call_notification_if_needed` have been removed, since the event type they send is outdated, and `Client` is not actually supposed to be able to join MatrixRTC sessions (yet). In practice, users of these methods probably already rely on another MatrixRTC implementation to participate in sessions, and such an implementation should be capable of sending notifications itself.
+- [**breaking**] `Room::send_call_notification` and
+  `Room::send_call_notification_if_needed` have been removed, since the event
+  type they send is outdated, and `Client` is not actually supposed to be able
+  to join MatrixRTC sessions (yet). In practice, users of these methods probably
+  already rely on another MatrixRTC implementation to participate in sessions,
+  and such an implementation should be capable of sending notifications itself.
   ([#5452](https://github.com/matrix-org/matrix-rust-sdk/pull/5452))
 
 ### Bugfix
@@ -484,47 +555,55 @@ All notable changes to this project will be documented in this file.
 - The event handlers APIs now properly support events whose type is not fully
   statically-known. Before, those events would never trigger an event handler.
   ([#5444](https://github.com/matrix-org/matrix-rust-sdk/pull/5444))
-- All HTTP requests now have a default `read_timeout` of 60s, which means they'll disconnect if the connection stalls.
- `RequestConfig::timeout` is now optional and can be disabled on a per-request basis. This will be done for
- the requests used to download media, so they don't get cancelled after the default 30s timeout for no good reason.
- ([#5437](https://github.com/matrix-org/matrix-rust-sdk/pull/5437))
+- All HTTP requests now have a default `read_timeout` of 60s, which means
+  they'll disconnect if the connection stalls.
+`RequestConfig::timeout` is now optional and can be disabled on a per-request
+basis. This will be done for the requests used to download media, so they don't
+get cancelled after the default 30s timeout for no good reason.
+([#5437](https://github.com/matrix-org/matrix-rust-sdk/pull/5437))
 
 ## [0.13.0] - 2025-07-10
 
-### Security Fixes
+### Security fixes
 
 - Fix SQL injection vulnerability in `EventCache`
-  ([d0c0100](https://github.com/matrix-org/matrix-rust-sdk/commit/d0c01006e4808db5eb96ad5c496416f284d8bd3c), Moderate, [CVE-2025-53549](https://www.cve.org/CVERecord?id=CVE-2025-53549), [GHSA-275g-g844-73jh](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-275g-g844-73jh))
+  ([d0c0100](https://github.com/matrix-org/matrix-rust-sdk/commit/d0c01006e4808db5eb96ad5c496416f284d8bd3c),
+  Moderate, [CVE-2025-53549](https://www.cve.org/CVERecord?id=CVE-2025-53549),
+  [GHSA-275g-g844-73jh](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-275g-g844-73jh))
 
 ### Bug fixes
 
 - `Room.leave()` will now attempt to leave all reachable predecessors too.
   ([#5381](https://github.com/matrix-org/matrix-rust-sdk/pull/5381))
-- When joining a room via `Client::join_room_by_id()`, if the client has `enable_share_history_on_invite` enabled,
-  we will correctly check for received room key bundles. Previously this was only done when calling `Room::join`.
+- When joining a room via `Client::join_room_by_id()`, if the client has
+  `enable_share_history_on_invite` enabled, we will correctly check for received
+  room key bundles. Previously this was only done when calling `Room::join`.
   ([#5043](https://github.com/matrix-org/matrix-rust-sdk/pull/5043))
 
 ### Features
 
-- Add `Client::supported_versions()`, which returns the results of both `Client::server_versions()` and
-  `Client::unstable_features()` with a single call.
-  ([#5357](https://github.com/matrix-org/matrix-rust-sdk/pull/5357))
-- `WidgetDriver::send_to_device` Now supports sending encrypted to-device messages.
-  ([#5252](https://github.com/matrix-org/matrix-rust-sdk/pull/5252))
-- `Client::add_event_handler`: Set `Option<EncryptionInfo>` in `EventHandlerData` for to-device messages.
-  If the to-device message was encrypted, the `EncryptionInfo` will be set. If it is `None` the message was sent in clear.
+- Add `Client::supported_versions()`, which returns the results of both
+  `Client::server_versions()` and `Client::unstable_features()` with a single
+  call. ([#5357](https://github.com/matrix-org/matrix-rust-sdk/pull/5357))
+- `WidgetDriver::send_to_device` Now supports sending encrypted to-device
+  messages. ([#5252](https://github.com/matrix-org/matrix-rust-sdk/pull/5252))
+- `Client::add_event_handler`: Set `Option<EncryptionInfo>` in
+  `EventHandlerData` for to-device messages. If the to-device message was
+  encrypted, the `EncryptionInfo` will be set. If it is `None` the message was
+  sent in clear.
   ([#5099](https://github.com/matrix-org/matrix-rust-sdk/pull/5099))
 - `EventCache::subscribe_to_room_generic_updates` is added to subscribe to _all_
   room updates without having to subscribe to all rooms individually
   ([#5247](https://github.com/matrix-org/matrix-rust-sdk/pull/5247))
-- [**breaking**] The element call widget URL configuration struct uses the new `header` url parameter
-  instead of the now deprecated `hideHeader` parameter. This is only compatible with EC v0.13.0 or newer.
-- [**breaking**] `RoomEventCacheGenericUpdate` gains a new `Clear` variant, and sees
-  its `TimelineUpdated` variant being renamed to `UpdateTimeline`.
+- [**breaking**] The element call widget URL configuration struct uses the new
+  `header` url parameter instead of the now deprecated `hideHeader` parameter.
+  This is only compatible with EC v0.13.0 or newer.
+- [**breaking**] `RoomEventCacheGenericUpdate` gains a new `Clear` variant, and
+  sees its `TimelineUpdated` variant being renamed to `UpdateTimeline`.
   ([#5363](https://github.com/matrix-org/matrix-rust-sdk/pull/5363/))
-- [**breaking**]: The element call widget URL configuration struct uses the new `header` url parameter
-  instead of the now deprecated `hideHeader` parameter. This is only compatible
-  with EC v0.13.0 or newer.
+- [**breaking**]: The element call widget URL configuration struct uses the new
+  `header` url parameter instead of the now deprecated `hideHeader` parameter.
+  This is only compatible with EC v0.13.0 or newer.
 - [**breaking**]: The experimental `Encryption::encrypt_and_send_raw_to_device`
   function now takes a `share_strategy` parameter, and will not send to devices
   that do not satisfy the given share strategy.
@@ -532,113 +611,130 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- [**breaking**]: `Client::unstable_features()` returns a `BTreeSet<FeatureFlag>`, containing only
-  the features whose value was set to true in the response to the `/versions` endpoint.
+- [**breaking**]: `Client::unstable_features()` returns a
+  `BTreeSet<FeatureFlag>`, containing only the features whose value was set to
+  true in the response to the `/versions` endpoint.
   ([#5357](https://github.com/matrix-org/matrix-rust-sdk/pull/5357))
 - [**breaking**]: The family of `Room::can_user_*` methods has been removed. The
   same functionality can be accessed using the `RoomPowerLevels::user_can_*`
   family of methods. The `RoomPowerLevels` object can be accessed using the
   `Room::power_levels()` method.
   ([#5250](https://github.com/matrix-org/matrix-rust-sdk/pull/5250/))
-- `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside this,
-  `Client::reset_server_info` is now `Client::reset_server_info` and `Client::fetch_server_capabilities`
-  is now `Client::fetch_server_versions`, returning the server versions response directly.
+- `ClientServerCapabilities` has been renamed to `ClientServerInfo`. Alongside
+  this, `Client::reset_server_info` is now `Client::reset_server_info` and
+  `Client::fetch_server_capabilities` is now `Client::fetch_server_versions`,
+  returning the server versions response directly.
   ([#5167](https://github.com/matrix-org/matrix-rust-sdk/pull/5167))
 - `RoomEventCacheListener` is renamed `RoomEventCacheSubscriber`
   ([#5269](https://github.com/matrix-org/matrix-rust-sdk/pull/5269))
-- `RoomPreview::join_rule` is now optional, and will be set to `None` if the join rule state event
-  is missing for a given room.
+- `RoomPreview::join_rule` is now optional, and will be set to `None` if the
+  join rule state event is missing for a given room.
   ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
 
 ### Bug fixes
 
-- `m.room.avatar` has been added as required state for sliding sync until [the existing backend issue](https://github.com/element-hq/synapse/issues/18598)
-causing deleted room avatars to not be flagged is fixed. ([#5293](https://github.com/matrix-org/matrix-rust-sdk/pull/5293))
+- `m.room.avatar` has been added as required state for sliding sync until
+  [the existing backend issue](https://github.com/element-hq/synapse/issues/18598)
+causing deleted room avatars to not be flagged is fixed.
+([#5293](https://github.com/matrix-org/matrix-rust-sdk/pull/5293))
 
 ## [0.12.0] - 2025-06-10
 
 ### Features
 
-- `Client::send_call_notification_if_needed` now returns `Result<bool>` instead of `Result<()>` so we can check if
-  the event was sent.
+- `Client::send_call_notification_if_needed` now returns `Result<bool>` instead
+  of `Result<()>` so we can check if the event was sent.
   ([#5171](https://github.com/matrix-org/matrix-rust-sdk/pull/5171))
-- Added `SendMediaUploadRequest` wrapper for `SendRequest`, which checks the size of the request to
-  upload making sure it doesn't exceed the `m.upload.size` value that can be fetched through
+- Added `SendMediaUploadRequest` wrapper for `SendRequest`, which checks the
+  size of the request to upload making sure it doesn't exceed the
+  `m.upload.size` value that can be fetched through
   `Client::load_or_fetch_max_upload_size`.
   ([#5119](https://github.com/matrix-org/matrix-rust-sdk/pull/5119))
-- Add `ClientBuilder::with_enable_share_history_on_invite` to enable experimental support for sharing encrypted room history on invite, per [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
+- Add `ClientBuilder::with_enable_share_history_on_invite` to enable
+  experimental support for sharing encrypted room history on invite, per
+  [MSC4268](https://github.com/matrix-org/matrix-spec-proposals/pull/4268).
   ([#5141](https://github.com/matrix-org/matrix-rust-sdk/pull/5141))
 - `Room::list_threads()` is a new method to list all the threads in a room.
   ([#4973](https://github.com/matrix-org/matrix-rust-sdk/pull/4973))
-- `Room::relations()` is a new method to list all the events related to another event
-  ("relations"), with additional filters for relation type or relation type + event type.
+- `Room::relations()` is a new method to list all the events related to another
+  event ("relations"), with additional filters for relation type or relation
+  type + event type.
   ([#4973](https://github.com/matrix-org/matrix-rust-sdk/pull/4973))
-- The `EventCache`'s persistent storage has been enabled by default. This means that all the events
-  received by sync or back-paginations will be stored, in memory or on disk, by default, as soon as
-  `EventCache::subscribe()` has been called (which happens automatically if you're using the
-  `matrix_sdk_ui::Timeline`). This offers offline access and super quick back-paginations (when the
-  cache has been filled) whenever the event cache is enabled. It's also not possible to disable the
-  persistent storage anymore. Note that by default, the event cache store uses an in-memory store,
-  so the events will be lost when the process exits. To store the events on disk, you need to use
-  the sqlite event cache store.
+- The `EventCache`'s persistent storage has been enabled by default. This means
+  that all the events received by sync or back-paginations will be stored, in
+  memory or on disk, by default, as soon as `EventCache::subscribe()` has been
+  called (which happens automatically if you're using the
+  `matrix_sdk_ui::Timeline`). This offers offline access and super quick
+  back-paginations (when the cache has been filled) whenever the event cache is
+  enabled. It's also not possible to disable the persistent storage anymore.
+  Note that by default, the event cache store uses an in-memory store, so the
+  events will be lost when the process exits. To store the events on disk, you
+  need to use the sqlite event cache store.
   ([#4308](https://github.com/matrix-org/matrix-rust-sdk/pull/4308))
-- `Room::set_unread_flag()` now sets the stable `m.marked_unread` room account data, which was
-  stabilized in Matrix 1.12. `Room::is_marked_unread()` also ignores the unstable
-  `com.famedly.marked_unread` room account data if the stable variant is present.
+- `Room::set_unread_flag()` now sets the stable `m.marked_unread` room account
+  data, which was stabilized in Matrix 1.12. `Room::is_marked_unread()` also
+  ignores the unstable `com.famedly.marked_unread` room account data if the
+  stable variant is present.
   ([#5034](https://github.com/matrix-org/matrix-rust-sdk/pull/5034))
-- `Encryption::encrypt_and_send_raw_to_device`: Introduced as an experimental method for
-  sending custom encrypted to-device events. This feature is gated behind the
-  `experimental-send-custom-to-device` flag, as it remains under active development and may undergo changes.
+- `Encryption::encrypt_and_send_raw_to_device`: Introduced as an experimental
+  method for sending custom encrypted to-device events. This feature is gated
+  behind the `experimental-send-custom-to-device` flag, as it remains under
+  active development and may undergo changes.
   ([4998](https://github.com/matrix-org/matrix-rust-sdk/pull/4998))
-- `Room::send_single_receipt()` and `Room::send_multiple_receipts()` now also unset the unread
-  flag of the room if an unthreaded read receipt is sent.
+- `Room::send_single_receipt()` and `Room::send_multiple_receipts()` now also
+  unset the unread flag of the room if an unthreaded read receipt is sent.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
-- `Client::is_user_ignored(&UserId)` can be used to check if a user is currently ignored.
-  ([#5081](https://github.com/matrix-org/matrix-rust-sdk/pull/5081))
-- `RoomSendQueue::send_gallery` has been added to allow sending MSC4274-style media galleries
-  via the send queue under the `unstable-msc4274` feature.
+- `Client::is_user_ignored(&UserId)` can be used to check if a user is currently
+  ignored. ([#5081](https://github.com/matrix-org/matrix-rust-sdk/pull/5081))
+- `RoomSendQueue::send_gallery` has been added to allow sending MSC4274-style
+  media galleries via the send queue under the `unstable-msc4274` feature.
   ([#4977](https://github.com/matrix-org/matrix-rust-sdk/pull/4977))
 
 ### Bug fixes
 
-- A invited DM room joined with `Client::join_room_by_id()` or `Client::join_room_by_id_or_alias()`
-  will now be correctly marked as a DM.
+- A invited DM room joined with `Client::join_room_by_id()` or
+  `Client::join_room_by_id_or_alias()` will now be correctly marked as a DM.
   ([#5043](https://github.com/matrix-org/matrix-rust-sdk/pull/5043))
-- API responses with an HTTP status code `520` won't be retried anymore, as this is used by some proxies
-  (including Cloudflare) to warn that an unknown error has happened in the actual server.
+- API responses with an HTTP status code `520` won't be retried anymore, as this
+  is used by some proxies (including Cloudflare) to warn that an unknown error
+  has happened in the actual server.
   ([#5105](https://github.com/matrix-org/matrix-rust-sdk/pull/5105))
 
 ### Refactor
 
-- Support for the deprecated `GET /auth_issuer` endpoint was removed in the `OAuth` API. Only the
-  `GET /auth_metadata` endpoint is used now.
+- Support for the deprecated `GET /auth_issuer` endpoint was removed in the
+  `OAuth` API. Only the `GET /auth_metadata` endpoint is used now.
   ([#5302](https://github.com/matrix-org/matrix-rust-sdk/pull/5302))
-- `Room::push_context()` has been renamed into `Room::push_condition_room_ctx()`. The newer
-  `Room::push_context` now returns a `matrix_sdk::Room::PushContext`, which can be used to compute
-  the push actions for any event.
+- `Room::push_context()` has been renamed into
+  `Room::push_condition_room_ctx()`. The newer `Room::push_context` now returns
+  a `matrix_sdk::Room::PushContext`, which can be used to compute the push
+  actions for any event.
   ([#4962](https://github.com/matrix-org/matrix-rust-sdk/pull/4962))
-- `Room::decrypt_event()` now requires an extra `matrix_sdk::Room::PushContext` parameter to
-  compute the push notifications for the decrypted event.
+- `Room::decrypt_event()` now requires an extra `matrix_sdk::Room::PushContext`
+  parameter to compute the push notifications for the decrypted event.
   ([#4962](https://github.com/matrix-org/matrix-rust-sdk/pull/4962))
 - `SlidingSyncRoom` has been removed. With it, the `SlidingSync::get_room`,
   `get_all_rooms`, `get_rooms`, `get_number_of_rooms`, and
   `FrozenSlidingSync` methods and type have been removed.
   ([#5047](https://github.com/matrix-org/matrix-rust-sdk/pull/5047))
-- `Room::set_unread_flag()` is now a no-op if the unread flag already has the wanted value.
+- `Room::set_unread_flag()` is now a no-op if the unread flag already has the
+  wanted value.
   ([#5055](https://github.com/matrix-org/matrix-rust-sdk/pull/5055))
 
 ## [0.11.0] - 2025-04-11
 
 ### Features
 
-- `Room::load_or_fetch_event()` is a new method that will find an event in the event cache (if
-  enabled), or using network like `Room::event()` does.
+- `Room::load_or_fetch_event()` is a new method that will find an event in the
+  event cache (if enabled), or using network like `Room::event()` does.
   ([#4837](https://github.com/matrix-org/matrix-rust-sdk/pull/4837))
 - [**breaking**]: The element call widget URL configuration struct
   (`VirtualElementCallWidgetOptions`) and URL generation have changed.
-  - It supports the new fields: `hide_screensharing`, `posthog_api_host`, `posthog_api_key`,
+  - It supports the new fields: `hide_screensharing`, `posthog_api_host`,
+    `posthog_api_key`,
   `rageshake_submit_url`, `sentry_dsn`, `sentry_environment`.
-  - The widget URL will no longer automatically add `/room` to the base domain. For backward compatibility
+  - The widget URL will no longer automatically add `/room` to the base domain.
+    For backward compatibility
   the app itself would need to add `/room` to the `element_call_url`.
   - And replaced:
     - `analytics_id` -> `posthog_user_id` (The widget URL query parameters will
@@ -648,28 +744,33 @@ causing deleted room avatars to not be flagged is fixed. ([#5293](https://github
       `Intent.StartCall` for backward compatibility)
   - `VirtualElementCallWidgetOptions` now implements `Default`.
   ([#4822](https://github.com/matrix-org/matrix-rust-sdk/pull/4822))
-- [**breaking**]: The `RoomPagination::run_backwards` method has been removed and replaced by two
+- [**breaking**]: The `RoomPagination::run_backwards` method has been removed
+  and replaced by two
 simpler methods:
-  - `RoomPagination::run_backwards_until()`, which will retrigger back-paginations until a certain
-  number of events have been received (and retry if the timeline has been reset in the background).
-  - `RoomPagination::run_backwards_once()`, which will run a single back-pagination (and retry if
+  - `RoomPagination::run_backwards_until()`, which will retrigger
+    back-paginations until a certain
+  number of events have been received (and retry if the timeline has been reset in
+  the background).
+  - `RoomPagination::run_backwards_once()`, which will run a single
+    back-pagination (and retry if
   the timeline has been reset in the background).
   ([#4689](https://github.com/matrix-org/matrix-rust-sdk/pull/4689))
 - [**breaking**]: The `OAuth::account_management_url` method now caches the
   result of a call, subsequent calls to the method will not contact the server
   for a while, instead the cached URI will be returned. If caching of this URI
-  is not desirable, the `OAuth::fetch_account_management_url` method can be used.
-  ([#4663](https://github.com/matrix-org/matrix-rust-sdk/pull/4663))
+  is not desirable, the `OAuth::fetch_account_management_url` method can be
+  used. ([#4663](https://github.com/matrix-org/matrix-rust-sdk/pull/4663))
 - The `MediaRetentionPolicy` can now trigger regular cleanups with its new
   `cleanup_frequency` setting.
   ([#4603](https://github.com/matrix-org/matrix-rust-sdk/pull/4603))
 - [**breaking**] The HTTP client only allows TLS 1.2 or newer, as recommended by
   [BCP 195](https://datatracker.ietf.org/doc/bcp195/).
   ([#4647](https://github.com/matrix-org/matrix-rust-sdk/pull/4647))
-- Add `Room::report_room` api. ([#4713](https://github.com/matrix-org/matrix-rust-sdk/pull/4713))
+- Add `Room::report_room` api.
+  ([#4713](https://github.com/matrix-org/matrix-rust-sdk/pull/4713))
 - `Client::notification_client` will create a copy of the existing `Client`,
-  but now it'll make sure  it doesn't handle any verification events to
-  avoid an issue with these events being received and  processed twice if
+  but now it'll make sure it doesn't handle any verification events to
+  avoid an issue with these events being received and processed twice if
   `NotificationProcessSetup` was `SingleSetup`.
 - [**breaking**] `Room::is_encrypted` is replaced by
   `Room::latest_encryption_state` which returns a value of the new
@@ -688,6 +789,7 @@ simpler methods:
   ```rust
   room.latest_encryption_state().await?.is_encrypted()
   ```
+
 - `LocalServerBuilder`, behind the `local-server` feature, can be used to spawn
   a server when the end-user needs to be redirected to an address on localhost.
   It was used for `SsoLoginBuilder` and can now be used in other cases, like for
@@ -704,7 +806,7 @@ simpler methods:
   is used for the session.
   ([#4886](https://github.com/matrix-org/matrix-rust-sdk/pull/4886))
 
-### Bug Fixes
+### Bug fixes
 
 - Ensure all known secrets are removed from secret storage when invoking the
   `Recovery::disable()` method. While the server is not guaranteed to delete
@@ -716,14 +818,14 @@ simpler methods:
 
 ### Refactor
 
-
-- [**breaking**] Switched from the unmaintained backoff crate to the [backon](https://docs.rs/backon/1.5.0/backon/)
-  crate. As part of this change, the `RequestConfig::retry_limit` method was
-  renamed to `RequestConfig::max_retry_time` and the parameter for the method was
-  updated from a `u64` to a `usize`.
+- [**breaking**] Switched from the unmaintained backoff crate to the
+  [backon](https://docs.rs/backon/1.5.0/backon/) crate. As part of this change,
+  the `RequestConfig::retry_limit` method was renamed to
+  `RequestConfig::max_retry_time` and the parameter for the method was updated
+  from a `u64` to a `usize`.
   ([#4916](https://github.com/matrix-org/matrix-rust-sdk/pull/4916))
-- [**breaking**] We now require Rust 1.85 as the minimum supported Rust version to compile.
-  Yay for async closures!
+- [**breaking**] We now require Rust 1.85 as the minimum supported Rust version
+  to compile. Yay for async closures!
   ([#4745](https://github.com/matrix-org/matrix-rust-sdk/pull/4745))
 - [**breaking**] The `server_url` and `server_response` methods of
   `SsoLoginBuilder` are replaced by `server_builder()`, which allows more
@@ -736,10 +838,10 @@ simpler methods:
   `Client::subscribe_to_session_changes()` and then calling
   `Client::session_tokens()` on a `SessionChange::TokenRefreshed`.
   ([#4772](https://github.com/matrix-org/matrix-rust-sdk/pull/4772))
-- [**breaking**] `Oidc::url_for_oidc()` doesn't take the `VerifiedClientMetadata`
-  to register as an argument, the one in `OidcRegistrations` is used instead.
-  However it now takes the redirect URI to use, instead of always using the
-  first one in the client metadata.
+- [**breaking**] `Oidc::url_for_oidc()` doesn't take the
+  `VerifiedClientMetadata` to register as an argument, the one in
+  `OidcRegistrations` is used instead. However it now takes the redirect URI to
+  use, instead of always using the first one in the client metadata.
   ([#4771](https://github.com/matrix-org/matrix-rust-sdk/pull/4771))
 - [**breaking**] The `server_url` and `server_response` methods of
   `SsoLoginBuilder` are replaced by `server_builder()`, which allows more
@@ -757,7 +859,8 @@ simpler methods:
   - `OidcError` was renamed to `OAuthError` and the `RefreshTokenError::Oidc`
     variant was renamed to `RefreshTokenError::OAuth`.
   - `Oidc::provider_metadata()` was renamed to `OAuth::server_metadata()`.
-- [**breaking**]: `OAuth::finish_login()` must always be called, instead of `OAuth::finish_authorization()`
+- [**breaking**]: `OAuth::finish_login()` must always be called, instead of
+  `OAuth::finish_authorization()`
   ([#4817](https://github.com/matrix-org/matrix-rust-sdk/pull/4817))
   - `OAuth::abort_authorization()` was renamed to `OAuth::abort_login()`.
   - `OAuth::finish_login()` can be called several times for the same session,
@@ -799,8 +902,8 @@ simpler methods:
   ([#4831](https://github.com/matrix-org/matrix-rust-sdk/pull/4831))
 - [**breaking**] `Client::store` is renamed `state_store`
   ([#4851](https://github.com/matrix-org/matrix-rust-sdk/pull/4851))
-- [**breaking**] The parameters `event_id` and `enforce_thread` on [`Room::make_reply_event()`]
-  have been wrapped in a `reply` struct parameter.
+- [**breaking**] The parameters `event_id` and `enforce_thread` on
+  [`Room::make_reply_event()`] have been wrapped in a `reply` struct parameter.
   ([#4880](https://github.com/matrix-org/matrix-rust-sdk/pull/4880/))
 - [**breaking**]: The `Oidc` API was updated to match the latest version of the
   next-gen auth MSCs. The most notable change is that these MSCs are now based
@@ -821,9 +924,9 @@ simpler methods:
     - `OidcError` was renamed to `OAuthError` and the `RefreshTokenError::Oidc`
       variant was renamed to `RefreshTokenError::OAuth`.
     - `Oidc::provider_metadata()` was renamed to `OAuth::server_metadata()`.
-  - The `authentication::qrcode` module was moved inside `authentication::oauth`,
-    because it is only available through the `OAuth` API.
-    ([#4687](https://github.com/matrix-org/matrix-rust-sdk/pull/4687/))
+  - The `authentication::qrcode` module was moved inside
+    `authentication::oauth`, because it is only available through the `OAuth`
+    API. ([#4687](https://github.com/matrix-org/matrix-rust-sdk/pull/4687/))
   - The `OAuth` API only supports public clients, i.e. clients
     without a secret.
     ([#4634](https://github.com/matrix-org/matrix-rust-sdk/pull/4634))
@@ -835,9 +938,10 @@ simpler methods:
     case anymore, according to the latest version of
     [MSC2967](https://github.com/matrix-org/matrix-spec-proposals/pull/2967).
     ([#4664](https://github.com/matrix-org/matrix-rust-sdk/pull/4664))
-  - The `OAuth` API uses the `GET /auth_metadata` endpoint from the
-    latest version of [MSC2965](https://github.com/matrix-org/matrix-spec-proposals/pull/2965)
-    by default. The previous `GET /auth_issuer` endpoint is still supported as a
+  - The `OAuth` API uses the `GET /auth_metadata` endpoint from the latest
+    version of
+    [MSC2965](https://github.com/matrix-org/matrix-spec-proposals/pull/2965) by
+    default. The previous `GET /auth_issuer` endpoint is still supported as a
     fallback for now.
     ([#4673](https://github.com/matrix-org/matrix-rust-sdk/pull/4673))
     - It is not possible to provide a custom issuer anymore:
@@ -852,7 +956,8 @@ simpler methods:
   - The behavior of `OAuth::logout()` is now aligned with
     [MSC4254](https://github.com/matrix-org/matrix-spec-proposals/pull/4254)
     ([#4674](https://github.com/matrix-org/matrix-rust-sdk/pull/4674))
-    - Support for [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+    - Support for
+      [RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
       was removed, so it doesn't return an `OidcEndSessionUrlBuilder` anymore.
     - Only one request is made to revoke the access token, since the server is
       supposed to revoke both the access token and the associated refresh token
@@ -881,7 +986,8 @@ simpler methods:
       exported from the `oauth` module or available from `ruma`.
     - `AccountManagementUrlFull` now takes an `OwnedDeviceId` when a device ID
       is required.
-    - `(Verified)ProviderMetadata` was replaced by `AuthorizationServerMetadata`.
+    - `(Verified)ProviderMetadata` was replaced by
+      `AuthorizationServerMetadata`.
     - `OAuth::register_client()` doesn't accept a software statement anymore.
     - `(Verified)ClientMetadata` was replaced by `Raw<ClientMetadata>`.
       `ClientMetadata` is an opinionated type that only supports the fields
@@ -947,7 +1053,8 @@ simpler methods:
 - Enable HTTP/2 support in the HTTP client.
   ([#4566](https://github.com/matrix-org/matrix-rust-sdk/pull/4566))
 
-- Add support for creating custom conditional push rules in `NotificationSettings::create_custom_conditional_push_rule`.
+- Add support for creating custom conditional push rules in
+  `NotificationSettings::create_custom_conditional_push_rule`.
   ([#4587](https://github.com/matrix-org/matrix-rust-sdk/pull/4587))
 
 - The media contents stored in the media cache can now be controlled with a
@@ -955,7 +1062,8 @@ simpler methods:
   `set_media_retention_policy()`, `clean_up_media_cache()`.
   ([#4571](https://github.com/matrix-org/matrix-rust-sdk/pull/4571))
 
-- Add support for creating custom conditional push rules in `NotificationSettings::create_custom_conditional_push_rule`.
+- Add support for creating custom conditional push rules in
+  `NotificationSettings::create_custom_conditional_push_rule`.
   ([#4587](https://github.com/matrix-org/matrix-rust-sdk/pull/4587))
 
 ### Refactor
@@ -968,9 +1076,10 @@ simpler methods:
 - Improve the performance of `EventCache` (approximately 4.5 times faster).
   ([#4616](https://github.com/matrix-org/matrix-rust-sdk/pull/4616))
 
-- [**breaking**]: The reexported types `SyncTimelineEvent` and `TimelineEvent` have been fused into a single type
-  `TimelineEvent`, and its field `push_actions` has been made `Option`al (it is set to `None` when
-  we couldn't compute the push actions, because we lacked some information).
+- [**breaking**]: The reexported types `SyncTimelineEvent` and `TimelineEvent`
+  have been fused into a single type `TimelineEvent`, and its field
+  `push_actions` has been made `Option`al (it is set to `None` when we couldn't
+  compute the push actions, because we lacked some information).
   ([#4568](https://github.com/matrix-org/matrix-rust-sdk/pull/4568))
 
 - [**breaking**] Move the optional `RequestConfig` argument of the
@@ -984,11 +1093,13 @@ simpler methods:
   call `AttachmentConfig::new().thumbnail(thumbnail)` now instead.
   ([#4452](https://github.com/matrix-org/matrix-rust-sdk/pull/4452))
 
-- [**breaking**] `Room::send_attachment()` and `RoomSendQueue::send_attachment()`
-  now take any type that implements `Into<String>` for the filename.
+- [**breaking**] `Room::send_attachment()` and
+  `RoomSendQueue::send_attachment()` now take any type that implements
+  `Into<String>` for the filename.
   ([#4451](https://github.com/matrix-org/matrix-rust-sdk/pull/4451))
 
-- [**breaking**] `Recovery::are_we_the_last_man_standing()` has been renamed to `is_last_device()`.
+- [**breaking**] `Recovery::are_we_the_last_man_standing()` has been renamed to
+  `is_last_device()`.
   ([#4522](https://github.com/matrix-org/matrix-rust-sdk/pull/4522))
 
 - [**breaking**] The `matrix_auth` module is now at `authentication::matrix`.
@@ -999,7 +1110,7 @@ simpler methods:
 
 ## [0.9.0] - 2024-12-18
 
-### Bug Fixes
+### Bug fixes
 
 - Use the inviter's server name and the server name from the room alias as
   fallback values for the via parameter when requesting the room summary from
@@ -1022,19 +1133,17 @@ simpler methods:
 - [**breaking**] Make all fields of Thumbnail required
   ([#4324](https://github.com/matrix-org/matrix-rust-sdk/pull/4324))
 
-- `Backups::exists_on_server`, which always fetches up-to-date information from the
-  server about whether a key storage backup exists, was renamed to
+- `Backups::exists_on_server`, which always fetches up-to-date information from
+  the server about whether a key storage backup exists, was renamed to
   `fetch_exists_on_the_server`, and a new implementation of `exists_on_server`
   which caches the most recent answer is now provided.
 
 ## [0.8.0] - 2024-11-19
 
-### Bug Fixes
+### Bug fixes
 
 - Add more invalid characters for room aliases.
-
 - Match the right status code in `Client::is_room_alias_available`.
-
 - Fix a bug where room keys were considered to be downloaded before backups were
   enabled. This bug only affects the
   `BackupDownloadStrategy::AfterDecryptionFailure`, where no attempt would be
@@ -1045,78 +1154,66 @@ simpler methods:
 
 - Improve documentation of `Client::observe_events`.
 
-
 ### Features
 
-
 - Add `create_room_alias` function.
-
 - `Client::cross_process_store_locks_holder_name` is used everywhere:
- - `StoreConfig::new()` now takes a
-   `cross_process_store_locks_holder_name` argument.
- - `StoreConfig` no longer implements `Default`.
- - `BaseClient::new()` has been removed.
- - `BaseClient::clone_with_in_memory_state_store()` now takes a
-   `cross_process_store_locks_holder_name` argument.
- - `BaseClient` no longer implements `Default`.
- - `EventCacheStoreLock::new()` no longer takes a `key` argument.
- - `BuilderStoreConfig` no longer has
-   `cross_process_store_locks_holder_name` field for `Sqlite` and
-   `IndexedDb`.
+- `StoreConfig::new()` now takes a
+  `cross_process_store_locks_holder_name` argument.
+- `StoreConfig` no longer implements `Default`.
+- `BaseClient::new()` has been removed.
+- `BaseClient::clone_with_in_memory_state_store()` now takes a
+  `cross_process_store_locks_holder_name` argument.
+- `BaseClient` no longer implements `Default`.
+- `EventCacheStoreLock::new()` no longer takes a `key` argument.
+- `BuilderStoreConfig` no longer has
+  `cross_process_store_locks_holder_name` field for `Sqlite` and
+  `IndexedDb`.
 
-- `EncryptionSyncService` and `Notification` are using `Client::cross_process_store_locks_holder_name`.
+- `EncryptionSyncService` and `Notification` are using
+  `Client::cross_process_store_locks_holder_name`.
 
 - Allow passing a custom `RequestConfig` to an upload request.
-
 - Retry uploads if they've failed with transient errors.
-
 - Implement `EventHandlerContext` for tuples.
-
 - Introduce a mechanism similar to `Client::add_event_handler` and
   `Client::add_room_event_handler` but with a reactive programming pattern. Add
   `Client::observe_events` and `Client::observe_room_events`.
 
- ```rust
- // Get an observer.
- let observer =
+  ```rust
+  // Get an observer.
+  let observer =
      client.observe_events::<SyncRoomMessageEvent, (Room, Vec<Action>)>();
 
- // Subscribe to the observer.
- let mut subscriber = observer.subscribe();
+  // Subscribe to the observer.
+  let mut subscriber = observer.subscribe();
 
- // Use the subscriber as a `Stream`.
- let (message_event, (room, push_actions)) = subscriber.next().await.unwrap();
- ```
+  // Use the subscriber as a `Stream`.
+  let (message_event, (room, push_actions)) = subscriber.next().await.unwrap();
+  ```
 
- When calling `observe_events`, one has to specify the type of event (in the
- example, `SyncRoomMessageEvent`) and a context (in the example, `(Room,
- Vec<Action>)`, respectively for the room and the push actions).
+  When calling `observe_events`, one has to specify the type of event (in the
+  example, `SyncRoomMessageEvent`) and a context (in the example, `(Room,
+  Vec<Action>)`, respectively for the room and the push actions).
 
 - Implement unwedging for media uploads.
-
-- Send state from state sync and not from timeline to widget ([#4254](https://github.com/matrix-org/matrix-rust-sdk/pull/4254))
+- Send state from state sync and not from timeline to widget
+  ([#4254](https://github.com/matrix-org/matrix-rust-sdk/pull/4254))
 
 - Allow aborting media uploads.
-
 - Add `RoomPreviewInfo::num_active_members`.
-
 - Use room directory search as another data source.
-
 - Check if the user is allowed to do a room mention before trying to send a call
   notify event.
   ([#4271](https://github.com/matrix-org/matrix-rust-sdk/pull/4271))
 
 - Add `Client::cross_process_store_locks_holder_name()`.
-
 - Add a `PreviouslyVerified` variant to `VerificationLevel` indicating that the
   identity is unverified and previously it was verified.
 
 - New `UserIdentity::pin` method.
-
 - New `ClientBuilder::with_decryption_trust_requirement` method.
-
 - New `ClientBuilder::with_room_key_recipient_strategy` method
-
 - New `Room.set_account_data` and `Room.set_account_data_raw` RoomAccountData
   setters, analogous to the GlobalAccountData
 
@@ -1127,30 +1224,19 @@ simpler methods:
 - Implement proper redact handling in the widget driver. This allows the Rust
   SDK widget driver to support widgets that rely on redacting.
 
-
 ### Refactor
+
 - [**breaking**] Rename `DisplayName` to `RoomDisplayName`.
-
 - Improve `is_room_alias_format_valid` so it's more strict.
-
 - Remove duplicated fields in media event contents.
-
 - Use `SendHandle` for media uploads too.
-
 - Move `event_cache_store/` to `event_cache/store/` in `matrix-sdk-base`.
-
 - Move `linked_chunk` from `matrix-sdk` to `matrix-sdk-common`.
-
 - Move `Event` and `Gap` into `matrix_sdk_base::event_cache`.
-
 - Move `formatted_caption_from` to the SDK, rename it.
-
 - Tidy up and start commenting the widget code.
-
 - Get rid of `ProcessingContext` and inline it in its callers.
-
 - Get rid of unused `limits` parameter when constructing a `WidgetMachine`.
-
 - Use a specialized mutex for locking access to the state store and
   `being_sent`.
 
@@ -1167,8 +1253,8 @@ simpler methods:
   between `*_redact_own` and `*_redact_other`.
 
 - [**breaking**] `AmbiguityCache` contains the room member's user ID.
-
-- [**breaking**] Replace `impl MediaEventContent` with `&impl MediaEventContent` in
+- [**breaking**] Replace `impl MediaEventContent` with `&impl MediaEventContent`
+  in
   `Media::get_file`/`Media::remove_file`/`Media::get_thumbnail`/`Media::remove_thumbnail`
 
 - [**breaking**] A custom sliding sync proxy set with
@@ -1200,45 +1286,58 @@ simpler methods:
 - [**breaking**] The `body` parameter in `get_media_file` has been replaced with
   a `filename` parameter now that Ruma has a `filename()` method.
 
-# 0.7.0
+## 0.7.0
 
 Breaking changes:
 
 - The `Client::sync_token` accessor function is no longer public. If you were
   using this for `Client::sync_once()`, you can get the token from the result of
-  the `Client::sync_once()` method instead ([#1216](https://github.com/matrix-org/matrix-rust-sdk/pull/1216)).
-- `Common::members` and `Common::members_no_sync` take a `RoomMemberships` to be able to filter the
-  results by any membership state.
-  - `Common::active_members(_no_sync)` and `Common::joined_members(_no_sync)` are deprecated.
-- `matrix-sdk-sqlite` is the new default store implementation outside of WASM, behind the `sqlite` feature.
-  - The `sled` feature was removed. The `matrix-sdk-sled` crate is deprecated and no longer maintained.
-- Replace `Client::authentication_issuer` with `Client::authentication_server_info` that contains
-  all the fields discovered from the homeserver for authenticating with OIDC
-- Remove `HttpSend` trait in favor of allowing a custom `reqwest::Client` instance to be supplied
-- Move all the types and methods using the native Matrix login and registration APIs from `Client`
-  to the new `matrix_auth::MatrixAuth` API that is accessible via `Client::matrix_auth()`.
+  the `Client::sync_once()` method instead
+  ([#1216](https://github.com/matrix-org/matrix-rust-sdk/pull/1216)).
+- `Common::members` and `Common::members_no_sync` take a `RoomMemberships` to be
+  able to filter the results by any membership state.
+  - `Common::active_members(_no_sync)` and `Common::joined_members(_no_sync)`
+    are deprecated.
+- `matrix-sdk-sqlite` is the new default store implementation outside of WASM,
+  behind the `sqlite` feature.
+  - The `sled` feature was removed. The `matrix-sdk-sled` crate is deprecated
+    and no longer maintained.
+- Replace `Client::authentication_issuer` with
+  `Client::authentication_server_info` that contains all the fields discovered
+  from the homeserver for authenticating with OIDC
+- Remove `HttpSend` trait in favor of allowing a custom `reqwest::Client`
+  instance to be supplied
+- Move all the types and methods using the native Matrix login and registration
+  APIs from `Client` to the new `matrix_auth::MatrixAuth` API that is accessible
+  via `Client::matrix_auth()`.
 - Move `Session` and `SessionTokens` to the `matrix_auth` module.
   - Move the session methods on `Client` to the `MatrixAuth` API.
-  - Split `Session`'s content into several types. Its (de)serialization is still backwards
-    compatible.
+  - Split `Session`'s content into several types. Its (de)serialization is still
+    backwards compatible.
 - The room API has been simplified
   - Removed the previous `Room`, `Joined`, `Invited` and `Left` types
-  - Merged all of the functionality from `Joined`, `Invited` and `Left` into `room::Common`
-  - Renamed `room::Common` to just `Room` and made it accessible as `matrix_sdk::Room`
-- Event handler closures now need to implement `FnOnce` + `Clone` instead of `Fn`
-  - As a consequence, you no longer need to explicitly need to `clone` variables they capture
-    before constructing an `async move {}` block inside
-- `Room::sync_members` doesn't return the underlying Ruma response anymore. If you need to get the
-  room members, you can use `Room::members` or `Room::get_member` which will make sure that the
-  members are up to date.
+  - Merged all of the functionality from `Joined`, `Invited` and `Left` into
+    `room::Common`
+  - Renamed `room::Common` to just `Room` and made it accessible as
+    `matrix_sdk::Room`
+- Event handler closures now need to implement `FnOnce` + `Clone` instead of
+  `Fn`
+  - As a consequence, you no longer need to explicitly need to `clone` variables
+    they capture before constructing an `async move {}` block inside
+- `Room::sync_members` doesn't return the underlying Ruma response anymore. If
+  you need to get the room members, you can use `Room::members` or
+  `Room::get_member` which will make sure that the members are up to date.
 - The `transaction_id` parameter of `Room::{send, send_raw}` was removed
-  - Instead, both methods now return types that implement `IntoFuture` (so can be awaited like
-    before) and have a `with_transaction_id` builder-style method
-- The parameter order of `Room::{send_raw, send_state_event_raw}` has changed, `content` is now last
-  - The parameter type of `content` has also changed to a generic; `serde_json::Value` arguments
-    are still allowed, but so are other types like `Box<serde_json::value::RawValue>`
-- All "named futures" (structs implementing `IntoFuture`) are now exported from modules named
-  `futures` instead of directly in the respective parent module
+  - Instead, both methods now return types that implement `IntoFuture` (so can
+    be awaited like before) and have a `with_transaction_id` builder-style
+    method
+- The parameter order of `Room::{send_raw, send_state_event_raw}` has changed,
+  `content` is now last
+  - The parameter type of `content` has also changed to a generic;
+    `serde_json::Value` arguments are still allowed, but so are other types like
+    `Box<serde_json::value::RawValue>`
+- All "named futures" (structs implementing `IntoFuture`) are now exported from
+  modules named `futures` instead of directly in the respective parent module
 - `Verification` is non-exhaustive, to make the `qrcode` cargo feature additive
 
 Bug fixes:
@@ -1255,18 +1354,21 @@ Additions:
   and listen to changes in the state of the `VerificationRequest`. This removes
   the need to listen to individual matrix events once the `VerificationRequest`
   object has been acquired.
-- The `Room` methods to retrieve state events can now return a sync or stripped event,
-  so they can be used for invited rooms too.
-- Add `Client::subscribe_to_room_updates` and `room::Common::subscribe_to_updates`
+- The `Room` methods to retrieve state events can now return a sync or stripped
+  event, so they can be used for invited rooms too.
+- Add `Client::subscribe_to_room_updates` and
+  `room::Common::subscribe_to_updates`
 - Add `Client::rooms_filtered`
 - Add methods on `Client` that can handle several authentication APIs.
-- Add new method `force_discard_session` on `Room` that allows to discard the current
-  outbound session (room key) for that room. Can be used by clients for the `/discardsession` command.
+- Add new method `force_discard_session` on `Room` that allows to discard the
+  current outbound session (room key) for that room. Can be used by clients for
+  the `/discardsession` command.
 
-# 0.6.2
+## 0.6.2
 
 - Fix the access token being printed in tracing span fields.
 
-# 0.6.1
+## 0.6.1
 
-- Fixes a bug where the access token used for Matrix requests was added as a field to a tracing span.
+- Fixes a bug where the access token used for Matrix requests was added as a
+  field to a tracing span.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -579,6 +579,10 @@ get cancelled after the default 30s timeout for no good reason.
   `enable_share_history_on_invite` enabled, we will correctly check for received
   room key bundles. Previously this was only done when calling `Room::join`.
   ([#5043](https://github.com/matrix-org/matrix-rust-sdk/pull/5043))
+- `m.room.avatar` has been added as required state for sliding sync until
+  [the existing backend issue](https://github.com/element-hq/synapse/issues/18598)
+causing deleted room avatars to not be flagged is fixed.
+([#5293](https://github.com/matrix-org/matrix-rust-sdk/pull/5293))
 
 ### Features
 
@@ -630,13 +634,6 @@ get cancelled after the default 30s timeout for no good reason.
 - `RoomPreview::join_rule` is now optional, and will be set to `None` if the
   join rule state event is missing for a given room.
   ([#5278](https://github.com/matrix-org/matrix-rust-sdk/pull/5278))
-
-### Bug fixes
-
-- `m.room.avatar` has been added as required state for sliding sync until
-  [the existing backend issue](https://github.com/element-hq/synapse/issues/18598)
-causing deleted room avatars to not be flagged is fixed.
-([#5293](https://github.com/matrix-org/matrix-rust-sdk/pull/5293))
 
 ## [0.12.0] - 2025-06-10
 
@@ -748,9 +745,8 @@ causing deleted room avatars to not be flagged is fixed.
   and replaced by two
 simpler methods:
   - `RoomPagination::run_backwards_until()`, which will retrigger
-    back-paginations until a certain
-  number of events have been received (and retry if the timeline has been reset in
-  the background).
+    back-paginations until a certain number of events have been received (and
+    retry if the timeline has been reset in the background).
   - `RoomPagination::run_backwards_once()`, which will run a single
     back-pagination (and retry if
   the timeline has been reset in the background).

--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -6,14 +6,15 @@ Matrix [Client-Server API](https://spec.matrix.org/latest/client-server-api/)
 to communicate with a Matrix homeserver. If you're writing a typical Matrix
 client or bot, this is likely the crate you need.
 
-However, the crate is designed in a modular way and depends on several
-other lower-level crates. If you're attempting something more custom, you might be interested in these:
+However, the crate is designed in a modular way and depends on several other
+lower-level crates. If you're attempting something more custom, you might be
+interested in these:
 
 - [`matrix_sdk_base`]: A no-network-IO client state machine which can be used
   to embed a Matrix client into an existing network stack or to build a new
   Matrix client library on top.
-- [`matrix_sdk_crypto`]: A no-network-IO encryption state machine which can be used to add Matrix E2EE
-  support into an existing client or library.
+- [`matrix_sdk_crypto`]: A no-network-IO encryption state machine which can be
+  used to add Matrix E2EE support into an existing client or library.
 
 # Getting started
 
@@ -51,27 +52,27 @@ async fn main() -> anyhow::Result<()> {
 
 More examples can be found in the [examples] directory.
 
-# Crate Feature Flags
+## Crate feature flags
 
 The following crate feature flags are available:
 
-| Feature             | Default | Description                                                                                                                |
-| ------------------- | :-----: | -------------------------------------------------------------------------------------------------------------------------- |
-| `anyhow`            |   No    | Better logging for event handlers that return `anyhow::Result`                                                             |
-| `e2e-encryption`    |   Yes   | End-to-end encryption (E2EE) support                                                                                       |
-| `eyre`              |   No    | Better logging for event handlers that return `eyre::Result`                                                               |
-| `js`                |   No    | Enables JavaScript API usage on WASM (does nothing on other targets)                                                       |
-| `markdown`          |   No    | Support for sending Markdown-formatted messages                                                                            |
-| `qrcode`            |   Yes   | QR code verification support                                                                                               |
-| `sqlite`            |   Yes   | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite available on system  |
-| `bundled-sqlite`    |   No  | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite compiled and bundled with the binary  |
-| `indexeddb`         |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled) for browsers, via IndexedDB |
-| `socks`             |   No    | SOCKS support in the default HTTP client, [`reqwest`]                                                                      |
-| `sso-login`         |   No    | Support for SSO login with a local HTTP server                                                                             |
+| Feature          | Default | Description                                                                                                                                     |
+| ---------------- | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `anyhow`         |   No    | Better logging for event handlers that return `anyhow::Result`                                                                                  |
+| `e2e-encryption` |   Yes   | End-to-end encryption (E2EE) support                                                                                                            |
+| `eyre`           |   No    | Better logging for event handlers that return `eyre::Result`                                                                                    |
+| `js`             |   No    | Enables JavaScript API usage on WASM (does nothing on other targets)                                                                            |
+| `markdown`       |   No    | Support for sending Markdown-formatted messages                                                                                                 |
+| `qrcode`         |   Yes   | QR code verification support                                                                                                                    |
+| `sqlite`         |   Yes   | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite available on system                  |
+| `bundled-sqlite` |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite compiled and bundled with the binary |
+| `indexeddb`      |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled) for browsers, via IndexedDB                      |
+| `socks`          |   No    | SOCKS support in the default HTTP client, [`reqwest`]                                                                                           |
+| `sso-login`      |   No    | Support for SSO login with a local HTTP server                                                                                                  |
 
 [`reqwest`]: https://docs.rs/reqwest/0.11.5/reqwest/index.html
 
-# Enabling logging
+## Enabling logging
 
 Users of the matrix-sdk crate can enable log output by depending on the
 `tracing-subscriber` crate and including the following line in their

--- a/crates/matrix-sdk/changelog.d/6574.changed.md
+++ b/crates/matrix-sdk/changelog.d/6574.changed.md
@@ -1,3 +1,3 @@
-[**breaking**] `RumaApiError` is now a type alias for `UiaaResponse`, because they have similar
-variants containing the same data. The `ClientApi` variant is now `MatrixError`, and the `Uiaa`
-variant is `AuthResponse`.
+[**breaking**] `RumaApiError` is now a type alias for `UiaaResponse`, because
+they have similar variants containing the same data. The `ClientApi` variant is
+now `MatrixError`, and the `Uiaa` variant is `AuthResponse`.

--- a/crates/matrix-sdk/src/docs/encryption.md
+++ b/crates/matrix-sdk/src/docs/encryption.md
@@ -228,9 +228,6 @@ is **not** supported using the default store.
 [Restoring a Client]: #restoring-a-client
 [spec]: https://spec.matrix.org/unstable/client-server-api/#relationship-between-access-tokens-and-devices
 [device keys]: https://spec.matrix.org/unstable/client-server-api/#device-keys
-[`store`]: crate::store
-[`CryptoStore`]: matrix_sdk_base::crypto::store::CryptoStore
-[`StoreConfig`]: crate::config::StoreConfig
 [`ClientBuilder`]: crate::ClientBuilder
 [`ClientBuilder::store_config`]: crate::ClientBuilder::store_config
 [`MatrixAuth::login_username()`]: crate::authentication::matrix::MatrixAuth::login_username

--- a/crates/matrix-sdk/src/docs/encryption.md
+++ b/crates/matrix-sdk/src/docs/encryption.md
@@ -38,11 +38,11 @@ get sent to such a room.
 
 We already mentioned that a message in a end-to-end encrypted world needs to
 be encrypted for each individual member, though that isn't completely
-correct. A message needs to be encrypted for each individual *end*. An *end*
+correct. A message needs to be encrypted for each individual _end_. An _end_
 in Matrix land is a client that communicates with the homeserver. The spec
-calls an *end* a Device, while other clients might call an *end* a Session.
+calls an _end_ a Device, while other clients might call an _end_ a Session.
 
-The matrix-sdk represents an *end* as a [`Device`] object. Each individual
+The matrix-sdk represents an _end_ as a [`Device`] object. Each individual
 message should be encrypted for each individual [`Device`] of each
 individual room member.
 
@@ -52,14 +52,14 @@ been introduced.
 
 ## Room keys
 
-Room keys remove the need to encrypt each message for each *end*.
-Instead a room key needs to be shared with each *end*, and after that a message
+Room keys remove the need to encrypt each message for each _end_.
+Instead a room key needs to be shared with each _end_, and after that a message
 can be encrypted in a single, O(1), step.
 
 A room key is backed by a [Megolm] session, which consists of two
 parts. The first part, the outbound group session, is used for encryption.
 This part never leaves your device. The second part is the inbound group
-session, which is shared with each *end*.
+session, which is shared with each _end_.
 
 ```text
             ┌────────────────────────┬───────────────────────┐
@@ -89,17 +89,17 @@ stores all room keys locally in an encrypted manner.
 Besides storing them as part of the SDK store, users can export room keys
 using the [`Encryption::export_room_keys`] method.
 
-# Verification
+## Verification
 
-One important aspect of end-to-end encryption is to check that the *end* you
+One important aspect of end-to-end encryption is to check that the _end_ you
 are communicating with is indeed the person you expect. This checking is
 done in Matrix via interactive verification. While interactively verifying,
 we'll need to exchange some critical piece of information over another
 communication channel. (Good ways to make this exchange would be in person or
 via a phone call.)
 
-Usually each *end* will need to verify every *end* it communicates with. An
-*end* is represented as a [`Device`] in the matrix-sdk. This gets rather
+Usually each _end_ will need to verify every _end_ it communicates with. An
+_end_ is represented as a [`Device`] in the matrix-sdk. This gets rather
 complicated quickly as is shown below, with Alice and Bob each having two
 devices. Each arrow represents who needs to verify whom for the
 communication between Alice and Bob to be considered secure.
@@ -153,7 +153,7 @@ To add interactive verification support to your client please see the
 [`Device::is_verified()`] method, which explains in more detail what
 it means for a [`Device`] to be verified.
 
-# Client setup
+## Client setup
 
 The matrix-sdk aims to provide encryption support transparently. If
 encryption is enabled and correctly set up, events that need to be encrypted
@@ -168,7 +168,7 @@ to work.
 2. To persist the encryption keys, you can use [`ClientBuilder::store_config`]
    or one of the `_store` methods on [`ClientBuilder`].
 
-## Restoring a client
+### Restoring a client
 
 Restoring a Client is relatively easy, but there are some things that need to be
 kept in mind before doing so.
@@ -186,7 +186,7 @@ After we log in, the client will upload the end-to-end encryption related
 [device keys] to the server. Those device keys cannot be replaced once they
 have been uploaded and tied to a device ID.
 
-### Using an access token
+#### Using an access token
 
 1. Log in with the password using [`MatrixAuth::login_username()`].
 2. Store the access token, preferably somewhere secure.
@@ -197,7 +197,7 @@ lives on a server. If you're skipping step one of this method, remember that
 you **can't** use an access token that already has some device keys tied to
 the device ID.
 
-### Using a password.
+#### Using a password
 
 1. Log in using [`MatrixAuth::login_username()`].
 2. Store the `device_id` that was returned in the login response from the
@@ -211,7 +211,7 @@ the device ID.
 with a different device ID (either `None` or a device ID of another client)
 is **not** supported using the default store.
 
-## Common pitfalls
+### Common pitfalls
 
 | Failure | Cause | Fix |
 | ------------------- | ----- | ----------- |

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -78,11 +78,12 @@ let list_builder = SlidingSyncList::builder("main_list")
 ```
 
 Please refer to the [specification][MSC], the [Ruma types][ruma-types],
-specifically [`SyncRequestListFilter`](https://docs.rs/ruma/latest/ruma/api/client/sync/sync_events/v4/struct.SyncRequestListFilters.html) and the
-[`SlidingSyncListBuilder`] for details on the filters, and
-range-options and data one requests to be sent. Once the list is fully
-configured, `build()` it and add the list to the sliding sync session
-by supplying it to [`add_list`][`SlidingSyncBuilder::add_list`].
+specifically
+[`SyncRequestListFilter`](https://docs.rs/ruma/latest/ruma/api/client/sync/sync_events/v4/struct.SyncRequestListFilters.html)
+and the [`SlidingSyncListBuilder`] for details on the filters, and range-options
+and data one requests to be sent. Once the list is fully configured, `build()`
+it and add the list to the sliding sync session by supplying it to
+[`add_list`][`SlidingSyncBuilder::add_list`].
 
 Lists are inherently stateful and all updates are applied on the shared
 list-object. Once a list has been added to [`SlidingSync`], a cloned shared
@@ -92,12 +93,12 @@ of the list. Next to the configuration settings (like name and
 [`maximum_number_of_rooms`](SlidingSyncList::maximum_number_of_rooms) and
 [`state`](SlidingSyncList::state):
 
- - `maximum_number_of_rooms` is the number of rooms _total_ there were found
-   matching the filters given.
- - `state` is a [`SlidingSyncMode`] signalling meta information about the
-   list and its stateful data — whether this is the state loaded from local
-   cache, whether the [full sync](#helper-lists) is in progress or whether
-   this is the current live information
+- `maximum_number_of_rooms` is the number of rooms _total_ there were found
+  matching the filters given.
+- `state` is a [`SlidingSyncMode`] signalling meta information about the
+  list and its stateful data — whether this is the state loaded from local
+  cache, whether the [full sync](#helper-lists) is in progress or whether
+  this is the current live information
 
 These are updated upon every update received from the server. One can query
 these for their current value at any time, or use the [Reactive API
@@ -149,14 +150,14 @@ account-data-extensions.
 
 ## Timeline events
 
-Both the list configuration as well as the [room subscription
-settings](`http::request::RoomSubscription`) allow to specify a `timeline_limit` to
-receive timeline events. If that is unset or set to 0, no events are sent by
-the server (which is the default), if multiple limits are found, the highest
-takes precedence. Any positive number indicates that on the first request a
-room should come into list, up to that count of messages are sent
-(depending how many the server has in cache). Following, whenever new events
-are found for the matching rooms, the server relays them to the client.
+Both the list configuration as well as the
+[room subscription settings](`http::request::RoomSubscription`) allow to specify
+a `timeline_limit` to receive timeline events. If that is unset or set to 0, no
+events are sent by the server (which is the default), if multiple limits are
+found, the highest takes precedence. Any positive number indicates that on the
+first request a room should come into list, up to that count of messages are
+sent (depending how many the server has in cache). Following, whenever new
+events are found for the matching rooms, the server relays them to the client.
 
 All timeline events coming through Sliding Sync will be processed through
 the [`BaseClient`][`matrix_sdk_base::BaseClient`] as in previous sync. This
@@ -172,7 +173,7 @@ To allow for a quick startup, client might want to request only a very low
 `timeline_limit` (maybe 1 or even 0) at first and update the count later on
 the list or room subscription (see [reactive api](#reactive-api)).
 
-## Long Polling
+## Long polling
 
 [Sliding Sync][MSC] is a long-polling API. That means that immediately after
 one has received data from the server, they re-open the network connection

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -1,34 +1,37 @@
-# Widget Driver
+# Widget driver
 
-This module implements a widget driver. The widget driver allows a client to give widgets (webviews) access to Matrix via
-a specified `postMessage` API.
-Details about the features implemented by this driver can be found in the following MSC's:
+This module implements a widget driver. The widget driver allows a client to
+give widgets (webviews) access to Matrix via a specified `postMessage` API.
+Details about the features implemented by this driver can be found in the
+following MSC's:
 
 - [MSC3803: Matrix Widget API v2](https://github.com/matrix-org/matrix-spec-proposals/issues/3803)
 - [MSC2762: Allowing widgets to send/receive events](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/widgets-send-receive-events/proposals/2762-widget-event-receiving.md)
 - [MSC4157: Delayed Events (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4157)
 - [MSC3819: Allowing widgets to send/receive to-device messages](https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
 
-It supports sending and reading events and provides some rudimentary client navigation features.
-There are some additional actions:
+It supports sending and reading events and provides some rudimentary client
+navigation features. There are some additional actions:
 
 - Get an OpenID token (not OAuth) to identify a user.
 - Ask for supported API versions.
 - Inform the client that the widget has loaded its content and is ready.
 
-## The Widget Api
+## The widget api
 
-_from [MSC3803: Matrix Widget API v2](https://github.com/matrix-org/matrix-spec-proposals/issues/3803)_
+_from [MSC3803: Matrix Widget API
+v2](https://github.com/matrix-org/matrix-spec-proposals/issues/3803)_
 
 The widget postMessage API is split into two halves:
 
-- Matrix client (e.g. Element) postMessage API (api: “fromWidget”) -- This API listens within
-  a Matrix client for inbound messages from widgets.
-- Widget client postMessage API (api: “toWidget”) -- This API listens within
-  a widget for inbound messages coming from the Matrix client, or the container embedding the widget.
+- Matrix client (e.g. Element) postMessage API (api: “fromWidget”) -- This API
+  listens within a Matrix client for inbound messages from widgets.
+- Widget client postMessage API (api: “toWidget”) -- This API listens within a
+  widget for inbound messages coming from the Matrix client, or the container
+  embedding the widget.
 
-The API follows a request/response pattern. So each request can be sent in both direction.
-This makes for four valid `postMessage` structures:
+The API follows a request/response pattern. So each request can be sent in both
+direction. This makes for four valid `postMessage` structures:
 
 - Widget -> Client: `api: FromWidget`, ~~`response:`~~
 - Client -> Widget: `api: FromWidget`, `response: {...}`
@@ -49,7 +52,8 @@ An example request / response:
 }
 ```
 
-The complete request object is returned to the caller with an additional `response` key like so:
+The complete request object is returned to the caller with an additional
+`response` key like so:
 
 ```json
 {
@@ -62,21 +66,26 @@ The complete request object is returned to the caller with an additional `respon
 }
 ```
 
-The `api` field is required on all requests and must be either `"fromWidget"` or `"toWidget"` depending upon the direction
-of messaging.
+The `api` field is required on all requests and must be either `"fromWidget"` or
+`"toWidget"` depending upon the direction of messaging.
 
-The "requestId" field should be unique and included in all requests. This field has been omitted from all of the
-following examples, for the sake of brevity.
+The "requestId" field should be unique and included in all requests. This field
+has been omitted from all of the following examples, for the sake of brevity.
 
-The "action" determines the format of the request and response. All actions can return an error response.
+The "action" determines the format of the request and response. All actions can
+return an error response.
 
-The "widgetId" field denotes the widget that the request originates from and is required.
+The "widgetId" field denotes the widget that the request originates from and is
+required.
 
-Additional data can be sent as arbitrary fields. However, typically the "data" object should be used.
+Additional data can be sent as arbitrary fields. However, typically the "data"
+object should be used.
 
-A success response is an object with zero or more keys where none of keys are “error”.
+A success response is an object with zero or more keys where none of keys are
+“error”.
 
-An error response is a "response" object which consists of a sole "error" key to indicate an error.
+An error response is a "response" object which consists of a sole "error" key to
+indicate an error.
 
 They look like:
 
@@ -96,23 +105,27 @@ The "message" key should be a human-friendly string.
 
 Internally the driver consists of two main message types:
 
-- [`machine::IncomingMessage`] collects all possible "input" information which can come from the [`MatrixDriver`]
-  or the [`WidgetDriverHandle`] channel, that passes over the actions from the widget.
+- [`machine::IncomingMessage`] collects all possible "input" information which
+  can come from the [`MatrixDriver`] or the [`WidgetDriverHandle`] channel, that
+  passes over the actions from the widget.
   - `WidgetMessage`: An incoming raw message from the widget.
-  - `MatrixDriverResponse`: A response to a request from the `WidgetMachine` to the `MatrixDriver`.
-    For example if the `WidgetMachine` requests the `MatrixDriver` to get approved capabilities,
-    the response would contain what capabilities actually were approved.
-  - `MatrixEventReceived`: The `MatrixDriver` notified the `WidgetMachine` of a new Matrix event.
-- [`machine::Action`] describes an operation that the `WidgetDriver` wants to perform:
+  - `MatrixDriverResponse`: A response to a request from the `WidgetMachine` to
+    the `MatrixDriver`. For example if the `WidgetMachine` requests the
+    `MatrixDriver` to get approved capabilities, the response would contain what
+    capabilities actually were approved.
+  - `MatrixEventReceived`: The `MatrixDriver` notified the `WidgetMachine` of a
+    new Matrix event.
+- [`machine::Action`] describes an operation that the `WidgetDriver` wants to
+  perform:
   - `SendToWidget`: Send a raw message to the widget.
-  - `MatrixDriverRequest`: A command sent from the client widget API state machine to the
-    client (driver). Once the command is executed,
-    the client will typically generate an `MatrixDriverResponse` with the result.
+  - `MatrixDriverRequest`: A command sent from the client widget API state
+    machine to the client (driver). Once the command is executed, the client
+    will typically generate an `MatrixDriverResponse` with the result.
   - `Subscribe`: Subscribe to the events that the widget capabilities allow,
     in the _current_ room, i.e. a room which this widget is instantiated with.
     The client is aware of the room.
-  - `Unsubscribe`: Unsubscribe from the events that the widget capabilities allow,
-    in the _current_ room. Symmetrical to `Subscribe`.
+  - `Unsubscribe`: Unsubscribe from the events that the widget capabilities
+    allow, in the _current_ room. Symmetrical to `Subscribe`.
 
 ```ascii
                                        Public API ──╮                                                      
@@ -156,10 +169,12 @@ Internally the driver consists of two main message types:
 
 The `WidgetDriver` itself is responsible for:
 
-- processing the `Action`s (capability checks) and feeding new `IncomingMessage` to the `WidgetMachine`
+- processing the `Action`s (capability checks) and feeding new `IncomingMessage`
+  to the `WidgetMachine`
 - doing the serialization,
 - spawning the different loops (`MatrixDriver`, `WidgetMachine`),
-- Exposing the channels `WidgetDriverHandle` for the client to hook up the widget,
+- Exposing the channels `WidgetDriverHandle` for the client to hook up the
+  widget,
 
 The `WidgetMachine` is a no IO state machine responsible for the stateful logic.
 
@@ -174,14 +189,17 @@ The `WidgetMachine` is a no IO state machine responsible for the stateful logic.
 
 To use this module, two structs are needed:
 
-- The `CapabilitiesProvider`: This trait uses the `acquire_capabilities` method to ask a client which capabilities
-  the widget is allowed. An example capability can be: reading events of type `"m.room.message"`.
+- The `CapabilitiesProvider`: This trait uses the `acquire_capabilities` method
+  to ask a client which capabilities the widget is allowed. An example
+  capability can be: reading events of type `"m.room.message"`.
 
 - The `WidgetDriver` itself, which consists of:
-  - The `driver`: Its only public method is `run`, which is used to actually start the widget communication.
-  - The message `handle`: This handle has `recv` and `send` methods.
-    A JSON message sent from the widget to the client needs to be passed to the handle via `send`.
-    Any JSON message the handle emits via `recv` needs to be sent to the widget via `postMessage`.
+  - The `driver`: Its only public method is `run`, which is used to actually
+    start the widget communication.
+  - The message `handle`: This handle has `recv` and `send` methods. A JSON
+    message sent from the widget to the client needs to be passed to the handle
+    via `send`. Any JSON message the handle emits via `recv` needs to be sent to
+    the widget via `postMessage`.
 
 ```rust
 #[derive(Clone)]
@@ -229,6 +247,7 @@ spawn(async move {
 });
 ```
 
-## Feature Flags
+## Feature flags
 
-This module will only be active when used with the `experimental-widgets` feature flag.
+This module will only be active when used with the `experimental-widgets`
+feature flag.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,7 @@
-# Matrix SDK Examples
+# Matrix SDK examples
 
-In this folder you find examples for using the matrix-sdk (and its various components) to implement specific common features, each as a separate crate. You can run each of them from the root of the repository, mind you that `_` becomes `-` and the crate names are prefixed with `example-`. So to run the image bot example you can do `cargo run -p example-image-bot`.
+In this folder you find examples for using the matrix-sdk (and its various
+components) to implement specific common features, each as a separate crate. You
+can run each of them from the root of the repository, mind you that `_` becomes
+`-` and the crate names are prefixed with `example-`. So to run the image bot
+example you can do `cargo run -p example-image-bot`.

--- a/labs/README.md
+++ b/labs/README.md
@@ -1,19 +1,21 @@
 # Experiments
 
-This directory contains experiments, work-in-progress crates, or other code and documentation, that
-do not fall under the same stability guarantees as the main crates (`matrix-sdk`,
-`matrix-sdk-crypto`, etc.).
+This directory contains experiments, work-in-progress crates, or other code and
+documentation, that do not fall under the same stability guarantees as the main
+crates (`matrix-sdk`, `matrix-sdk-crypto`, etc.).
 
 Lab projects might be abandoned and possibly removed at any time.
 
 ---
 
-That said, this directory is meant to freely explore unconventional or interesting ways the Matrix
-Rust SDK can evolve, feel free to propose an experiment.
+That said, this directory is meant to freely explore unconventional or
+interesting ways the Matrix Rust SDK can evolve, feel free to propose an
+experiment.
 
 ## Current experiments
 
-- multiverse: a TUI client mostly for quick development iteration of SDK features and debugging.
+- multiverse: a TUI client mostly for quick development iteration of SDK
+  features and debugging.
   - Run with `cargo run --bin multiverse matrix.org ~/.cache/multiverse-cache`.
   - To inspect network requests, there is a `--proxy` option which can use in
     combination with [mitmproxy](https://www.mitmproxy.org/):

--- a/labs/setup-pattern.md
+++ b/labs/setup-pattern.md
@@ -1,71 +1,84 @@
-# The Setup Pattern
+# The setup pattern
 
-One pattern that bot developers might find useful when using the Matrix Rust SDK is to use a "setup"
-pattern, which, simply put, consists of having a bot user bootstrap the bot through a dedicated
-`setup` (sub)command, and then run the main executable.
+One pattern that bot developers might find useful when using the Matrix Rust SDK
+is to use a "setup" pattern, which, simply put, consists of having a bot user
+bootstrap the bot through a dedicated `setup` (sub)command, and then run the
+main executable.
 
-Then, together with that, create an invariant in the main executable: Always expect state.
+Then, together with that, create an invariant in the main executable: Always
+expect state.
 
 The latter can be done by checking if the path to a stored and serialized
-[`Session`](https://docs.rs/matrix-sdk/latest/matrix_sdk/struct.Session.html) configuration exists
-(as created during the `setup` command), and/or by checking for files under the path provided to
+[`Session`](https://docs.rs/matrix-sdk/latest/matrix_sdk/struct.Session.html)
+configuration exists (as created during the `setup` command), and/or by checking
+for files under the path provided to
 [`make_store_config`](https://docs.rs/matrix-sdk/latest/matrix_sdk/store/fn.make_store_config.html).
 
 If the main executable can't find this configuration, abort running.
 
 ## Context
 
-The context of this pattern document, and the reason for the crystallization of this idea, is that
-currently the "modus operandi" of Instant Messaging bots is quite stateless. Bots might still have
-state pertaining to users, databases and whatnot that contain explicit state of business logic, but
-it's not expected that the *bot itself* has state.
+The context of this pattern document, and the reason for the crystallization of
+this idea, is that currently the "modus operandi" of Instant Messaging bots is
+quite stateless. Bots might still have state pertaining to users, databases and
+whatnot that contain explicit state of business logic, but it's not expected
+that the _bot itself_ has state.
 
-This expectation becomes especially problematic when combined with E2EE, where the running
-application has to not lose sight of it, or else it'll lose access to E2EE (group) chats.
+This expectation becomes especially problematic when combined with E2EE, where
+the running application has to not lose sight of it, or else it'll lose access
+to E2EE (group) chats.
 
-This expectation exists both on the developer and user side of bots, and so to start fixing
-it, this pattern is recommended to bot creators, as then the lifetime cycle of the bot
-(and its data) is clear to every party involved, and errors are not necessarily "fatal" (or
-catastrophic while confusing).
+This expectation exists both on the developer and user side of bots, and so to
+start fixing it, this pattern is recommended to bot creators, as then the
+lifetime cycle of the bot (and its data) is clear to every party involved, and
+errors are not necessarily "fatal" (or catastrophic while confusing).
 
 ## Consequence
 
-Some of the consequences of the above invariant (setup phase initializes state, run phase expects it initialized) are the following;
-- If the bot starts, but cannot find a state directory, it'll abort without implicitly creating one.
-- If the setup command is ran while state already exists, it would either abort or offer
-  modification (such as a different client URL) to the operator.
-- E2EE state cannot easily become wedged or confusingly absent inbetween bot runs, as the run phase
-  will not run (and alter E2EE server state, such as device keys) unless it can find the existing
-  E2EE state, which should already be initialized.
-  - This prevents problems where a bot will try to re-create a device after it lost its state, and
-    the new device/login is not verified and thus not trusted in E2EE rooms, which is hard to debug.
-  - Instead, the bot will refuse to run at all, preventing it digging itself a deeper ditch, letting
-    the operator be notified something is wrong, and either restore the state, or recover it.
-- During the setup phase, while the operator is actively interacting with the bot to set it up, an
-  E2EE recovery phrase / password / blob could be printed to the terminal for safekeeping, to be used in
-  case the original E2EE data ever becomes lost.
-  - This would be done during setup instead of a run phase to make: a. make sure the operator sees
-    it, and b. if the operator forgets to point the bot's state directories to a persistent file
-    system, it has already taken note of the recovery information separately, and so the problem
-    with a lost E2EE state can be resolved as long as they still have access to that
-    information.
+Some of the consequences of the above invariant (setup phase initializes state,
+run phase expects it initialized) are the following;
 
-## Extra Notes
+- If the bot starts, but cannot find a state directory, it'll abort without
+  implicitly creating one.
+- If the setup command is ran while state already exists, it would either abort
+  or offer modification (such as a different client URL) to the operator.
+- E2EE state cannot easily become wedged or confusingly absent inbetween bot
+  runs, as the run phase will not run (and alter E2EE server state, such as
+  device keys) unless it can find the existing E2EE state, which should already
+  be initialized.
+  - This prevents problems where a bot will try to re-create a device after it
+    lost its state, and the new device/login is not verified and thus not
+    trusted in E2EE rooms, which is hard to debug.
+  - Instead, the bot will refuse to run at all, preventing it digging itself a
+    deeper ditch, letting the operator be notified something is wrong, and
+    either restore the state, or recover it.
+- During the setup phase, while the operator is actively interacting with the
+  bot to set it up, an E2EE recovery phrase / password / blob could be printed
+  to the terminal for safekeeping, to be used in case the original E2EE data
+  ever becomes lost.
+  - This would be done during setup instead of a run phase to make: a. make sure
+    the operator sees it, and b. if the operator forgets to point the bot's
+    state directories to a persistent file system, it has already taken note of
+    the recovery information separately, and so the problem with a lost E2EE
+    state can be resolved as long as they still have access to that information.
 
-This pattern would work well in a docker environment, as a bot developer could recommend the
-following;
+## Extra notes
 
-They can recommend a `docker-compose.yml` file to be used for keeping track of a container
-lifecycle, and recommend the `docker-compose run bot setup` command before `docker-compose up -d`,
-to give bot operators an easy time setting it up, despite matrix's unconventional stateful nature
-(compared to other bot ecosystems).
+This pattern would work well in a docker environment, as a bot developer could
+recommend the following;
+
+They can recommend a `docker-compose.yml` file to be used for keeping track of a
+container lifecycle, and recommend the `docker-compose run bot setup` command
+before `docker-compose up -d`, to give bot operators an easy time setting it up,
+despite matrix's unconventional stateful nature (compared to other bot
+ecosystems).
 
 ## What this means for `matrix_sdk`
 
-`matrix_sdk` could help this pattern by building in either a "create" or "open" intent for state,
-where it'll error if it can't do either.
+`matrix_sdk` could help this pattern by building in either a "create" or "open"
+intent for state, where it'll error if it can't do either.
 
-Currently I don't see this in `make_store_config`, where it seems to implicitly choose either one,
-but if it's made more explicit to *either* open the state database, *or* create it, it would help
-guide developers a lot to this pattern, which in turn could guide bot operators to follow this
-pattern as well.
+Currently I don't see this in `make_store_config`, where it seems to implicitly
+choose either one, but if it's made more explicit to _either_ open the state
+database, _or_ create it, it would help guide developers a lot to this pattern,
+which in turn could guide bot operators to follow this pattern as well.

--- a/testing/data/storage/alice/README.md
+++ b/testing/data/storage/alice/README.md
@@ -1,8 +1,9 @@
-This database was built using a developer build of EXA using a localhost synapse.
-Contains several olm sessions, megolm sessions, identities.
-Used as a snapshot to test migrations to futures versions. 
-The database file is exported using the Android Studio `Device Explorer` tool (in `files/sessions/xxx`).
-In order to get the passphrase a breakpoint must be added in the ClientBuilder to get it.
-Passphrase: `/rCia2fYAJ+twCZ1Xm2mxFCYcmJdyzkdJjwtgXsziWpYS/UeNxnixuSieuwZXm+x1VsJHmWplH+QIQBZpEGZtC9/S/l8xK+WOCesmET0o6yJ/KP73ofDtjBlnNpPwuHLKFpyTbyicpCgQ4UT+5EUBuJ08TY9Ujdf1D13k5kr5tSZUefDKKCuG1fCRqlU8ByRas1PMQsZxT2W8t7QgBrQiiGmhpo/OTi4hfx97GOxncKcxTzppiYQNoHs/f15+XXQD7/oiCcqRIuUlXNsU6hRpFGmbYx2Pi1eyQViQCtB5dAEiSD0N8U81wXYnpynuTPtnL+hfnOJIn7Sy7mkERQeKg`
+This database was built using a developer build of EXA using a localhost
+synapse. Contains several olm sessions, megolm sessions, identities. Used as a
+snapshot to test migrations to futures versions. The database file is exported
+using the Android Studio `Device Explorer` tool (in `files/sessions/xxx`). In
+order to get the passphrase a breakpoint must be added in the ClientBuilder to
+get it. Passphrase:
+`/rCia2fYAJ+twCZ1Xm2mxFCYcmJdyzkdJjwtgXsziWpYS/UeNxnixuSieuwZXm+x1VsJHmWplH+QIQBZpEGZtC9/S/l8xK+WOCesmET0o6yJ/KP73ofDtjBlnNpPwuHLKFpyTbyicpCgQ4UT+5EUBuJ08TY9Ujdf1D13k5kr5tSZUefDKKCuG1fCRqlU8ByRas1PMQsZxT2W8t7QgBrQiiGmhpo/OTi4hfx97GOxncKcxTzppiYQNoHs/f15+XXQD7/oiCcqRIuUlXNsU6hRpFGmbYx2Pi1eyQViQCtB5dAEiSD0N8U81wXYnpynuTPtnL+hfnOJIn7Sy7mkERQeKg`
 
 Username is @alice:localhost

--- a/testing/matrix-sdk-integration-testing/README.md
+++ b/testing/matrix-sdk-integration-testing/README.md
@@ -1,13 +1,14 @@
 # Matrix SDK integration test
 
-This set of tests requires a Synapse instance, and it runs the tests from this directory against
-this real-world server. As a result, these tests depend on the load of the machine/server, and as
-such they might be more sensitive to timing issues than other tests in the code base.
+This set of tests requires a Synapse instance, and it runs the tests from this
+directory against this real-world server. As a result, these tests depend on the
+load of the machine/server, and as such they might be more sensitive to timing
+issues than other tests in the code base.
 
 ## Requirements
 
-This requires a synapse backend with a configuration patched for CI. You can get it up and running
-with `docker compose` via:
+This requires a synapse backend with a configuration patched for CI. You can get
+it up and running with `docker compose` via:
 
 ```sh
 docker compose -f assets/docker-compose.yml up -d
@@ -16,18 +17,19 @@ docker compose -f assets/docker-compose.yml logs --tail 100 -f
 
 Note that this works also with `podman compose`.
 
-**Patches**
-You can see the patches we do to configuration (namely activate registration and resetting rate
-limits, enable a few experimental features), check out what `assets/ci-start.sh` changes.
+**Patches** You can see the patches we do to configuration (namely activate
+registration and resetting rate limits, enable a few experimental features),
+check out what `assets/ci-start.sh` changes.
 
 ## Running
 
 The integration tests can be run with `cargo test` or `cargo nextest run`.
 
-The integration tests expect the environment variables `HOMESERVER_URL` to be the HTTP URL to
-access the synapse server and `HOMESERVER_DOMAIN` to be set to the domain configured in
-that server. These variables are set to a default value that matches the default `docker-compose.yml`
-template; if you haven't touched it, you don't need to manually set those environment variables.
+The integration tests expect the environment variables `HOMESERVER_URL` to be
+the HTTP URL to access the synapse server and `HOMESERVER_DOMAIN` to be set to
+the domain configured in that server. These variables are set to a default value
+that matches the default `docker-compose.yml` template; if you haven't touched
+it, you don't need to manually set those environment variables.
 
 ## Maintenance
 
@@ -41,8 +43,8 @@ docker compose -f assets/docker-compose.yml down --volumes --remove-orphans -t 0
 
 ### Rebuild the synapse image
 
-If the Synapse image has been updated in version, you may need to rebuild the custom Synapse image
-using the following:
+If the Synapse image has been updated in version, you may need to rebuild the
+custom Synapse image using the following:
 
 ```bash
 docker compose -f assets/docker-compose.yml build --pull synapse

--- a/testing/matrix-sdk-test-macros/README.md
+++ b/testing/matrix-sdk-test-macros/README.md
@@ -3,9 +3,10 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![#matrix-rust-sdk](https://img.shields.io/badge/matrix-%23matrix--rust--sdk-blue?style=flat-square)](https://matrix.to/#/#matrix-rust-sdk:matrix.org)
 
-# matrix-sdk-test-macros
+# Matrix-sdk-test-macros
 
-**matrix-rust-sdk** is an implementation of a [Matrix][] client-server library in [Rust][].
+**matrix-rust-sdk** is an implementation of a [Matrix][matrix] client-server
+library in [Rust][rust].
 
 **NOTE:** These are just macros that help test the matrix-rust-sdk, you're
 probably interested in the main

--- a/testing/matrix-sdk-test-macros/README.md
+++ b/testing/matrix-sdk-test-macros/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![#matrix-rust-sdk](https://img.shields.io/badge/matrix-%23matrix--rust--sdk-blue?style=flat-square)](https://matrix.to/#/#matrix-rust-sdk:matrix.org)
 
-# Matrix-sdk-test-macros
+# `matrix-sdk-test-macros`
 
 **matrix-rust-sdk** is an implementation of a [Matrix][matrix] client-server
 library in [Rust][rust].

--- a/testing/matrix-sdk-test/README.md
+++ b/testing/matrix-sdk-test/README.md
@@ -3,9 +3,10 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![#matrix-rust-sdk](https://img.shields.io/badge/matrix-%23matrix--rust--sdk-blue?style=flat-square)](https://matrix.to/#/#matrix-rust-sdk:matrix.org)
 
-# matrix-sdk-test
+# `matrix-sdk-test`
 
-**matrix-rust-sdk** is an implementation of a [Matrix][] client-server library in [Rust][].
+**matrix-rust-sdk** is an implementation of a [Matrix][matrix] client-server
+library in [Rust][rust].
 
 **NOTE:** These are just test helpers for the matrix-rust-sdk, you're
 probably interested in the main


### PR DESCRIPTION
These patches are an attempt to use [`rumdl`](https://github.com/rvben/rumdl) in the Matrix Rust SDK. This is not yet enabled on CI. I first want everyone to agree on the set of rules and their configuration, plus how it applies on real files, before going further.

---

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.
