### PR TITLE
feat(ffi): Expose `SqliteStoreBuilder::key` in the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6805.feature.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6805.feature.md
@@ -1,0 +1,17 @@
+Expose `SqliteStoreBuilder::key` to allow clients to specify a key as a 32-bytes array that will be used as is, skipping the key derivation process and speeding up opening DB connections. Note this should only be used for truly random values with high entropy, for user-provided passphrases the `SqliteStoreBuilder::passphrase` function should still be used. Some examples for the bindings are:
+
+Kotlin:
+
+```kotlin
+val buffer = ByteArray(size = 32)
+SecureRandom().nextBytes(buffer)
+return buffer // this now contains the key
+```
+
+Swift:
+
+```swift
+var bytes = [UInt8](repeating: 0, count: 32)
+SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+return Data(bytes: bytes) // this now contains the key
+```

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -82,6 +82,8 @@ pub enum ClientBuildError {
     Sdk(MatrixClientBuildError),
     #[error(transparent)]
     EventCache(#[from] EventCacheError),
+    #[error("The supplied raw key is invalid. Check it's a byte array of 32 bytes.")]
+    InvalidRawKey,
     #[error("Failed to build the client: {message}")]
     Generic { message: String },
 }

--- a/bindings/matrix-sdk-ffi/src/store.rs
+++ b/bindings/matrix-sdk-ffi/src/store.rs
@@ -64,6 +64,7 @@ mod sqlite {
     pub struct SqliteStoreBuilder {
         paths: StorePaths,
         passphrase: Zeroizing<Option<String>>,
+        key: Zeroizing<Option<Vec<u8>>>,
         pool_max_size: Option<usize>,
         cache_size: Option<u32>,
         journal_size_limit: Option<u32>,
@@ -75,6 +76,7 @@ mod sqlite {
             Self {
                 paths: StorePaths { data_path, cache_path },
                 passphrase: Zeroizing::new(None),
+                key: Zeroizing::new(None),
                 pool_max_size: None,
                 cache_size: None,
                 journal_size_limit: None,
@@ -96,10 +98,21 @@ mod sqlite {
             Arc::new(Self::raw_new(data_path, cache_path))
         }
 
-        /// Set the passphrase for the stores.
+        /// Set the passphrase for the stores and removes any [`Self::key`]
+        /// previously set.
         pub fn passphrase(self: Arc<Self>, passphrase: Option<String>) -> Arc<Self> {
             let mut builder = unwrap_or_clone_arc(self);
             builder.passphrase = Zeroizing::new(passphrase);
+            builder.key = Zeroizing::new(None);
+            Arc::new(builder)
+        }
+
+        /// Set the raw key for the stores and removes any [`Self::passphrase`]
+        /// previously set.
+        pub fn key(self: Arc<Self>, key: Option<Vec<u8>>) -> Arc<Self> {
+            let mut builder = unwrap_or_clone_arc(self);
+            builder.key = Zeroizing::new(key);
+            builder.passphrase = Zeroizing::new(None);
             Arc::new(builder)
         }
 
@@ -182,7 +195,14 @@ mod sqlite {
                 SqliteStoreConfig::new(data_path)
             };
 
-            sqlite_store_config = sqlite_store_config.passphrase(self.passphrase.as_deref());
+            if let Some(key) = self.key.as_deref() {
+                match key.try_into() {
+                    Ok(data) => sqlite_store_config = sqlite_store_config.key(Some(&data)),
+                    Err(_) => return Err(ClientBuildError::InvalidRawKey),
+                }
+            } else if let Some(passphrase) = self.passphrase.as_deref() {
+                sqlite_store_config = sqlite_store_config.passphrase(Some(passphrase));
+            }
 
             if let Some(size) = self.pool_max_size {
                 sqlite_store_config = sqlite_store_config.pool_max_size(size);


### PR DESCRIPTION
This allows clients to provide a raw key instead of a passphrase for the key used to encrypt and decrypt data in the store DBs.

Using a raw key with enough entropy should be safe, and we can skip the key derivation performed in the passphrase, which slows down session restoration (it's now 50% faster in my local tests).

<!-- description of the changes in this PR -->

- [x] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
