### PR TITLE
Fix timeline beacon info replacement path

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -195,7 +195,7 @@ impl<P: RoomDataProvider> TimelineState<P> {
         };
 
         let timeline_action = TimelineAction::from_content(content, in_reply_to, thread_root, None);
-        TimelineEventHandler::new(&mut txn, ctx)
+        TimelineEventHandler::new(&mut txn, &ctx)
             .handle_event(&mut date_divider_adjuster, timeline_action, None)
             .await;
         txn.adjust_date_dividers(date_divider_adjuster);

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -243,7 +243,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         let event_id = deserialized.event_id().to_owned();
         let txn_id = deserialized.transaction_id().map(ToOwned::to_owned);
 
-        let timeline_action = TimelineAction::from_event(
+        let timeline_actions = TimelineAction::from_event(
             deserialized,
             raw_event,
             room_data_provider,
@@ -254,56 +254,53 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         )
         .await;
 
-        match timeline_action {
-            Some(action @ TimelineAction::AddItem { .. })
-            | Some(action @ TimelineAction::HandleAggregation { .. }) => {
-                let encryption_info = event.kind.encryption_info().cloned();
-                let sender_profile = room_data_provider.profile_from_user_id(&sender).await;
+        if timeline_actions.is_empty() {
+            return;
+        }
 
-                let (forwarder, forwarder_profile) =
-                    get_forwarder_info(&event, room_data_provider).await;
+        let encryption_info = event.kind.encryption_info().cloned();
+        let sender_profile = room_data_provider.profile_from_user_id(&sender).await;
 
-                let mut ctx = TimelineEventContext {
-                    sender,
-                    sender_profile,
-                    forwarder,
-                    forwarder_profile,
-                    timestamp,
-                    // These are not used when handling an aggregation.
-                    read_receipts: Default::default(),
-                    is_highlighted: false,
-                    flow: Flow::Remote {
-                        event_id: event_id.clone(),
-                        raw_event: event.raw().clone(),
-                        encryption_info,
-                        txn_id,
-                        position,
-                    },
-                    // This field is not used when handling an aggregation.
-                    should_add_new_items: false,
-                };
+        let (forwarder, forwarder_profile) = get_forwarder_info(&event, room_data_provider).await;
 
-                // FIXME: Continuation of the hackjob to get UTDs for focused timelines
-                // working from `handle_remote_aggregations()`.
-                if let TimelineAction::AddItem { .. } = action
-                    && let TimelineItemPosition::UpdateAt { timeline_item_index } = position
-                    && let Some(event) = self.items.get(timeline_item_index)
-                    && event
-                        .as_event()
-                        .map(|e| {
-                            e.content().is_unable_to_decrypt() && e.event_id() == Some(&event_id)
-                        })
-                        .unwrap_or_default()
-                {
-                    // Except when this is an UTD transitioning into a decrypted event.
-                    ctx.should_add_new_items = true;
-                }
+        let mut ctx = TimelineEventContext {
+            sender,
+            sender_profile,
+            forwarder,
+            forwarder_profile,
+            timestamp,
+            // These are not used when handling an aggregation.
+            read_receipts: Default::default(),
+            is_highlighted: false,
+            flow: Flow::Remote {
+                event_id: event_id.clone(),
+                raw_event: event.raw().clone(),
+                encryption_info,
+                txn_id,
+                position,
+            },
+            // This field is not used when handling an aggregation.
+            should_add_new_items: false,
+        };
 
-                TimelineEventHandler::new(self, &ctx)
-                    .handle_event(date_divider_adjuster, action, None)
-                    .await;
-            }
-            None => {}
+        // FIXME: Continuation of the hackjob to get UTDs for focused timelines
+        // working from `handle_remote_aggregations()`.
+        if let [TimelineAction::AddItem { .. }] = timeline_actions.as_slice()
+            && let TimelineItemPosition::UpdateAt { timeline_item_index } = position
+            && let Some(item) = self.items.get(timeline_item_index)
+            && item
+                .as_event()
+                .map(|e| e.content().is_unable_to_decrypt() && e.event_id() == Some(&event_id))
+                .unwrap_or_default()
+        {
+            // Except when this is an UTD transitioning into a decrypted event.
+            ctx.should_add_new_items = true;
+        }
+
+        for action in timeline_actions {
+            TimelineEventHandler::new(self, &ctx)
+                .handle_event(date_divider_adjuster, action, None)
+                .await;
         }
     }
 
@@ -590,7 +587,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         OwnedUserId,
         MilliSecondsSinceUnixEpoch,
         Option<OwnedTransactionId>,
-        Option<TimelineAction>,
+        Vec<TimelineAction>,
         Option<OwnedEventId>,
         bool,
         bool,
@@ -650,7 +647,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     sender,
                     origin_server_ts,
                     transaction_id,
-                    Some(TimelineAction::failed_to_parse(event_type, deserialization_error)),
+                    vec![TimelineAction::failed_to_parse(event_type, deserialization_error)],
                     None,
                     true,
                     true,
@@ -831,7 +828,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             sender,
             timestamp,
             txn_id,
-            timeline_action,
+            timeline_actions,
             thread_root,
             should_add,
             can_show_read_receipts,
@@ -903,7 +900,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         .await;
 
         // Handle the event to create or update a timeline item.
-        let item_added = if let Some(timeline_action) = timeline_action {
+        let item_added = if !timeline_actions.is_empty() {
             let sender_profile = if let Some(profile) = profiles.get(&sender) {
                 profile.clone()
             } else {
@@ -912,6 +909,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 profile
             };
 
+            let mut item_added = false;
             let ctx = TimelineEventContext {
                 sender,
                 sender_profile,
@@ -930,6 +928,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 } else {
                     Default::default()
                 },
+
                 is_highlighted,
                 flow: Flow::Remote {
                     event_id: event_id.clone(),
@@ -940,10 +939,20 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 },
                 should_add_new_items: should_add,
             };
+            // A recycled timeline ID carries the TimelineUniqueId from a previously
+            // removed item (see VectorDiff::Remove), so that when the same event is
+            // re-added in the same diff batch the UI sees a stable identifier.
+            // It is only applicable when the event produces a single AddItem action;
+            // with multiple actions (e.g. beacon replace) there
+            // is no single item to associate it with, so it's safe to ignore.
+            let recycled_timeline_id = recycled_timeline_id.filter(|_| timeline_actions.len() == 1);
 
-            TimelineEventHandler::new(self, &ctx)
-                .handle_event(date_divider_adjuster, timeline_action, recycled_timeline_id)
-                .await
+            for action in timeline_actions {
+                item_added |= TimelineEventHandler::new(self, &ctx)
+                    .handle_event(date_divider_adjuster, action, recycled_timeline_id.clone())
+                    .await;
+            }
+            item_added
         } else {
             // No item has been added to the timeline.
             false

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -299,7 +299,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     ctx.should_add_new_items = true;
                 }
 
-                TimelineEventHandler::new(self, ctx)
+                TimelineEventHandler::new(self, &ctx)
                     .handle_event(date_divider_adjuster, action, None)
                     .await;
             }
@@ -941,7 +941,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 should_add_new_items: should_add,
             };
 
-            TimelineEventHandler::new(self, ctx)
+            TimelineEventHandler::new(self, &ctx)
                 .handle_event(date_divider_adjuster, timeline_action, recycled_timeline_id)
                 .await
         } else {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -221,9 +221,9 @@ impl TimelineAction {
         Self::AddItem { content }
     }
 
-    /// Create a new [`TimelineAction`] from a given remote event.
+    /// Create all timeline actions from a given remote event.
     ///
-    /// The return value may be `None` if the event was a redacted reaction.
+    /// The return value may be empty if the event was a redacted reaction.
     #[allow(clippy::too_many_arguments)]
     pub async fn from_event<P: RoomDataProvider>(
         event: AnySyncTimelineEvent,
@@ -233,7 +233,7 @@ impl TimelineAction {
         in_reply_to: Option<InReplyToDetails>,
         thread_root: Option<OwnedEventId>,
         thread_summary: Option<ThreadSummary>,
-    ) -> Option<Self> {
+    ) -> Vec<TimelineAction> {
         let redaction_rules = room_data_provider.room_version_rules().redaction;
 
         let redacted_message_or_none = |event_type: MessageLikeEventType| {
@@ -241,15 +241,18 @@ impl TimelineAction {
                 .then_some(TimelineItemContent::MsgLike(MsgLikeContent::redacted()))
         };
 
-        Some(match event {
+        match event {
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) => {
                 if let Some(redacts) = ev.redacts(&redaction_rules).map(ToOwned::to_owned) {
-                    Self::HandleAggregation {
+                    vec![Self::HandleAggregation {
                         related_event: redacts,
                         kind: HandleAggregationKind::Redaction,
-                    }
+                    }]
                 } else {
-                    Self::add_item(redacted_message_or_none(ev.event_type())?)
+                    redacted_message_or_none(ev.event_type())
+                        .map(Self::add_item)
+                        .into_iter()
+                        .collect()
                 }
             }
 
@@ -277,50 +280,53 @@ impl TimelineAction {
                             .await;
                         }
 
-                        Self::add_item(TimelineItemContent::MsgLike(
+                        vec![Self::add_item(TimelineItemContent::MsgLike(
                             MsgLikeContent::unable_to_decrypt(EncryptedMessage::from_content(
                                 content, utd_cause,
                             )),
-                        ))
+                        ))]
                     } else {
                         // If we get here, it means that some part of the code has created a
                         // `TimelineEvent` containing an `m.room.encrypted` event without
                         // decrypting it. Possibly this means that encryption has not been
                         // configured. We treat it the same as any other message-like event.
-                        Self::from_content(
+                        vec![Self::from_content(
                             AnyMessageLikeEventContent::RoomEncrypted(content),
                             in_reply_to,
                             thread_root,
                             thread_summary,
-                        )
+                        )]
                     }
                 }
 
                 Some(content) => {
-                    Self::from_content(content, in_reply_to, thread_root, thread_summary)
+                    vec![Self::from_content(content, in_reply_to, thread_root, thread_summary)]
                 }
 
-                None => Self::add_item(redacted_message_or_none(ev.event_type())?),
+                None => redacted_message_or_none(ev.event_type())
+                    .map(Self::add_item)
+                    .into_iter()
+                    .collect(),
             },
 
             AnySyncTimelineEvent::State(ev) => match ev {
                 AnySyncStateEvent::RoomMember(ev) => match ev {
                     SyncStateEvent::Original(ev) => {
-                        Self::add_item(TimelineItemContent::room_member(
+                        vec![Self::add_item(TimelineItemContent::room_member(
                             ev.state_key,
                             StateEventContentChange::Original {
                                 content: ev.content,
                                 prev_content: ev.unsigned.prev_content,
                             },
                             ev.sender,
-                        ))
+                        ))]
                     }
                     SyncStateEvent::Redacted(ev) => {
-                        Self::add_item(TimelineItemContent::room_member(
+                        vec![Self::add_item(TimelineItemContent::room_member(
                             ev.state_key,
                             StateEventContentChange::Redacted(ev.content),
                             ev.sender,
-                        ))
+                        ))]
                     }
                 },
                 AnySyncStateEvent::BeaconInfo(ev) => match ev {
@@ -330,37 +336,39 @@ impl TimelineAction {
                         // beacon_info that was started as live, regardless of whether
                         // the timeout has since expired.
                         if ev.content.live {
-                            Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
+                            vec![Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
                                 kind: MsgLikeKind::LiveLocation(LiveLocationState::new(ev.content)),
                                 reactions: Default::default(),
                                 thread_root: None,
                                 in_reply_to: None,
                                 thread_summary: None,
-                            }))
+                            }))]
                         } else {
                             // A non-live beacon_info is a stop event: it should update the
                             // existing live item from the same sender rather than creating a
                             // new timeline item.
-                            Self::HandleAggregation {
+                            vec![Self::HandleAggregation {
                                 // There is no explicit relates_to on a beacon_info state event;
                                 // the target is identified by sender in handle_beacon_stop.
                                 related_event: ev.event_id,
                                 kind: HandleAggregationKind::BeaconStop { content: ev.content },
-                            }
+                            }]
                         }
                     }
                     SyncStateEvent::Redacted(_) => {
-                        Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent::redacted()))
+                        vec![Self::add_item(TimelineItemContent::MsgLike(
+                            MsgLikeContent::redacted(),
+                        ))]
                     }
                 },
-                ev => Self::add_item(TimelineItemContent::OtherState(OtherState {
+                ev => vec![Self::add_item(TimelineItemContent::OtherState(OtherState {
                     state_key: ev.state_key().to_owned(),
                     content: AnyOtherStateEventContentChange::with_event_content(
                         ev.content_change(),
                     ),
-                })),
+                }))],
             },
-        })
+        }
     }
 
     /// Create a new [`TimelineAction`] from a given event's content.

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -627,64 +627,75 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
         }
 
-        let mut added_item = false;
+        self.handle_timeline_action(timeline_action, recycled_timeline_id)
+    }
 
+    fn handle_timeline_action(
+        &mut self,
+        timeline_action: TimelineAction,
+        recycled_timeline_id: Option<TimelineUniqueId>,
+    ) -> bool {
         match timeline_action {
             TimelineAction::AddItem { content } => {
                 if self.ctx.should_add_new_items {
                     self.add_item(content, recycled_timeline_id);
-                    added_item = true;
+                    true
+                } else {
+                    false
                 }
             }
-
-            TimelineAction::HandleAggregation { related_event, kind } => match kind {
-                HandleAggregationKind::Reaction { key } => {
-                    self.handle_reaction(related_event, key);
-                }
-                HandleAggregationKind::Redaction => {
-                    self.handle_redaction(related_event);
-                }
-                HandleAggregationKind::Edit { replacement } => {
-                    self.handle_edit(
-                        replacement.event_id.clone(),
-                        PendingEditKind::RoomMessage(replacement),
-                    );
-                }
-                HandleAggregationKind::PollResponse { answers } => {
-                    self.handle_poll_response(related_event, answers);
-                }
-                HandleAggregationKind::PollEdit { replacement } => {
-                    self.handle_edit(
-                        replacement.event_id.clone(),
-                        PendingEditKind::Poll(replacement),
-                    );
-                }
-                HandleAggregationKind::PollEnd => {
-                    self.handle_poll_end(related_event);
-                }
-                HandleAggregationKind::BeaconUpdate { mut location } => {
-                    // Propagate the encryption info from the event context into
-                    // the beacon location update so it can be inspected later
-                    // (e.g. for shield state computation).
-                    let encryption_info = as_variant!(
-                        &self.ctx.flow,
-                        Flow::Remote { encryption_info, .. } => encryption_info.clone()
-                    )
-                    .flatten();
-                    location.encryption_info = encryption_info;
-
-                    self.handle_beacon_update(related_event, location);
-                }
-                HandleAggregationKind::BeaconStop { own_id, content } => {
-                    self.handle_beacon_stop(own_id, content);
-                }
-                HandleAggregationKind::CallDeclined => {
-                    self.handle_call_declined(related_event);
-                }
-            },
+            TimelineAction::HandleAggregation { related_event, kind } => {
+                self.handle_aggregation_action(related_event, kind);
+                false
+            }
         }
+    }
 
-        added_item
+    fn handle_aggregation_action(
+        &mut self,
+        related_event: OwnedEventId,
+        kind: HandleAggregationKind,
+    ) {
+        match kind {
+            HandleAggregationKind::Reaction { key } => {
+                self.handle_reaction(related_event, key);
+            }
+            HandleAggregationKind::Redaction => {
+                self.handle_redaction(related_event);
+            }
+            HandleAggregationKind::Edit { replacement } => {
+                self.handle_edit(
+                    replacement.event_id.clone(),
+                    PendingEditKind::RoomMessage(replacement),
+                );
+            }
+            HandleAggregationKind::PollResponse { answers } => {
+                self.handle_poll_response(related_event, answers);
+            }
+            HandleAggregationKind::PollEdit { replacement } => {
+                self.handle_edit(replacement.event_id.clone(), PendingEditKind::Poll(replacement));
+            }
+            HandleAggregationKind::PollEnd => {
+                self.handle_poll_end(related_event);
+            }
+            HandleAggregationKind::BeaconUpdate { mut location } => {
+                // Propagate the encryption info from the event context into the
+                // beacon location update so it can be inspected later.
+                let encryption_info = as_variant!(
+                    &self.ctx.flow,
+                    Flow::Remote { encryption_info, .. } => encryption_info.clone()
+                )
+                .flatten();
+                location.encryption_info = encryption_info;
+                self.handle_beacon_update(related_event, location);
+            }
+            HandleAggregationKind::BeaconStop { own_id, content } => {
+                self.handle_beacon_stop(own_id, content);
+            }
+            HandleAggregationKind::CallDeclined => {
+                self.handle_call_declined(related_event);
+            }
+        }
     }
 
     #[instrument(skip(self, edit_kind))]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -336,13 +336,36 @@ impl TimelineAction {
                         // beacon_info that was started as live, regardless of whether
                         // the timeout has since expired.
                         if ev.content.live {
-                            vec![Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
-                                kind: MsgLikeKind::LiveLocation(LiveLocationState::new(ev.content)),
-                                reactions: Default::default(),
-                                thread_root: None,
-                                in_reply_to: None,
-                                thread_summary: None,
-                            }))]
+                            let add_item_action =
+                                Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
+                                    kind: MsgLikeKind::LiveLocation(LiveLocationState::new(
+                                        ev.content,
+                                    )),
+                                    reactions: Default::default(),
+                                    thread_root: None,
+                                    in_reply_to: None,
+                                    thread_summary: None,
+                                }));
+                            let handle_aggregation_action = ev.unsigned.prev_content.map(|prev| {
+                                let prev_content = BeaconInfoEventContent::new(
+                                    prev.description,
+                                    prev.timeout,
+                                    false,
+                                    prev.ts,
+                                );
+                                Self::HandleAggregation {
+                                    related_event: ev.event_id.clone(),
+                                    kind: HandleAggregationKind::BeaconStop {
+                                        own_id: TimelineEventItemId::TransactionId(
+                                            TransactionId::new(),
+                                        ),
+                                        content: prev_content,
+                                    },
+                                }
+                            });
+                            let mut actions = vec![add_item_action];
+                            actions.extend(handle_aggregation_action);
+                            actions
                         } else {
                             // A non-live beacon_info is a stop event: it should update the
                             // existing live item from the same sender rather than creating a

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -563,13 +563,13 @@ pub(super) type RemovedItem = bool;
 pub(super) struct TimelineEventHandler<'a, 'o> {
     items: &'a mut ObservableItemsTransaction<'o>,
     meta: &'a mut TimelineMetadata,
-    ctx: TimelineEventContext,
+    ctx: &'a TimelineEventContext,
 }
 
 impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     pub(super) fn new<P: RoomDataProvider>(
         state: &'a mut TimelineStateTransaction<'o, P>,
-        ctx: TimelineEventContext,
+        ctx: &'a TimelineEventContext,
     ) -> Self {
         let TimelineStateTransaction { items, meta, .. } = state;
         Self { items, meta, ctx }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -165,7 +165,7 @@ pub(super) enum HandleAggregationKind {
     /// Sent when the user stops sharing their location. Unlike [`BeaconUpdate`]
     /// this does not carry a `relates_to` event ID; instead the target live
     /// item is found by matching the sender.
-    BeaconStop { content: BeaconInfoEventContent },
+    BeaconStop { own_id: TimelineEventItemId, content: BeaconInfoEventContent },
 
     /// A decline for an `m.rtc.notification` call.
     CallDeclined,
@@ -347,11 +347,15 @@ impl TimelineAction {
                             // A non-live beacon_info is a stop event: it should update the
                             // existing live item from the same sender rather than creating a
                             // new timeline item.
+                            let event_id = ev.event_id.clone();
                             vec![Self::HandleAggregation {
                                 // There is no explicit relates_to on a beacon_info state event;
                                 // the target is identified by sender in handle_beacon_stop.
-                                related_event: ev.event_id,
-                                kind: HandleAggregationKind::BeaconStop { content: ev.content },
+                                related_event: event_id.clone(),
+                                kind: HandleAggregationKind::BeaconStop {
+                                    own_id: TimelineEventItemId::EventId(event_id),
+                                    content: ev.content,
+                                },
                             }]
                         }
                     }
@@ -671,8 +675,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                     self.handle_beacon_update(related_event, location);
                 }
-                HandleAggregationKind::BeaconStop { content } => {
-                    self.handle_beacon_stop(content);
+                HandleAggregationKind::BeaconStop { own_id, content } => {
+                    self.handle_beacon_stop(own_id, content);
                 }
                 HandleAggregationKind::CallDeclined => {
                     self.handle_call_declined(related_event);
@@ -801,7 +805,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     /// The stop event's content must match the start item's content (except for
     /// the `live` field) to ensure we apply the stop to the correct session.
     #[instrument(skip(self, content))]
-    fn handle_beacon_stop(&mut self, content: BeaconInfoEventContent) {
+    fn handle_beacon_stop(&mut self, own_id: TimelineEventItemId, content: BeaconInfoEventContent) {
         let sender = &self.ctx.sender;
 
         // Find the live start item by sender and matching content.
@@ -811,10 +815,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         })
         .and_then(|(_, event_item)| event_item.inner.event_id().map(ToOwned::to_owned));
 
-        let aggregation = Aggregation::new(
-            self.ctx.flow.timeline_item_id(),
-            AggregationKind::BeaconStop { content },
-        );
+        let aggregation = Aggregation::new(own_id, AggregationKind::BeaconStop { content });
 
         let Some(target_event_id) = target_event_id else {
             // The live start item hasn't arrived yet (or the content doesn't match).

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -53,6 +53,7 @@ use ruma::{
     html::RemoveReplyFallback,
     room_version_rules::RedactionRules,
 };
+use tracing::warn;
 
 mod live_location;
 mod message;
@@ -162,7 +163,7 @@ impl TimelineItemContent {
         let raw_event = timeline_event.into_raw();
         let deserialized_event = raw_event.deserialize().ok()?;
 
-        match TimelineAction::from_event(
+        let actions = TimelineAction::from_event(
             deserialized_event,
             &raw_event,
             room,
@@ -171,30 +172,33 @@ impl TimelineItemContent {
             None,
             None,
         )
-        .await
-        {
-            Some(TimelineAction::AddItem { content }) => Some(content),
-
+        .await;
+        match actions.as_slice() {
+            [TimelineAction::AddItem { content }] => Some(content.clone()),
             // Aggregated event: only edits and beacon stop are supported at the moment.
-            Some(TimelineAction::HandleAggregation {
-                kind: HandleAggregationKind::BeaconStop { content },
-                ..
-            }) => Some(TimelineItemContent::MsgLike(MsgLikeContent {
-                kind: MsgLikeKind::LiveLocation(LiveLocationState::new(content)),
+            [
+                TimelineAction::HandleAggregation {
+                    kind: HandleAggregationKind::BeaconStop { content, .. },
+                    ..
+                },
+            ] => Some(TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::LiveLocation(LiveLocationState::new(content.clone())),
                 reactions: Default::default(),
                 thread_root: None,
                 in_reply_to: None,
                 thread_summary: None,
             })),
-
-            Some(TimelineAction::HandleAggregation {
-                kind: HandleAggregationKind::Edit { replacement: Replacement { new_content, .. } },
-                ..
-            }) => {
+            [
+                TimelineAction::HandleAggregation {
+                    kind:
+                        HandleAggregationKind::Edit { replacement: Replacement { new_content, .. } },
+                    ..
+                },
+            ] => {
                 // Map the edit to a regular message.
                 match TimelineAction::from_content(
                     AnyMessageLikeEventContent::RoomMessage(RoomMessageEventContent::new(
-                        new_content.msgtype,
+                        new_content.msgtype.clone(),
                     )),
                     None,
                     None,
@@ -204,7 +208,17 @@ impl TimelineItemContent {
                     _ => None,
                 }
             }
-
+            [] => {
+                warn!("No action for event content processing");
+                None
+            }
+            [_, _, ..] => {
+                // Multiple actions can happen e.g. when a beacon_info with prev_content
+                // is processed: it produces both an AddItem and a HandleAggregation.
+                // There is no meaningful single content to extract in that case.
+                warn!("Ignoring event that produced multiple timeline actions");
+                None
+            }
             _ => None,
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -123,7 +123,7 @@ impl EmbeddedEvent {
         let sender = event.sender().to_owned();
         let timestamp = event.origin_server_ts();
         let identifier = TimelineEventItemId::EventId(event.event_id().to_owned());
-        let action = TimelineAction::from_event(
+        let actions = TimelineAction::from_event(
             event,
             &raw_event,
             room_data_provider,
@@ -133,16 +133,15 @@ impl EmbeddedEvent {
             thread_summary,
         )
         .await;
-
-        match action {
-            Some(TimelineAction::AddItem { content }) => {
+        match actions.as_slice() {
+            [TimelineAction::AddItem { content }] => {
+                let content = content.clone();
                 let sender_profile = TimelineDetails::from_initial_value(
                     room_data_provider.profile_from_user_id(&sender).await,
                 );
                 Ok(Some(Self { content, sender, sender_profile, timestamp, identifier }))
             }
-
-            Some(TimelineAction::HandleAggregation { kind, .. }) => {
+            [TimelineAction::HandleAggregation { kind, .. }] => {
                 // As an exception, edits are allowed to be embedded events.
 
                 // For an embedded event, we don't need to fill a few fields; it's in an
@@ -155,10 +154,10 @@ impl EmbeddedEvent {
 
                 let content = match kind {
                     HandleAggregationKind::Edit { replacement } => {
-                        let msg = replacement.new_content;
+                        let msg = &replacement.new_content;
                         Some(TimelineItemContent::message(
-                            msg.msgtype,
-                            msg.mentions,
+                            msg.msgtype.clone(),
+                            msg.mentions.clone(),
                             reactions,
                             thread_root,
                             in_reply_to,
@@ -167,8 +166,8 @@ impl EmbeddedEvent {
                     }
 
                     HandleAggregationKind::PollEdit { replacement } => {
-                        let msg = replacement.new_content;
-                        let poll_state = PollState::new(msg.poll_start, msg.text);
+                        let msg = &replacement.new_content;
+                        let poll_state = PollState::new(msg.poll_start.clone(), msg.text.clone());
                         Some(TimelineItemContent::MsgLike(MsgLikeContent {
                             kind: MsgLikeKind::Poll(poll_state),
                             reactions: Default::default(),
@@ -194,9 +193,15 @@ impl EmbeddedEvent {
                     Ok(None)
                 }
             }
-
-            None => {
-                warn!("embedded event lead to no action (neither an aggregation nor a new item)");
+            [] => {
+                warn!("No action for an embedded event");
+                Ok(None)
+            }
+            [_, _, ..] => {
+                // Multiple actions can happen e.g. when a beacon_info with prev_content
+                // is replied to: it produces both an AddItem and a HandleAggregation.
+                // There is no meaningful single content to extract in that case.
+                warn!("Ignoring embedded event that produced multiple timeline actions");
                 Ok(None)
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
@@ -43,10 +43,12 @@ async fn test_beacon_info_creates_timeline_item() {
         .send_beacon_info(
             &ALICE,
             beacon_id,
-            Some("Alice's walk".to_owned()),
-            Duration::from_secs(3600),
-            true,
-            None,
+            BeaconInfoFields {
+                description: Some("Alice's walk".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
         )
         .await;
 
@@ -73,7 +75,18 @@ async fn test_beacon_info_with_expired_timeout_still_creates_item() {
     let past_ts = MilliSecondsSinceUnixEpoch(uint!(1_000)); // Very early timestamp
     let short_duration = Duration::from_millis(1); // Effectively expired immediately
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, short_duration, true, Some(past_ts)).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: short_duration,
+                live: true,
+                ts: Some(past_ts),
+            },
+        )
+        .await;
 
     // The item should still be created even though the timeout has expired.
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -95,7 +108,18 @@ async fn test_beacon_info_stopped_without_start_produces_no_item() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_stop:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(60), false, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(60),
+                live: false,
+                ts: None,
+            },
+        )
+        .await;
 
     assert_pending!(stream);
 
@@ -113,7 +137,18 @@ async fn test_beacon_update_aggregates_onto_beacon_info() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let state = item.content().as_live_location_state().unwrap();
@@ -146,7 +181,18 @@ async fn test_multiple_beacon_updates_accumulate_in_order() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
     let _item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
     // Send in non-chronological order.
@@ -199,7 +245,16 @@ async fn test_beacon_update_before_beacon_info_is_applied_when_parent_arrives() 
 
     // Now the beacon_info arrives.
     timeline
-        .send_beacon_info(&ALICE, &beacon_id, None, Duration::from_secs(3600), true, None)
+        .send_beacon_info(
+            &ALICE,
+            &beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
         .await;
 
     // A single PushBack with the stashed location already applied.
@@ -225,10 +280,12 @@ async fn test_multiple_users_sharing_produce_independent_items() {
         .send_beacon_info(
             &ALICE,
             alice_beacon_id,
-            Some("Alice".to_owned()),
-            Duration::from_secs(3600),
-            true,
-            None,
+            BeaconInfoFields {
+                description: Some("Alice".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
         )
         .await;
 
@@ -240,10 +297,12 @@ async fn test_multiple_users_sharing_produce_independent_items() {
         .send_beacon_info(
             &BOB,
             bob_beacon_id,
-            Some("Bob".to_owned()),
-            Duration::from_secs(3600),
-            true,
-            None,
+            BeaconInfoFields {
+                description: Some("Bob".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
         )
         .await;
 
@@ -320,7 +379,16 @@ async fn test_beacon_stop_updates_existing_item() {
     let session_ts = MilliSecondsSinceUnixEpoch::now();
 
     timeline
-        .send_beacon_info(&ALICE, start_id, None, Duration::from_secs(3600), true, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            start_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(session_ts),
+            },
+        )
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -330,7 +398,16 @@ async fn test_beacon_stop_updates_existing_item() {
     assert_pending!(stream);
 
     timeline
-        .send_beacon_info(&ALICE, stop_id, None, Duration::from_secs(3600), false, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            stop_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: false,
+                ts: Some(session_ts),
+            },
+        )
         .await;
 
     // The existing item is updated — a Set diff, not a PushBack.
@@ -358,7 +435,16 @@ async fn test_beacon_stop_preserves_locations() {
     let session_ts = MilliSecondsSinceUnixEpoch::now();
 
     timeline
-        .send_beacon_info(&ALICE, start_id, None, Duration::from_secs(3600), true, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            start_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(session_ts),
+            },
+        )
         .await;
     let _item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
@@ -370,7 +456,16 @@ async fn test_beacon_stop_preserves_locations() {
 
     // Stop the session.
     timeline
-        .send_beacon_info(&ALICE, stop_id, None, Duration::from_secs(3600), false, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            stop_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: false,
+                ts: Some(session_ts),
+            },
+        )
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
@@ -397,7 +492,16 @@ async fn test_beacon_stop_before_start_is_applied_later() {
 
     // Send the stop event first — the live start item doesn't exist yet.
     timeline
-        .send_beacon_info(&ALICE, stop_id, None, Duration::from_secs(3600), false, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            stop_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: false,
+                ts: Some(session_ts),
+            },
+        )
         .await;
 
     // No item should have been added to the timeline yet.
@@ -409,7 +513,16 @@ async fn test_beacon_stop_before_start_is_applied_later() {
 
     // Now send the live start event.
     timeline
-        .send_beacon_info(&ALICE, start_id, None, Duration::from_secs(3600), true, Some(session_ts))
+        .send_beacon_info(
+            &ALICE,
+            start_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(session_ts),
+            },
+        )
         .await;
 
     // The item should appear already stopped — a single PushBack, no follow-up Set.
@@ -447,10 +560,12 @@ async fn test_pending_beacon_stop_not_applied_to_different_session() {
         .send_beacon_info(
             &ALICE,
             old_stop_id,
-            None,
-            Duration::from_secs(3600),
-            false,
-            Some(old_session_ts),
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: false,
+                ts: Some(old_session_ts),
+            },
         )
         .await;
 
@@ -462,10 +577,12 @@ async fn test_pending_beacon_stop_not_applied_to_different_session() {
         .send_beacon_info(
             &ALICE,
             new_start_id,
-            Some("New session".to_owned()),
-            Duration::from_secs(3600),
-            true,
-            Some(new_session_ts),
+            BeaconInfoFields {
+                description: Some("New session".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(new_session_ts),
+            },
         )
         .await;
 
@@ -483,6 +600,84 @@ async fn test_pending_beacon_stop_not_applied_to_different_session() {
     assert_pending!(stream);
 }
 
+/// A new live `beacon_info` replacing a previous live session should implicitly
+/// stop the previous timeline item, even if no explicit stop event was sent.
+#[async_test]
+async fn test_replacing_live_beacon_stops_previous_item() {
+    let timeline = TestTimeline::new().await;
+    let mut stream = timeline.subscribe_events().await;
+    let old_start_id = event_id!("$old_start:example.org");
+    let new_start_id = event_id!("$new_start:example.org");
+    let old_session_ts = MilliSecondsSinceUnixEpoch::now();
+    let new_session_ts = MilliSecondsSinceUnixEpoch::now();
+
+    let old_content = BeaconInfoEventContent::new(
+        Some("Old session".to_owned()),
+        Duration::from_secs(3600),
+        true,
+        Some(old_session_ts),
+    );
+
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            old_start_id,
+            BeaconInfoFields {
+                description: Some("Old session".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(old_session_ts),
+            },
+        )
+        .await;
+
+    let old_item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    assert_eq!(old_item.event_id().unwrap(), old_start_id);
+    assert!(old_item.content().as_live_location_state().unwrap().is_live());
+    assert_eq!(
+        old_item.content().as_live_location_state().unwrap().description(),
+        Some("Old session")
+    );
+
+    timeline
+        .send_beacon_info_with_prev_content(
+            &ALICE,
+            new_start_id,
+            BeaconInfoFields {
+                description: Some("New session".to_owned()),
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: Some(new_session_ts),
+            },
+            old_content,
+        )
+        .await;
+
+    let new_item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    assert_eq!(new_item.event_id().unwrap(), new_start_id);
+    assert!(
+        new_item.content().as_live_location_state().unwrap().is_live(),
+        "the replacement session should stay live"
+    );
+    assert_eq!(
+        new_item.content().as_live_location_state().unwrap().description(),
+        Some("New session")
+    );
+
+    let old_item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
+    assert_eq!(old_item.event_id().unwrap(), old_start_id);
+    assert!(
+        !old_item.content().as_live_location_state().unwrap().is_live(),
+        "the replaced live beacon should be considered stopped once a new session replaces it"
+    );
+    assert_eq!(
+        old_item.content().as_live_location_state().unwrap().description(),
+        Some("Old session")
+    );
+
+    assert_pending!(stream);
+}
+
 /// Duplicate beacon location updates (same timestamp) are de-duplicated.
 #[async_test]
 async fn test_duplicate_beacon_location_is_deduplicated() {
@@ -490,7 +685,18 @@ async fn test_duplicate_beacon_location_is_deduplicated() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
     let _item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
     let ts = MilliSecondsSinceUnixEpoch(uint!(1_000));
@@ -545,7 +751,18 @@ async fn test_reaction_on_live_location_item() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert!(item.content().as_live_location_state().is_some());
@@ -574,7 +791,18 @@ async fn test_multiple_reactions_on_live_location_item() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
     let _item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
     // ALICE and BOB both react, with different keys.
@@ -610,7 +838,18 @@ async fn test_reaction_before_live_location_item_is_applied_when_parent_arrives(
     assert_pending!(stream);
 
     // Now the beacon_info arrives.
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
 
     // The item is inserted with the reaction already applied.
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -631,7 +870,18 @@ async fn test_local_reaction_on_live_location_item() {
     let mut stream = timeline.subscribe_events().await;
     let beacon_id = event_id!("$beacon_info:example.org");
 
-    timeline.send_beacon_info(&ALICE, beacon_id, None, Duration::from_secs(3600), true, None).await;
+    timeline
+        .send_beacon_info(
+            &ALICE,
+            beacon_id,
+            BeaconInfoFields {
+                description: None,
+                duration: Duration::from_secs(3600),
+                live: true,
+                ts: None,
+            },
+        )
+        .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let item_id = TimelineEventItemId::EventId(item.event_id().unwrap().to_owned());
@@ -751,6 +1001,14 @@ fn test_beacon_info_matches_different_description() {
     assert!(!beacon_info_matches(&a, &b), "different description should not match");
 }
 
+/// Bundles the inner fields of a `beacon_info` event for the test helpers.
+struct BeaconInfoFields {
+    description: Option<String>,
+    duration: Duration,
+    live: bool,
+    ts: Option<MilliSecondsSinceUnixEpoch>,
+}
+
 impl TestTimeline {
     /// Collect every event timeline item (no virtual items).
     async fn live_location_event_items(&self) -> Vec<EventTimelineItem> {
@@ -762,17 +1020,33 @@ impl TestTimeline {
         &self,
         sender: &ruma::UserId,
         event_id: &EventId,
-        description: Option<String>,
-        duration: Duration,
-        live: bool,
-        ts: Option<MilliSecondsSinceUnixEpoch>,
+        info: BeaconInfoFields,
     ) {
         let event = self
             .factory
-            .beacon_info(description, duration, live, ts)
+            .beacon_info(info.description, info.duration, info.live, info.ts)
             .sender(sender)
             .state_key(sender)
             .event_id(event_id);
+        self.handle_live_event(event).await;
+    }
+
+    /// Convenience: send a `beacon_info` state event from `sender` with
+    /// `prev_content`, to model replacement of a previous session.
+    async fn send_beacon_info_with_prev_content(
+        &self,
+        sender: &ruma::UserId,
+        event_id: &EventId,
+        info: BeaconInfoFields,
+        prev_content: BeaconInfoEventContent,
+    ) {
+        let event = self
+            .factory
+            .beacon_info(info.description, info.duration, info.live, info.ts)
+            .sender(sender)
+            .state_key(sender)
+            .event_id(event_id)
+            .prev_content(prev_content);
         self.handle_live_event(event).await;
     }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

This updates the timeline action flow to support multi-action event handling and fixes the m.beacon_info replacement path.

Replacing a live m.beacon_info session now correctly adds the new timeline item while marking the previous one as stopped.

Fix https://github.com/element-hq/element-internal/issues/714

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
