### PR TITLE
Revert "only start with a timeline reset diff if the timeline isn't empty"

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -286,14 +286,7 @@ impl Timeline {
         // Note we pass initial items as a reset update, as a way to give the callers a
         // unified way to handle the initial batch of items as well as other
         // batches, instead of having a separate callback for the initial items.
-        //
-        // Start with passing all the items of a *non-empty* timeline as a reset update
-        // (if the initial items are empty, then the timeline would transition
-        // from empty to empty, which is a no-op).
-        if !timeline_items.is_empty() {
-            listener
-                .on_update(vec![TimelineDiff::new(VectorDiff::Reset { values: timeline_items })]);
-        }
+        listener.on_update(vec![TimelineDiff::new(VectorDiff::Reset { values: timeline_items })]);
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             pin_mut!(timeline_stream);


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Revert https://github.com/matrix-org/matrix-rust-sdk/pull/6380 (but partially keep the updated comment)

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
