### PR TITLE
feat: expose append parameter on Pusher::set

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6600.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6600.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] `Client::set_pusher` now takes an `append: bool` parameter, forwarded to the homeserver. Pass `true` to keep an existing pusher with the same `app_id` and `pushkey` registered for other users (e.g. multi-profile clients on a single device); pass `false` to preserve the previous default behaviour.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1477,6 +1477,7 @@ impl Client {
         device_display_name: String,
         profile_tag: Option<String>,
         lang: String,
+        append: bool,
     ) -> Result<(), ClientError> {
         let ids = identifiers.into();
 
@@ -1488,7 +1489,7 @@ impl Client {
             profile_tag,
             lang,
         };
-        self.inner.pusher().set(pusher_init.into(), false).await?;
+        self.inner.pusher().set(pusher_init.into(), append).await?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1468,6 +1468,7 @@ impl Client {
     }
 
     /// Registers a pusher with given parameters
+    #[allow(clippy::too_many_arguments)]
     pub async fn set_pusher(
         &self,
         identifiers: PusherIdentifiers,
@@ -1487,7 +1488,7 @@ impl Client {
             profile_tag,
             lang,
         };
-        self.inner.pusher().set(pusher_init.into()).await?;
+        self.inner.pusher().set(pusher_init.into(), false).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk/changelog.d/6600.changed.md
+++ b/crates/matrix-sdk/changelog.d/6600.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] `Pusher::set` now takes an `append: bool` parameter, forwarded to the homeserver on `POST /_matrix/client/v3/pushers/set`. Pass `true` to keep an existing pusher with the same `app_id` and `pushkey` registered for other users (e.g. multi-profile clients on a single device); pass `false` to preserve the previous default behaviour.

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -33,9 +33,12 @@ impl Pusher {
         Self { client }
     }
 
-    /// Sets a given pusher
-    pub async fn set(&self, pusher: ruma::api::client::push::Pusher) -> Result<()> {
-        let request = set_pusher::v3::Request::post(pusher);
+    /// Sets a given pusher.
+    pub async fn set(&self, pusher: ruma::api::client::push::Pusher, append: bool) -> Result<()> {
+        let mut request = set_pusher::v3::Request::post(pusher);
+        if let set_pusher::v3::PusherAction::Post(data) = &mut request.action {
+            data.append = append;
+        }
         self.client.send(request).await?;
         Ok(())
     }
@@ -56,9 +59,10 @@ mod tests {
         api::client::push::{PusherIds, PusherInit, PusherKind},
         push::HttpPusherData,
     };
+    use serde_json::json;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{method, path},
+        matchers::{body_partial_json, method, path},
     };
 
     use crate::test_utils::logged_in_client;
@@ -71,23 +75,42 @@ mod tests {
             .await;
     }
 
-    #[async_test]
-    async fn test_set_pusher() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-        mock_api(server).await;
-
-        // prepare dummy pusher
-        let pusher = PusherInit {
+    fn dummy_pusher() -> PusherInit {
+        PusherInit {
             ids: PusherIds::new("pushKey".to_owned(), "app_id".to_owned()),
             app_display_name: "name".to_owned(),
             kind: PusherKind::Http(HttpPusherData::new("dummy".to_owned())),
             lang: "EN".to_owned(),
             device_display_name: "name".to_owned(),
             profile_tag: None,
-        };
+        }
+    }
 
-        let response = client.pusher().set(pusher.into()).await;
+    #[async_test]
+    async fn test_set_pusher() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        mock_api(server).await;
+
+        let response = client.pusher().set(dummy_pusher().into(), false).await;
+
+        assert!(response.is_ok());
+    }
+
+    #[async_test]
+    async fn test_set_pusher_forwards_append_flag() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("POST"))
+            .and(path("_matrix/client/r0/pushers/set"))
+            .and(body_partial_json(json!({ "append": true })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = client.pusher().set(dummy_pusher().into(), true).await;
 
         assert!(response.is_ok());
     }


### PR DESCRIPTION
For multiple profile clients, when registering for push notifications, the "append" flag has to be used, or else only one account can receive notifications at that device. To support future multi-profile work, this PR exposes the append flag.

- [x] I've documented the public API changes in the appropriate changelog files
- [x] This PR was made with the help of AI.

Signed-off-by: Daniel Anderson <daniel.anderson@toptal.com>
