### PR TITLE
Update `rpassword` to `v7.5.1` to fix clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,9 +4781,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.0"
+version = "7.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bc4a3dd492cd6974dd3f32d6626ba9f36e5122e3df3b083474b104aebd139b"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
 dependencies = [
  "libc",
  "rtoolbox",

--- a/labs/multiverse/Cargo.toml
+++ b/labs/multiverse/Cargo.toml
@@ -26,7 +26,7 @@ matrix-sdk-base = { path = "../../crates/matrix-sdk-base" }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common" }
 matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
-rpassword = "7.5.0"
+rpassword = "7.5.1"
 serde_json.workspace = true
 strum = { version = "0.27.2", features = ["derive"] }
 textwrap = "0.16.2"


### PR DESCRIPTION
This was happening for non-linux targets. Fixed in https://github.com/conradkleinespel/rpassword/pull/128.

```
error[E0425]: cannot find function `__errno_location` in crate `libc`
  --> /Users/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rpassword-7.5.0/src/unix.rs:26:16
   |
26 |         *libc::__errno_location() = 0;
   |                ^^^^^^^^^^^^^^^^ not found in `libc`

    Checking gloo-utils v0.2.0
For more information about this error, try `rustc --explain E0425`.
error: could not compile `rpassword` (lib) due to 1 previous error
```

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
