### PR TITLE
feat (bindings): expose tile_server to FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6610.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6610.added.md
@@ -1,0 +1,5 @@
+Expose `Client::tile_server` on the FFI, returning a `TileServerInfo` record
+when the homeserver advertises a map tile server through its matrix client
+well-known ([MSC3488](https://github.com/matrix-org/matrix-spec-proposals/pull/3488)).
+The record carries a single `map_style_url` field pointing at a MapLibre
+`style.json`.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2063,6 +2063,15 @@ impl Client {
             .any(|focus| matches!(focus, RtcFocusInfo::LiveKit(_))))
     }
 
+    /// Get information about the homeserver's advertised map tile server, if any.
+    ///
+    /// Reads the `tile_server` field of the matrix client well-known (MSC3488).
+    /// Uses the cached well-known when available, otherwise fetches it from the
+    /// homeserver.
+    pub async fn tile_server(&self) -> Option<matrix_sdk::TileServerInfo> {
+        self.inner.tile_server().await
+    }
+
     /// Checks if the server supports login using a QR code.
     pub async fn is_login_with_qr_code_supported(&self) -> Result<bool, ClientError> {
         Ok(matches!(self.inner.auth_api(), Some(AuthApi::OAuth(_)))

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2063,7 +2063,8 @@ impl Client {
             .any(|focus| matches!(focus, RtcFocusInfo::LiveKit(_))))
     }
 
-    /// Get information about the homeserver's advertised map tile server, if any.
+    /// Get information about the homeserver's advertised map tile server, if
+    /// any.
     ///
     /// Reads the `tile_server` field of the matrix client well-known (MSC3488).
     /// Uses the cached well-known when available, otherwise fetches it from the

--- a/crates/matrix-sdk/changelog.d/6610.added.md
+++ b/crates/matrix-sdk/changelog.d/6610.added.md
@@ -1,0 +1,5 @@
+Add `Client::tile_server` and a `TileServerInfo` struct to expose the
+homeserver-advertised map tile server (`tile_server` field of the matrix client
+well-known, [MSC3488](https://github.com/matrix-org/matrix-spec-proposals/pull/3488)).
+Returns `None` when the homeserver hasn't advertised one or the well-known is
+unavailable.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2579,8 +2579,8 @@ impl Client {
         Ok(well_known.map(|well_known| well_known.rtc_foci).unwrap_or_default())
     }
 
-    /// Get information about the homeserver's advertised map tile server, if any,
-    /// by fetching the well-known file from the server or the cache.
+    /// Get information about the homeserver's advertised map tile server, if
+    /// any, by fetching the well-known file from the server or the cache.
     ///
     /// Returns `None` if the homeserver has not advertised a tile server in its
     /// well-known, or if the well-known is otherwise unavailable.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -180,6 +180,23 @@ pub struct ServerVendorInfo {
     pub version: String,
 }
 
+/// Information about a map tile server advertised by the homeserver through the
+/// `tile_server` field of the matrix client well-known (MSC3488).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct TileServerInfo {
+    /// The URL of a map tile server's `style.json` file. See the
+    /// [Mapbox Style Specification](https://docs.mapbox.com/mapbox-gl-js/style-spec/)
+    /// for more details.
+    pub map_style_url: String,
+}
+
+impl From<discover_homeserver::TileServerInfo> for TileServerInfo {
+    fn from(value: discover_homeserver::TileServerInfo) -> Self {
+        Self { map_style_url: value.map_style_url }
+    }
+}
+
 /// An async/await enabled Matrix client.
 ///
 /// All of the state is held in an `Arc` so the `Client` can be cloned freely.
@@ -2560,6 +2577,15 @@ impl Client {
         let well_known = self.well_known().await;
 
         Ok(well_known.map(|well_known| well_known.rtc_foci).unwrap_or_default())
+    }
+
+    /// Get information about the homeserver's advertised map tile server, if any,
+    /// by fetching the well-known file from the server or the cache.
+    ///
+    /// Returns `None` if the homeserver has not advertised a tile server in its
+    /// well-known, or if the well-known is otherwise unavailable.
+    pub async fn tile_server(&self) -> Option<TileServerInfo> {
+        self.well_known().await.and_then(|well_known| well_known.tile_server).map(Into::into)
     }
 
     /// Empty the well-known cache.

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -74,7 +74,7 @@ pub use client::homeserver_capabilities::HomeserverCapabilities;
 pub mod search_index;
 pub use client::{
     Client, ClientBuildError, ClientBuilder, LoopCtrl, ServerVendorInfo, SessionChange, StoreSizes,
-    sanitize_server_name,
+    TileServerInfo, sanitize_server_name,
 };
 pub use error::{
     BeaconError, Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError,


### PR DESCRIPTION
In this way clients can get the homeserver's well known value for the map tile server URL, if available, in case the homeserver would like the client to override it.