### PR TITLE
fix: resolve room alias to id before evaluating pre-join info

### DIFF
--- a/crates/matrix-sdk/changelog.d/6618.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6618.fixed.md
@@ -1,0 +1,1 @@
+Resolve the room alias to a room id before evaluating pre-join info. This resolves the asymmetry when using `join_room_by_id_or_alias`, ensuring possibly crucial invite handling is handled correctly.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -4398,6 +4398,41 @@ pub(crate) mod tests {
     }
 
     #[async_test]
+    async fn test_join_room_by_id_or_alias() {
+        use wiremock::{
+            Mock, ResponseTemplate,
+            matchers::{method, path_regex},
+        };
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let target_room_id = room_id!("!some_id:matrix.org");
+        let target_alias = room_alias_id!("#some_alias:matrix.org");
+
+        Mock::given(method("POST"))
+            .and(path_regex("^/_matrix/client/v3/join/.*$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "room_id": target_room_id
+            })))
+            .mount(server.server())
+            .await;
+
+        server
+            .mock_room_directory_resolve_alias()
+            .ok(target_room_id.as_str(), Vec::new())
+            .mount()
+            .await;
+
+        server.mock_room_join(target_room_id).ok().mount().await;
+
+        let ret = client.join_room_by_id_or_alias(target_alias.into(), &[]).await;
+        assert_matches!(ret, Ok(_));
+
+        let ret = client.join_room_by_id_or_alias(target_room_id.into(), &[]).await;
+        assert_matches!(ret, Ok(_));
+    }
+
+    #[async_test]
     async fn test_room_preview_for_invited_room_hits_summary_endpoint() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1687,17 +1687,11 @@ impl Client {
         alias: &RoomOrAliasId,
         server_names: &[OwnedServerName],
     ) -> Result<Room> {
-        let pre_join_info = {
-            match alias.try_into() {
-                Ok(room_id) => self.prepare_join_room_by_id(room_id).await,
-                Err(_) => {
-                    // The id is a room alias. We assume (possibly incorrectly?) that we are not
-                    // responding to an invitation to the room, and therefore don't need to handle
-                    // things that happen as a result of invites.
-                    None
-                }
-            }
+        let room_id = match <&RoomId>::try_from(alias) {
+            Ok(room_id) => room_id,
+            Err(room_alias) => &self.resolve_room_alias(room_alias).await?.room_id,
         };
+        let pre_join_info = self.prepare_join_room_by_id(room_id).await;
         let request = assign!(join_room_by_id_or_alias::v3::Request::new(alias.to_owned()), {
             via: server_names.to_owned(),
         });

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -4426,10 +4426,10 @@ pub(crate) mod tests {
         server.mock_room_join(target_room_id).ok().mount().await;
 
         let ret = client.join_room_by_id_or_alias(target_alias.into(), &[]).await;
-        assert_matches!(ret, Ok(_));
+        assert!(ret.is_ok());
 
         let ret = client.join_room_by_id_or_alias(target_room_id.into(), &[]).await;
-        assert_matches!(ret, Ok(_));
+        assert!(ret.is_ok());
     }
 
     #[async_test]


### PR DESCRIPTION
This PR resolves the asymmetry in `join_room_by_id_or_alias` where providing a room alias skipped (in some cases) crucial pre-join invite handling. 

Following the second suggested approach in the issue, the logic has been updated to normalize the behavior of both branches. When a room alias is provided, it is now resolved to a room id before calling `prepare_join_room_by_id`.

Fixes #6533

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

Signed-off-by: Paul8711 <154304377+Paulprojects8711@users.noreply.github.com>

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
