### PR TITLE
feat(sdk): Flatten the hierarchy of caches in the Event Cache, bonus: Recompute the `ThreadSummary` when an in-thread event is decrypted

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -23,8 +23,10 @@ use ruma::{
     EventId, OwnedEventId, OwnedUserId,
     events::{
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-        BundledMessageLikeRelations, poll::unstable_start::UnstablePollStartEventContent,
-        relation::Replacement, room::message::RelationWithoutReplacement,
+        BundledMessageLikeRelations,
+        poll::unstable_start::UnstablePollStartEventContent,
+        relation::Replacement,
+        room::{encrypted::Relation, message::RelationWithoutReplacement},
     },
     room_version_rules::RoomVersionRules,
     serde::Raw,
@@ -442,6 +444,26 @@ impl TimelineMetadata {
                         );
                     }
 
+                    self.mark_response(ctx.event_id, in_reply_to.as_ref());
+                }
+
+                (in_reply_to, thread_root)
+            }
+
+            AnyMessageLikeEventContent::RoomEncrypted(msg) => {
+                let (in_reply_to, thread_root) = Self::extract_reply_and_thread_root(
+                    msg.relates_to.clone().and_then(|rel| match rel {
+                        Relation::Reply(reply) => Some(RelationWithoutReplacement::Reply(reply)),
+                        Relation::Thread(thread) => {
+                            Some(RelationWithoutReplacement::Thread(thread))
+                        }
+                        _ => None,
+                    }),
+                    timeline_items,
+                    is_thread_focus,
+                );
+
+                if let Some(ctx) = remote_ctx {
                     self.mark_response(ctx.event_id, in_reply_to.as_ref());
                 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -41,7 +41,7 @@ pub async fn aggregate_timeline_for_threads(
     };
 
     // Look for in-thread events, i.e. events that are part of threads.
-    for event in &timeline.events {
+    for (nth, event) in timeline.events.iter().enumerate() {
         match extract_relation(event.raw()) {
             // Ohh, this event relates to another event!
             Some((relation_type, related_event_id)) => match relation_type {
@@ -61,12 +61,22 @@ pub async fn aggregate_timeline_for_threads(
                 | RelationType::Replacement
                 | RelationType::Reference
                 | _ => {
-                    // TODO(@hywan): It's good to look for the related event in the memory and
-                    // store, but we MUST also look for it in `timeline`!
-                    if let Some((_location, related_event)) =
-                        room_event_cache.find_event(&related_event_id).await?
-                        && let Some(thread_root) = extract_thread_root(related_event.raw())
+                    // First, look for the related event in `timeline` backwards.
+                    if let Some(thread_root) = match timeline.events[..nth]
+                        .iter()
+                        .rev()
+                        .find(|event| event.event_id().as_ref() == Some(&related_event_id))
                     {
+                        // The related event has been found in the `timeline`! Extract its thread
+                        // root.
+                        Some(related_event) => extract_thread_root(related_event.raw()),
+
+                        // Not in `timeline`, okay, look for the related event in the `room` as it
+                        // knows about all the events, and then extract its thread root.
+                        None => room_event_cache.find_event(&related_event_id).await?.and_then(
+                            |(_location, related_event)| extract_thread_root(related_event.raw()),
+                        ),
+                    } {
                         new_events_by_thread
                             .entry(thread_root)
                             .or_insert_with(default_timeline)
@@ -92,8 +102,6 @@ pub async fn aggregate_timeline_for_threads(
                 // Otherwise, this event might be a redaction that applies to a thread.
                 else if let Some(redaction_target) =
                     extract_redaction_target(event.raw(), redaction_rules)
-                    // TODO(@hywan): It's good to look for the redacted event in the memory and
-                    // store, but we MUST also look for it in `timeline`!
                     && room_event_cache.find_event(&redaction_target).await?.is_some()
                 {
                     // The redacted event exists (in the room, because it contains _all_ the

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -261,7 +261,7 @@ impl RoomEventCache {
         Ok(())
     }
 
-    pub(super) async fn update_thread_summary(
+    pub(in super::super) async fn update_thread_summary(
         &self,
         thread_id: &EventId,
         new_thread_summary: Option<ThreadSummary>,

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -39,6 +39,8 @@ pub(super) use self::{
     state::{LockedThreadEventCacheState, OwnedThreadEventCacheStateLockWriteGuard},
     updates::ThreadEventCacheUpdateSender,
 };
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::ResolvedUtd;
 use super::{
     super::Result,
     EventsOrigin, TimelineVectorDiffs,
@@ -253,6 +255,25 @@ impl ThreadEventCache {
             .await
             .ok()
             .flatten())
+    }
+
+    /// Try to locate the events in the linked chunk corresponding to the given
+    /// list of decrypted events, and replace them, while alerting observers
+    /// about the update.
+    #[cfg(feature = "e2e-encryption")]
+    pub(in super::super) async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
+        let timeline_event_diffs = self.inner.state.write().await?.replace_utds(events).await?;
+
+        if let Some(timeline_event_diffs) = timeline_event_diffs
+            && !timeline_event_diffs.is_empty()
+        {
+            self.inner.update_sender.send(
+                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Cache },
+                Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -162,7 +162,7 @@ impl ThreadEventCache {
     }
 
     /// Return a reference to the state.
-    pub(super) fn state(&self) -> &LockedThreadEventCacheState {
+    pub(in super::super) fn state(&self) -> &LockedThreadEventCacheState {
         &self.inner.state
     }
 
@@ -260,20 +260,29 @@ impl ThreadEventCache {
     /// Try to locate the events in the linked chunk corresponding to the given
     /// list of decrypted events, and replace them, while alerting observers
     /// about the update.
+    ///
+    /// Return `true` if at least one event has been updated.
     #[cfg(feature = "e2e-encryption")]
-    pub(in super::super) async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
+    pub(in super::super) async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<bool> {
         let timeline_event_diffs = self.inner.state.write().await?.replace_utds(events).await?;
 
-        if let Some(timeline_event_diffs) = timeline_event_diffs
-            && !timeline_event_diffs.is_empty()
-        {
-            self.inner.update_sender.send(
-                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Cache },
-                Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
-            );
-        }
+        Ok(
+            if let Some(timeline_event_diffs) = timeline_event_diffs
+                && !timeline_event_diffs.is_empty()
+            {
+                self.inner.update_sender.send(
+                    TimelineVectorDiffs {
+                        diffs: timeline_event_diffs,
+                        origin: EventsOrigin::Cache,
+                    },
+                    Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
+                );
 
-        Ok(())
+                true
+            } else {
+                false
+            },
+        )
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -35,6 +35,8 @@ use ruma::{
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::super::redecryptor::ResolvedUtd;
 use super::{
     super::{
         super::{
@@ -676,6 +678,24 @@ impl<'a> ThreadEventCacheStateLockWriteGuard<'a> {
     async fn apply_store_only_updates(&mut self, updates: Vec<Update<Event, Gap>>) -> Result<()> {
         self.state.thread_linked_chunk.order_tracker.map_updates(&updates);
         self.state.send_updates_to_store(updates, &self.store).await
+    }
+
+    /// Try to locate the events in the linked chunk corresponding to the given
+    /// list of decrypted events, and replace them, while alerting observers
+    /// about the update.
+    #[cfg(feature = "e2e-encryption")]
+    #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
+    pub(in super::super) async fn replace_utds(
+        &mut self,
+        events: &[ResolvedUtd],
+    ) -> Result<Option<Vec<VectorDiff<Event>>>> {
+        Ok(if self.thread_linked_chunk_mut().replace_utds(events) {
+            self.state.propagate_changes(&self.store).await?;
+
+            Some(self.thread_linked_chunk_mut().updates_as_vector_diffs())
+        } else {
+            None
+        })
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -409,6 +409,24 @@ impl EventCache {
             );
         }
 
+        // Resolve on the thread caches.
+        {
+            // TODO: This ain't great for performance; there shouldn't be
+            // that many thread caches alive at the same time, but they could
+            // accumulate over time. Consider keeping track of which linked
+            // chunk contain which event id, to avoid doing the linear searches
+            // here.
+            join_all(
+                all_caches
+                    .threads
+                    .read()
+                    .await
+                    .values()
+                    .map(|thread_cache| thread_cache.replace_utds(&events)),
+            )
+            .await;
+        }
+
         // Resolve on the pinned-events cache.
         if let Some(pinned_events_cache) = all_caches.pinned_events.get() {
             pinned_events_cache.replace_utds(&events).await?;

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -121,7 +121,11 @@ use std::{
 
 use as_variant::as_variant;
 use futures_core::Stream;
-use futures_util::{StreamExt, future::join_all, pin_mut};
+use futures_util::{
+    StreamExt,
+    future::{join_all, try_join_all},
+    pin_mut,
+};
 #[cfg(doc)]
 use matrix_sdk_base::{BaseClient, crypto::OlmMachine};
 use matrix_sdk_base::{
@@ -416,15 +420,33 @@ impl EventCache {
             // accumulate over time. Consider keeping track of which linked
             // chunk contain which event id, to avoid doing the linear searches
             // here.
-            join_all(
-                all_caches
-                    .threads
-                    .read()
-                    .await
-                    .values()
-                    .map(|thread_cache| thread_cache.replace_utds(&events)),
+
+            // Replaces UTDs in each thread, and maybe update the thread summary.
+            for (thread_id, thread_cache) in try_join_all(
+                all_caches.threads.read().await.iter().map(|(thread_id, thread_cache)| async {
+                    Result::<_, EventCacheError>::Ok(
+                        // If at least one event has been replaced, return the `thread_id` and the
+                        // `thread_cache` to update the thread summary later.
+                        thread_cache
+                            .replace_utds(&events)
+                            .await?
+                            .then(|| (thread_id.clone(), thread_cache.clone())),
+                    )
+                }),
             )
-            .await;
+            .await?
+            .into_iter()
+            // Filter out results that are `None`, i.e. a thread where no UTD has been replaced.
+            .flatten()
+            {
+                all_caches
+                    .room
+                    .update_thread_summary(
+                        &thread_id,
+                        thread_cache.state().read().await?.compute_thread_summary().await?,
+                    )
+                    .await?;
+            }
         }
 
         // Resolve on the pinned-events cache.

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -418,7 +418,7 @@ impl EventCache {
             // TODO: This ain't great for performance; there shouldn't be
             // that many thread caches alive at the same time, but they could
             // accumulate over time. Consider keeping track of which linked
-            // chunk contain which event id, to avoid doing the linear searches
+            // chunk contains which event ID, to avoid doing the linear searches
             // here.
 
             // Replaces UTDs in each thread, and maybe update the thread summary.
@@ -459,7 +459,7 @@ impl EventCache {
             // TODO: This ain't great for performance; there shouldn't be that many
             // event-focused caches alive at the same time, but they could
             // accumulate over time. Consider keeping track of which linked chunk
-            // contain which event id, to avoid doing the linear searches here.
+            // contains which event ID, to avoid doing the linear searches here.
             join_all(
                 all_caches
                     .event_focused

--- a/testing/matrix-sdk-integration-testing/src/lib.rs
+++ b/testing/matrix-sdk-integration-testing/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![cfg(test)]
 
 matrix_sdk_test_utils::init_tracing_for_tests!();

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -22,7 +22,7 @@ use eyeball_im::{Vector, VectorDiff};
 use futures::pin_mut;
 use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{
-    Client, Room, RoomState, assert_let_timeout, assert_next_with_timeout,
+    Client, Room, RoomState, ThreadingSupport, assert_let_timeout, assert_next_with_timeout,
     config::SyncSettings,
     deserialized_responses::{VerificationLevel, VerificationState},
     encryption::{
@@ -56,7 +56,8 @@ use matrix_sdk_ui::{
     sync_service::SyncService,
     timeline::{
         EventSendState, EventTimelineItem, ReactionStatus, RoomExt, TimelineBuilder,
-        TimelineEventFocusThreadMode, TimelineFocus, TimelineItem,
+        TimelineDetails, TimelineEventFocusThreadMode, TimelineEventItemId, TimelineFocus,
+        TimelineItem,
     },
 };
 use similar_asserts::assert_eq;
@@ -1383,7 +1384,6 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
     Ok(())
 }
 
-/*
 /// Test that UTDs as the latest thread event (in the summary), once decrypted
 /// by R2D2 (the redecryptor), get replaced in the timeline with the decrypted
 /// variant of the latest event, in the summary.
@@ -1459,7 +1459,7 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
     let event = room2.event(&thread_root_event_id, Default::default()).await?;
     assert!(event.kind.is_utd());
 
-    // Alright, let's now go to a main (threaded) timeline.
+    // Alright, let's now go to a main timeline.
     let timeline = room2
         .timeline_builder()
         .with_focus(TimelineFocus::Live { hide_threaded_events: true })
@@ -1547,16 +1547,6 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
         let next_item = assert_next_with_timeout!(stream, 5000);
         assert_let!(VectorDiff::Set { index: 7, value } = next_item);
         assert!(!value.content().is_unable_to_decrypt());
-
-        // At first, the latest event is a UTD.
-        let summary =
-            value.content().thread_summary().expect("We should have a thread summary now");
-        assert_let!(TimelineDetails::Ready(latest_event) = summary.latest_event);
-        assert_eq!(
-            latest_event.identifier,
-            TimelineEventItemId::EventId(thread_reply_event_id.clone())
-        );
-        assert!(latest_event.content.is_unable_to_decrypt());
     }
 
     {
@@ -1583,7 +1573,6 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
 
     Ok(())
 }
-*/
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_send_message_updates() -> Result<()> {

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -1499,13 +1499,9 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
     // value.
     let next_item = assert_next_with_timeout!(stream, 5000);
     assert_let!(VectorDiff::Set { index: 7, value } = next_item);
-
-    let content = value.content();
-
+    assert_eq!(value.event_id(), Some(thread_root_event_id.as_ref()));
     // And we're not a UTD anymore.
-    assert!(!content.is_unable_to_decrypt());
-    let message = content.as_message().expect("The focused event should be a message");
-    assert_eq!(message.body(), "It's a secret to everybody");
+    assert!(!value.content().is_unable_to_decrypt());
 
     // Pause alice2's sync.
     sync_service2.stop().await;
@@ -1536,33 +1532,25 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
     sync_service2.start().await;
 
     {
-        // Her timeline sees a new item for the thread reply, because we don't know yet
-        // that the thread reply is part of the thread, as it's encrypted.
-        // TODO: we should know it, since an encrypted event includes the relationship?
-        let next_item = assert_next_with_timeout!(stream, 5000);
-        assert_let!(VectorDiff::PushBack { value } = next_item);
-        assert!(value.content().is_unable_to_decrypt());
-        assert_eq!(value.event_id().unwrap(), &thread_reply_event_id);
-
+        // The thread root is updated with a new thread summary!
         let next_item = assert_next_with_timeout!(stream, 5000);
         assert_let!(VectorDiff::Set { index: 7, value } = next_item);
+        assert_eq!(value.event_id(), Some(thread_root_event_id.as_ref()));
         assert!(!value.content().is_unable_to_decrypt());
+
+        // The thread summary is not available because it is a UTD!
+        let summary =
+            value.content().thread_summary().expect("We should have a thread summary now");
+        assert_matches!(summary.latest_event, TimelineDetails::Unavailable);
     }
 
     {
-        // But it gets replaced with the decrypted event later:
-        //
-        // 1. The timeline realizes the decrypted event was part of the thread, so it
-        //    removes it.
-        let next_item = assert_next_with_timeout!(stream, 5000);
-        assert_let!(VectorDiff::Remove { index: 8 } = next_item);
-
-        // 2. Then, the timeline replaces the thread summary for the thread root.
+        // The thread root is updated with a decrypted, ready thread summary!
         let next_item = assert_next_with_timeout!(stream, 5000);
         assert_let!(VectorDiff::Set { index: 7, value } = next_item);
+
         let summary =
             value.content().thread_summary().expect("We should have a thread summary now");
-        assert!(!value.content().is_unable_to_decrypt());
         assert_let!(TimelineDetails::Ready(latest_event) = summary.latest_event);
         assert_eq!(
             latest_event.identifier,


### PR DESCRIPTION
This patch restores a feature, and implements two new ones.

1. It brings back the ability for R2D2 to replace UTD in threads. The `ThreadSummary` is re-computed when necessary. It restores the `test_latest_thread_event_is_redecrypted_and_updated` test.
2. It updates the `Timeline` to infer whether an encrypted event is part of a thread or not.
    - Before, when an in-thread encrypted event was received, it was **not** appearing in the _thread timeline_, but in the _main timeline_. Once decrypted (thanks R2D2), it was removed from the _main timeline_ and inserted in the _thread timeline_.
    - Now, the in-thread encrypted event is inserted in the _thread timeline_ and decrypted there.
3. With these changes, CodSpeed started to yell about a performance regression in the `timeline` benchmark. This benchmark inserts 10_000 events in the Event Cache, as a single sync response, and check the performance of the Timeline. The prelude isn't realistic, but the performance bottleneck was located around a `TODO` I wanted to solve later:
    - In `aggregate_timeline_for_threads`, when an event has a relation, we need to know if the related event is part of a thread. If that's the case, it means the event is part of the thread too.
    - To know if the related event is part of a thread, we were looking in the `RoomEventCache` as all events must have been inserted there first. That's solid, but not efficient. It often happens that an in-thread event and its replacement/edit event are both part of the same sync response. In that case, before looking in the `RoomEventCache`, it's good to look in the received sync response's `timeline`. That's a small optimisation, but in the case of the `timeline` benchmark, it has entirely resolved the performance regression.

---

- Address https://github.com/matrix-org/matrix-rust-sdk/issues/6152
- Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/6517

---

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
