### PR TITLE
feat: Add content scanner support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,6 +3461,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrix-sdk-contentscanner"
+version = "0.18.0"
+dependencies = [
+ "assert_matches2",
+ "matrix-sdk",
+ "matrix-sdk-crypto",
+ "matrix-sdk-test",
+ "ruma",
+ "serde",
+ "tokio",
+ "tracing",
+ "uniffi",
+ "wiremock",
+]
+
+[[package]]
 name = "matrix-sdk-crypto"
 version = "0.18.0"
 dependencies = [
@@ -3561,6 +3577,7 @@ dependencies = [
  "matrix-sdk",
  "matrix-sdk-base",
  "matrix-sdk-common",
+ "matrix-sdk-contentscanner",
  "matrix-sdk-ffi-macros",
  "matrix-sdk-ui",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ zeroize = { version = "1.8.2", default-features = false }
 matrix-sdk = { path = "crates/matrix-sdk", version = "0.18.0", default-features = false }
 matrix-sdk-base = { path = "crates/matrix-sdk-base", version = "0.18.0" }
 matrix-sdk-common = { path = "crates/matrix-sdk-common", version = "0.18.0" }
+matrix-sdk-contentscanner = { path = "crates/matrix-sdk-contentscanner", version = "0.18.0" }
 matrix-sdk-crypto = { path = "crates/matrix-sdk-crypto", version = "0.18.0" }
 matrix-sdk-ffi-macros = { path = "bindings/matrix-sdk-ffi-macros", version = "0.7.0" }
 matrix-sdk-indexeddb = { path = "crates/matrix-sdk-indexeddb", version = "0.18.0", default-features = false }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -62,6 +62,7 @@ matrix-sdk = { workspace = true, features = [
 matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true
 matrix-sdk-ffi-macros.workspace = true
+matrix-sdk-contentscanner = { workspace = true, features = ["uniffi"] }
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = { version = "0.3.17", default-features = false }
 ruma = { workspace = true, features = [

--- a/bindings/matrix-sdk-ffi/changelog.d/6625.feature.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6625.feature.md
@@ -1,0 +1,2 @@
+Add `ClientBuilder::enable_content_scanner(String)` to be able to replace the default `MediaFetcher` 
+with one backed by the content scanner server in the provided URL.

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -29,6 +29,7 @@ use matrix_sdk::{
     cross_process_lock::CrossProcessLockConfig as SdkCrossProcessLockConfig,
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     event_cache::EventCacheError,
+    media::MediaFetcher,
     ruma::{ServerName, UserId},
     sliding_sync::{
         Error as MatrixSlidingSyncError, VersionBuilder as MatrixSlidingSyncVersionBuilder,
@@ -163,6 +164,8 @@ pub struct ClientBuilder {
     threading_support: ThreadingSupport,
 
     dm_room_definition: DmRoomDefinition,
+
+    media_fetcher: Option<Arc<dyn MediaFetcher>>,
 }
 
 /// The timeout applies to each read operation, and resets after a successful
@@ -209,6 +212,7 @@ impl ClientBuilder {
             #[cfg(feature = "experimental-search")]
             search_index_store: None,
             dm_room_definition: DmRoomDefinition::MatrixSpec,
+            media_fetcher: None,
         })
     }
 
@@ -543,6 +547,10 @@ impl ClientBuilder {
         inner_builder = inner_builder
             .dm_room_definition(builder.dm_room_definition)
             .with_threading_support(builder.threading_support);
+
+        if let Some(media_fetcher) = builder.media_fetcher {
+            inner_builder = inner_builder.media_fetcher(media_fetcher.clone());
+        }
 
         let sdk_client = inner_builder.build().await?;
 

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -40,6 +40,7 @@ use matrix_sdk_base::{
     DmRoomDefinition,
     crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
 };
+use matrix_sdk_contentscanner::ContentScannerMediaFetcher;
 use ruma::api::error::{DeserializationError, FromHttpResponseError};
 use tracing::debug;
 
@@ -214,6 +215,12 @@ impl ClientBuilder {
             dm_room_definition: DmRoomDefinition::MatrixSpec,
             media_fetcher: None,
         })
+    }
+
+    pub fn enable_content_scanner(self: Arc<Self>, scanner_url: String) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.media_fetcher = Some(Arc::new(ContentScannerMediaFetcher::new(scanner_url)));
+        Arc::new(builder)
     }
 
     pub fn dm_room_definition(self: Arc<Self>, dm_room_definition: DmRoomDefinition) -> Arc<Self> {

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -24,6 +24,7 @@ use matrix_sdk::{
     room::{calls::CallError, edit::EditError},
     send_queue::RoomSendQueueError,
 };
+use matrix_sdk_contentscanner::ContentScannerError;
 use matrix_sdk_ui::{encryption_sync_service, notification_client, spaces, sync_service, timeline};
 use ruma::{
     MilliSecondsSinceUnixEpoch,
@@ -39,6 +40,8 @@ pub enum ClientError {
     Generic { msg: String, details: Option<String> },
     #[error("api error {code}: {msg}")]
     MatrixApi { kind: ErrorKind, code: String, msg: String, details: Option<String> },
+    #[error("content scanner error {reason:?}: {info}")]
+    ContentScanner { reason: matrix_sdk_contentscanner::ErrorReason, info: String },
 }
 
 impl ClientError {
@@ -75,23 +78,39 @@ impl From<matrix_sdk::Error> for ClientError {
     fn from(e: matrix_sdk::Error) -> Self {
         match e {
             matrix_sdk::Error::Http(http_error) => {
-                if let Some(api_error) = http_error.as_client_api_error()
-                    && let ErrorBody::Standard(StandardErrorBody { kind, message, .. }) =
-                        &api_error.body
-                {
-                    let code = kind.errcode().to_string();
-                    let Ok(kind) = kind.to_owned().try_into() else {
-                        // We couldn't parse the API error, so we return a generic one instead
-                        return (*http_error).into();
-                    };
-                    return Self::MatrixApi {
-                        kind,
-                        code,
-                        msg: message.to_owned(),
-                        details: Some(format!("{api_error:?}")),
-                    };
+                if let Some(api_error) = http_error.as_client_api_error() {
+                    match &api_error.body {
+                        ErrorBody::Standard(StandardErrorBody { kind, message, .. }) => {
+                            let Ok(ffi_error_kind) = kind.clone().try_into() else {
+                                // We couldn't parse the API error, so we return a generic one
+                                // instead
+                                return (*http_error).into();
+                            };
+                            let code = kind.errcode().to_string();
+                            Self::MatrixApi {
+                                kind: ffi_error_kind,
+                                code,
+                                msg: message.to_owned(),
+                                details: Some(format!("{api_error:?}")),
+                            }
+                        }
+                        ErrorBody::Json(json) => {
+                            if let Ok(api_error) =
+                                serde_json::from_value::<ContentScannerError>(json.to_owned())
+                            {
+                                Self::ContentScanner {
+                                    reason: api_error.reason,
+                                    info: api_error.info,
+                                }
+                            } else {
+                                (*http_error).into()
+                            }
+                        }
+                        ErrorBody::NotJson { .. } => (*http_error).into(),
+                    }
+                } else {
+                    (*http_error).into()
                 }
-                (*http_error).into()
             }
             _ => Self::from_err(e),
         }

--- a/crates/matrix-sdk-contentscanner/Cargo.toml
+++ b/crates/matrix-sdk-contentscanner/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+authors = ["Jorge Martín Espinosa <jorgem@element.io>"]
+description = "Optional crate used to allow scanning the contents of media to prevent malware infections"
+name = "matrix-sdk-contentscanner"
+version = "0.18.0"
+edition = "2024"
+license = "Apache-2.0"
+rust-version.workspace = true
+
+[features]
+uniffi = ["dep:uniffi", "matrix-sdk/uniffi"]
+
+[dependencies]
+assert_matches2.workspace = true
+matrix-sdk = { workspace = true, features = ["testing", "e2e-encryption"] }
+matrix-sdk-crypto.workspace = true
+ruma = { workspace = true, features = ["client-api"] }
+serde.workspace = true
+tracing.workspace = true
+uniffi = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+matrix-sdk-test.workspace = true
+wiremock.workspace = true
+
+[lints]
+workspace = true

--- a/crates/matrix-sdk-contentscanner/changelog.d/6625.feature.md
+++ b/crates/matrix-sdk-contentscanner/changelog.d/6625.feature.md
@@ -1,0 +1,2 @@
+Add `ContentScanner` and `ContentScannerMediaFetcher` to be able to scan and download media files 
+using a content scanner server.

--- a/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
@@ -1,0 +1,85 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::RumaApiError;
+use matrix_sdk_crypto::olm::Curve25519PublicKey;
+use ruma::{
+    api::{
+        Metadata, OutgoingRequest,
+        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
+        error::IntoHttpError,
+        path_builder::PathBuilder,
+    },
+    events::room::EncryptedFile,
+    exports::{bytes::BufMut, http::Request},
+    metadata,
+};
+
+use crate::api::{DownloadAndScanMediaResponse, encrypted_file_request_from};
+
+metadata! {
+    @for DownloadAndScanEncryptedMediaRequest,
+    method: POST,
+    rate_limited: false,
+    authentication: AccessTokenOptional,
+    history: {
+        unstable => "/_matrix/media_proxy/unstable/download_encrypted",
+    },
+}
+
+/// The HTTP request body for downloading and scanning encrypted media.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#post-_matrixmedia_proxyunstabledownload_encrypted>
+#[derive(Debug, Clone)]
+pub(crate) struct DownloadAndScanEncryptedMediaRequest {
+    scanner_url: String,
+    public_key: Option<Curve25519PublicKey>,
+    encrypted_file: EncryptedFile,
+}
+
+impl DownloadAndScanEncryptedMediaRequest {
+    pub(crate) fn new(
+        scanner_url: impl Into<String>,
+        public_key: Option<Curve25519PublicKey>,
+        encrypted_file: EncryptedFile,
+    ) -> Self {
+        Self { scanner_url: scanner_url.into(), public_key, encrypted_file }
+    }
+}
+
+impl OutgoingRequest for DownloadAndScanEncryptedMediaRequest {
+    type EndpointError = RumaApiError;
+    type IncomingResponse = DownloadAndScanMediaResponse;
+
+    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+        _base_url: &str,
+        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
+        path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
+    ) -> Result<Request<T>, IntoHttpError> {
+        let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
+
+        let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
+        let body = ruma::serde::json_to_buf(&body)?;
+
+        let mut request = Request::builder().method(Self::METHOD).uri(url).body(body)?;
+        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
+            Self::Authentication::add_authentication(
+                &mut request,
+                SendAccessToken::IfRequired(access_token),
+            )?
+        }
+
+        Ok(request)
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/download/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod unencrypted;

--- a/crates/matrix-sdk-contentscanner/src/api/download/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod encrypted;
 pub mod unencrypted;

--- a/crates/matrix-sdk-contentscanner/src/api/download/unencrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/unencrypted.rs
@@ -1,0 +1,89 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::RumaApiError;
+use ruma::{
+    api::{
+        Metadata, OutgoingRequest,
+        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
+        error::IntoHttpError,
+        path_builder::PathBuilder,
+    },
+    exports::{bytes::BufMut, http::Request},
+    metadata,
+};
+
+use crate::api::DownloadAndScanMediaResponse;
+
+metadata! {
+    @for DownloadAndScanMediaRequest,
+    method: GET,
+    rate_limited: false,
+    authentication: AccessTokenOptional,
+    history: {
+        unstable => "/_matrix/media_proxy/unstable/download/{server_name}/{media_id}",
+    },
+}
+
+/// The HTTP request body for downloading and scanning unencrypted media.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#get-_matrixmedia_proxyunstabledownloadservernamemediaid>
+#[derive(Debug, Clone)]
+pub(crate) struct DownloadAndScanMediaRequest {
+    scanner_url: String,
+    server_name: String,
+    media_id: String,
+}
+
+impl DownloadAndScanMediaRequest {
+    pub(crate) fn new(
+        scanner_url: impl Into<String>,
+        server_name: impl Into<String>,
+        media_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            scanner_url: scanner_url.into(),
+            server_name: server_name.into(),
+            media_id: media_id.into(),
+        }
+    }
+}
+
+impl OutgoingRequest for DownloadAndScanMediaRequest {
+    type EndpointError = RumaApiError;
+    type IncomingResponse = DownloadAndScanMediaResponse;
+
+    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+        _base_url: &str,
+        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
+        path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
+    ) -> Result<Request<T>, IntoHttpError> {
+        let url = Self::make_endpoint_url(
+            path_builder_input,
+            &self.scanner_url,
+            &[&self.server_name, &self.media_id],
+            "",
+        )?;
+
+        let mut request = Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
+        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
+            Self::Authentication::add_authentication(
+                &mut request,
+                SendAccessToken::IfRequired(access_token),
+            )?
+        }
+
+        Ok(request)
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/mod.rs
@@ -24,6 +24,8 @@ use ruma::{
 };
 use serde::Deserialize;
 
+use crate::EncryptedFileRequest;
+
 pub mod download;
 pub mod public_server_key;
 pub mod scan;
@@ -48,5 +50,27 @@ impl IncomingResponse for DownloadAndScanMediaResponse {
         } else {
             Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(response)))
         }
+    }
+}
+
+/// Creates an [`EncryptedFileRequest`] from [`EncryptedFile`], using the
+/// optionally provided public key if present.
+pub(crate) fn encrypted_file_request_from(
+    public_key: Option<Curve25519PublicKey>,
+    encrypted_file: &EncryptedFile,
+) -> Result<EncryptedFileRequest, IntoHttpError> {
+    if let Some(public_key) = public_key {
+        // Generate an encrypted request body.
+        let encryption =
+            PkEncryption::from_key(Curve25519PublicKey::from_bytes(*public_key.as_bytes()));
+
+        let body_to_encrypt = EncryptedFileRequest::from_file_info(encrypted_file.clone());
+        let json_body_to_encrypt = serde_json::to_string(&body_to_encrypt)?;
+        let pk_message = encryption
+            .encrypt(json_body_to_encrypt.as_bytes())
+            .map_err(|e| IntoHttpError::Authentication(e.into()))?;
+        Ok(EncryptedFileRequest::from_encrypted_body(pk_message.into()))
+    } else {
+        Ok(EncryptedFileRequest::from_file_info(encrypted_file.clone()))
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/mod.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::{RumaApiError, encryption::vodozemac::pk_encryption::PkEncryption};
+use matrix_sdk_crypto::vodozemac::Curve25519PublicKey;
+use ruma::{
+    api::{
+        EndpointError, IncomingResponse,
+        error::{FromHttpResponseError, IntoHttpError},
+    },
+    events::room::EncryptedFile,
+    exports::{http::Response, serde_json},
+};
+use serde::Deserialize;
+
+pub mod download;
+pub mod public_server_key;
+pub mod scan;
+
+/// The HTTP response content for a successful request to download and scan
+/// media.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md>
+#[derive(Debug, Deserialize)]
+pub struct DownloadAndScanMediaResponse {
+    /// The content that was previously uploaded.
+    pub content: Vec<u8>,
+}
+
+impl IncomingResponse for DownloadAndScanMediaResponse {
+    type EndpointError = RumaApiError;
+
+    fn try_from_http_response<T: AsRef<[u8]>>(
+        response: Response<T>,
+    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
+        if response.status().is_success() {
+            Ok(Self { content: response.body().as_ref().to_vec() })
+        } else {
+            Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(response)))
+        }
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::RumaApiError;
+use ruma::{
+    api::{
+        IncomingResponse, Metadata, OutgoingRequest,
+        auth_scheme::{AuthScheme, NoAuthentication},
+        error::{FromHttpResponseError, IntoHttpError},
+        path_builder::PathBuilder,
+    },
+    exports::{
+        bytes::BufMut,
+        http::{Request, Response},
+        serde_json,
+    },
+    metadata,
+};
+use serde::Deserialize;
+
+metadata! {
+    @for PublicServerKeyRequest,
+    method: GET,
+    rate_limited: false,
+    authentication: NoAuthentication,
+    history: {
+        unstable => "/_matrix/media_proxy/unstable/public_key",
+    },
+}
+
+/// The HTTP request body for fetching the public server key.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#get-_matrixmedia_proxyunstablepublic_key>
+#[derive(Debug, Clone)]
+pub(crate) struct PublicServerKeyRequest {
+    scanner_url: String,
+}
+
+impl PublicServerKeyRequest {
+    pub(crate) fn new(scanner_url: impl Into<String>) -> Self {
+        Self { scanner_url: scanner_url.into() }
+    }
+}
+
+impl OutgoingRequest for PublicServerKeyRequest {
+    type EndpointError = RumaApiError;
+    type IncomingResponse = PublicServerKeyResponse;
+
+    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+        _base_url: &str,
+        _authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
+        path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
+    ) -> Result<Request<T>, IntoHttpError> {
+        let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(T::default())?)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PublicServerKeyResponse {
+    pub(crate) public_key: String,
+}
+
+impl IncomingResponse for PublicServerKeyResponse {
+    type EndpointError = RumaApiError;
+
+    fn try_from_http_response<T: AsRef<[u8]>>(
+        response: Response<T>,
+    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
+        Ok(serde_json::from_slice::<PublicServerKeyResponse>(response.body().as_ref())?)
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
@@ -1,0 +1,85 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::{RumaApiError, bytes::BufMut, encryption::vodozemac::Curve25519PublicKey};
+use ruma::{
+    api::{
+        Metadata, OutgoingRequest,
+        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
+        error::IntoHttpError,
+        path_builder::PathBuilder,
+    },
+    events::room::EncryptedFile,
+    exports::http::Request,
+    metadata,
+};
+
+use crate::api::{encrypted_file_request_from, scan::MediaScanResponse};
+
+metadata! {
+    @for EncryptedMediaScanRequest,
+    method: POST,
+    rate_limited: false,
+    authentication: AccessTokenOptional,
+    history: {
+        unstable => "/_matrix/media_proxy/unstable/scan_encrypted",
+    },
+}
+
+/// A request to scan an encrypted media file using the content scanner.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#post-_matrixmedia_proxyunstablescan_encrypted>
+#[derive(Debug, Clone)]
+pub struct EncryptedMediaScanRequest {
+    scanner_url: String,
+    public_key: Option<Curve25519PublicKey>,
+    encrypted_file: EncryptedFile,
+}
+
+impl EncryptedMediaScanRequest {
+    pub fn new(
+        scanner_url: String,
+        public_key: Option<Curve25519PublicKey>,
+        encrypted_file: EncryptedFile,
+    ) -> Self {
+        Self { scanner_url, public_key, encrypted_file }
+    }
+}
+
+impl OutgoingRequest for EncryptedMediaScanRequest {
+    type EndpointError = RumaApiError;
+    type IncomingResponse = MediaScanResponse;
+
+    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+        _base_url: &str,
+        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
+        path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
+    ) -> Result<Request<T>, IntoHttpError> {
+        let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
+
+        let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
+        let body = ruma::serde::json_to_buf(&body)?;
+
+        let mut request = Request::builder().method(Self::METHOD).uri(url).body(body)?;
+
+        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
+            Self::Authentication::add_authentication(
+                &mut request,
+                SendAccessToken::IfRequired(access_token),
+            )?
+        }
+
+        Ok(request)
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::RumaApiError;
+use ruma::{
+    api::{EndpointError, IncomingResponse, error::FromHttpResponseError},
+    exports::{http::Response, serde_json},
+};
+use serde::Deserialize;
+
+pub mod encrypted;
+pub mod unencrypted;
+
+/// A media scan response containing the result of the scan.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#get-_matrixmedia_proxyunstablescanservernamemediaid>
+#[derive(Debug, Deserialize)]
+pub struct MediaScanResponse {
+    /// Whether the media is clean or contained something dangerous.
+    pub clean: bool,
+    /// Extra information about the scan.
+    pub info: String,
+}
+
+impl IncomingResponse for MediaScanResponse {
+    type EndpointError = RumaApiError;
+
+    fn try_from_http_response<T: AsRef<[u8]>>(
+        response: Response<T>,
+    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
+        if response.status().is_success() {
+            let content = response.body().as_ref().to_vec();
+            let media_scan_response: MediaScanResponse = serde_json::from_slice(&content)?;
+            Ok(media_scan_response)
+        } else {
+            Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(response)))
+        }
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/api/scan/unencrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/unencrypted.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::{RumaApiError, bytes::BufMut};
+use ruma::{
+    api::{
+        Metadata, OutgoingRequest,
+        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
+        error::IntoHttpError,
+        path_builder::PathBuilder,
+    },
+    exports::http::Request,
+    metadata,
+};
+
+use crate::api::scan::MediaScanResponse;
+
+metadata! {
+    @for MediaScanRequest,
+    method: GET,
+    rate_limited: false,
+    authentication: AccessTokenOptional,
+    history: {
+        unstable => "/_matrix/media_proxy/unstable/scan/{server_name}/{media_id}",
+    },
+}
+
+/// A request to scan an unencrypted media file using the content scanner.
+/// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#get-_matrixmedia_proxyunstablescanservernamemediaid>
+#[derive(Debug, Clone)]
+pub struct MediaScanRequest {
+    scanner_url: String,
+    server_name: String,
+    media_id: String,
+}
+
+impl MediaScanRequest {
+    pub fn new(scanner_url: String, server_name: String, media_id: String) -> Self {
+        Self { scanner_url, server_name, media_id }
+    }
+}
+
+impl OutgoingRequest for MediaScanRequest {
+    type EndpointError = RumaApiError;
+    type IncomingResponse = MediaScanResponse;
+
+    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+        _base_url: &str,
+        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
+        path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
+    ) -> Result<Request<T>, IntoHttpError> {
+        let url = Self::make_endpoint_url(
+            path_builder_input,
+            &self.scanner_url,
+            &[&self.server_name, &self.media_id],
+            "",
+        )?;
+
+        let mut request = Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
+
+        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
+            Self::Authentication::add_authentication(
+                &mut request,
+                SendAccessToken::IfRequired(access_token),
+            )?
+        }
+
+        Ok(request)
+    }
+}

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -28,13 +28,20 @@ use matrix_sdk::{
     ruma::events::room::MediaSource,
 };
 use matrix_sdk_crypto::olm::Curve25519PublicKey;
+use ruma::{
+    events::room::EncryptedFile,
+    serde::{Base64, base64::Standard},
+};
+use serde::{Deserialize, Serialize};
 use tracing::trace;
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
+pub use crate::api::scan::MediaScanResponse;
 use crate::api::{
     DownloadAndScanMediaResponse,
+    scan::{encrypted::EncryptedMediaScanRequest, unencrypted::MediaScanRequest},
 };
 
 mod api;
@@ -109,6 +116,41 @@ impl ContentScanner {
             }
         }
     }
+
+    /// Scan a media source, returning a [`MediaScanResponse`] with the scan
+    /// result, or an error if something failed when trying to scan the media.
+    pub async fn scan(
+        &self,
+        client: &Client,
+        media_source: &MediaSource,
+    ) -> Result<MediaScanResponse, Error> {
+        match &media_source {
+            MediaSource::Encrypted(encrypted) => {
+                // Get the public server key if we don't have it yet.
+                let public_server_key = self.get_or_fetch_public_server_key(client).await;
+
+                Ok(client
+                    .send(EncryptedMediaScanRequest::new(
+                        self.scanner_url.clone(),
+                        public_server_key,
+                        *encrypted.clone(),
+                    ))
+                    .await?)
+            }
+            MediaSource::Plain(mxc) => {
+                let (server_name, media_id) =
+                    mxc.parts().map_err(|e| Error::Identifier(IdParseError::InvalidMxcUri(e)))?;
+                Ok(client
+                    .send(MediaScanRequest::new(
+                        self.scanner_url.clone(),
+                        server_name.to_string(),
+                        media_id.to_owned(),
+                    ))
+                    .await?)
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 struct EncryptedBody {
@@ -229,7 +271,7 @@ mod tests {
         matchers::{header_exists, method, path, path_regex},
     };
 
-    use crate::ContentScanner;
+    use crate::{ContentScanner, ContentScannerError, ErrorReason};
 
     #[async_test]
     async fn test_fetch_public_key() {
@@ -379,5 +421,116 @@ mod tests {
             client_error.to_string(),
             "[403] {\"info\":\"File type: application/octet-stream not allowed\",\"reason\":\"MCS_MIME_TYPE_FORBIDDEN\"}"
         );
+    }
+
+    #[async_test]
+    async fn test_scan_media() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/media_proxy/unstable/scan/.+/.+"))
+            .and(header_exists("Authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "clean": true,
+                "info": "All clear!"
+            })))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let media_source =
+            MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
+        let response = content_scanner.scan(&client, &media_source).await.expect("Get media");
+        assert!(response.clean);
+    }
+
+    #[async_test]
+    async fn test_scan_encrypted_media() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/media_proxy/unstable/scan_encrypted"))
+            .and(header_exists("Authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "clean": true,
+                "info": "All clear!"
+            })))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let file_info = EncryptedFileInfo::V2(V2EncryptedFileInfo::new(
+            Base64::parse("9lpOscZyMOZRCF3v867nPPo3WPNMZt9JXMsuYiWRszc".as_bytes()).expect("k"),
+            Base64::parse("czvdfKSjfLEAAAAAAAAAAA".as_bytes()).expect("iv"),
+        ));
+        let mut hashes = EncryptedFileHashes::new();
+        hashes.insert(EncryptedFileHash::Sha256(
+            Base64::parse("SBbJ3hINT2LgwXK8ev82enjnhubUy5UuKGDF3SezAhs".as_bytes()).expect("hash"),
+        ));
+        let media_source = MediaSource::Encrypted(Box::new(EncryptedFile::new(
+            owned_mxc_uri!(
+                "mxc://element.io/b50f38aa8ae820c75992370e4e944a045481e3932057062074730676224"
+            ),
+            file_info,
+            hashes,
+        )));
+        let response = content_scanner.scan(&client, &media_source).await.expect("Get media");
+        assert!(response.clean);
+    }
+
+    #[async_test]
+    async fn test_scan_media_unsupported() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/media_proxy/unstable/scan/.+/.+"))
+            .and(header_exists("Authorization"))
+            .respond_with(
+                // This always returns a 200 status code for scan results, even for failures
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "clean": false,
+                    "info": "***VIRUS DETECTED***"
+                })),
+            )
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let media_source =
+            MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
+        let response = content_scanner.scan(&client, &media_source).await.expect("Get media");
+        assert!(response.clean.not());
+    }
+
+    #[test]
+    fn test_error_mapping() {
+        let error = HttpError::Api(Box::new(FromHttpResponseError::Server(
+            RumaApiError::MatrixError(ruma::api::error::Error::new(
+                StatusCode::FORBIDDEN,
+                ErrorBody::Json(json!({
+                    "info": "***VIRUS DETECTED***",
+                    "reason": "MCS_MEDIA_NOT_CLEAN"
+                })),
+            )),
+        )));
+        let api_error = error.as_client_api_error().expect("error as api error");
+        assert_eq!(
+            api_error.to_string(),
+            "[403] {\"info\":\"***VIRUS DETECTED***\",\"reason\":\"MCS_MEDIA_NOT_CLEAN\"}"
+        );
+        assert_matches!(&api_error.body, ErrorBody::Json(json_body));
+        let content_scanner_error =
+            ContentScannerError::deserialize(json_body).expect("deserialize");
+        assert_eq!(content_scanner_error.info, "***VIRUS DETECTED***");
+        assert_matches!(content_scanner_error.reason, ErrorReason::MCS_MEDIA_NOT_CLEAN);
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -18,6 +18,7 @@ use api::{
     download::{
         unencrypted::DownloadAndScanMediaRequest,
     },
+    public_server_key::PublicServerKeyRequest,
 };
 use matrix_sdk::{
     BoxFuture, Client, Error, IdParseError,
@@ -26,6 +27,8 @@ use matrix_sdk::{
     media::{MediaFetcher, MediaRequestParameters},
     ruma::events::room::MediaSource,
 };
+use matrix_sdk_crypto::olm::Curve25519PublicKey;
+use tracing::trace;
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
@@ -47,6 +50,32 @@ impl ContentScanner {
     /// Instantiate a new [`ContentScanner`] using the `scanner_url`.
     pub fn new(scanner_url: impl Into<String>) -> Self {
         Self { scanner_url: scanner_url.into(), public_server_key: Arc::new(Mutex::new(None)) }
+    }
+
+    pub(crate) async fn fetch_public_server_key(&self, client: &Client) -> Result<String, Error> {
+        let response = client.send(PublicServerKeyRequest::new(self.scanner_url.clone())).await?;
+        Ok(response.public_key)
+    }
+
+    async fn get_or_fetch_public_server_key(&self, client: &Client) -> Option<Curve25519PublicKey> {
+        let public_server_key =
+            if let Some(public_server_key) = (*self.public_server_key.lock()).clone() {
+                trace!("Using cached public server key");
+                Some(public_server_key)
+            } else {
+                trace!("Using cached public server key");
+                let ret = self.fetch_public_server_key(client).await.ok();
+
+                if let Some(public_server_key) = &ret {
+                    trace!("Saved new public server key");
+                    let mut guard = self.public_server_key.lock();
+                    let _ = guard.insert(public_server_key.clone());
+                }
+
+                ret
+            };
+
+        public_server_key.and_then(|key| Curve25519PublicKey::from_base64(&key).ok())
     }
 
     pub(crate) async fn get_media(
@@ -95,4 +124,73 @@ impl MediaFetcher for ContentScannerMediaFetcher {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use assert_matches2::assert_matches;
+    use matrix_sdk::{HttpError, RumaApiError, test_utils::mocks::MatrixMockServer};
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        api::{
+            MatrixVersion,
+            error::{ErrorBody, FromHttpResponseError},
+        },
+        events::room::{
+            EncryptedFile, EncryptedFileHash, EncryptedFileHashes, EncryptedFileInfo, MediaSource,
+            V2EncryptedFileInfo,
+        },
+        exports::{http::StatusCode, serde_json::json},
+        owned_mxc_uri,
+        serde::Base64,
+    };
+    use serde::Deserialize;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{header_exists, method, path, path_regex},
+    };
+
+    use crate::ContentScanner;
+
+    #[async_test]
+    async fn test_fetch_public_key() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/_matrix/media_proxy/unstable/public_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "public_key": "1234567890"
+            })))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        content_scanner.fetch_public_server_key(&client).await.expect("Load public key");
+    }
+
+    #[async_test]
+    async fn test_get_media() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/media_proxy/unstable/download/.+/.+"))
+            .and(header_exists("Authorization"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            )
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let media_source =
+            MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
+        content_scanner.get_media(&client, &media_source).await.expect("Get media");
+    }
 }

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -14,16 +14,27 @@
 
 use std::sync::Arc;
 
-use matrix_sdk::locks::Mutex;
+use api::{
+    download::{
+        unencrypted::DownloadAndScanMediaRequest,
+    },
+};
 use matrix_sdk::{
     BoxFuture, Client, Error, IdParseError,
+    encryption::vodozemac::pk_encryption::Message,
     locks::Mutex,
     media::{MediaFetcher, MediaRequestParameters},
+    ruma::events::room::MediaSource,
 };
 
 #[cfg(feature = "uniffi")]
 uniffi::setup_scaffolding!();
 
+use crate::api::{
+    DownloadAndScanMediaResponse,
+};
+
+mod api;
 
 /// A helper component to download and scan media from a content scanner server.
 #[derive(Debug)]
@@ -36,6 +47,29 @@ impl ContentScanner {
     /// Instantiate a new [`ContentScanner`] using the `scanner_url`.
     pub fn new(scanner_url: impl Into<String>) -> Self {
         Self { scanner_url: scanner_url.into(), public_server_key: Arc::new(Mutex::new(None)) }
+    }
+
+    pub(crate) async fn get_media(
+        &self,
+        client: &Client,
+        media_source: &MediaSource,
+    ) -> Result<DownloadAndScanMediaResponse, Error> {
+        match &media_source {
+            MediaSource::Encrypted(_encrypted) => {
+                todo!("Let's start with unencrypted media first.")
+            }
+            MediaSource::Plain(mxc) => {
+                let (server_name, media_id) =
+                    mxc.parts().map_err(|e| Error::Identifier(IdParseError::InvalidMxcUri(e)))?;
+                Ok(client
+                    .send(DownloadAndScanMediaRequest::new(
+                        &self.scanner_url,
+                        server_name.as_str(),
+                        media_id,
+                    ))
+                    .await?)
+            }
+        }
     }
 
 /// A media fetcher that uses the content scanner to download and scan media.
@@ -53,11 +87,11 @@ impl ContentScannerMediaFetcher {
 impl MediaFetcher for ContentScannerMediaFetcher {
     fn fetch_media_content<'a>(
         &'a self,
-        _client: &'a Client,
-        _request: &'a MediaRequestParameters,
+        client: &'a Client,
+        request: &'a MediaRequestParameters,
     ) -> BoxFuture<'a, matrix_sdk::Result<Vec<u8>, Error>> {
         Box::pin(async move {
-            todo!("Implement fetch_media_content")
+            Ok(self.content_scanner.get_media(client, &request.source).await?.content)
         })
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use api::{
     download::{
-        unencrypted::DownloadAndScanMediaRequest,
+        encrypted::DownloadAndScanEncryptedMediaRequest, unencrypted::DownloadAndScanMediaRequest,
     },
     public_server_key::PublicServerKeyRequest,
 };
@@ -84,8 +84,17 @@ impl ContentScanner {
         media_source: &MediaSource,
     ) -> Result<DownloadAndScanMediaResponse, Error> {
         match &media_source {
-            MediaSource::Encrypted(_encrypted) => {
-                todo!("Let's start with unencrypted media first.")
+            MediaSource::Encrypted(encrypted) => {
+                // Get the public server key if we don't have it yet.
+                let public_server_key = self.get_or_fetch_public_server_key(client).await;
+
+                Ok(client
+                    .send(DownloadAndScanEncryptedMediaRequest::new(
+                        self.scanner_url.clone(),
+                        public_server_key,
+                        *encrypted.clone(),
+                    ))
+                    .await?)
             }
             MediaSource::Plain(mxc) => {
                 let (server_name, media_id) =
@@ -100,6 +109,41 @@ impl ContentScanner {
             }
         }
     }
+
+#[derive(Debug, Clone, Serialize)]
+struct EncryptedBody {
+    ciphertext: String,
+    mac: String,
+    ephemeral: String,
+}
+
+impl From<Message> for EncryptedBody {
+    fn from(value: Message) -> Self {
+        Self {
+            ciphertext: Base64::<Standard>::new(value.ciphertext).to_string(),
+            mac: Base64::<Standard>::new(value.mac).to_string(),
+            ephemeral: value.ephemeral_key.to_base64(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EncryptedFileRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<EncryptedFile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_body: Option<EncryptedBody>,
+}
+
+impl EncryptedFileRequest {
+    pub(crate) fn from_file_info(file_info: EncryptedFile) -> Self {
+        Self { file: Some(file_info), encrypted_body: None }
+    }
+
+    pub(crate) fn from_encrypted_body(encrypted_body: EncryptedBody) -> Self {
+        Self { file: None, encrypted_body: Some(encrypted_body) }
+    }
+}
 
 /// A media fetcher that uses the content scanner to download and scan media.
 pub struct ContentScannerMediaFetcher {
@@ -123,6 +167,40 @@ impl MediaFetcher for ContentScannerMediaFetcher {
             Ok(self.content_scanner.get_media(client, &request.source).await?.content)
         })
     }
+}
+
+/// A content scanner error.
+#[derive(Debug, Deserialize)]
+pub struct ContentScannerError {
+    pub info: String,
+    pub reason: ErrorReason,
+}
+
+/// The reason for the content scanner error.
+#[allow(non_camel_case_types)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Clone, Debug, Deserialize)]
+pub enum ErrorReason {
+    /// The JSON file is malformed.
+    MCS_MALFORMED_JSON,
+    /// The media could not be decrypted.
+    MCS_MEDIA_FAILED_TO_DECRYPT,
+    /// No access token was provided.
+    M_MISSING_TOKEN,
+    /// The access token provided is invalid.
+    M_UNKNOWN_TOKEN,
+    /// The media was not found.
+    M_NOT_FOUND,
+    /// The media has some potentially dangerous content.
+    MCS_MEDIA_NOT_CLEAN,
+    /// The media has been blocked by the server because of its mime type.
+    MCS_MIME_TYPE_FORBIDDEN,
+    /// The used public key is wrong.
+    MCS_BAD_DECRYPTION,
+    /// An unknown error occurred.
+    M_UNKNOWN,
+    /// The server failed to request media from the media repo.
+    MCS_MEDIA_REQUEST_FAILED,
 }
 
 #[cfg(test)]
@@ -192,5 +270,114 @@ mod tests {
         let media_source =
             MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
         content_scanner.get_media(&client, &media_source).await.expect("Get media");
+    }
+
+    #[async_test]
+    async fn test_get_media_unsupported() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/media_proxy/unstable/download/.+/.+"))
+            .and(header_exists("Authorization"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "reason": "MCS_MIME_TYPE_FORBIDDEN",
+                "info": "File type: application/octet-stream not allowed",
+            })))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let media_source =
+            MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/ckTaStcNnFXLzKApkBmgRDoC"));
+        let err =
+            content_scanner.get_media(&client, &media_source).await.expect_err("Get media error");
+        let client_error = err.as_client_api_error().expect("Get client error");
+        assert_eq!(client_error.status_code, StatusCode::FORBIDDEN);
+        assert_eq!(
+            client_error.to_string(),
+            "[403] {\"info\":\"File type: application/octet-stream not allowed\",\"reason\":\"MCS_MIME_TYPE_FORBIDDEN\"}"
+        );
+    }
+
+    #[async_test]
+    async fn test_get_encrypted_media() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/media_proxy/unstable/download_encrypted"))
+            .and(header_exists("Authorization"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            )
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let file_info = EncryptedFileInfo::V2(V2EncryptedFileInfo::new(
+            Base64::parse("9lpOscZyMOZRCF3v867nPPo3WPNMZt9JXMsuYiWRszc".as_bytes()).expect("k"),
+            Base64::parse("czvdfKSjfLEAAAAAAAAAAA".as_bytes()).expect("iv"),
+        ));
+        let mut hashes = EncryptedFileHashes::new();
+        hashes.insert(EncryptedFileHash::Sha256(
+            Base64::parse("SBbJ3hINT2LgwXK8ev82enjnhubUy5UuKGDF3SezAhs".as_bytes()).expect("hash"),
+        ));
+        let media_source = MediaSource::Encrypted(Box::new(EncryptedFile::new(
+            owned_mxc_uri!(
+                "mxc://element.io/b50f38aa8ae820c75992370e4e944a045481e3932057062074730676224"
+            ),
+            file_info,
+            hashes,
+        )));
+        content_scanner.get_media(&client, &media_source).await.expect("Get media");
+    }
+
+    #[async_test]
+    async fn test_get_encrypted_media_unsupported() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/_matrix/media_proxy/unstable/download_encrypted"))
+            .and(header_exists("Authorization"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "reason": "MCS_MIME_TYPE_FORBIDDEN",
+                "info": "File type: application/octet-stream not allowed",
+            })))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let file_info = EncryptedFileInfo::V2(V2EncryptedFileInfo::new(
+            Base64::parse("tdHdCI5mc-g29IYfhYx2wkA5o-bILP9-nXY6Np1uSnM".as_bytes()).expect("k"),
+            Base64::parse("IBFdH65KqhoAAAAAAAAAAA".as_bytes()).expect("iv"),
+        ));
+        let mut hashes = EncryptedFileHashes::new();
+        hashes.insert(EncryptedFileHash::Sha256(
+            Base64::parse("HSkkamvMSvF3Q30HInorh0ccPrxjgu+wp1vyUOmov/8".as_bytes()).expect("hash"),
+        ));
+        let media_source = MediaSource::Encrypted(Box::new(EncryptedFile::new(
+            owned_mxc_uri!("mxc://matrix.org/WlfuejQQdpvWiWVpAGwfIKJL"),
+            file_info,
+            hashes,
+        )));
+        let err = content_scanner
+            .get_media(&client, &media_source)
+            .await
+            .expect_err("Invalid type error");
+        let client_error = err.as_client_api_error().expect("Invalid error");
+        assert_eq!(client_error.status_code, StatusCode::FORBIDDEN);
+        assert_eq!(
+            client_error.to_string(),
+            "[403] {\"info\":\"File type: application/octet-stream not allowed\",\"reason\":\"MCS_MIME_TYPE_FORBIDDEN\"}"
+        );
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use matrix_sdk::locks::Mutex;
+use matrix_sdk::{
+    BoxFuture, Client, Error, IdParseError,
+    locks::Mutex,
+    media::{MediaFetcher, MediaRequestParameters},
+};
+
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+
+/// A helper component to download and scan media from a content scanner server.
+#[derive(Debug)]
+pub struct ContentScanner {
+    scanner_url: String,
+    public_server_key: Arc<Mutex<Option<String>>>,
+}
+
+impl ContentScanner {
+    /// Instantiate a new [`ContentScanner`] using the `scanner_url`.
+    pub fn new(scanner_url: impl Into<String>) -> Self {
+        Self { scanner_url: scanner_url.into(), public_server_key: Arc::new(Mutex::new(None)) }
+    }
+
+/// A media fetcher that uses the content scanner to download and scan media.
+pub struct ContentScannerMediaFetcher {
+    pub content_scanner: ContentScanner,
+}
+
+impl ContentScannerMediaFetcher {
+    /// Instantiate a new [`MediaFetcher`] using the provided `scanner_url`.
+    pub fn new(scanner_url: impl Into<String>) -> Self {
+        Self { content_scanner: ContentScanner::new(scanner_url.into()) }
+    }
+}
+
+impl MediaFetcher for ContentScannerMediaFetcher {
+    fn fetch_media_content<'a>(
+        &'a self,
+        _client: &'a Client,
+        _request: &'a MediaRequestParameters,
+    ) -> BoxFuture<'a, matrix_sdk::Result<Vec<u8>, Error>> {
+        Box::pin(async move {
+            todo!("Implement fetch_media_content")
+        })
+    }
+}
+}

--- a/crates/matrix-sdk-contentscanner/uniffi.toml
+++ b/crates/matrix-sdk-contentscanner/uniffi.toml
@@ -1,0 +1,5 @@
+[bindings.kotlin]
+android_cleaner = true
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true

--- a/crates/matrix-sdk/changelog.d/6625.feature.md
+++ b/crates/matrix-sdk/changelog.d/6625.feature.md
@@ -1,0 +1,2 @@
+Create a `MediaFetcher` trait that allows us to replace the existing `DefaultMediaFetcher` 
+with any other implementation when building a `Client`. 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -64,6 +64,7 @@ use crate::{
     config::RequestConfig,
     error::RumaApiError,
     http_client::HttpClient,
+    media::{DefaultMediaFetcher, MediaFetcher},
     send_queue::SendQueueData,
     sliding_sync::VersionBuilder as SlidingSyncVersionBuilder,
 };
@@ -131,6 +132,7 @@ pub struct ClientBuilder {
     #[cfg(feature = "experimental-search")]
     search_index_store_kind: SearchIndexStoreKind,
     dm_room_definition: DmRoomDefinition,
+    media_fetcher: Arc<dyn MediaFetcher>,
 }
 
 impl ClientBuilder {
@@ -168,7 +170,15 @@ impl ClientBuilder {
             #[cfg(feature = "experimental-search")]
             search_index_store_kind: SearchIndexStoreKind::InMemory,
             dm_room_definition: DmRoomDefinition::MatrixSpec,
+            media_fetcher: Arc::new(DefaultMediaFetcher),
         }
+    }
+
+    /// Sets a [`MediaFetcher`] that will be used to get media from the media
+    /// server.
+    pub fn media_fetcher(mut self, media_fetcher: Arc<dyn MediaFetcher>) -> Self {
+        self.media_fetcher = media_fetcher.clone();
+        self
     }
 
     /// Sets the definition the [`Client`] will use to check if a room is a DM.
@@ -664,6 +674,7 @@ impl ClientBuilder {
             #[cfg(feature = "experimental-search")]
             search_index,
             thread_subscriptions_catchup,
+            self.media_fetcher.clone(),
         )
         .await;
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -107,7 +107,7 @@ use crate::{
     http_client::{HttpClient, SupportedAuthScheme, SupportedPathBuilder},
     latest_events::LatestEvents,
     live_locations_observer::BeaconInfoUpdate,
-    media::MediaError,
+    media::{MediaError, MediaFetcher},
     notification_settings::NotificationSettings,
     room::RoomMember,
     room_preview::RoomPreview,
@@ -409,6 +409,8 @@ pub(crate) struct ClientInner {
     #[cfg(feature = "e2e-encryption")]
     pub(crate) duplicate_key_upload_error_sender:
         broadcast::Sender<Option<DuplicateOneTimeKeyErrorMessage>>,
+
+    pub(crate) media_fetcher: Arc<dyn MediaFetcher>,
 }
 
 impl ClientInner {
@@ -436,6 +438,7 @@ impl ClientInner {
         cross_process_lock_config: CrossProcessLockConfig,
         #[cfg(feature = "experimental-search")] search_index_handler: SearchIndex,
         thread_subscription_catchup: OnceCell<Arc<ThreadSubscriptionCatchup>>,
+        media_fetcher: Arc<dyn MediaFetcher>,
     ) -> Arc<Self> {
         let caches = ClientCaches {
             supported_versions: Cache::with_value(supported_versions),
@@ -479,6 +482,7 @@ impl ClientInner {
             task_monitor: TaskMonitor::new(),
             #[cfg(feature = "e2e-encryption")]
             duplicate_key_upload_error_sender: broadcast::channel(1).0,
+            media_fetcher,
         };
 
         #[allow(clippy::let_and_return)]
@@ -797,7 +801,7 @@ impl Client {
 
     /// Get the media manager of the client.
     pub fn media(&self) -> Media {
-        Media::new(self.clone())
+        Media::new(self.clone(), self.inner.media_fetcher.clone())
     }
 
     /// Get the pusher manager of the client.
@@ -3256,6 +3260,7 @@ impl Client {
                 #[cfg(feature = "experimental-search")]
                 self.inner.search_index.clone(),
                 self.inner.thread_subscription_catchup.clone(),
+                self.inner.media_fetcher.clone(),
             )
             .await,
         };
@@ -3596,7 +3601,7 @@ pub(crate) struct WeakClient {
 
 impl WeakClient {
     /// Construct a [`WeakClient`] from a `Arc<ClientInner>`.
-    pub fn from_inner(client: &Arc<ClientInner>) -> Self {
+    pub(crate) fn from_inner(client: &Arc<ClientInner>) -> Self {
         Self { client: Arc::downgrade(client) }
     }
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -17,14 +17,15 @@
 
 #[cfg(feature = "e2e-encryption")]
 use std::io::Read;
-use std::time::Duration;
+use std::{fmt, sync::Arc, time::Duration};
 #[cfg(not(target_family = "wasm"))]
-use std::{fmt, fs::File, path::Path};
+use std::{fs::File, path::Path};
 
 use eyeball::SharedObservable;
 use futures_util::future::try_join;
 use matrix_sdk_base::media::store::IgnoreMediaRetentionPolicy;
 pub use matrix_sdk_base::media::{store::MediaRetentionPolicy, *};
+use matrix_sdk_common::{BoxFuture, SendOutsideWasm, SyncOutsideWasm};
 use mime::Mime;
 use ruma::{
     MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
@@ -65,6 +66,7 @@ const LOCAL_MXC_SERVER_NAME: &str = "send-queue.localhost";
 pub struct Media {
     /// The underlying HTTP client.
     client: Client,
+    media_fetcher: Arc<dyn MediaFetcher>,
 }
 
 /// A file handle that takes ownership of a media file on disk. When the handle
@@ -161,9 +163,26 @@ pub enum MediaError {
     FetchMaxUploadSizeFailed(String),
 }
 
+/// A generic trait for fetching media content.
+pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm {
+    /// Fetches the media content for the given [`MediaRequestParameters`].
+    /// Returns either a byte array or an [`crate::Error`].
+    fn fetch_media_content<'a>(
+        &'a self,
+        client: &'a Client,
+        request: &'a MediaRequestParameters,
+    ) -> BoxFuture<'a, Result<Vec<u8>, Error>>;
+}
+
+impl fmt::Debug for dyn MediaFetcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("MediaFetcher")
+    }
+}
+
 impl Media {
-    pub(crate) fn new(client: Client) -> Self {
-        Self { client }
+    pub(crate) fn new(client: Client, media_fetcher: Arc<dyn MediaFetcher>) -> Self {
+        Self { client, media_fetcher: media_fetcher.clone() }
     }
 
     /// Upload some media to the server.
@@ -434,90 +453,7 @@ impl Media {
             return Ok(content);
         }
 
-        let request_config = self
-            .client
-            .request_config()
-            // Downloading a file should have no timeout as we don't know the network connectivity
-            // available for the user or the file size
-            .timeout(Some(Duration::MAX));
-
-        // Use the authenticated endpoints when the server supports it.
-        let supported_versions = self.client.supported_versions().await?;
-
-        let use_auth = authenticated_media::get_content::v1::Request::PATH_BUILDER
-            .is_supported(&supported_versions);
-
-        let content: Vec<u8> = match &request.source {
-            MediaSource::Encrypted(file) => {
-                let content = if use_auth {
-                    let request =
-                        authenticated_media::get_content::v1::Request::from_uri(&file.url)?;
-                    self.client.send(request).with_request_config(request_config).await?.file
-                } else {
-                    #[allow(deprecated)]
-                    let request = media::get_content::v3::Request::from_url(&file.url)?;
-                    self.client.send(request).with_request_config(request_config).await?.file
-                };
-
-                #[cfg(feature = "e2e-encryption")]
-                let content = {
-                    let content_len = content.len();
-                    let mut cursor = std::io::Cursor::new(content);
-                    let mut reader = matrix_sdk_base::crypto::AttachmentDecryptor::new(
-                        &mut cursor,
-                        file.as_ref().clone().into(),
-                    )?;
-
-                    // Encrypted size should be the same as the decrypted size,
-                    // rounded up to a cipher block.
-                    let mut decrypted = Vec::with_capacity(content_len);
-
-                    reader.read_to_end(&mut decrypted)?;
-
-                    decrypted
-                };
-
-                content
-            }
-
-            MediaSource::Plain(uri) => {
-                if let MediaFormat::Thumbnail(settings) = &request.format {
-                    if use_auth {
-                        let mut request =
-                            authenticated_media::get_content_thumbnail::v1::Request::from_uri(
-                                uri,
-                                settings.width,
-                                settings.height,
-                            )?;
-                        request.method = Some(settings.method.clone());
-                        request.animated = Some(settings.animated);
-
-                        self.client.send(request).with_request_config(request_config).await?.file
-                    } else {
-                        #[allow(deprecated)]
-                        let request = {
-                            let mut request = media::get_content_thumbnail::v3::Request::from_url(
-                                uri,
-                                settings.width,
-                                settings.height,
-                            )?;
-                            request.method = Some(settings.method.clone());
-                            request.animated = Some(settings.animated);
-                            request
-                        };
-
-                        self.client.send(request).with_request_config(request_config).await?.file
-                    }
-                } else if use_auth {
-                    let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
-                    self.client.send(request).with_request_config(request_config).await?.file
-                } else {
-                    #[allow(deprecated)]
-                    let request = media::get_content::v3::Request::from_url(uri)?;
-                    self.client.send(request).with_request_config(request_config).await?.file
-                }
-            }
-        };
+        let content = self.media_fetcher.fetch_media_content(&self.client, request).await?;
 
         if use_cache {
             self.client
@@ -787,6 +723,106 @@ impl Media {
         uri.server_name()
             .is_ok_and(|server_name| server_name == LOCAL_MXC_SERVER_NAME)
             .then_some(uri)
+    }
+}
+
+/// A [`MediaFetcher`] that uses the default media/authenticated media endpoints
+/// to fetch new media.
+#[derive(Debug, Clone)]
+pub(crate) struct DefaultMediaFetcher;
+
+impl MediaFetcher for DefaultMediaFetcher {
+    fn fetch_media_content<'a>(
+        &'a self,
+        client: &'a Client,
+        request: &'a MediaRequestParameters,
+    ) -> BoxFuture<'a, Result<Vec<u8>, Error>> {
+        Box::pin(async move {
+            let request_config = client
+                .request_config()
+                // Downloading a file should have no timeout as we don't know the network
+                // connectivity available for the user or the file size
+                .timeout(Some(Duration::MAX));
+
+            // Use the authenticated endpoints when the server supports it.
+            let supported_versions = client.supported_versions().await?;
+
+            let use_auth = authenticated_media::get_content::v1::Request::PATH_BUILDER
+                .is_supported(&supported_versions);
+
+            match &request.source {
+                MediaSource::Encrypted(file) => {
+                    let content = if use_auth {
+                        let request =
+                            authenticated_media::get_content::v1::Request::from_uri(&file.url)?;
+                        client.send(request).with_request_config(request_config).await?.file
+                    } else {
+                        #[allow(deprecated)]
+                        let request = media::get_content::v3::Request::from_url(&file.url)?;
+                        client.send(request).with_request_config(request_config).await?.file
+                    };
+
+                    #[cfg(feature = "e2e-encryption")]
+                    let content = {
+                        let content_len = content.len();
+                        let mut cursor = std::io::Cursor::new(content);
+                        let mut reader = matrix_sdk_base::crypto::AttachmentDecryptor::new(
+                            &mut cursor,
+                            file.as_ref().clone().into(),
+                        )?;
+
+                        // Encrypted size should be the same as the decrypted size,
+                        // rounded up to a cipher block.
+                        let mut decrypted = Vec::with_capacity(content_len);
+
+                        reader.read_to_end(&mut decrypted)?;
+
+                        decrypted
+                    };
+
+                    Ok(content)
+                }
+
+                MediaSource::Plain(uri) => {
+                    if let MediaFormat::Thumbnail(settings) = &request.format {
+                        if use_auth {
+                            let mut request =
+                                authenticated_media::get_content_thumbnail::v1::Request::from_uri(
+                                    uri,
+                                    settings.width,
+                                    settings.height,
+                                )?;
+                            request.method = Some(settings.method.clone());
+                            request.animated = Some(settings.animated);
+
+                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                        } else {
+                            #[allow(deprecated)]
+                            let request = {
+                                let mut request =
+                                    media::get_content_thumbnail::v3::Request::from_url(
+                                        uri,
+                                        settings.width,
+                                        settings.height,
+                                    )?;
+                                request.method = Some(settings.method.clone());
+                                request.animated = Some(settings.animated);
+                                request
+                            };
+
+                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                        }
+                    } else if use_auth {
+                        let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
+                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                    } else {
+                        #[allow(deprecated)]
+                        let request = media::get_content::v3::Request::from_url(uri)?;
+                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                    }
+                }
+            }
+        })
     }
 }
 


### PR DESCRIPTION
- Create a new `matrix-sdk-contentscanner` crate.
- Create a `ContentScanner` helper to download and scan media.
- Create a new `MediaFetcher` trait to use in `Media` to download media files. Keep the current behavior as `DefaultMediaFetcher` and the content scanner one as `ContentScannerMediaFetcher`, creating some ruma-style requests and responses to be used with `Client::send`.
- Keep `media_fetcher` inside the `ClientInner` struct.
- Add `ContentScanner::scan` method to only scan a media file, not download it.

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
