### PR TITLE
perf(common): Cache `TimelineEventKind::event_id()` in `TimelineEvent::event_id`

### DIFF
--- a/benchmarks/benches/event_cache.rs
+++ b/benchmarks/benches/event_cache.rs
@@ -207,7 +207,7 @@ fn find_event_relations(c: &mut Criterion) {
         // Add the target event.
         let target_event = event_factory.text_msg("hello world").into_event();
         let target_event_id =
-            { &target_event.event_id().expect("generated event has an event ID") };
+            &target_event.event_id().expect("generated event has an event ID").to_owned();
         joined_room_update.timeline.events.push(target_event);
 
         // Add the numerous edits.
@@ -231,7 +231,7 @@ fn find_event_relations(c: &mut Criterion) {
         // Add other events, in the same room, related to other events.
         let other_target_event = event_factory.text_msg("hello world").into_event();
         let other_target_event_id =
-            other_target_event.event_id().expect("generated event has an event ID");
+            other_target_event.event_id().expect("generated event has an event ID").to_owned();
         joined_room_update.timeline.events.push(other_target_event);
 
         for _i in 0..NUM_OTHER_EVENTS {
@@ -326,7 +326,7 @@ fn find_event_relations(c: &mut Criterion) {
                                     .await
                                     .unwrap()
                                     .unwrap();
-                                assert_eq!(target.event_id().unwrap(), *target_event_id);
+                                assert_eq!(target.event_id().unwrap(), target_event_id);
                                 assert_eq!(relations.len(), num_related_events as usize);
                             },
                             criterion::BatchSize::PerIteration,

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -423,11 +423,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Verify the event is in both.
         assert_matches!(&room_chunks[0].content, ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(event_id));
+            assert_eq!(events[0].event_id(), Some(event_id));
         });
         assert_matches!(&thread_chunks[0].content, ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(event_id));
+            assert_eq!(events[0].event_id(), Some(event_id));
         });
     }
 
@@ -1437,12 +1437,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             self.filter_duplicated_events(
                 linked_chunk_id,
                 vec![
-                    event_comte.event_id().unwrap(),
-                    event_raclette.event_id().unwrap(),
-                    event_morbier.event_id().unwrap(),
-                    event_gruyere.event_id().unwrap(),
-                    event_tome.event_id().unwrap(),
-                    event_mont_dor.event_id().unwrap(),
+                    event_comte.event_id().unwrap().to_owned(),
+                    event_raclette.event_id().unwrap().to_owned(),
+                    event_morbier.event_id().unwrap().to_owned(),
+                    event_gruyere.event_id().unwrap().to_owned(),
+                    event_tome.event_id().unwrap().to_owned(),
+                    event_mont_dor.event_id().unwrap().to_owned(),
                 ],
             )
             .await
@@ -1452,15 +1452,15 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(duplicated_events.len(), 3);
 
         assert_eq!(
-            *duplicated_events.get(&event_comte.event_id().unwrap()).unwrap(),
+            *duplicated_events.get(event_comte.event_id().unwrap()).unwrap(),
             Position::new(CId::new(0), 0)
         );
         assert_eq!(
-            *duplicated_events.get(&event_morbier.event_id().unwrap()).unwrap(),
+            *duplicated_events.get(event_morbier.event_id().unwrap()).unwrap(),
             Position::new(CId::new(2), 0)
         );
         assert_eq!(
-            *duplicated_events.get(&event_mont_dor.event_id().unwrap()).unwrap(),
+            *duplicated_events.get(event_mont_dor.event_id().unwrap()).unwrap(),
             Position::new(CId::new(2), 1)
         );
     }
@@ -1650,14 +1650,10 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(relations.len(), 2);
         // The position is `None` for items outside the linked chunk.
         assert!(
-            relations
-                .iter()
-                .any(|(ev, pos)| ev.event_id().as_deref() == Some(edit_eid1) && pos.is_none())
+            relations.iter().any(|(ev, pos)| ev.event_id() == Some(edit_eid1) && pos.is_none())
         );
         assert!(
-            relations
-                .iter()
-                .any(|(ev, pos)| ev.event_id().as_deref() == Some(reaction_eid1) && pos.is_none())
+            relations.iter().any(|(ev, pos)| ev.event_id() == Some(reaction_eid1) && pos.is_none())
         );
 
         // Finding relations with a filter only returns a subset.
@@ -1666,7 +1662,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             .await
             .unwrap();
         assert_eq!(relations.len(), 1);
-        assert_eq!(relations[0].0.event_id().as_deref(), Some(edit_eid1));
+        assert_eq!(relations[0].0.event_id(), Some(edit_eid1));
 
         let relations = self
             .find_event_relations(
@@ -1677,8 +1673,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             .await
             .unwrap();
         assert_eq!(relations.len(), 2);
-        assert!(relations.iter().any(|r| r.0.event_id().as_deref() == Some(edit_eid1)));
-        assert!(relations.iter().any(|r| r.0.event_id().as_deref() == Some(reaction_eid1)));
+        assert!(relations.iter().any(|r| r.0.event_id() == Some(edit_eid1)));
+        assert!(relations.iter().any(|r| r.0.event_id() == Some(reaction_eid1)));
 
         // We can't find relations using the wrong room.
         let relations = self
@@ -1707,15 +1703,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // The position is set for `reaction_eid1` now.
         assert!(relations.iter().any(|(ev, pos)| {
-            ev.event_id().as_deref() == Some(reaction_eid1)
-                && *pos == Some(Position::new(CId::new(0), 0))
+            ev.event_id() == Some(reaction_eid1) && *pos == Some(Position::new(CId::new(0), 0))
         }));
 
         // But it's still not set for the other related events.
         assert!(
-            relations
-                .iter()
-                .any(|(ev, pos)| ev.event_id().as_deref() == Some(edit_eid1) && pos.is_none())
+            relations.iter().any(|(ev, pos)| ev.event_id() == Some(edit_eid1) && pos.is_none())
         );
     }
 
@@ -1881,8 +1874,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         assert_eq!(events.len(), 2);
 
-        let got_ids: Vec<_> = events.into_iter().map(|ev| ev.event_id()).collect();
-        let expected_ids = vec![event_comte.event_id(), event_gruyere.event_id()];
+        let got_ids: Vec<_> =
+            events.into_iter().map(|ev| ev.event_id().map(ToOwned::to_owned)).collect();
+        let expected_ids = vec![
+            event_comte.event_id().map(ToOwned::to_owned),
+            event_gruyere.event_id().map(ToOwned::to_owned),
+        ];
 
         for expected in expected_ids {
             assert!(
@@ -1895,8 +1892,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     async fn test_get_room_events_filtered(&self) {
         macro_rules! assert_expected_events {
             ($events:expr, [$($item:expr),* $(,)?]) => {{
-                let got_ids: BTreeSet<_> = $events.into_iter().map(|ev| ev.event_id().unwrap()).collect();
-                let expected_ids = BTreeSet::from([$($item.event_id().unwrap()),*]);
+                let got_ids: BTreeSet<_> = $events.into_iter().map(|ev| ev.event_id().map(ToOwned::to_owned)).flatten().collect();
+                let expected_ids = BTreeSet::from([$($item.event_id().unwrap().to_owned()),*]);
 
                 assert_eq!(got_ids, expected_ids);
             }};
@@ -2024,7 +2021,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_matches!(self.get_room_events(room_id, None, None).await, Ok(events) => {
             assert_eq!(events.len(), 3);
             assert!(events.iter().all(|event| {
-                expected_event_ids.contains(&event.event_id().unwrap().as_ref())
+                expected_event_ids.contains(event.event_id().unwrap())
             }));
         });
     }
@@ -2123,12 +2120,12 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Verify the event has been updated in both room and thread
         assert_matches!(&room_chunks[0].content, ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(event_id));
+            assert_eq!(events[0].event_id(), Some(event_id));
             check_test_event(&events[0], updated_content);
         });
         assert_matches!(&thread_chunks[0].content, ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(event_id));
+            assert_eq!(events[0].event_id(), Some(event_id));
             check_test_event(&events[0], updated_content);
         });
     }
@@ -2148,7 +2145,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Add one event in a thread linked chunk.
         self.handle_linked_chunk_updates(
-            LinkedChunkId::Thread(room_id, thread_root1.event_id().unwrap().as_ref()),
+            LinkedChunkId::Thread(room_id, thread_root1.event_id().unwrap()),
             vec![
                 Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 Update::PushItems {
@@ -2162,7 +2159,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Add one event in another thread linked chunk (same room).
         self.handle_linked_chunk_updates(
-            LinkedChunkId::Thread(room_id, thread_root2.event_id().unwrap().as_ref()),
+            LinkedChunkId::Thread(room_id, thread_root2.event_id().unwrap()),
             vec![
                 Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
                 Update::PushItems {
@@ -2212,8 +2209,11 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Finding duplicates operates based on the linked chunk id.
         let dups = self
             .filter_duplicated_events(
-                LinkedChunkId::Thread(room_id, thread_root1.event_id().unwrap().as_ref()),
-                vec![thread1_ev.event_id().unwrap(), room_ev.event_id().unwrap()],
+                LinkedChunkId::Thread(room_id, thread_root1.event_id().unwrap()),
+                vec![
+                    thread1_ev.event_id().unwrap().to_owned(),
+                    room_ev.event_id().unwrap().to_owned(),
+                ],
             )
             .await
             .unwrap();
@@ -2222,10 +2222,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Loading all chunks operates based on the linked chunk id.
         let all_chunks = self
-            .load_all_chunks(LinkedChunkId::Thread(
-                room_id,
-                thread_root2.event_id().unwrap().as_ref(),
-            ))
+            .load_all_chunks(LinkedChunkId::Thread(room_id, thread_root2.event_id().unwrap()))
             .await
             .unwrap();
         assert_eq!(all_chunks.len(), 1);
@@ -2240,7 +2237,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let metas = self
             .load_all_chunks_metadata(LinkedChunkId::Thread(
                 room_id,
-                thread_root2.event_id().unwrap().as_ref(),
+                thread_root2.event_id().unwrap(),
             ))
             .await
             .unwrap();
@@ -2250,10 +2247,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Loading the last chunk operates based on the linked chunk id.
         let (last_chunk, _chunk_identifier_generator) = self
-            .load_last_chunk(LinkedChunkId::Thread(
-                room_id,
-                thread_root1.event_id().unwrap().as_ref(),
-            ))
+            .load_last_chunk(LinkedChunkId::Thread(room_id, thread_root1.event_id().unwrap()))
             .await
             .unwrap();
         let last_chunk = last_chunk.unwrap();

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -179,7 +179,7 @@ impl EventCacheStore for MemoryStore {
             if let Some(known_event_id) = event.event_id() {
                 // This event is a duplicate!
                 if let Some(index) =
-                    events.iter().position(|new_event_id| &known_event_id == new_event_id)
+                    events.iter().position(|new_event_id| known_event_id == new_event_id)
                 {
                     duplicated_events.push((events.remove(index), position));
                 }
@@ -240,7 +240,8 @@ impl EventCacheStore for MemoryStore {
         for (linked_chunk_id, (event, position)) in related_events {
             let event_id = event
                 .event_id()
-                .ok_or(Self::Error::InvalidData { details: String::from("missing event id") })?;
+                .ok_or(Self::Error::InvalidData { details: String::from("missing event id") })?
+                .to_owned();
             match linked_chunk_id.as_ref() {
                 LinkedChunkId::Room(_) => {
                     // Prioritize events that come from a room linked chunk
@@ -275,9 +276,12 @@ impl EventCacheStore for MemoryStore {
             })
             .filter(|e| session_id.is_none_or(|s| Some(s) == e.kind.session_id()))
             .map(|e| {
-                e.event_id()
-                    .map(|id| (id, e))
-                    .ok_or(Self::Error::InvalidData { details: String::from("missing event id") })
+                let id = e
+                    .event_id()
+                    .ok_or(Self::Error::InvalidData { details: String::from("missing event id") })?
+                    .to_owned();
+
+                Ok((id, e))
             })
             .collect::<Result<Vec<_>>>()?
             .into_iter()

--- a/crates/matrix-sdk-base/src/event_cache/store/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/mod.rs
@@ -232,7 +232,7 @@ impl TryLock for LockableEventCacheStore {
 /// Helper to extract the relation information from an event.
 ///
 /// If the event isn't in relation to another event, then this will return
-/// `None`. Otherwise, returns both the event id this event relates to, and the
+/// `None`. Otherwise, returns both the event ID this event relates to, and the
 /// kind of relation as a string (e.g. `m.replace`).
 pub fn extract_event_relation(event: &Raw<AnySyncTimelineEvent>) -> Option<(OwnedEventId, String)> {
     #[derive(serde::Deserialize)]

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -116,7 +116,7 @@ impl LatestEventValue {
     /// [`LatestEventValue`].
     pub fn event_id(&self) -> Option<OwnedEventId> {
         match self {
-            Self::Remote(event) => event.event_id(),
+            Self::Remote(event) => event.event_id().map(ToOwned::to_owned),
             Self::RemoteInvite { event_id, .. } => event_id.clone(),
             Self::LocalHasBeenSent { event_id, .. } => Some(event_id.clone()),
             Self::LocalIsSending(_) | Self::LocalCannotBeSent(_) | Self::None => None,

--- a/crates/matrix-sdk-common/changelog.d/6626.changed.md
+++ b/crates/matrix-sdk-common/changelog.d/6626.changed.md
@@ -1,0 +1,9 @@
+The `TimelineEvent::event_id` now returns an `Option<&EventId>` instead of an
+`Option<OwnedEventId>`. This is possible because the event ID is now eagerly
+parsed when constructing this type and kept in memory for performance concerns.
+
+This cached event ID is not serialized: it is backward compatible regarding the
+storage, while it is not regarding the `event_id()` method signature.
+
+If one needs an `OwnedEventId` from an `&EventId`, let's just use
+`EventId::to_owned`.

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -2210,4 +2210,41 @@ mod tests {
         assert!(utd_info.session_id.is_some());
         assert_eq!(utd_info.session_id.unwrap(), session_id);
     }
+
+    #[test]
+    fn test_timeline_event_replace_raw_update_the_event_id() {
+        let mut timeline_event = TimelineEvent::from_plaintext(
+            Raw::new(&json!({
+                "event_id": "$ev0",
+                "type": "m.room.message",
+                "sender": "@alice",
+                "origin_server_ts": 42,
+                "content": {
+                    "body": "Hello, World!",
+                },
+                "unsigned": {},
+            }))
+            .unwrap()
+            .cast_unchecked(),
+        );
+
+        assert_eq!(timeline_event.event_id(), Some(owned_event_id!("$ev0")));
+
+        timeline_event.replace_raw(
+            Raw::new(&json!({
+                "event_id": "$ev1",
+                "type": "m.room.message",
+                "sender": "@bob",
+                "origin_server_ts": 153,
+                "content": {
+                    "body": "Bonjour !",
+                },
+                "unsigned": {},
+            }))
+            .unwrap()
+            .cast_unchecked(),
+        );
+
+        assert_eq!(timeline_event.event_id(), Some(owned_event_id!("$ev1")));
+    }
 }

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -490,6 +490,16 @@ impl ThreadSummaryStatus {
 // [`recursion_limit`]: https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute
 #[derive(Clone, Debug, Serialize)]
 pub struct TimelineEvent {
+    /// The event ID (cached from `Self::kind`).
+    ///
+    /// This field contains a copy of `self.kind.event_id()`. Why? Because
+    /// reading the event ID is done **a lot** in the SDK.
+    /// [`TimelineEventKind::event_id`] implies parsing/deserializing the JSON
+    /// payload looking for the event ID. It has a non-negligible cost. Hence
+    /// this cache.
+    #[serde(skip)]
+    event_id: Option<OwnedEventId>,
+
     /// The event itself, together with any information on decryption.
     pub kind: TimelineEventKind,
 
@@ -612,7 +622,14 @@ impl TimelineEvent {
 
         let timestamp = extract_timestamp(raw, max_timestamp);
 
-        Self { kind, push_actions, timestamp, thread_summary, bundled_latest_thread_event }
+        Self {
+            event_id: kind.event_id(),
+            kind,
+            push_actions,
+            timestamp,
+            thread_summary,
+            bundled_latest_thread_event,
+        }
     }
 
     /// Transform this [`TimelineEvent`] into another [`TimelineEvent`] with the
@@ -632,8 +649,13 @@ impl TimelineEvent {
             "`TimelineEvent::to_decrypted` has been called on an already decrypted `TimelineEvent`."
         );
 
+        let kind = TimelineEventKind::Decrypted(decrypted);
+
         Self {
-            kind: TimelineEventKind::Decrypted(decrypted),
+            // We could clone `self.event_id`, but we prefer to re-parse the event ID from
+            // `decrypted` in case it has changed (it MUST NOT happen, but we never know).
+            event_id: kind.event_id(),
+            kind,
             timestamp: self.timestamp,
             push_actions,
             thread_summary: self.thread_summary.clone(),
@@ -655,6 +677,7 @@ impl TimelineEvent {
         );
 
         Self {
+            event_id: self.event_id.clone(),
             kind: TimelineEventKind::UnableToDecrypt { event: self.raw().clone(), utd_info },
             timestamp: self.timestamp,
             push_actions: None,
@@ -778,10 +801,10 @@ impl TimelineEvent {
         self.push_actions = Some(push_actions);
     }
 
-    /// Get the event id of this [`TimelineEvent`] if the event has any valid
-    /// id.
+    /// Get the (cached) event ID of this [`TimelineEvent`] if the event has any
+    /// valid ID.
     pub fn event_id(&self) -> Option<OwnedEventId> {
-        self.kind.event_id()
+        self.event_id.clone()
     }
 
     /// Get the sender of this [`TimelineEvent`] if the event has one.
@@ -806,6 +829,8 @@ impl TimelineEvent {
                 *event = replacement.cast();
             }
         }
+
+        self.event_id = self.kind.event_id();
     }
 
     /// Get the timestamp.
@@ -924,13 +949,13 @@ impl TimelineEventKind {
         }
     }
 
-    /// Get the event id of this `TimelineEventKind` if the event has any valid
-    /// id.
+    /// Parse the event ID of this `TimelineEventKind` if the event has any
+    /// valid id.
     pub fn event_id(&self) -> Option<OwnedEventId> {
         self.raw().get_field::<OwnedEventId>("event_id").ok().flatten()
     }
 
-    /// Get the sender of this [`TimelineEventKind`] if the event has one.
+    /// Parse the sender of this [`TimelineEventKind`] if the event has one.
     pub fn sender(&self) -> Option<OwnedUserId> {
         self.raw().get_field::<OwnedUserId>("sender").ok().flatten()
     }
@@ -987,7 +1012,7 @@ impl TimelineEventKind {
         }
     }
 
-    /// Get the event type of this event.
+    /// Parse the event type of this event.
     ///
     /// Returns `None` if there isn't an event type or if the event failed to be
     /// deserialized.
@@ -1327,6 +1352,7 @@ impl From<SyncTimelineEventDeserializationHelperV1> for TimelineEvent {
         // [`TimelineEvent::timestamp`] to handle that case for us.
 
         TimelineEvent {
+            event_id: kind.event_id(),
             kind,
             timestamp,
             push_actions: Some(push_actions),
@@ -1395,6 +1421,7 @@ impl From<SyncTimelineEventDeserializationHelperV0> for TimelineEvent {
         };
 
         TimelineEvent {
+            event_id: kind.event_id(),
             kind,
             timestamp,
             push_actions: Some(push_actions),
@@ -1641,28 +1668,30 @@ mod tests {
 
     #[test]
     fn sync_timeline_event_serialisation() {
-        let room_event = TimelineEvent {
-            kind: TimelineEventKind::Decrypted(DecryptedRoomEvent {
-                event: Raw::new(&example_event()).unwrap().cast_unchecked(),
-                encryption_info: Arc::new(EncryptionInfo {
-                    sender: owned_user_id!("@sender:example.com"),
-                    sender_device: None,
-                    forwarder: None,
-                    algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
-                        curve25519_key: "xxx".to_owned(),
-                        sender_claimed_keys: Default::default(),
-                        session_id: Some("xyz".to_owned()),
-                    },
-                    verification_state: VerificationState::Verified,
-                }),
-                unsigned_encryption_info: Some(BTreeMap::from([(
-                    UnsignedEventLocation::RelationsReplace,
-                    UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
-                        session_id: Some("xyz".to_owned()),
-                        reason: UnableToDecryptReason::MalformedEncryptedEvent,
-                    }),
-                )])),
+        let kind = TimelineEventKind::Decrypted(DecryptedRoomEvent {
+            event: Raw::new(&example_event()).unwrap().cast_unchecked(),
+            encryption_info: Arc::new(EncryptionInfo {
+                sender: owned_user_id!("@sender:example.com"),
+                sender_device: None,
+                forwarder: None,
+                algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
+                    curve25519_key: "xxx".to_owned(),
+                    sender_claimed_keys: Default::default(),
+                    session_id: Some("xyz".to_owned()),
+                },
+                verification_state: VerificationState::Verified,
             }),
+            unsigned_encryption_info: Some(BTreeMap::from([(
+                UnsignedEventLocation::RelationsReplace,
+                UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
+                    session_id: Some("xyz".to_owned()),
+                    reason: UnableToDecryptReason::MalformedEncryptedEvent,
+                }),
+            )])),
+        });
+        let room_event = TimelineEvent {
+            event_id: kind.event_id(),
+            kind,
             timestamp: Some(MilliSecondsSinceUnixEpoch(UInt::new_saturating(2189))),
             push_actions: Default::default(),
             thread_summary: ThreadSummaryStatus::Unknown,
@@ -1712,7 +1741,8 @@ mod tests {
 
         // And it can be properly deserialized from the new format.
         let event: TimelineEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(event.event_id(), Some(owned_event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id, Some(owned_event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id, event.event_id());
         assert_matches!(
             event.encryption_info().unwrap().algorithm_info,
             AlgorithmInfo::MegolmV1AesSha2 { .. }
@@ -1778,7 +1808,8 @@ mod tests {
             }
         });
         let event: TimelineEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(event.event_id(), Some(owned_event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id, event.event_id());
+        assert_eq!(event.event_id, Some(owned_event_id!("$xxxxx:example.org")));
         assert_matches!(
             event.encryption_info().unwrap().algorithm_info,
             AlgorithmInfo::MegolmV1AesSha2 { .. }
@@ -2088,39 +2119,41 @@ mod tests {
 
     #[test]
     fn snapshot_test_sync_timeline_event() {
-        let room_event = TimelineEvent {
-            kind: TimelineEventKind::Decrypted(DecryptedRoomEvent {
-                event: Raw::new(&example_event()).unwrap().cast_unchecked(),
-                encryption_info: Arc::new(EncryptionInfo {
-                    sender: owned_user_id!("@sender:example.com"),
-                    sender_device: Some(owned_device_id!("ABCDEFGHIJ")),
-                    forwarder: None,
-                    algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
-                        curve25519_key: "xxx".to_owned(),
-                        sender_claimed_keys: BTreeMap::from([
-                            (
-                                DeviceKeyAlgorithm::Ed25519,
-                                "I3YsPwqMZQXHkSQbjFNEs7b529uac2xBpI83eN3LUXo".to_owned(),
-                            ),
-                            (
-                                DeviceKeyAlgorithm::Curve25519,
-                                "qzdW3F5IMPFl0HQgz5w/L5Oi/npKUFn8Um84acIHfPY".to_owned(),
-                            ),
-                        ]),
-                        session_id: Some("mysessionid112".to_owned()),
-                    },
-                    verification_state: VerificationState::Verified,
-                }),
-                unsigned_encryption_info: Some(BTreeMap::from([(
-                    UnsignedEventLocation::RelationsThreadLatestEvent,
-                    UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
-                        session_id: Some("xyz".to_owned()),
-                        reason: UnableToDecryptReason::MissingMegolmSession {
-                            withheld_code: Some(WithheldCode::Unverified),
-                        },
-                    }),
-                )])),
+        let kind = TimelineEventKind::Decrypted(DecryptedRoomEvent {
+            event: Raw::new(&example_event()).unwrap().cast_unchecked(),
+            encryption_info: Arc::new(EncryptionInfo {
+                sender: owned_user_id!("@sender:example.com"),
+                sender_device: Some(owned_device_id!("ABCDEFGHIJ")),
+                forwarder: None,
+                algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
+                    curve25519_key: "xxx".to_owned(),
+                    sender_claimed_keys: BTreeMap::from([
+                        (
+                            DeviceKeyAlgorithm::Ed25519,
+                            "I3YsPwqMZQXHkSQbjFNEs7b529uac2xBpI83eN3LUXo".to_owned(),
+                        ),
+                        (
+                            DeviceKeyAlgorithm::Curve25519,
+                            "qzdW3F5IMPFl0HQgz5w/L5Oi/npKUFn8Um84acIHfPY".to_owned(),
+                        ),
+                    ]),
+                    session_id: Some("mysessionid112".to_owned()),
+                },
+                verification_state: VerificationState::Verified,
             }),
+            unsigned_encryption_info: Some(BTreeMap::from([(
+                UnsignedEventLocation::RelationsThreadLatestEvent,
+                UnsignedDecryptionResult::UnableToDecrypt(UnableToDecryptInfo {
+                    session_id: Some("xyz".to_owned()),
+                    reason: UnableToDecryptReason::MissingMegolmSession {
+                        withheld_code: Some(WithheldCode::Unverified),
+                    },
+                }),
+            )])),
+        });
+        let room_event = TimelineEvent {
+            event_id: kind.event_id(),
+            kind,
             timestamp: Some(MilliSecondsSinceUnixEpoch(UInt::new_saturating(2189))),
             push_actions: Default::default(),
             thread_summary: ThreadSummaryStatus::Some(ThreadSummary {

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1523,7 +1523,7 @@ mod tests {
     use ruma::{
         DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, UInt, event_id,
         events::{AnySyncTimelineEvent, room::message::RoomMessageEventContent},
-        owned_device_id, owned_event_id, owned_user_id,
+        owned_device_id, owned_user_id,
         serde::Raw,
     };
     use serde::Deserialize;
@@ -1742,8 +1742,8 @@ mod tests {
 
         // And it can be properly deserialized from the new format.
         let event: TimelineEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(event.event_id, Some(owned_event_id!("$xxxxx:example.org")));
-        assert_eq!(event.event_id, event.event_id());
+        assert_eq!(event.event_id.as_deref(), Some(event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id.as_deref(), event.event_id());
         assert_matches!(
             event.encryption_info().unwrap().algorithm_info,
             AlgorithmInfo::MegolmV1AesSha2 { .. }
@@ -1774,7 +1774,7 @@ mod tests {
             },
         });
         let event: TimelineEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(event.event_id(), Some(owned_event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id(), Some(event_id!("$xxxxx:example.org")));
         assert_matches!(
             event.encryption_info().unwrap().algorithm_info,
             AlgorithmInfo::MegolmV1AesSha2 { session_id: None, .. }
@@ -1809,8 +1809,8 @@ mod tests {
             }
         });
         let event: TimelineEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(event.event_id, event.event_id());
-        assert_eq!(event.event_id, Some(owned_event_id!("$xxxxx:example.org")));
+        assert_eq!(event.event_id.as_deref(), event.event_id());
+        assert_eq!(event.event_id.as_deref(), Some(event_id!("$xxxxx:example.org")));
         assert_matches!(
             event.encryption_info().unwrap().algorithm_info,
             AlgorithmInfo::MegolmV1AesSha2 { .. }
@@ -2229,7 +2229,7 @@ mod tests {
             .cast_unchecked(),
         );
 
-        assert_eq!(timeline_event.event_id(), Some(owned_event_id!("$ev0")));
+        assert_eq!(timeline_event.event_id(), Some(event_id!("$ev0")));
 
         timeline_event.replace_raw(
             Raw::new(&json!({
@@ -2246,6 +2246,6 @@ mod tests {
             .cast_unchecked(),
         );
 
-        assert_eq!(timeline_event.event_id(), Some(owned_event_id!("$ev1")));
+        assert_eq!(timeline_event.event_id(), Some(event_id!("$ev1")));
     }
 }

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -492,11 +492,11 @@ impl ThreadSummaryStatus {
 pub struct TimelineEvent {
     /// The event ID (cached from `Self::kind`).
     ///
-    /// This field contains a copy of `self.kind.event_id()`. Why? Because
-    /// reading the event ID is done **a lot** in the SDK.
-    /// [`TimelineEventKind::event_id`] implies parsing/deserializing the JSON
-    /// payload looking for the event ID. It has a non-negligible cost. Hence
-    /// this cache.
+    /// This field contains a copy of `TimeilneEventKind::parse_event_id`. Why?
+    /// Because reading the event ID is done **a lot** in the SDK.
+    /// `TimelineEventKind::parse_event_id` implies parsing/deserializing the
+    /// JSON payload looking for the event ID. It has a non-negligible cost.
+    /// Hence this cache.
     #[serde(skip)]
     event_id: Option<OwnedEventId>,
 
@@ -623,7 +623,7 @@ impl TimelineEvent {
         let timestamp = extract_timestamp(raw, max_timestamp);
 
         Self {
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             push_actions,
             timestamp,
@@ -654,7 +654,7 @@ impl TimelineEvent {
         Self {
             // We could clone `self.event_id`, but we prefer to re-parse the event ID from
             // `decrypted` in case it has changed (it MUST NOT happen, but we never know).
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             timestamp: self.timestamp,
             push_actions,
@@ -809,7 +809,7 @@ impl TimelineEvent {
 
     /// Get the sender of this [`TimelineEvent`] if the event has one.
     pub fn sender(&self) -> Option<OwnedUserId> {
-        self.kind.sender()
+        self.kind.parse_sender()
     }
 
     /// Returns a reference to the (potentially decrypted) Matrix event inside
@@ -830,7 +830,7 @@ impl TimelineEvent {
             }
         }
 
-        self.event_id = self.kind.event_id();
+        self.event_id = self.kind.parse_event_id();
     }
 
     /// Get the timestamp.
@@ -951,12 +951,12 @@ impl TimelineEventKind {
 
     /// Parse the event ID of this `TimelineEventKind` if the event has any
     /// valid id.
-    pub fn event_id(&self) -> Option<OwnedEventId> {
+    pub fn parse_event_id(&self) -> Option<OwnedEventId> {
         self.raw().get_field::<OwnedEventId>("event_id").ok().flatten()
     }
 
     /// Parse the sender of this [`TimelineEventKind`] if the event has one.
-    pub fn sender(&self) -> Option<OwnedUserId> {
+    pub fn parse_sender(&self) -> Option<OwnedUserId> {
         self.raw().get_field::<OwnedUserId>("sender").ok().flatten()
     }
 
@@ -1352,7 +1352,7 @@ impl From<SyncTimelineEventDeserializationHelperV1> for TimelineEvent {
         // [`TimelineEvent::timestamp`] to handle that case for us.
 
         TimelineEvent {
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             timestamp,
             push_actions: Some(push_actions),
@@ -1421,7 +1421,7 @@ impl From<SyncTimelineEventDeserializationHelperV0> for TimelineEvent {
         };
 
         TimelineEvent {
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             timestamp,
             push_actions: Some(push_actions),
@@ -1690,7 +1690,7 @@ mod tests {
             )])),
         });
         let room_event = TimelineEvent {
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             timestamp: Some(MilliSecondsSinceUnixEpoch(UInt::new_saturating(2189))),
             push_actions: Default::default(),
@@ -2152,7 +2152,7 @@ mod tests {
             )])),
         });
         let room_event = TimelineEvent {
-            event_id: kind.event_id(),
+            event_id: kind.parse_event_id(),
             kind,
             timestamp: Some(MilliSecondsSinceUnixEpoch(UInt::new_saturating(2189))),
             push_actions: Default::default(),

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -15,7 +15,8 @@
 use std::{collections::BTreeMap, fmt, ops::Not, sync::Arc};
 
 use ruma::{
-    DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedUserId,
+    DeviceKeyAlgorithm, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId,
+    OwnedUserId,
     events::{
         AnySyncMessageLikeEvent, AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent,
         MessageLikeEventType, room::encrypted::EncryptedEventScheme,
@@ -801,10 +802,10 @@ impl TimelineEvent {
         self.push_actions = Some(push_actions);
     }
 
-    /// Get the (cached) event ID of this [`TimelineEvent`] if the event has any
-    /// valid ID.
-    pub fn event_id(&self) -> Option<OwnedEventId> {
-        self.event_id.clone()
+    /// Get the (cached) event ID of this [`TimelineEvent`] if the event has
+    /// any valid ID.
+    pub fn event_id(&self) -> Option<&EventId> {
+        self.event_id.as_deref()
     }
 
     /// Get the sender of this [`TimelineEvent`] if the event has one.

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -115,6 +115,7 @@ impl IndexableItem for TimelineEvent {
     fn id(&self) -> Self::ItemId {
         self.event_id()
             .expect("all events saved into a relational linked chunk must have a valid event id")
+            .to_owned()
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -494,13 +494,13 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                         match event.linked_chunk_id() {
                             LinkedChunkId::Room(_) => {
                                 // Prioritize events that come from a room linked chunk
-                                related_events.insert(event_id, event);
+                                related_events.insert(event_id.to_owned(), event);
                             }
                             _ => {
                                 // Remove position information from events that come
                                 // from any other type of linked chunk
                                 related_events
-                                    .entry(event_id)
+                                    .entry(event_id.to_owned())
                                     .or_insert_with(|| event.into_out_of_band_event());
                             }
                         }
@@ -515,13 +515,13 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                     match event.linked_chunk_id() {
                         LinkedChunkId::Room(_) => {
                             // Prioritize events that come from a room linked chunk
-                            related_events.insert(event_id, event);
+                            related_events.insert(event_id.to_owned(), event);
                         }
                         _ => {
                             // Remove position information from events that come
                             // from any other type of linked chunk
                             related_events
-                                .entry(event_id)
+                                .entry(event_id.to_owned())
                                 .or_insert_with(|| event.into_out_of_band_event());
                         }
                     }
@@ -589,7 +589,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         let transaction = self.transaction(&[keys::EVENTS], IdbTransactionMode::Readwrite)?;
 
         let mut events = transaction
-            .get_events_by_room(room_id, &event_id)
+            .get_events_by_room(room_id, event_id)
             .await?
             .into_iter()
             .map(|e| e.with_content(event.clone()))

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -348,8 +348,8 @@ impl Indexed for Event {
         serializer: &SafeEncodeSerializer,
     ) -> Result<Self::IndexedType, Self::Error> {
         let event_id = self.event_id().ok_or(Self::Error::NoEventId)?;
-        let id = IndexedEventIdKey::encode((self.linked_chunk_id(), &event_id), serializer);
-        let room = IndexedEventRoomKey::encode((self.room_id(), &event_id), serializer);
+        let id = IndexedEventIdKey::encode((self.linked_chunk_id(), event_id), serializer);
+        let room = IndexedEventRoomKey::encode((self.room_id(), event_id), serializer);
         let position = self.position().map(|position| {
             IndexedEventPositionKey::encode((self.linked_chunk_id(), position), serializer)
         });

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -20,7 +20,7 @@ use matrix_sdk_base::{
     event_cache::store::extract_event_relation,
     linked_chunk::{ChunkIdentifier, LinkedChunkId, OwnedLinkedChunkId},
 };
-use ruma::{OwnedEventId, RoomId};
+use ruma::{EventId, OwnedEventId, RoomId};
 use serde::{Deserialize, Serialize};
 
 /// Representation of a time-based lock on the entire
@@ -101,8 +101,8 @@ impl Event {
         }
     }
 
-    /// The [`OwnedEventId`] of the underlying event.
-    pub fn event_id(&self) -> Option<OwnedEventId> {
+    /// The [`EventId`] of the underlying event.
+    pub fn event_id(&self) -> Option<&EventId> {
         match self {
             Event::InBand(e) => e.event_id(),
             Event::OutOfBand(e) => e.event_id(),
@@ -169,8 +169,8 @@ impl<P> GenericEvent<P> {
         self.linked_chunk_id.room_id()
     }
 
-    /// The [`OwnedEventId`] of the underlying event.
-    pub fn event_id(&self) -> Option<OwnedEventId> {
+    /// The [`EventId`] of the underlying event.
+    pub fn event_id(&self) -> Option<&EventId> {
         self.content.event_id()
     }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -2007,7 +2007,7 @@ mod encrypted_tests {
         // The event needs to be the edit event, otherwise something is wrong.
         let (found_event, _) = &results[0];
         assert_eq!(
-            found_event.event_id().as_deref(),
+            found_event.event_id(),
             Some(edit_id),
             "The single event we found should be the edit event"
         );

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -1485,7 +1485,7 @@ impl TimelineController {
         let mut related_events = Vector::new();
         for event_id in events.iter().filter_map(|event| event.event_id()) {
             if let Some((_original, related)) =
-                event_cache.find_event_with_relations(&event_id, None).await?
+                event_cache.find_event_with_relations(event_id, None).await?
             {
                 related_events.extend(related);
             }

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -114,7 +114,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     for event in events {
                         let recycled_timeline_id = event
                             .event_id()
-                            .and_then(|event_id| recycled_timeline_ids.remove(&event_id));
+                            .and_then(|event_id| recycled_timeline_ids.remove(event_id));
                         self.handle_remote_event(
                             event,
                             TimelineItemPosition::End { origin },
@@ -131,7 +131,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 VectorDiff::PushFront { value: event } => {
                     let recycled_timeline_id = event
                         .event_id()
-                        .and_then(|event_id| recycled_timeline_ids.remove(&event_id));
+                        .and_then(|event_id| recycled_timeline_ids.remove(event_id));
                     self.handle_remote_event(
                         event,
                         TimelineItemPosition::Start { origin },
@@ -147,7 +147,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 VectorDiff::PushBack { value: event } => {
                     let recycled_timeline_id = event
                         .event_id()
-                        .and_then(|event_id| recycled_timeline_ids.remove(&event_id));
+                        .and_then(|event_id| recycled_timeline_ids.remove(event_id));
                     self.handle_remote_event(
                         event,
                         TimelineItemPosition::End { origin },
@@ -163,7 +163,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 VectorDiff::Insert { index: event_index, value: event } => {
                     let recycled_timeline_id = event
                         .event_id()
-                        .and_then(|event_id| recycled_timeline_ids.remove(&event_id));
+                        .and_then(|event_id| recycled_timeline_ids.remove(event_id));
                     self.handle_remote_event(
                         event,
                         TimelineItemPosition::At { event_index, origin },
@@ -382,8 +382,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                         )
                         .await;
                     } else if let Some(event_id) = event.event_id()
-                        && let Some(meta) =
-                            self.items.all_remote_events().get_by_event_id(&event_id)
+                        && let Some(meta) = self.items.all_remote_events().get_by_event_id(event_id)
                         && let Some(timeline_item_index) = meta.timeline_item_index
                     {
                         // FIXME: This branch is a complete hackjob.
@@ -738,7 +737,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             room_data_provider
                 .load_user_receipt(
                     ReceiptType::Read,
-                    ReceiptThread::Thread(event_id),
+                    ReceiptThread::Thread(event_id.to_owned()),
                     &self.meta.own_user_id,
                 )
                 .await
@@ -751,7 +750,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             room_data_provider
                 .load_user_receipt(
                     ReceiptType::ReadPrivate,
-                    ReceiptThread::Thread(event_id),
+                    ReceiptThread::Thread(event_id.to_owned()),
                     &self.meta.own_user_id,
                 )
                 .await

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -366,7 +366,7 @@ impl ThreadListService {
         room: &Room,
         timeline_event: TimelineEvent,
     ) -> Option<ThreadListItemEvent> {
-        let event_id = timeline_event.event_id()?;
+        let event_id = timeline_event.event_id()?.to_owned();
         let timestamp = timeline_event.timestamp()?;
         let sender = timeline_event.sender()?;
         let is_own = room.own_user_id() == sender;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -378,7 +378,7 @@ async fn test_focused_timeline_handles_threaded_event() {
     let f = EventFactory::new().room(room_id).sender(user_id);
     let threaded_event =
         f.text_msg("Hey").in_thread(root_thread_id, prev_thread_event_id).into_event();
-    let threaded_event_id = threaded_event.event_id().unwrap().clone();
+    let threaded_event_id = threaded_event.event_id().unwrap().to_owned();
 
     // Mock the initial /context request to check if the event is in a thread.
     let events_before = vec![
@@ -766,7 +766,7 @@ async fn test_focused_timeline_filters_out_threaded_events() {
 
     let f = EventFactory::new().room(room_id).sender(user_id);
     let focus_event = f.text_msg("Hey").into_event();
-    let focus_event_id = focus_event.event_id().unwrap().clone();
+    let focus_event_id = focus_event.event_id().unwrap().to_owned();
 
     // Mock the initial /context request to check if the event is in a thread.
     let events_before = vec![

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -65,7 +65,7 @@ pub async fn aggregate_timeline_for_threads(
                     if let Some(thread_root) = match timeline.events[..nth]
                         .iter()
                         .rev()
-                        .find(|event| event.event_id().as_ref() == Some(&related_event_id))
+                        .find(|event| event.event_id() == Some(&related_event_id))
                     {
                         // The related event has been found in the `timeline`! Extract its thread
                         // root.
@@ -91,10 +91,10 @@ pub async fn aggregate_timeline_for_threads(
                 // We previously found events that are part of a thread, but we didn't see the
                 // thread root yet. And guess what? This might be this event!
                 if let Some(event_id) = event.event_id()
-                    && existing_threads.contains_key(&event_id)
+                    && existing_threads.contains_key(event_id)
                 {
                     new_events_by_thread
-                        .entry(event_id)
+                        .entry(event_id.to_owned())
                         .or_insert_with(default_timeline)
                         .events
                         .push(event.clone());

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -144,7 +144,7 @@ impl EventFocusedCacheState {
                 let focused_event = result
                     .events
                     .iter()
-                    .find(|event| event.event_id().as_ref() == Some(&self.focused_event_id));
+                    .find(|event| event.event_id() == Some(&self.focused_event_id));
 
                 // If the focused event has a thread root, use it.
                 let mut thread_root =
@@ -167,7 +167,7 @@ impl EventFocusedCacheState {
                 result
                     .events
                     .iter()
-                    .find(|event| event.event_id().as_ref() == Some(&self.focused_event_id))
+                    .find(|event| event.event_id() == Some(&self.focused_event_id))
                     .and_then(|event| extract_thread_root(event.raw()))
             }
         };
@@ -182,7 +182,7 @@ impl EventFocusedCacheState {
             // beginning, since it's more likely to be around there, in that
             // case.
             let includes_root =
-                result.events.iter().any(|event| event.event_id().as_ref() == Some(&root_id));
+                result.events.iter().any(|event| event.event_id() == Some(&root_id));
 
             self.pagination_mode =
                 EventFocusedPaginationMode::Thread { thread_root: root_id.clone() };
@@ -193,7 +193,7 @@ impl EventFocusedCacheState {
                 .iter()
                 .filter(|event| {
                     extract_thread_root(event.raw()).as_ref() == Some(&root_id)
-                        || event.event_id().as_ref() == Some(&root_id)
+                        || event.event_id() == Some(&root_id)
                 })
                 .cloned()
                 .collect();

--- a/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
@@ -470,7 +470,7 @@ impl EventLinkedChunk {
     #[cfg(feature = "e2e-encryption")]
     pub fn find_event(&self, event_id: &ruma::EventId) -> Option<(Position, Event)> {
         for (position, event) in self.revents() {
-            if event.event_id().as_deref() == Some(event_id) {
+            if event.event_id() == Some(event_id) {
                 return Some((position, event.clone()));
             }
         }
@@ -483,8 +483,10 @@ impl EventLinkedChunk {
     /// Returns true if at least one event has been replaced, false otherwise.
     #[cfg(feature = "e2e-encryption")]
     pub fn replace_utds(&mut self, events: &[ResolvedUtd]) -> bool {
-        let event_set =
-            self.events().filter_map(|(_pos, ev)| ev.event_id()).collect::<BTreeSet<_>>();
+        let event_set = self
+            .events()
+            .filter_map(|(_pos, ev)| ev.event_id().map(ToOwned::to_owned))
+            .collect::<BTreeSet<_>>();
 
         let mut replaced_some = false;
 
@@ -860,15 +862,15 @@ mod tests {
             &diffs[0],
             VectorDiff::Append { values } => {
                 assert_eq!(values.len(), 2);
-                assert_eq!(values[0].event_id(), Some(event_id_0));
-                assert_eq!(values[1].event_id(), Some(event_id_1));
+                assert_eq!(values[0].event_id(), Some(event_id_0.as_ref()));
+                assert_eq!(values[1].event_id(), Some(event_id_1.as_ref()));
             }
         );
         assert_matches!(
             &diffs[1],
             VectorDiff::Append { values } => {
                 assert_eq!(values.len(), 1);
-                assert_eq!(values[0].event_id(), Some(event_id_2));
+                assert_eq!(values[0].event_id(), Some(event_id_2.as_ref()));
             }
         );
 
@@ -886,7 +888,7 @@ mod tests {
             &diffs[1],
             VectorDiff::Append { values } => {
                 assert_eq!(values.len(), 1);
-                assert_eq!(values[0].event_id(), Some(event_id_3));
+                assert_eq!(values[0].event_id(), Some(event_id_3.as_ref()));
             }
         );
     }

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -383,8 +383,12 @@ impl<'a> PinnedEventsCacheStateLockWriteGuard<'a> {
 
         let previous_pinned_event_ids = self.state.current_event_ids();
 
-        if new_events.iter().filter_map(|e| e.event_id()).collect::<BTreeSet<_>>()
-            == previous_pinned_event_ids.iter().cloned().collect()
+        if new_events
+            .iter()
+            .filter_map(|e| e.event_id())
+            .map(ToOwned::to_owned)
+            .collect::<BTreeSet<_>>()
+            == previous_pinned_event_ids.into_iter().collect()
         {
             // No change in the list of pinned events.
             return Ok(());
@@ -434,7 +438,10 @@ impl<'a> PinnedEventsCacheStateLockWriteGuard<'a> {
 impl PinnedEventsCacheState {
     /// Return a list of the current event IDs in this linked chunk.
     pub(super) fn current_event_ids(&self) -> Vec<OwnedEventId> {
-        self.chunk.events().filter_map(|(_position, event)| event.event_id()).collect()
+        self.chunk
+            .events()
+            .filter_map(|(_position, event)| event.event_id().map(ToOwned::to_owned))
+            .collect()
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -279,10 +279,10 @@ fn select_best_receipt(
     {
         if receipt.is_none() {
             // Try to see if the latest active receipt is still the most recent receipt.
-            if latest_active == Some(&event_id) {
+            if latest_active == Some(event_id) {
                 // The latest active receipt is still the most recent receipt, so keep it.
                 trace!(active = %event_id, "the latest active receipt is still the most recent; stopping search");
-                receipt = Some(event_id.clone());
+                receipt = Some(event_id.to_owned());
             }
             // Try to find an implicit read receipt (i.e. an event sent by the current
             // user).
@@ -292,7 +292,7 @@ fn select_best_receipt(
                 && (!with_threading_support || extract_thread_root(event.raw()).is_none())
             {
                 trace!(implicit = %event_id, "found an implicit receipt; stopping search");
-                receipt = Some(event_id.clone());
+                receipt = Some(event_id.to_owned());
             }
         }
 
@@ -311,7 +311,7 @@ fn select_best_receipt(
             if *pending == event_id {
                 if receipt.is_none() {
                     trace!(pending = %event_id, "found a pending receipt; stopping search");
-                    receipt = Some(event_id.clone());
+                    receipt = Some(event_id.to_owned());
                 } else {
                     trace!(%event_id, "discarding a pending receipt that wasn't selected");
                 }

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -737,7 +737,7 @@ mod tests {
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
 
         // Save the original event.
-        let original_event_id = original_event.event_id().unwrap();
+        let original_event_id = original_event.event_id().unwrap().to_owned();
         room_event_cache.save_events([original_event]).await;
 
         // Save an unrelated event to check it's not in the related events list.
@@ -750,7 +750,7 @@ mod tests {
             .await;
 
         // Save the related event.
-        let related_id = related_event.event_id().unwrap();
+        let related_id = related_event.event_id().unwrap().to_owned();
         room_event_cache.save_events([related_event]).await;
 
         let (event, related_events) = room_event_cache
@@ -879,7 +879,7 @@ mod timed_tests {
         // Then we have the stored event.
         assert_matches!(chunks.next().unwrap().content(), ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(event_id_0));
+            assert_eq!(events[0].event_id(), Some(event_id_0));
         });
 
         // That's all, folks!
@@ -1538,7 +1538,7 @@ mod timed_tests {
         // Sanity check: lazily loaded, so only includes one item at start.
         let (events, mut stream) = room_event_cache.subscribe().await.unwrap();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_id().as_deref(), Some(evid2));
+        assert_eq!(events[0].event_id(), Some(evid2));
         assert!(stream.is_empty());
 
         let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
@@ -1546,7 +1546,7 @@ mod timed_tests {
         // Force loading the full linked chunk by back-paginating.
         let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
         assert_eq!(outcome.events.len(), 1);
-        assert_eq!(outcome.events[0].event_id().as_deref(), Some(evid1));
+        assert_eq!(outcome.events[0].event_id(), Some(evid1));
         assert!(outcome.reached_start);
 
         // We also get an update about the loading from the store.
@@ -1556,7 +1556,7 @@ mod timed_tests {
         );
         assert_eq!(diffs.len(), 1);
         assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value } => {
-            assert_eq!(value.event_id().as_deref(), Some(evid1));
+            assert_eq!(value.event_id(), Some(evid1));
         });
 
         assert!(stream.is_empty());
@@ -1588,7 +1588,7 @@ mod timed_tests {
         assert_matches!(&diffs[0], VectorDiff::Clear);
         assert_matches!(&diffs[1], VectorDiff::Append { values} => {
             assert_eq!(values.len(), 1);
-            assert_eq!(values[0].event_id().as_deref(), Some(evid2));
+            assert_eq!(values[0].event_id(), Some(evid2));
         });
 
         assert!(stream.is_empty());
@@ -1600,13 +1600,13 @@ mod timed_tests {
         // When reading the events, we do get only the last one.
         let events = room_event_cache.events().await.unwrap();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_id().as_deref(), Some(evid2));
+        assert_eq!(events[0].event_id(), Some(evid2));
 
         // But if we back-paginate, we don't need access to network to find out about
         // the previous event.
         let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
         assert_eq!(outcome.events.len(), 1);
-        assert_eq!(outcome.events[0].event_id().as_deref(), Some(evid1));
+        assert_eq!(outcome.events[0].event_id(), Some(evid1));
         assert!(outcome.reached_start);
     }
 
@@ -1691,7 +1691,7 @@ mod timed_tests {
             let mut events = room_linked_chunk.events();
             let (pos, ev) = events.next().unwrap();
             assert_eq!(pos, Position::new(ChunkIdentifier::new(1), 0));
-            assert_eq!(ev.event_id().as_deref(), Some(evid3));
+            assert_eq!(ev.event_id(), Some(evid3));
             assert_eq!(room_linked_chunk.event_order(pos), Some(2));
 
             // No other loaded events.
@@ -1738,11 +1738,11 @@ mod timed_tests {
             let mut events = room_linked_chunk.events();
 
             let (pos, ev) = events.next().unwrap();
-            assert_eq!(ev.event_id().as_deref(), Some(evid3));
+            assert_eq!(ev.event_id(), Some(evid3));
             assert_eq!(room_linked_chunk.event_order(pos), Some(2));
 
             let (pos, ev) = events.next().unwrap();
-            assert_eq!(ev.event_id().as_deref(), Some(evid4));
+            assert_eq!(ev.event_id(), Some(evid4));
             assert_eq!(room_linked_chunk.event_order(pos), Some(3));
 
             // No other loaded events.
@@ -1827,7 +1827,7 @@ mod timed_tests {
         // Sanity check: lazily loaded, so only includes one item at start.
         let (events1, mut stream1) = room_event_cache.subscribe().await.unwrap();
         assert_eq!(events1.len(), 1);
-        assert_eq!(events1[0].event_id().as_deref(), Some(evid2));
+        assert_eq!(events1[0].event_id(), Some(evid2));
         assert!(stream1.is_empty());
 
         let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
@@ -1835,7 +1835,7 @@ mod timed_tests {
         // Force loading the full linked chunk by back-paginating.
         let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
         assert_eq!(outcome.events.len(), 1);
-        assert_eq!(outcome.events[0].event_id().as_deref(), Some(evid1));
+        assert_eq!(outcome.events[0].event_id(), Some(evid1));
         assert!(outcome.reached_start);
 
         // We also get an update about the loading from the store. Ignore it, for this
@@ -1846,7 +1846,7 @@ mod timed_tests {
         );
         assert_eq!(diffs.len(), 1);
         assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value } => {
-            assert_eq!(value.event_id().as_deref(), Some(evid1));
+            assert_eq!(value.event_id(), Some(evid1));
         });
 
         assert!(stream1.is_empty());
@@ -1862,8 +1862,8 @@ mod timed_tests {
         // the second subscribers sees them all.
         let (events2, stream2) = room_event_cache.subscribe().await.unwrap();
         assert_eq!(events2.len(), 2);
-        assert_eq!(events2[0].event_id().as_deref(), Some(evid1));
-        assert_eq!(events2[1].event_id().as_deref(), Some(evid2));
+        assert_eq!(events2[0].event_id(), Some(evid1));
+        assert_eq!(events2[1].event_id(), Some(evid2));
         assert!(stream2.is_empty());
 
         // Drop the first stream, and wait a bit.
@@ -1888,7 +1888,7 @@ mod timed_tests {
         // Getting the events will only give us the latest chunk.
         let events3 = room_event_cache.events().await.unwrap();
         assert_eq!(events3.len(), 1);
-        assert_eq!(events3[0].event_id().as_deref(), Some(evid2));
+        assert_eq!(events3[0].event_id(), Some(evid2));
     }
 
     #[async_test]
@@ -1960,7 +1960,7 @@ mod timed_tests {
         assert_matches!(
             room_event_cache
                 .rfind_map_event_in_memory_by(|event| {
-                    (event.sender().as_deref() == Some(*BOB)).then(|| event.event_id())
+                    (event.sender().as_deref() == Some(*BOB)).then(|| event.event_id().map(ToOwned::to_owned))
                 })
                 .await,
             Ok(Some(event_id)) => {
@@ -1973,7 +1973,7 @@ mod timed_tests {
         assert_matches!(
             room_event_cache
                 .rfind_map_event_in_memory_by(|event| {
-                    (event.sender().as_deref() == Some(*ALICE)).then(|| event.event_id())
+                    (event.sender().as_deref() == Some(*ALICE)).then(|| event.event_id().map(ToOwned::to_owned))
                 })
                 .await,
             Ok(Some(event_id)) => {
@@ -1985,7 +1985,8 @@ mod timed_tests {
         assert!(
             room_event_cache
                 .rfind_map_event_in_memory_by(|event| {
-                    (event.sender().as_deref() == Some(user_id)).then(|| event.event_id())
+                    (event.sender().as_deref() == Some(user_id))
+                        .then(|| event.event_id().map(ToOwned::to_owned))
                 })
                 .await
                 .unwrap()
@@ -2101,7 +2102,7 @@ mod timed_tests {
 
             // Initial updates contain `ev_id_1` only.
             assert_eq!(initial_updates.len(), 1);
-            assert_eq!(initial_updates[0].event_id().as_deref(), Some(ev_id_1));
+            assert_eq!(initial_updates[0].event_id(), Some(ev_id_1));
             assert!(updates_stream.is_empty());
 
             // `ev_id_1` must be loaded in memory.
@@ -2121,7 +2122,7 @@ mod timed_tests {
                     assert_matches!(
                         &diffs[0],
                         VectorDiff::Insert { index: 0, value: event } => {
-                            assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                            assert_eq!(event.event_id(), Some(ev_id_0));
                         }
                     );
                 }
@@ -2141,7 +2142,7 @@ mod timed_tests {
 
             // Initial updates contain `ev_id_1` only.
             assert_eq!(initial_updates.len(), 1);
-            assert_eq!(initial_updates[0].event_id().as_deref(), Some(ev_id_1));
+            assert_eq!(initial_updates[0].event_id(), Some(ev_id_1));
             assert!(updates_stream.is_empty());
 
             // `ev_id_1` must be loaded in memory.
@@ -2161,7 +2162,7 @@ mod timed_tests {
                     assert_matches!(
                         &diffs[0],
                         VectorDiff::Insert { index: 0, value: event } => {
-                            assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                            assert_eq!(event.event_id(), Some(ev_id_0));
                         }
                     );
                 }
@@ -2199,7 +2200,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2219,7 +2220,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2250,7 +2251,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2270,7 +2271,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2304,7 +2305,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2331,7 +2332,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2360,7 +2361,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2387,7 +2388,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2416,7 +2417,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2440,7 +2441,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2466,7 +2467,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(ev_id_1));
+                                assert_eq!(events[0].event_id(), Some(ev_id_1));
                             }
                         );
                     }
@@ -2490,7 +2491,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(ev_id_0));
+                                assert_eq!(event.event_id(), Some(ev_id_0));
                             }
                         );
                     }
@@ -2623,7 +2624,7 @@ mod timed_tests {
     async fn event_loaded(room_event_cache: &RoomEventCache, event_id: &EventId) -> bool {
         room_event_cache
             .rfind_map_event_in_memory_by(|event| {
-                (event.event_id().as_deref() == Some(event_id)).then_some(())
+                (event.event_id() == Some(event_id)).then_some(())
             })
             .await
             .unwrap()

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -375,7 +375,7 @@ mod timed_tests {
                 assert_matches!(&diffs[0], VectorDiff::Clear);
                 assert_matches!(&diffs[1], VectorDiff::Append { values: events } => {
                     assert_eq!(events.len(), 1);
-                    assert_eq!(events[0].event_id().as_deref(), Some(thread_event_id_0));
+                    assert_eq!(events[0].event_id(), Some(thread_event_id_0));
                 });
             }
         );
@@ -403,7 +403,7 @@ mod timed_tests {
         // Then we have the stored event.
         assert_matches!(chunks.next().unwrap().content(), ChunkContent::Items(events) => {
             assert_eq!(events.len(), 1);
-            assert_eq!(events[0].event_id().as_deref(), Some(thread_event_id_0));
+            assert_eq!(events[0].event_id(), Some(thread_event_id_0));
         });
 
         // That's all, folks!
@@ -616,7 +616,7 @@ mod timed_tests {
                     assert_eq!(diffs.len(), 1);
                     assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value: event } => {
                         // Here you are `thread_event_0`!
-                        assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                        assert_eq!(event.event_id(), Some(thread_event_id_0));
                     });
                 }
             );
@@ -797,7 +797,7 @@ mod timed_tests {
             Ok(TimelineVectorDiffs { diffs, .. }) => {
                 assert_eq!(diffs.len(), 1);
                 assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value: event } => {
-                    assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                    assert_eq!(event.event_id(), Some(thread_event_id_0));
                 });
             }
         );
@@ -830,8 +830,8 @@ mod timed_tests {
         // element anymore), and it's added to the back of the list.
         let (thread_events, _) = thread_event_cache.subscribe().await.unwrap();
         assert_eq!(thread_events.len(), 2);
-        assert_eq!(thread_events[0].event_id().as_deref(), Some(thread_event_id_0));
-        assert_eq!(thread_events[1].event_id().as_deref(), Some(thread_event_id_1));
+        assert_eq!(thread_events[0].event_id(), Some(thread_event_id_0));
+        assert_eq!(thread_events[1].event_id(), Some(thread_event_id_1));
     }
 
     #[async_test]
@@ -1024,7 +1024,7 @@ mod timed_tests {
 
             // Initial updates contain `thread_event_id_1` only.
             assert_eq!(initial_updates.len(), 1);
-            assert_eq!(initial_updates[0].event_id().as_deref(), Some(thread_event_id_1));
+            assert_eq!(initial_updates[0].event_id(), Some(thread_event_id_1));
             assert!(updates_stream.is_empty());
 
             // Load one more event with a backpagination.
@@ -1038,7 +1038,7 @@ mod timed_tests {
                     assert_matches!(
                         &diffs[0],
                         VectorDiff::Insert { index: 0, value: event } => {
-                            assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                            assert_eq!(event.event_id(), Some(thread_event_id_0));
                         }
                     );
                 }
@@ -1055,7 +1055,7 @@ mod timed_tests {
 
             // Initial updates contain `thread_event_id_1` only.
             assert_eq!(initial_updates.len(), 1);
-            assert_eq!(initial_updates[0].event_id().as_deref(), Some(thread_event_id_1));
+            assert_eq!(initial_updates[0].event_id(), Some(thread_event_id_1));
             assert!(updates_stream.is_empty());
 
             // Load one more event with a backpagination.
@@ -1069,7 +1069,7 @@ mod timed_tests {
                     assert_matches!(
                         &diffs[0],
                         VectorDiff::Insert { index: 0, value: event } => {
-                            assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                            assert_eq!(event.event_id(), Some(thread_event_id_0));
                         }
                     );
                 }
@@ -1093,7 +1093,7 @@ mod timed_tests {
                 let (initial_updates, _) = thread_event_cache.subscribe().await.unwrap();
 
                 assert_eq!(initial_updates.len(), 1);
-                assert_eq!(initial_updates[0].event_id().as_deref(), Some(thread_event_id_1));
+                assert_eq!(initial_updates[0].event_id(), Some(thread_event_id_1));
 
                 // The reload can be observed via the updates too.
                 assert_matches!(
@@ -1105,7 +1105,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(thread_event_id_1));
+                                assert_eq!(events[0].event_id(), Some(thread_event_id_1));
                             }
                         );
                     }
@@ -1123,7 +1123,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                                assert_eq!(event.event_id(), Some(thread_event_id_0));
                             }
                         );
                     }
@@ -1143,7 +1143,7 @@ mod timed_tests {
                 let (initial_updates, _) = thread_event_cache.subscribe().await.unwrap();
 
                 assert_eq!(initial_updates.len(), 1);
-                assert_eq!(initial_updates[0].event_id().as_deref(), Some(thread_event_id_1));
+                assert_eq!(initial_updates[0].event_id(), Some(thread_event_id_1));
 
                 // The reload can be observed via the updates too.
                 assert_matches!(
@@ -1155,7 +1155,7 @@ mod timed_tests {
                             &diffs[1],
                             VectorDiff::Append { values: events } => {
                                 assert_eq!(events.len(), 1);
-                                assert_eq!(events[0].event_id().as_deref(), Some(thread_event_id_1));
+                                assert_eq!(events[0].event_id(), Some(thread_event_id_1));
                             }
                         );
                     }
@@ -1173,7 +1173,7 @@ mod timed_tests {
                         assert_matches!(
                             &diffs[0],
                             VectorDiff::Insert { index: 0, value: event } => {
-                                assert_eq!(event.event_id().as_deref(), Some(thread_event_id_0));
+                                assert_eq!(event.event_id(), Some(thread_event_id_0));
                             }
                         );
                     }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -357,13 +357,13 @@ impl<'a> ThreadEventCacheStateLockReadGuard<'a> {
                     )
                     .is_break()
                 })
-                .and_then(|(_position, event)| event.event_id());
+                .and_then(|(_position, event)| event.event_id().map(ToOwned::to_owned));
 
             // If there's an edit to the latest event in the thread, use the latest edit
             // event ID as the latest event ID for the thread summary.
             //
             // TODO(@hywan): This is one of the inefficiency I am talking about above.
-            if let Some(event_id) = latest_event_id.as_ref()
+            if let Some(event_id) = &latest_event_id
                 && let Some((original_event, edits)) = self
                     .find_event_with_relations(event_id, Some(vec![RelationType::Replacement]))
                     .await?
@@ -384,7 +384,7 @@ impl<'a> ThreadEventCacheStateLockReadGuard<'a> {
                 });
 
                 if let Some(latest_valid_edit) = latest_valid_edit {
-                    latest_event_id = latest_valid_edit.event_id();
+                    latest_event_id = latest_valid_edit.event_id().map(ToOwned::to_owned);
                 }
             }
 

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -47,7 +47,7 @@ pub async fn filter_duplicate_events(
         new_events.retain(|event| {
             // Only keep events with IDs, and those for which `insert` returns `true`
             // (meaning they were not in the set).
-            event.event_id().is_some_and(|event_id| event_ids.insert(event_id))
+            event.event_id().is_some_and(|event_id| event_ids.insert(event_id.to_owned()))
         });
     }
 
@@ -55,7 +55,7 @@ pub async fn filter_duplicate_events(
     let duplicated_event_ids = store_guard
         .filter_duplicated_events(
             linked_chunk_id,
-            new_events.iter().filter_map(|event| event.event_id()).collect(),
+            new_events.iter().filter_map(|event| event.event_id().map(ToOwned::to_owned)).collect(),
         )
         .await?;
 
@@ -279,11 +279,11 @@ mod tests {
 
         // The deduplication says 5 events are valid.
         assert_eq!(outcome.all_events.len(), 5);
-        assert_eq!(outcome.all_events[0].event_id(), Some(event_id_0.clone()));
-        assert_eq!(outcome.all_events[1].event_id(), Some(event_id_1.clone()));
-        assert_eq!(outcome.all_events[2].event_id(), Some(event_id_2.clone()));
-        assert_eq!(outcome.all_events[3].event_id(), Some(event_id_3.clone()));
-        assert_eq!(outcome.all_events[4].event_id(), Some(event_id_4.clone()));
+        assert_eq!(outcome.all_events[0].event_id(), Some(event_id_0.as_ref()));
+        assert_eq!(outcome.all_events[1].event_id(), Some(event_id_1.as_ref()));
+        assert_eq!(outcome.all_events[2].event_id(), Some(event_id_2.as_ref()));
+        assert_eq!(outcome.all_events[3].event_id(), Some(event_id_3.as_ref()));
+        assert_eq!(outcome.all_events[4].event_id(), Some(event_id_4.as_ref()));
 
         // From these 5 events, 2 are duplicated and have been loaded in memory.
         //
@@ -398,9 +398,9 @@ mod tests {
         assert!(non_empty_all_duplicates.not());
 
         assert_eq!(events.len(), 3);
-        assert_eq!(events[0].event_id().as_deref(), Some(eid1));
-        assert_eq!(events[1].event_id().as_deref(), Some(eid2));
-        assert_eq!(events[2].event_id().as_deref(), Some(eid3));
+        assert_eq!(events[0].event_id(), Some(eid1));
+        assert_eq!(events[1].event_id(), Some(eid2));
+        assert_eq!(events[2].event_id(), Some(eid3));
 
         assert!(in_memory_duplicated_event_ids.is_empty());
 

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -281,7 +281,7 @@ pub async fn find_event(
     // There are supposedly fewer events loaded in memory than in the store. Let's
     // start by looking up in the `EventLinkedChunk`.
     for (position, event) in event_linked_chunk.revents() {
-        if event.event_id().as_deref() == Some(event_id) {
+        if event.event_id() == Some(event_id) {
             return Ok(Some((EventLocation::Memory(position), event.clone())));
         }
     }
@@ -345,7 +345,10 @@ pub async fn find_event_relations(
     // Initialize the stack with all the related events, to find the
     // transitive closure of all the related events.
     let mut related = store.find_event_relations(room_id, event_id, filters.as_deref()).await?;
-    let mut stack = related.iter().filter_map(|(event, _pos)| event.event_id()).collect::<Vec<_>>();
+    let mut stack = related
+        .iter()
+        .filter_map(|(event, _pos)| event.event_id().map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
 
     // Also keep track of already seen events, in case there's a loop in the
     // relation graph.
@@ -364,7 +367,11 @@ pub async fn find_event_relations(
         let other_related =
             store.find_event_relations(room_id, &event_id, filters.as_deref()).await?;
 
-        stack.extend(other_related.iter().filter_map(|(event, _pos)| event.event_id()));
+        stack.extend(
+            other_related
+                .iter()
+                .filter_map(|(event, _pos)| event.event_id().map(ToOwned::to_owned)),
+        );
         related.extend(other_related);
 
         num_iters += 1;

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -232,7 +232,7 @@ impl RedecryptorChannels {
 fn filter_timeline_event_to_utd(
     event: TimelineEvent,
 ) -> Option<(OwnedEventId, Raw<AnySyncTimelineEvent>)> {
-    let event_id = event.event_id();
+    let event_id = event.event_id().map(ToOwned::to_owned);
 
     // Only pick out events that are UTDs, get just the Raw event as this is what
     // the OlmMachine needs.
@@ -250,7 +250,7 @@ fn filter_timeline_event_to_utd(
 fn filter_timeline_event_to_decrypted(
     event: TimelineEvent,
 ) -> Option<(OwnedEventId, DecryptedRoomEvent)> {
-    let event_id = event.event_id();
+    let event_id = event.event_id().map(ToOwned::to_owned);
 
     let event = as_variant!(event.kind, TimelineEventKind::Decrypted(event) => event);
     // Zip the event ID and event together so we don't have to pick out the event ID

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -439,7 +439,7 @@ async fn handle_thread_subscriber_linked_chunk_update(
                 // Shouldn't happen.
                 continue;
             };
-            subscribe_up_to = Some(event_id);
+            subscribe_up_to = Some(event_id.to_owned());
             break;
         }
     }

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -96,7 +96,7 @@ impl Builder {
                         // Return the latest known edit of the event or the event itself if it
                         // hasn't been replaced or the replacement is invalid.
                         if let Some(event_id) = event.event_id()
-                            && let Some(edit) = latest_edit_for_event.get(&event_id)
+                            && let Some(edit) = latest_edit_for_event.get(event_id)
                         {
                             let original = event.kind.raw();
                             let original_encryption_info = event.kind.encryption_info();

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -689,7 +689,7 @@ mod tests_latest_event {
             assert_matches!(
                 latest_event.current_value.get().await,
                 LatestEventValue::Remote(remote) => {
-                    assert_eq!(remote.event_id().as_deref(), Some(event_id_1));
+                    assert_eq!(remote.event_id(), Some(event_id_1));
                 }
             );
         }
@@ -714,7 +714,7 @@ mod tests_latest_event {
                 latest_event.current_value.get().await,
                 LatestEventValue::Remote(remote) => {
                     // `$ev1` has been redacted, so `$ev0` is the new candidate!
-                    assert_eq!(remote.event_id().as_deref(), Some(event_id_0));
+                    assert_eq!(remote.event_id(), Some(event_id_0));
                 }
             );
         }

--- a/crates/matrix-sdk/src/message_search.rs
+++ b/crates/matrix-sdk/src/message_search.rs
@@ -442,7 +442,7 @@ mod tests {
             let maybe_results = room_search.next_events().await.unwrap();
             let results = maybe_results.unwrap();
             assert_eq!(results.len(), 1);
-            assert_eq!(results[0].event_id().as_deref().unwrap(), event_id,);
+            assert_eq!(results[0].event_id().unwrap(), event_id,);
 
             // And no more results after that.
             let maybe_results = room_search.next_events().await.unwrap();
@@ -531,10 +531,10 @@ mod tests {
             // Search results order is not guaranteed, so we check that both expected
             // results are present in the returned batch.
             assert!(results.iter().any(|(room_id, event)| {
-                room_id == room_id1 && event.event_id().as_deref() == Some(result_event_id1)
+                room_id == room_id1 && event.event_id() == Some(result_event_id1)
             }));
             assert!(results.iter().any(|(room_id, event)| {
-                room_id == room_id2 && event.event_id().as_deref() == Some(result_event_id2)
+                room_id == room_id2 && event.event_id() == Some(result_event_id2)
             }));
 
             // And no more results after that.
@@ -613,7 +613,7 @@ mod tests {
             let results = maybe_results.unwrap();
             assert_eq!(results.len(), 1);
             assert_eq!(results[0].0, room_id2);
-            assert_eq!(results[0].1.event_id().as_deref().unwrap(), result_event_id2);
+            assert_eq!(results[0].1.event_id().unwrap(), result_event_id2);
 
             // And no more results after that.
             let maybe_results = search.next().await.unwrap();

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -2998,7 +2998,7 @@ impl<'a> MockEndpoint<'a, RoomEventEndpoint> {
     /// event has been sent with the given event id.
     pub fn ok(self, event: TimelineEvent) -> MatrixMock<'a> {
         let event_path = if self.endpoint.match_event_id {
-            let event_id = event.kind.event_id().expect("an event id is required");
+            let event_id = event.event_id().expect("an event id is required");
             // The event id should begin with `$`, which would be taken as the end of the
             // regex so we need to escape it
             event_id.as_str().replace("$", "\\$")

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -2956,7 +2956,7 @@ async fn test_send_queue_does_insert_event_in_the_event_cache() {
             // The event is received via the Send Queue!
             assert_let!(VectorDiff::Append { values } = &diffs[0]);
             assert_eq!(values.len(), 1);
-            assert_eq!(values[0].event_id().as_deref(), Some(event_id_2));
+            assert_eq!(values[0].event_id(), Some(event_id_2));
         }
     );
 

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -92,7 +92,7 @@ async fn test_thread_contains_its_root_event() {
     // Sanity check: the event is added to the thread via the sync.
     let mut thread_events = wait_for_initial_events(thread_events, &mut thread_stream).await;
     assert_eq!(thread_events.len(), 1);
-    assert_eq!(thread_events.remove(0).event_id().as_deref(), Some(thread_resp_id));
+    assert_eq!(thread_events.remove(0).event_id(), Some(thread_resp_id));
 
     // Paginating the thread will return no more events.
     server
@@ -119,7 +119,7 @@ async fn test_thread_contains_its_root_event() {
     assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
     assert_eq!(diffs.len(), 1);
     assert_let!(VectorDiff::Insert { index: 0, value } = &diffs[0]);
-    assert_eq!(value.event_id().as_deref(), Some(thread_root_id));
+    assert_eq!(value.event_id(), Some(thread_root_id));
 }
 
 #[async_test]
@@ -510,7 +510,7 @@ async fn test_auto_subscribe_on_thread_paginate() {
     // Sanity check: the sync event is added to the thread.
     let mut thread_events = wait_for_initial_events(thread_events, &mut thread_stream).await;
     assert_eq!(thread_events.len(), 1);
-    assert_eq!(thread_events.remove(0).event_id().as_deref(), Some(thread_resp_id));
+    assert_eq!(thread_events.remove(0).event_id(), Some(thread_resp_id));
 
     assert!(thread_subscriber_updates.is_empty());
 
@@ -589,7 +589,7 @@ async fn test_auto_subscribe_on_thread_paginate_root_event() {
     // Sanity check: the sync event is added to the thread.
     let mut thread_events = wait_for_initial_events(thread_events, &mut thread_stream).await;
     assert_eq!(thread_events.len(), 1);
-    assert_eq!(thread_events.remove(0).event_id().as_deref(), Some(thread_resp_id));
+    assert_eq!(thread_events.remove(0).event_id(), Some(thread_resp_id));
 
     assert!(thread_subscriber_updates.is_empty());
 
@@ -706,15 +706,15 @@ async fn test_redact_touches_threads() {
     // is correct.
     {
         assert_eq!(thread_events.len(), 3);
-        assert_eq!(thread_events[0].event_id().as_ref(), Some(&thread_root_id));
-        assert_eq!(thread_events[1].event_id().as_ref(), Some(&thread_resp1));
-        assert_eq!(thread_events[2].event_id().as_ref(), Some(&thread_resp2));
+        assert_eq!(thread_events[0].event_id(), Some(thread_root_id.as_ref()));
+        assert_eq!(thread_events[1].event_id(), Some(thread_resp1.as_ref()));
+        assert_eq!(thread_events[2].event_id(), Some(thread_resp2.as_ref()));
 
         assert_eq!(room_events.len(), 3);
 
-        assert_eq!(room_events[0].event_id().as_ref(), Some(&thread_root_id));
-        assert_eq!(room_events[1].event_id().as_ref(), Some(&thread_resp1));
-        assert_eq!(room_events[2].event_id().as_ref(), Some(&thread_resp2));
+        assert_eq!(room_events[0].event_id(), Some(thread_root_id.as_ref()));
+        assert_eq!(room_events[1].event_id(), Some(thread_resp1.as_ref()));
+        assert_eq!(room_events[2].event_id(), Some(thread_resp2.as_ref()));
 
         // Thread summary.
         let summary = room_events[0].thread_summary.summary().unwrap();
@@ -745,11 +745,11 @@ async fn test_redact_touches_threads() {
         // The redaction event is appended to the thread cache.
         assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
         assert_eq!(new_events.len(), 1);
-        assert_eq!(new_events[0].event_id().as_deref(), Some(thread_resp1_redaction));
+        assert_eq!(new_events[0].event_id(), Some(thread_resp1_redaction));
 
         // The thread event is redacted.
         assert_let!(VectorDiff::Set { index: 1, value: new_event } = &diffs[1]);
-        assert_eq!(new_event.event_id().as_ref(), Some(&thread_resp1));
+        assert_eq!(new_event.event_id(), Some(thread_resp1.as_ref()));
         let deserialized = new_event.raw().deserialize().unwrap();
         assert!(deserialized.is_redacted());
 
@@ -772,13 +772,13 @@ async fn test_redact_touches_threads() {
         {
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(thread_resp1_redaction));
+            assert_eq!(new_events[0].event_id(), Some(thread_resp1_redaction));
         }
 
         // The room event is redacted.
         {
             assert_let!(VectorDiff::Set { index: 1, value: new_event } = &diffs[1]);
-            assert_eq!(new_event.event_id().as_ref(), Some(&thread_resp1));
+            assert_eq!(new_event.event_id(), Some(thread_resp1.as_ref()));
             let deserialized = new_event.raw().deserialize().unwrap();
             assert!(deserialized.is_redacted());
         }
@@ -792,7 +792,7 @@ async fn test_redact_touches_threads() {
         // The thread summary is updated.
         {
             assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[0]);
-            assert_eq!(new_root.event_id().as_ref(), Some(&thread_root_id));
+            assert_eq!(new_root.event_id(), Some(thread_root_id.as_ref()));
             let summary = new_root.thread_summary.summary().unwrap();
             assert_eq!(summary.latest_reply.as_ref(), Some(&thread_resp2));
             assert_eq!(summary.num_replies, 1);
@@ -819,11 +819,11 @@ async fn test_redact_touches_threads() {
         // The redaction event is appended to the thread cache.
         assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
         assert_eq!(new_events.len(), 1);
-        assert_eq!(new_events[0].event_id().as_deref(), Some(thread_resp2_redaction));
+        assert_eq!(new_events[0].event_id(), Some(thread_resp2_redaction));
 
         // The thread event is redacted.
         assert_let!(VectorDiff::Set { index: 2, value: new_event } = &diffs[1]);
-        assert_eq!(new_event.event_id().as_ref(), Some(&thread_resp2));
+        assert_eq!(new_event.event_id(), Some(thread_resp2.as_ref()));
         let deserialized = new_event.raw().deserialize().unwrap();
         assert!(deserialized.is_redacted());
 
@@ -846,13 +846,13 @@ async fn test_redact_touches_threads() {
         {
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(thread_resp2_redaction));
+            assert_eq!(new_events[0].event_id(), Some(thread_resp2_redaction));
         }
 
         // The room event is redacted.
         {
             assert_let!(VectorDiff::Set { index: 2, value: new_event } = &diffs[1]);
-            assert_eq!(new_event.event_id().as_ref(), Some(&thread_resp2));
+            assert_eq!(new_event.event_id(), Some(thread_resp2.as_ref()));
             let deserialized = new_event.raw().deserialize().unwrap();
             assert!(deserialized.is_redacted());
         }
@@ -866,7 +866,7 @@ async fn test_redact_touches_threads() {
         // The thread summary is removed.
         {
             assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[0]);
-            assert_eq!(new_root.event_id().as_ref(), Some(&thread_root_id));
+            assert_eq!(new_root.event_id(), Some(thread_root_id.as_ref()));
             assert!(new_root.thread_summary.summary().is_none());
         }
     }
@@ -918,7 +918,7 @@ async fn test_edits_touches_threads() {
             &s.client,
             JoinedRoomBuilder::new(&s.room_id).add_timeline_event(
                 f.text_msg("Nobody speaks English anymore.").event_id(first_edit).edit(
-                    &room_events[2].event_id().unwrap(),
+                    room_events[2].event_id().unwrap(),
                     RoomMessageEventContentWithoutRelation::text_plain("edited text"),
                 ),
             ),
@@ -938,7 +938,7 @@ async fn test_edits_touches_threads() {
             // Oh, an edit event.
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(first_edit));
+            assert_eq!(new_events[0].event_id(), Some(first_edit));
         }
 
         // Second update.
@@ -952,7 +952,7 @@ async fn test_edits_touches_threads() {
             // The thread summary is updated.
             {
                 assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[0]);
-                assert_eq!(new_root.event_id().as_ref(), Some(&thread_root_id));
+                assert_eq!(new_root.event_id(), Some(thread_root_id.as_ref()));
                 let summary = new_root.thread_summary.summary().unwrap();
                 assert_eq!(summary.latest_reply.as_deref(), Some(first_edit));
                 assert_eq!(summary.num_replies, 2);
@@ -973,7 +973,7 @@ async fn test_edits_touches_threads() {
             // Oh, an edit event.
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(first_edit));
+            assert_eq!(new_events[0].event_id(), Some(first_edit));
         }
 
         // That's it.
@@ -987,7 +987,7 @@ async fn test_edits_touches_threads() {
             &s.client,
             JoinedRoomBuilder::new(&s.room_id).add_timeline_event(
                 f.text_msg("Nobody speaks english anymore.").event_id(second_edit).edit(
-                    &room_events[1].event_id().unwrap(),
+                    room_events[1].event_id().unwrap(),
                     RoomMessageEventContentWithoutRelation::text_plain("edited text"),
                 ),
             ),
@@ -1007,7 +1007,7 @@ async fn test_edits_touches_threads() {
             // Oh, an edit event.
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(second_edit));
+            assert_eq!(new_events[0].event_id(), Some(second_edit));
         }
 
         // Second update.
@@ -1022,7 +1022,7 @@ async fn test_edits_touches_threads() {
             // It is always updated as soon as an update happens in the cache.
             {
                 assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[0]);
-                assert_eq!(new_root.event_id().as_ref(), Some(&thread_root_id));
+                assert_eq!(new_root.event_id(), Some(thread_root_id.as_ref()));
                 let summary = new_root.thread_summary.summary().unwrap();
                 // But the `latest_reply` is still `first_edit`, not `second_edit`!
                 assert_eq!(summary.latest_reply.as_deref(), Some(first_edit));
@@ -1044,7 +1044,7 @@ async fn test_edits_touches_threads() {
             // Oh, an edit event.
             assert_let!(VectorDiff::Append { values: new_events } = &diffs[0]);
             assert_eq!(new_events.len(), 1);
-            assert_eq!(new_events[0].event_id().as_deref(), Some(second_edit));
+            assert_eq!(new_events[0].event_id(), Some(second_edit));
         }
 
         // That's it.

--- a/crates/matrix-sdk/tests/integration/latest_event.rs
+++ b/crates/matrix-sdk/tests/integration/latest_event.rs
@@ -61,7 +61,7 @@ async fn test_latest_event_is_recomputed_when_a_user_is_ignored() {
     assert_matches!(
         latest_event_stream.next_now().await,
         LatestEventValue::Remote(event) => {
-            assert_eq!(event.event_id().as_deref(), Some(event_bob));
+            assert_eq!(event.event_id(), Some(event_bob));
         }
     );
 

--- a/crates/matrix-sdk/tests/integration/room/pinned_events.rs
+++ b/crates/matrix-sdk/tests/integration/room/pinned_events.rs
@@ -338,8 +338,8 @@ async fn test_pinned_events_are_reloaded_from_storage_from_many_chunks() {
 
     // Verify the pinned event was loaded from the storage and the network.
     assert_eq!(events.len(), 2, "Expected pinned events to be loaded from the network");
-    assert_eq!(events[0].event_id().as_deref(), Some(pinned_event_id_0));
-    assert_eq!(events[1].event_id().as_deref(), Some(pinned_event_id_1));
+    assert_eq!(events[0].event_id(), Some(pinned_event_id_0));
+    assert_eq!(events[1].event_id(), Some(pinned_event_id_1));
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1971,7 +1971,7 @@ async fn test_redaction() {
     assert_eq!(up.diffs.len(), 1);
     assert_let!(VectorDiff::Append { values } = &up.diffs[0]);
     assert_eq!(values.len(), 1);
-    assert_eq!(values[0].event_id().as_deref().unwrap(), msg_event_id);
+    assert_eq!(values[0].event_id().unwrap(), msg_event_id);
 
     // ----------------------
     // Send a redaction for the event.
@@ -1999,7 +1999,7 @@ async fn test_redaction() {
     // The redaction event itself is added.
     assert_let!(VectorDiff::Append { values } = &up.diffs[0]);
     assert_eq!(values.len(), 1);
-    assert_eq!(values[0].event_id().as_deref().unwrap(), redaction_event_id);
+    assert_eq!(values[0].event_id().unwrap(), redaction_event_id);
     // The target event is now redacted.
     assert_let!(VectorDiff::Set { index: 1, value: redacted_event } = &up.diffs[1]);
     let ev = redacted_event.raw().deserialize().unwrap();
@@ -4043,7 +4043,7 @@ async fn test_sending_event_still_saves_sync_gap() {
     assert_eq!(up.diffs.len(), 1);
     assert_let!(VectorDiff::Append { values } = &up.diffs[0]);
     assert_eq!(values.len(), 1);
-    assert_eq!(values[0].event_id().as_deref().unwrap(), event_id!("$msg_now"));
+    assert_eq!(values[0].event_id().unwrap(), event_id!("$msg_now"));
 
     // Now, assume that a /sync response comes with only this message as part of the
     // response, and with a previous gap.
@@ -4065,7 +4065,7 @@ async fn test_sending_event_still_saves_sync_gap() {
     assert_eq!(update.diffs.len(), 2);
     assert_let!(VectorDiff::Clear = &update.diffs[0]);
     assert_let!(VectorDiff::Append { values } = &update.diffs[1]);
-    assert_eq!(values[0].event_id().as_deref().unwrap(), event_id!("$msg_now"));
+    assert_eq!(values[0].event_id().unwrap(), event_id!("$msg_now"));
 
     // When paginating with this previous batch token, we should get new events from
     // this room.
@@ -4086,7 +4086,7 @@ async fn test_sending_event_still_saves_sync_gap() {
     assert_let_timeout!(Ok(RoomEventCacheUpdate::UpdateTimelineEvents(update)) = stream.recv());
     assert_eq!(update.diffs.len(), 1);
     assert_let!(VectorDiff::Insert { index: 0, value: event } = &update.diffs[0]);
-    assert_eq!(event.event_id().as_deref().unwrap(), event_id!("$past_msg"));
+    assert_eq!(event.event_id().unwrap(), event_id!("$past_msg"));
 
     assert!(stream.is_empty());
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -370,7 +370,7 @@ async fn test_unread_counts_get_updated_after_decryption() -> TestResult {
     // point.
     loop {
         if let LatestEventValue::Remote(timeline_event) = room1.latest_event() {
-            if timeline_event.event_id().as_ref() == Some(&edit_event_id) {
+            if timeline_event.event_id() == Some(edit_event_id.as_ref()) {
                 let message_event = timeline_event
                     .raw()
                     .deserialize_as_unchecked::<OriginalSyncRoomMessageEvent>()?;
@@ -422,9 +422,9 @@ async fn test_unread_counts_get_updated_after_decryption() -> TestResult {
     // Last two events in the room cache should be UTDs.
     let timeline_tail = events.iter().rev().take(2).collect::<Vec<_>>();
     // Note: events are reverted, because of .rev().
-    assert_eq!(timeline_tail[0].event_id().as_ref(), Some(&edit_event_id));
+    assert_eq!(timeline_tail[0].event_id(), Some(edit_event_id.as_ref()));
     assert!(timeline_tail[0].kind.is_utd());
-    assert_eq!(timeline_tail[1].event_id().as_ref(), Some(&original_event_id));
+    assert_eq!(timeline_tail[1].event_id(), Some(original_event_id.as_ref()));
     assert!(timeline_tail[1].kind.is_utd());
 
     // The unread counts should be incorrect.
@@ -452,8 +452,8 @@ async fn test_unread_counts_get_updated_after_decryption() -> TestResult {
     // Last two events in the room cache should now be decrypted!
     let timeline_tail = events.iter().rev().take(2).collect::<Vec<_>>();
     // Note: events are reverted, because of .rev().
-    assert_eq!(timeline_tail[0].event_id().as_ref(), Some(&edit_event_id));
-    assert_eq!(timeline_tail[1].event_id().as_ref(), Some(&original_event_id));
+    assert_eq!(timeline_tail[0].event_id(), Some(edit_event_id.as_ref()));
+    assert_eq!(timeline_tail[1].event_id(), Some(original_event_id.as_ref()));
     assert!(timeline_tail[0].kind.is_utd().not());
     assert!(timeline_tail[1].kind.is_utd().not());
 
@@ -557,7 +557,7 @@ async fn test_latest_event_few_rooms() -> Result<()> {
         if run_loop {
             loop {
                 assert_let_timeout!(Duration::from_secs(5), Some(latest_event) = room_sub.next());
-                if matches!(latest_event, LatestEventValue::Remote(event) if event.event_id().as_deref() == Some(event_id))
+                if matches!(latest_event, LatestEventValue::Remote(event) if event.event_id() == Some(event_id))
                 {
                     break;
                 }
@@ -573,7 +573,7 @@ async fn test_latest_event_few_rooms() -> Result<()> {
     sleep(Duration::from_secs(1)).await;
     while let Some(Some(up)) = room2_sub.next().now_or_never() {
         assert_let!(LatestEventValue::Remote(event) = up);
-        assert_eq!(event.event_id().as_ref(), Some(&room2_msg_event_id));
+        assert_eq!(event.event_id(), Some(room2_msg_event_id.as_ref()));
     }
 
     bob_sync_service.stop().await;


### PR DESCRIPTION
This patch starts with a simple analysis: `TimelineEvent::event_id()` is parsing/deserializing the event ID for every call. Not only this is useless but it can be a performance bottleneck.

To solve this problem, this patch eagerly parses the event ID and stores it in a new `TimelineEvent::event_id` field. Then, the `event_id()` method is updated to clone the value to keep the signature untouched. Only this improves the performance of some benchmarks up to 17%.

Then, we break the `event_id()` signature:

```diff
- fn event_id(&self) -> Option<OwnedEventId>
+ fn event_id(&self) -> Option<&EventId>
```

This is a breaking change, and it implies many updates, mostly in the tests. But it should improve performance even further as we don't allocate memory.

---

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
