### PR TITLE
Replace key request in store if we make a new one for the same key

### DIFF
--- a/crates/matrix-sdk-crypto/changelog.d/6631.changed
+++ b/crates/matrix-sdk-crypto/changelog.d/6631.changed
@@ -1,1 +1,1 @@
-Only keep the latest gossip request for each secret, for consistency with indexeddb.
+Only keep the latest gossip request for each secret.

--- a/crates/matrix-sdk-crypto/changelog.d/6631.changed
+++ b/crates/matrix-sdk-crypto/changelog.d/6631.changed
@@ -1,0 +1,1 @@
+Only keep the latest gossip request for each secret, for consistency with indexeddb.

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1061,6 +1061,44 @@ macro_rules! cryptostore_integration_tests {
                 assert!(store.get_unsent_secret_requests().await.unwrap().is_empty());
             }
 
+            /// Test that if we try to store multiple gossip requests for the
+            /// same secret, the latter request will replace the former.
+            #[async_test]
+            async fn test_secret_request_replacement() {
+                let (account, store) = get_loaded_store("key_request_saving").await;
+
+                let id1 = TransactionId::new();
+                let request1 = GossipRequest {
+                    request_recipient: account.user_id().to_owned(),
+                    request_id: id1.clone(),
+                    info: SecretName::RecoveryKey.into(),
+                    sent_out: false,
+                };
+
+                assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_none());
+
+                let mut changes = Changes::default();
+                changes.key_requests.push(request1.clone());
+                store.save_changes(changes).await.unwrap();
+
+                assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_some());
+
+                let id2 = TransactionId::new();
+                let request2 = GossipRequest {
+                    request_recipient: account.user_id().to_owned(),
+                    request_id: id2.clone(),
+                    info: SecretName::RecoveryKey.into(),
+                    sent_out: false,
+                };
+
+                let mut changes = Changes::default();
+                changes.key_requests.push(request2.clone());
+                store.save_changes(changes).await.unwrap();
+
+                assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_none());
+                assert!(store.get_outgoing_secret_requests(&id2).await.unwrap().is_some());
+            }
+
             #[async_test]
             async fn test_gossipped_secret_saving() {
                 let (account, store) = get_loaded_store("gossipped_secret_saving").await;

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1074,14 +1074,24 @@ macro_rules! cryptostore_integration_tests {
                     info: SecretName::RecoveryKey.into(),
                     sent_out: false,
                 };
+                let msk_id = TransactionId::new();
+                let msk_request = GossipRequest {
+                    request_recipient: account.user_id().to_owned(),
+                    request_id: msk_id.clone(),
+                    info: SecretName::CrossSigningMasterKey.into(),
+                    sent_out: false,
+                };
+
 
                 assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_none());
 
                 let mut changes = Changes::default();
                 changes.key_requests.push(request1.clone());
+                changes.key_requests.push(msk_request.clone());
                 store.save_changes(changes).await.unwrap();
 
                 assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_some());
+                assert!(store.get_outgoing_secret_requests(&msk_id).await.unwrap().is_some());
 
                 let id2 = TransactionId::new();
                 let request2 = GossipRequest {
@@ -1095,8 +1105,11 @@ macro_rules! cryptostore_integration_tests {
                 changes.key_requests.push(request2.clone());
                 store.save_changes(changes).await.unwrap();
 
+                // The first request for the recovery key should be replaced by
+                // the second request, but request for the MSK should remain.
                 assert!(store.get_outgoing_secret_requests(&id1).await.unwrap().is_none());
                 assert!(store.get_outgoing_secret_requests(&id2).await.unwrap().is_some());
+                assert!(store.get_outgoing_secret_requests(&msk_id).await.unwrap().is_some());
             }
 
             #[async_test]

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -294,6 +294,12 @@ impl CryptoStore for MemoryStore {
                 let id = key_request.request_id.clone();
                 let info_string = encode_key_info(&key_request.info);
 
+                // If we have an old request for the same key/secret, remove it.
+                if let Some(old_id) = key_requests_by_info.get(&info_string) {
+                    outgoing_key_requests.remove(old_id);
+                    key_requests_by_info.remove(&info_string);
+                }
+
                 outgoing_key_requests.insert(id.clone(), key_request);
                 key_requests_by_info.insert(info_string, id);
             }

--- a/crates/matrix-sdk-indexeddb/changelog.d/6631.changed
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6631.changed
@@ -1,0 +1,1 @@
+Remove existing gossip requests when a new request for the same secret is made.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -270,6 +270,7 @@ type Result<A, E = IndexeddbCryptoStoreError> = std::result::Result<A, E>;
 enum PendingOperation {
     Put { key: JsValue, value: JsValue },
     Delete(JsValue),
+    DeleteByIndex { index: &'static str, key: JsValue },
 }
 
 /// A struct that represents all the operations that need to be done to the
@@ -295,6 +296,10 @@ impl PendingStoreChanges<'_> {
 
     fn delete(&mut self, key: JsValue) {
         self.operations.push(PendingOperation::Delete(key));
+    }
+
+    fn delete_by_index(&mut self, index: &'static str, key: JsValue) {
+        self.operations.push(PendingOperation::DeleteByIndex { index, key });
     }
 }
 
@@ -324,7 +329,7 @@ impl PendingIndexeddbChanges {
     }
 
     /// Applies all the pending operations to the store.
-    fn apply(self, tx: &Transaction<'_>) -> Result<()> {
+    async fn apply(self, tx: &Transaction<'_>) -> Result<()> {
         for (store, operations) in self.store_to_key_values {
             if operations.is_empty() {
                 continue;
@@ -337,6 +342,17 @@ impl PendingIndexeddbChanges {
                     }
                     PendingOperation::Delete(key) => {
                         object_store.delete(&key).build()?;
+                    }
+                    PendingOperation::DeleteByIndex { index, key } => {
+                        let range = KeyRange::Only(key);
+                        let ids = object_store
+                            .index(index)?
+                            .get_all_keys::<JsValue>()
+                            .with_query::<JsValue, _>(range)
+                            .await?;
+                        for id in ids {
+                            object_store.delete(id.unwrap()).await?;
+                        }
                     }
                 }
             }
@@ -686,6 +702,12 @@ impl IndexeddbCryptoStore {
             let mut gossip_requests = indexeddb_changes.get(keys::GOSSIP_REQUESTS);
 
             for gossip_request in key_requests {
+                // Remove any previous requests for the same secret.
+                let key_request_info =
+                    self.serializer.encode_key(keys::GOSSIP_REQUESTS, gossip_request.info.as_key());
+                gossip_requests
+                    .delete_by_index(keys::GOSSIP_REQUESTS_BY_INFO_INDEX, key_request_info);
+
                 let key_request_id = self
                     .serializer
                     .encode_key(keys::GOSSIP_REQUESTS, gossip_request.request_id.as_str());
@@ -860,7 +882,7 @@ impl_crypto_store! {
 
         let tx = self.inner.transaction(stores).with_mode(TransactionMode::Readwrite).build()?;
 
-        indexeddb_changes.apply(&tx)?;
+        indexeddb_changes.apply(&tx).await?;
 
         tx.commit().await?;
 

--- a/crates/matrix-sdk-sqlite/changelog.d/6631.changed
+++ b/crates/matrix-sdk-sqlite/changelog.d/6631.changed
@@ -1,1 +1,1 @@
-Only keep the latest gossip request for each secret, for consistency with indexeddb.
+Only keep the latest gossip request for each secret.

--- a/crates/matrix-sdk-sqlite/changelog.d/6631.changed
+++ b/crates/matrix-sdk-sqlite/changelog.d/6631.changed
@@ -1,0 +1,1 @@
+Only keep the latest gossip request for each secret, for consistency with indexeddb.

--- a/crates/matrix-sdk-sqlite/migrations/crypto_store/018_add_gossip_request_info.sql
+++ b/crates/matrix-sdk-sqlite/migrations/crypto_store/018_add_gossip_request_info.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "key_requests"
+    ADD COLUMN "info" BLOB;
+
+CREATE UNIQUE INDEX "key_request_info_idx"
+    ON "key_requests" ("info");

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -996,12 +996,13 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
             .optional()?)
     }
 
-    async fn get_outgoing_secret_requests(&self) -> Result<Vec<(Vec<u8>, bool)>> {
+    async fn get_secret_request_by_info(&self, info: Key) -> Result<Option<(Vec<u8>, bool)>> {
         Ok(self
-            .prepare("SELECT data, sent_out FROM key_requests", |mut stmt| {
-                stmt.query(())?.mapped(|row| Ok((row.get(0)?, row.get(1)?))).collect()
+            .query_row("SELECT data, sent_out FROM key_requests WHERE info = ?", (info,), |row| {
+                Ok((row.get(0)?, row.get(1)?))
             })
-            .await?)
+            .await
+            .optional()?)
     }
 
     async fn get_unsent_secret_requests(&self) -> Result<Vec<Vec<u8>>> {
@@ -1653,14 +1654,14 @@ impl CryptoStore for SqliteCryptoStore {
         &self,
         key_info: &SecretInfo,
     ) -> Result<Option<GossipRequest>> {
-        let requests = self.read().await?.get_outgoing_secret_requests().await?;
-        for (request, sent_out) in requests {
-            let request = self.deserialize_key_request(&request, sent_out)?;
-            if request.info == *key_info {
-                return Ok(Some(request));
-            }
-        }
-        Ok(None)
+        let key_info = self.encode_key("key_requests", key_info.as_key());
+        Ok(self
+            .read()
+            .await?
+            .get_secret_request_by_info(key_info)
+            .await?
+            .map(|(value, sent_out)| self.deserialize_key_request(&value, sent_out))
+            .transpose()?)
     }
 
     async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>> {

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -2306,8 +2306,8 @@ mod tests {
 
     /// Test that we migrate the secrets inbox properly.
     ///
-    /// The format for the secrets inbox changed in version 15.  Previously, the
-    /// secrets inbox stored a full `GossippedSecrets` struct.  In version 15,
+    /// The format for the secrets inbox changed in version 17.  Previously, the
+    /// secrets inbox stored a full `GossippedSecrets` struct.  In version 17,
     /// the secrets inbox now stores only the secret.
     #[async_test]
     async fn test_secrets_inbox_migration() {
@@ -2383,6 +2383,151 @@ mod tests {
             store.get_secrets_from_inbox(&SecretName::CrossSigningMasterKey).await.unwrap();
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].deref(), "It is a secret to everybody");
+    }
+
+    /// Test that we migrate the key requests table properly.
+    ///
+    /// Version 18 added a new column, with a unique index on the column,
+    /// meaning that it can now only store one request per requested secret/key.
+    /// Test that when we migrate from an older version that has multiple
+    /// requests for the same secret, it only keeps one.
+    #[async_test]
+    async fn test_key_requests_migration() {
+        use matrix_sdk_crypto::{GossipRequest, SecretInfo};
+        use ruma::{TransactionId, events::secret::request::SecretName, owned_user_id};
+
+        use crate::utils::{EncryptableStore, SqliteAsyncConnExt};
+
+        // Create a database with version 16
+        let tmpdir = tempdir().unwrap();
+        let config = SqliteStoreConfig::new(tmpdir.path());
+        let pool = config.build_pool_of_connections(super::DATABASE_NAME).unwrap();
+        let conn = pool.get().await.unwrap();
+        let version = super::initialize_store(&conn, 0).await.unwrap();
+        let old_data_store = SqliteCryptoStore::create_raw(
+            config.secret.clone(),
+            pool,
+            conn,
+            config.pool_config(),
+            config.runtime_config(),
+        )
+        .await
+        .unwrap();
+        super::run_migrations(&old_data_store, version, Some(16)).await.unwrap();
+        old_data_store.write().await.unwrap().wal_checkpoint().await;
+
+        // Store a secret using the old format
+        let recovery_request1 = GossipRequest {
+            request_recipient: owned_user_id!("@alice:example.com"),
+            request_id: TransactionId::new(),
+            info: SecretInfo::SecretRequest(SecretName::RecoveryKey),
+            sent_out: true,
+        };
+        let serialized_recovery_request1 =
+            old_data_store.serialize_value(&recovery_request1).unwrap();
+        let recovery_request2 = GossipRequest {
+            request_recipient: owned_user_id!("@alice:example.com"),
+            request_id: TransactionId::new(),
+            info: SecretInfo::SecretRequest(SecretName::RecoveryKey),
+            sent_out: true,
+        };
+        let serialized_recovery_request2 =
+            old_data_store.serialize_value(&recovery_request2).unwrap();
+        let msk_request = GossipRequest {
+            request_recipient: owned_user_id!("@alice:example.com"),
+            request_id: TransactionId::new(),
+            info: SecretInfo::SecretRequest(SecretName::CrossSigningMasterKey),
+            sent_out: true,
+        };
+        let serialized_msk_request = old_data_store.serialize_value(&msk_request).unwrap();
+        let recovery_request1_clone = recovery_request1.clone();
+        let recovery_request2_clone = recovery_request2.clone();
+        let msk_request_clone = msk_request.clone();
+        old_data_store
+            .write()
+            .await
+            .unwrap()
+            .prepare(
+                "INSERT INTO key_requests (request_id, sent_out, data) VALUES (?1, ?2, ?3)",
+                move |mut stmt| {
+                    stmt.execute((
+                        old_data_store.encode_key(
+                            "key_requests",
+                            recovery_request1_clone.request_id.as_bytes(),
+                        ),
+                        recovery_request1_clone.sent_out,
+                        serialized_recovery_request1,
+                    ))?;
+                    stmt.execute((
+                        old_data_store.encode_key(
+                            "key_requests",
+                            recovery_request2_clone.request_id.as_bytes(),
+                        ),
+                        recovery_request2_clone.sent_out,
+                        serialized_recovery_request2,
+                    ))?;
+                    stmt.execute((
+                        old_data_store
+                            .encode_key("key_requests", msk_request_clone.request_id.as_bytes()),
+                        msk_request_clone.sent_out,
+                        serialized_msk_request,
+                    ))
+                },
+            )
+            .await
+            .unwrap();
+
+        // After we open the store, the data will be migrated
+        let store = SqliteCryptoStore::open_with_config(&config).await.unwrap();
+
+        // and we should be able to read one request for the recovery key and
+        // one request for the MSK
+        if let Some(GossipRequest {
+            request_id,
+            info: SecretInfo::SecretRequest(SecretName::RecoveryKey),
+            ..
+        }) = store
+            .get_secret_request_by_info(&SecretInfo::SecretRequest(SecretName::RecoveryKey))
+            .await
+            .unwrap()
+        {
+            if request_id == recovery_request1.request_id {
+                assert!(
+                    store
+                        .get_outgoing_secret_requests(&recovery_request2.request_id)
+                        .await
+                        .unwrap()
+                        .is_none()
+                );
+            } else if request_id == recovery_request2.request_id {
+                assert!(
+                    store
+                        .get_outgoing_secret_requests(&recovery_request1.request_id)
+                        .await
+                        .unwrap()
+                        .is_none()
+                );
+            } else {
+                panic!("unexpected record found");
+            }
+        } else {
+            panic!("expected to get a secret request");
+        }
+        if let Some(GossipRequest {
+            request_id,
+            info: SecretInfo::SecretRequest(SecretName::CrossSigningMasterKey),
+            ..
+        }) = store
+            .get_secret_request_by_info(&SecretInfo::SecretRequest(
+                SecretName::CrossSigningMasterKey,
+            ))
+            .await
+            .unwrap()
+        {
+            assert_eq!(request_id, msk_request.request_id);
+        } else {
+            panic!("expected to get a secret request");
+        }
     }
 
     async fn get_store(

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -467,6 +467,7 @@ pub(crate) async fn run_migrations(
     }
 
     if version < 17 {
+        debug!("Upgrading database to version 17");
         let store = store.clone();
         conn.with_transaction(move |txn| {
             txn.execute_batch(include_str!(
@@ -496,6 +497,33 @@ pub(crate) async fn run_migrations(
                 "../migrations/crypto_store/017_drop_old_secrets_inbox.sql"
             ))?;
             txn.set_db_version(17)
+        })
+        .await?;
+    }
+
+    if version < 18 {
+        debug!("Upgrading database to version 18");
+        let store = store.clone();
+        conn.with_transaction(move |txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/crypto_store/018_add_gossip_request_info.sql"
+            ))?;
+            let mut select_query =
+                txn.prepare("SELECT request_id, sent_out, data FROM key_requests")?;
+            let mut requests = select_query.query([])?;
+            let mut update_query =
+                txn.prepare("UPDATE OR REPLACE key_requests SET info = ?1 WHERE request_id = ?2")?;
+            while let Some(row) = requests.next()? {
+                let Ok(request) = store.deserialize_key_request(
+                    row.get::<_, Vec<u8>>(2)?.as_ref(),
+                    row.get::<_, bool>(1)?,
+                ) else {
+                    continue;
+                };
+                let info = store.encode_key("key_requests", request.info.as_key());
+                update_query.execute((info, row.get::<_, Vec<u8>>(0)?))?;
+            }
+            txn.set_db_version(18)
         })
         .await?;
     }
@@ -535,6 +563,7 @@ trait SqliteConnectionExt {
         request_id: &[u8],
         sent_out: bool,
         data: &[u8],
+        info: &[u8],
     ) -> rusqlite::Result<()>;
 
     fn set_direct_withheld(
@@ -646,12 +675,17 @@ impl SqliteConnectionExt for rusqlite::Connection {
         request_id: &[u8],
         sent_out: bool,
         data: &[u8],
+        info: &[u8],
     ) -> rusqlite::Result<()> {
+        // The first `ON CONFLICT` cause will update a request if we try to save
+        // it again.  The second `ON CONFLICT` will replace an old request for
+        // the same key/secret with the new request.
         self.execute(
-            "INSERT INTO key_requests (request_id, sent_out, data)
-            VALUES (?1, ?2, ?3)
-            ON CONFLICT (request_id) DO UPDATE SET sent_out = ?2, data = ?3",
-            (request_id, sent_out, data),
+            "INSERT INTO key_requests (request_id, sent_out, data, info)
+            VALUES (?1, ?2, ?3, ?4)
+            ON CONFLICT (request_id) DO UPDATE SET sent_out = ?2, data = ?3, info = ?4
+            ON CONFLICT (info) DO UPDATE SET request_id = ?1, sent_out = ?2, data = ?3",
+            (request_id, sent_out, data, info),
         )?;
         Ok(())
     }
@@ -1248,7 +1282,13 @@ impl CryptoStore for SqliteCryptoStore {
                 for request in changes.key_requests {
                     let request_id = this.encode_key("key_requests", request.request_id.as_bytes());
                     let serialized_request = this.serialize_value(&request)?;
-                    txn.set_key_request(&request_id, request.sent_out, &serialized_request)?;
+                    let serialized_info = this.encode_key("key_requests", request.info.as_key());
+                    txn.set_key_request(
+                        &request_id,
+                        request.sent_out,
+                        &serialized_request,
+                        &serialized_info,
+                    )?;
                 }
 
                 for (room_id, data) in changes.withheld_session_info {


### PR DESCRIPTION
If we make a new gossip request for a secret, and already have an outstanding request for that secret, replace the existing gossip request in the store with the new request.

Fixes https://github.com/element-hq/element-web/issues/33066

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
