### PR TITLE
MSC4287: remove unstable prefix m.org.matrix.custom.backup_disabled

### DIFF
--- a/crates/matrix-sdk/src/encryption/recovery/types.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/types.rs
@@ -116,12 +116,3 @@ pub(super) struct SecretStorageDisabledContent {}
 pub(super) struct KeyBackupContent {
     pub enabled: bool,
 }
-
-/// Unstable prefix form of [MSC4287].
-///
-/// [MSC4287]: https://github.com/matrix-org/matrix-spec-proposals/pull/4287
-#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
-#[ruma_event(type = "m.org.matrix.custom.backup_disabled", kind = GlobalAccountData)]
-pub(super) struct BackupDisabledContent {
-    pub disabled: bool,
-}

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -248,26 +248,6 @@ async fn enable(
 
     let backup_disabled_content = Arc::new(Mutex::new(None));
 
-    let _quard = Mock::given(method("PUT"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .and({
-            let backup_disabled_content = backup_disabled_content.clone();
-            move |request: &wiremock::Request| {
-                let content: Value = request.body_json().expect("The body should be a JSON body");
-
-                *backup_disabled_content.lock().unwrap() = Some(content);
-
-                true
-            }
-        })
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .expect(1)
-        .mount_as_scoped(server)
-        .await;
-
     let _guard = Mock::given(method("GET"))
         .and(path("_matrix/client/r0/room_keys/version"))
         .and(header("authorization", "Bearer 1234"))
@@ -533,28 +513,6 @@ async fn test_backups_enabling() {
         .mount(&server)
         .await;
 
-    Mock::given(method("PUT"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .and(|request: &wiremock::Request| {
-            #[derive(Deserialize)]
-            struct Disabled {
-                disabled: bool,
-            }
-
-            let content: Disabled = request.body_json().expect("The body should be a JSON body");
-
-            assert!(!content.disabled, "The backup support should be marked as enabled.");
-
-            true
-        })
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .expect(1)
-        .mount(&server)
-        .await;
-
     Mock::given(method("POST"))
         .and(path("_matrix/client/unstable/room_keys/version"))
         .and(header("authorization", "Bearer 1234"))
@@ -664,28 +622,6 @@ async fn test_recovery_disabling() {
             let content: Enabled = request.body_json().expect("The body should be a JSON body");
 
             assert!(!content.enabled, "The backup support should be marked as disabled.");
-
-            true
-        })
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    Mock::given(method("PUT"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .and(|request: &wiremock::Request| {
-            #[derive(Deserialize)]
-            struct Disabled {
-                disabled: bool,
-            }
-
-            let content: Disabled = request.body_json().expect("The body should be a JSON body");
-
-            assert!(content.disabled, "The backup support should be marked as disabled.");
 
             true
         })
@@ -973,17 +909,6 @@ async fn test_reset_identity() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)
         .named("m.key_backup PUT")
-        .mount(&server)
-        .await;
-
-    Mock::given(method("PUT"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .expect(1)
-        .named("m.org.matrix.custom.backup_disabled PUT")
         .mount(&server)
         .await;
 


### PR DESCRIPTION
On hold for now: https://github.com/matrix-org/matrix-rust-sdk/pull/6410 was merged on 2026-04-21 and we need to wait long enough for clients to write the value to the stable prefix `m.key_backup` before we turn off support for the unstable prefix.

Related:

* https://github.com/element-hq/element-web/pull/33695
* https://github.com/matrix-org/matrix-js-sdk/pull/5351

MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/4287

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- This PR was NOT made with any AI.