### PR TITLE
chore(sdk): Replace `async_once_cell` by `tokio::sync::OnceCell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,12 +262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
 name = "async-rx"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,7 +3315,6 @@ dependencies = [
  "assert_matches",
  "assert_matches2",
  "async-channel",
- "async-once-cell",
  "async-stream",
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ assert_matches = { version = "1.5.0", default-features = false }
 assert_matches2 = { version = "0.1.2", default-features = false }
 async_cell = { version = "0.2.3", default-features = false }
 async-compat = { version = "0.2.5", default-features = false }
-async-once-cell = { version = "0.5.4", default-features = false }
 async-rx = { version = "0.2.0", default-features = false }
 # Bumping this to 0.3.6 produces a test failure because the semantic between the
 # versions changed subtly: https://github.com/matrix-org/matrix-rust-sdk/issues/4599

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -100,7 +100,6 @@ assert_matches2 = { workspace = true, optional = true }
 async-channel = "2.5.0"
 async-stream.workspace = true
 async-trait.workspace = true
-async-once-cell.workspace = true
 axum = { version = "0.8.4", optional = true }
 bytes = { version = "1.11.1", default-features = false, features = ["std"] }
 bytesize = { version = "2.3.0", default-features = false, features = ["std"] }

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -14,10 +14,9 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use async_once_cell::OnceCell;
 use matrix_sdk_base::RoomInfoNotableUpdateReasons;
 use ruma::{EventId, OwnedEventId};
-use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
+use tokio::sync::{OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 use tracing::error;
 
 use super::{
@@ -169,7 +168,7 @@ impl RoomLatestEventsWriteGuard {
         // Lazy-load the `RoomEventCache`.
         let room_event_cache = match inner
             .room_event_cache
-            .get_or_try_init(async {
+            .get_or_try_init(|| async {
                 // It's fine to drop the `EventCacheDropHandles` here as the caller
                 // (`LatestEventState`) owns a clone of the `EventCache`.
                 let (room_event_cache, _drop_handles) =
@@ -219,7 +218,7 @@ impl RoomLatestEventsWriteGuard {
         // Lazy-load the `RoomEventCache`.
         let room_event_cache = match inner
             .room_event_cache
-            .get_or_try_init(async {
+            .get_or_try_init(|| async {
                 // It's fine to drop the `EventCacheDropHandles` here as the caller
                 // (`LatestEventState`) owns a clone of the `EventCache`.
                 let (room_event_cache, _drop_handles) =


### PR DESCRIPTION
This patch removes the `async_once_cell` dependency, and replaces it by `tokio::sync::OnceCell`.

---

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
