### PR TITLE
feat(ui): Allow specifying membership states for `TimelineEventFilter`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/configuration.rs
@@ -16,7 +16,10 @@ use std::sync::Arc;
 
 use matrix_sdk_ui::timeline::{
     TimelineEventFocusThreadMode, TimelineReadReceiptTracking,
-    event_filter::{TimelineEventCondition, TimelineEventFilter as InnerTimelineEventFilter},
+    event_filter::{
+        MembershipChangeFilter, TimelineEventCondition,
+        TimelineEventFilter as InnerTimelineEventFilter,
+    },
 };
 use ruma::{
     EventId,
@@ -104,7 +107,7 @@ pub enum FilterTimelineEventCondition {
     EventType { event_type: FilterTimelineEventType },
     /// The event is an `m.room.member` event that represents a membership
     /// change (join, leave, etc.).
-    MembershipChange,
+    MembershipChange { filter: MembershipChangeFilter },
     /// The event is an `m.room.member` event that represents a profile
     /// change (displayname or avatar URL).
     ProfileChange,
@@ -116,7 +119,9 @@ impl From<FilterTimelineEventCondition> for TimelineEventCondition {
             FilterTimelineEventCondition::EventType { event_type } => {
                 Self::EventType(event_type.into())
             }
-            FilterTimelineEventCondition::MembershipChange => Self::MembershipChange,
+            FilterTimelineEventCondition::MembershipChange { filter } => {
+                Self::MembershipChange(filter)
+            }
             FilterTimelineEventCondition::ProfileChange => Self::ProfileChange,
         }
     }

--- a/crates/matrix-sdk-ui/changelog.d/6644.feature
+++ b/crates/matrix-sdk-ui/changelog.d/6644.feature
@@ -1,0 +1,1 @@
+[**breaking**] Allow specifying membership states for `TimelineEventCondition::MembershipChange`, with a new `MembershipChangeFilter` enum.

--- a/crates/matrix-sdk-ui/src/timeline/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_filter.rs
@@ -14,7 +14,7 @@
 
 use ruma::events::{
     AnySyncStateEvent, AnySyncTimelineEvent, SyncStateEvent, TimelineEventType,
-    room::member::MembershipChange,
+    room::member::{MembershipChange, MembershipState},
 };
 
 /// A timeline filter that in- or excludes events based on their type or
@@ -51,10 +51,29 @@ pub enum TimelineEventCondition {
     EventType(TimelineEventType),
     /// The event is an `m.room.member` event that represents a membership
     /// change (join, leave, etc.).
-    MembershipChange,
+    MembershipChange(MembershipChangeFilter),
     /// The event is an `m.room.member` event that represents a profile
     /// change (displayname or avatar URL).
     ProfileChange,
+}
+
+/// The membership states that should be included/excluded from the timeline
+/// item filters.
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+#[derive(Clone)]
+pub enum MembershipChangeFilter {
+    /// Include/exclude all membership state events.
+    Any,
+    /// Include/exclude only `join` membership state events.
+    Join,
+    /// Include/exclude only `leave` membership state events.
+    Leave,
+    /// Include/exclude only `invite` membership state events.
+    Invite,
+    /// Include/exclude only `ban` membership state events.
+    Ban,
+    /// Include/exclude only `knock` membership state events.
+    Knock,
 }
 
 impl TimelineEventCondition {
@@ -69,10 +88,25 @@ impl TimelineEventCondition {
     fn matches(&self, event: &AnySyncTimelineEvent) -> bool {
         match self {
             Self::EventType(event_type) => event.event_type() == *event_type,
-            Self::MembershipChange => match event {
+            Self::MembershipChange(filter) => match event {
                 AnySyncTimelineEvent::State(AnySyncStateEvent::RoomMember(
                     SyncStateEvent::Original(ev),
-                )) => !matches!(ev.membership_change(), MembershipChange::ProfileChanged { .. }),
+                )) => {
+                    if matches!(ev.membership_change(), MembershipChange::ProfileChanged { .. }) {
+                        return false;
+                    }
+                    match (filter, &ev.content.membership) {
+                        (MembershipChangeFilter::Any, _) => {
+                            !matches!(ev.membership_change(), MembershipChange::None)
+                        }
+                        (MembershipChangeFilter::Join, MembershipState::Join) => true,
+                        (MembershipChangeFilter::Invite, MembershipState::Invite) => true,
+                        (MembershipChangeFilter::Leave, MembershipState::Leave) => true,
+                        (MembershipChangeFilter::Knock, MembershipState::Knock) => true,
+                        (MembershipChangeFilter::Ban, MembershipState::Ban) => true,
+                        _ => false,
+                    }
+                }
                 _ => false,
             },
             Self::ProfileChange => match event {

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -35,7 +35,7 @@ use super::TestTimeline;
 use crate::timeline::{
     AnyOtherStateEventContentChange, MsgLikeContent, MsgLikeKind, TimelineEventCondition,
     TimelineEventFilter, TimelineItem, TimelineItemContent, TimelineItemKind,
-    controller::TimelineSettings, tests::TestTimelineBuilder,
+    controller::TimelineSettings, event_filter::MembershipChangeFilter, tests::TestTimelineBuilder,
 };
 
 #[async_test]
@@ -271,7 +271,10 @@ async fn test_event_filter_exclude_messages() {
 #[async_test]
 async fn test_event_filter_include_only_membership_changes() {
     // Only return room name events
-    let event_filter = TimelineEventFilter::Include(vec![TimelineEventCondition::MembershipChange]);
+    let event_filter =
+        TimelineEventFilter::Include(vec![TimelineEventCondition::MembershipChange(
+            MembershipChangeFilter::Any,
+        )]);
 
     let timeline = TestTimelineBuilder::new()
         .settings(TimelineSettings {
@@ -377,7 +380,7 @@ async fn test_event_filter_include_only_messages_and_membership_changes() {
     // Only return room name events
     let event_filter = TimelineEventFilter::Include(vec![
         TimelineEventCondition::EventType(TimelineEventType::RoomMessage),
-        TimelineEventCondition::MembershipChange,
+        TimelineEventCondition::MembershipChange(MembershipChangeFilter::Any),
     ]);
 
     let timeline = TestTimelineBuilder::new()
@@ -430,7 +433,10 @@ async fn test_event_filter_include_only_messages_and_membership_changes() {
 #[async_test]
 async fn test_event_filter_exclude_membership_changes() {
     // Only return room name events
-    let event_filter = TimelineEventFilter::Exclude(vec![TimelineEventCondition::MembershipChange]);
+    let event_filter =
+        TimelineEventFilter::Exclude(vec![TimelineEventCondition::MembershipChange(
+            MembershipChangeFilter::Any,
+        )]);
 
     let timeline = TestTimelineBuilder::new()
         .settings(TimelineSettings {
@@ -537,7 +543,7 @@ async fn test_event_filter_exclude_messages_and_membership_changes() {
     // Only return room name events
     let event_filter = TimelineEventFilter::Exclude(vec![
         TimelineEventCondition::EventType(TimelineEventType::RoomMessage),
-        TimelineEventCondition::MembershipChange,
+        TimelineEventCondition::MembershipChange(MembershipChangeFilter::Any),
     ]);
 
     let timeline = TestTimelineBuilder::new()
@@ -585,6 +591,62 @@ async fn test_event_filter_exclude_messages_and_membership_changes() {
     assert_eq!(num_room_name_items, 1);
     assert_eq!(num_room_topic_items, 1);
     assert_eq!(num_membership_change_items, 0);
+    assert_eq!(num_profile_change_items, 2);
+}
+
+#[async_test]
+async fn test_event_filter_can_exclude_only_join_and_leave_membership_changes() {
+    let event_filter = TimelineEventFilter::Exclude(vec![
+        TimelineEventCondition::MembershipChange(MembershipChangeFilter::Join),
+        TimelineEventCondition::MembershipChange(MembershipChangeFilter::Leave),
+    ]);
+
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(move |event, _| event_filter.filter(event)),
+            ..Default::default()
+        })
+        .build();
+    let f = &timeline.factory;
+
+    // Add Alice's join event
+    timeline.handle_live_event(f.member(&ALICE).membership(MembershipState::Join)).await;
+    // Alice changes her avatar
+    timeline
+        .handle_live_event(
+            f.member(&ALICE)
+                .avatar_url(mxc_uri!("mxc://example.org/SEsfnsuifSDFSSEF"))
+                .previous(MembershipState::Join),
+        )
+        .await;
+    // Alice sends a message and changes the room name and topic
+    timeline.handle_live_event(f.text_msg("The first message").sender(&ALICE)).await;
+    timeline.handle_live_event(f.room_name("A new room name").sender(&ALICE)).await;
+    timeline.handle_live_event(f.room_topic("A new room topic").sender(&ALICE)).await;
+    // Alice invites Bob and Bob changes his display name and leaves
+    timeline.handle_live_event(f.member(&ALICE).invited(&BOB)).await;
+    timeline
+        .handle_live_event(
+            f.member(&BOB).display_name("Big Bob 99").previous(MembershipState::Join),
+        )
+        .await;
+    timeline.handle_live_event(f.member(&BOB).leave().previous(MembershipState::Invite)).await;
+
+    // The timeline should contain everything except for the message, invite and
+    // join events
+    let event_items: Vec<Arc<TimelineItem>> = timeline.get_event_items().await;
+    let num_text_message_items = event_items.iter().filter(is_text_message_item).count();
+    let num_room_name_items = event_items.iter().filter(is_room_name_item).count();
+    let num_room_topic_items = event_items.iter().filter(is_room_topic_item).count();
+    let num_membership_change_items = event_items.iter().filter(is_membership_change_item).count();
+    let num_profile_change_items = event_items.iter().filter(is_profile_change_item).count();
+    // 2 profile changes + 1 text message + 1 room name + 1 room topic + 1 invited
+    // membership change
+    assert_eq!(event_items.len(), 6);
+    assert_eq!(num_text_message_items, 1);
+    assert_eq!(num_room_name_items, 1);
+    assert_eq!(num_room_topic_items, 1);
+    assert_eq!(num_membership_change_items, 1);
     assert_eq!(num_profile_change_items, 2);
 }
 


### PR DESCRIPTION
This allows us to only include/exclude certain mebership changes.

cc @pixlwave .

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
