### PR TITLE
change: Remove `WebPkiServerVerifier` and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,8 +3357,6 @@ dependencies = [
  "rand 0.10.1",
  "reqwest",
  "ruma",
- "rustls",
- "rustls-native-certs",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -5342,7 +5340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,7 +3359,6 @@ dependencies = [
  "ruma",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -3382,7 +3381,6 @@ dependencies = [
  "uuid",
  "vodozemac",
  "wasm-bindgen-test",
- "webpki-roots",
  "wiremock",
  "zeroize",
 ]
@@ -7391,15 +7389,6 @@ name = "webpki-root-certs"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/bindings/matrix-sdk-ffi/changelog.d/6645.removed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6645.removed.md
@@ -1,0 +1,13 @@
+Removed a special case for Android bindings which used `WebPkiServerVerifier` for compatibility.
+
+Note this means on Android, you:
+
+1. Won't need to use `ClientBuilder.addRootCertificates` since user certificates will be checked by default.
+2. Will need to add some CLRs to `network_security_config`, like:
+
+```xml
+<domain-config cleartextTrafficPermitted="true">
+    <!-- Let's Encrypt disabled OCSP for certificate revocation and switched to CRL, which needs clear-text access. -->
+    <domain includeSubdomains="true">lencr.org</domain>
+</domain-config>
+```

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -19,7 +19,7 @@
 use std::{fs, path::PathBuf};
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-#[cfg(not(any(target_family = "wasm", target_os = "android")))]
+#[cfg(not(any(target_family = "wasm")))]
 use matrix_sdk::reqwest::Certificate;
 #[cfg(feature = "experimental-search")]
 use matrix_sdk::search_index::SearchIndexStoreKind;
@@ -446,34 +446,26 @@ impl ClientBuilder {
 
         #[cfg(not(target_family = "wasm"))]
         {
-            #[cfg(target_os = "android")]
-            {
-                inner_builder =
-                    inner_builder.add_raw_root_certificates(builder.additional_root_certificates)
-            }
-            #[cfg(not(target_os = "android"))]
-            {
-                let mut certificates = Vec::new();
-                for certificate in builder.additional_root_certificates {
-                    // We don't really know what type of certificate we may get here, so let's try
-                    // first one type, then the other.
-                    match Certificate::from_der(&certificate) {
-                        Ok(cert) => {
-                            certificates.push(cert);
-                        }
-                        Err(der_error) => {
-                            let cert = Certificate::from_pem(&certificate).map_err(|pem_error| {
-                                ClientBuildError::Generic {
-                                    message: format!("Failed to add a root certificate as DER ({der_error:?}) or PEM ({pem_error:?})"),
-                                }
-                            })?;
-                            certificates.push(cert);
-                        }
+            let mut certificates = Vec::new();
+            for certificate in builder.additional_root_certificates {
+                // We don't really know what type of certificate we may get here, so let's try
+                // first one type, then the other.
+                match Certificate::from_der(&certificate) {
+                    Ok(cert) => {
+                        certificates.push(cert);
+                    }
+                    Err(der_error) => {
+                        let cert = Certificate::from_pem(&certificate).map_err(|pem_error| {
+                            ClientBuildError::Generic {
+                                message: format!("Failed to add a root certificate as DER ({der_error:?}) or PEM ({pem_error:?})"),
+                            }
+                        })?;
+                        certificates.push(cert);
                     }
                 }
-
-                inner_builder = inner_builder.add_root_certificates(certificates);
             }
+
+            inner_builder = inner_builder.add_root_certificates(certificates);
 
             if builder.disable_built_in_root_certificates {
                 inner_builder = inner_builder.disable_built_in_root_certificates();

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -196,9 +196,7 @@ wasm-bindgen-test.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 rustls = "0.23.38"
-rustls-pki-types = "1.14.0"
 rustls-native-certs = "0.8.3"
-webpki-roots = "1.0.6"
 
 [[test]]
 name = "integration"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -194,10 +194,6 @@ wiremock.workspace = true
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
 
-[target.'cfg(target_os = "android")'.dependencies]
-rustls = "0.23.38"
-rustls-native-certs = "0.8.3"
-
 [[test]]
 name = "integration"
 required-features = ["testing"]

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -394,16 +394,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Add the given list of certificates in a raw byte format to the
-    /// certificate store of the HTTP client.
-    ///
-    /// Not this will only be used in Android for the webkpi workaround.
-    #[cfg(target_os = "android")]
-    pub fn add_raw_root_certificates(mut self, raw_certificates: Vec<Vec<u8>>) -> Self {
-        self.http_settings().additional_raw_root_certificates = raw_certificates;
-        self
-    }
-
     /// Don't trust any system root certificates, only trust the certificates
     /// provided through
     /// [`add_root_certificates`][ClientBuilder::add_root_certificates].

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -39,8 +39,6 @@ use ruma::{
     events::{room::power_levels::PowerLevelsError, tag::InvalidUserTagName},
     push::{InsertPushRuleError, RemovePushRuleError},
 };
-#[cfg(target_os = "android")]
-use rustls::client::VerifierBuilderError;
 use serde_json::Error as JsonError;
 use thiserror::Error;
 use url::ParseError as UrlParseError;
@@ -89,11 +87,6 @@ pub enum HttpError {
     /// [`HttpError`] into an [`Arc`] to be able to clone it.
     #[error(transparent)]
     Cached(Arc<HttpError>),
-
-    /// Error creating the TLS verifier.
-    #[cfg(target_os = "android")]
-    #[error(transparent)]
-    VerifierBuilder(#[from] VerifierBuilderError),
 }
 
 #[rustfmt::skip] // stop rustfmt breaking the `<code>` in docs across multiple lines

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(target_os = "android")]
-use std::sync::Arc;
 use std::{
     fmt::Debug,
     mem,
@@ -28,14 +26,8 @@ use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::Certificate;
-#[cfg(target_os = "android")]
-use reqwest::ClientBuilder;
 use reqwest::tls;
 use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
-#[cfg(target_os = "android")]
-use rustls::{RootCertStore, client::WebPkiServerVerifier};
-#[cfg(target_os = "android")]
-use rustls_pki_types::CertificateDer;
 use tracing::{debug, info, warn};
 
 use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
@@ -159,8 +151,6 @@ pub(crate) struct HttpSettings {
     pub(crate) timeout: Option<Duration>,
     pub(crate) read_timeout: Option<Duration>,
     pub(crate) additional_root_certificates: Vec<Certificate>,
-    #[cfg(target_os = "android")]
-    pub(crate) additional_raw_root_certificates: Vec<Vec<u8>>,
     pub(crate) disable_built_in_root_certificates: bool,
 }
 
@@ -174,8 +164,6 @@ impl Default for HttpSettings {
             timeout: Some(DEFAULT_REQUEST_TIMEOUT),
             read_timeout: None,
             additional_root_certificates: Default::default(),
-            #[cfg(target_os = "android")]
-            additional_raw_root_certificates: Default::default(),
             disable_built_in_root_certificates: false,
         }
     }
@@ -200,15 +188,6 @@ impl HttpSettings {
             http_client = http_client.read_timeout(read_timeout);
         }
 
-        // On Android there is a problem that causes some certificates to be incorrectly
-        // marked as revoked, so we build our own rustls instance with the right
-        // configuration.
-        // Remove when https://github.com/rustls/rustls-platform-verifier/issues/221 is fixed.
-        #[cfg(target_os = "android")]
-        {
-            http_client = self.android_setup_webkpi_verifier(http_client)?;
-        }
-
         if self.disable_ssl_verification {
             warn!("SSL verification disabled in the HTTP client!");
             http_client = http_client.danger_accept_invalid_certs(true);
@@ -227,53 +206,6 @@ impl HttpSettings {
         }
 
         Ok(http_client.build()?)
-    }
-
-    #[cfg(target_os = "android")]
-    fn android_setup_webkpi_verifier(
-        &self,
-        client_builder: ClientBuilder,
-    ) -> Result<ClientBuilder, HttpError> {
-        if !self.disable_ssl_verification {
-            let mut root_store = RootCertStore::empty();
-
-            if self.disable_built_in_root_certificates {
-                info!("Built-in root certificates disabled in the HTTP client.");
-            } else {
-                // This seems to fix the 'revoked certificate' false positives issue
-                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-                // Also load the native certs
-                let native_certs = rustls_native_certs::load_native_certs().certs;
-                root_store.add_parsable_certificates(native_certs);
-            }
-
-            if !self.additional_raw_root_certificates.is_empty() {
-                let mut additional_certs = Vec::new();
-
-                warn!(
-                    "Adding {} extra user certificates",
-                    self.additional_raw_root_certificates.len()
-                );
-
-                for certificate in self.additional_raw_root_certificates.iter() {
-                    additional_certs.push(CertificateDer::from_slice(certificate));
-                }
-
-                root_store.add_parsable_certificates(additional_certs);
-            }
-
-            let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
-                .build()
-                .map_err(HttpError::VerifierBuilder)?;
-
-            let config = rustls::ClientConfig::builder()
-                .with_webpki_verifier(verifier)
-                .with_no_client_auth();
-            Ok(client_builder.tls_backend_preconfigured(config))
-        } else {
-            Ok(client_builder)
-        }
     }
 }
 


### PR DESCRIPTION
We had these to not use the platform verifier on Android because there were some issues. We might have found a valid workaround by manually adding CLR entries as HTTP access exceptions for those that don't have an OCSP fallback (which Android will use by default). This is mainly Let's Encrypt.

This simplifies the http client setup quite a bit, it's the mentioned workaround for https://github.com/matrix-org/matrix-rust-sdk/issues/6319

Reverts https://github.com/matrix-org/matrix-rust-sdk/pull/6323 and https://github.com/matrix-org/matrix-rust-sdk/pull/6328.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
