### PR TITLE
fix(sqlite): Use single-quote for string literal instead of double-quote

### DIFF
--- a/crates/matrix-sdk-sqlite/changelog.d/6653.fixed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/6653.fixed.md
@@ -1,0 +1,8 @@
+Double-quotes are for SQL identifiers, while single-quotes are for string
+literals. SQLite however accepts both quotes for string literals, depending on
+some configuration. See the
+[_Double-quoted String Literals Are Accepted_ Section of the SQLite documentation][sqlite-quirks-string-literals].
+This patch fixes a bug where double-quotes were used for a string literal in a
+migration file for the crypto store.
+
+[sqlite-quirks-string-literals]: https://sqlite.org/quirks.html#double_quoted_string_literals_are_ accepted

--- a/crates/matrix-sdk-sqlite/migrations/NOTES.md
+++ b/crates/matrix-sdk-sqlite/migrations/NOTES.md
@@ -1,0 +1,29 @@
+# Notes about migration scripts
+
+This document aims at listing all errors we made in the past with the migration
+scripts, with the hope that future us won't replicate these errors.
+
+1. _Identifiers_ can be delimited by double-quotes, while _string literals_ must
+   be delimited by single-quotes. Even if SQLite has a compile-time
+   configuration to consider double-quotes to be string literals delimiters,
+   this configuration can be disabled, and would create an error.
+
+   The following example is correct
+
+   ```sql
+   CREATE TABLE "foo";
+   SELECT id FROM foo WHERE id = 'hello';
+   ```
+
+   But the following example is incorrect:
+
+   ```sql
+   CREATE TABLE 'foo';
+   SELECT id FROM foo WHERE id = "hello";
+   ```
+
+   See
+   [the _Double-quoted String Literals Are Accepted_ Section][quirks-double-quoted-string-literals]
+   in the SQLite documentation to learn more.
+
+[quirks-double-quoted-string-literals]: https://sqlite.org/quirks.html#double_quoted_string_literals_are_accepted

--- a/crates/matrix-sdk-sqlite/migrations/crypto_store/016_remove_old_generation_counter.sql
+++ b/crates/matrix-sdk-sqlite/migrations/crypto_store/016_remove_old_generation_counter.sql
@@ -1,3 +1,3 @@
 -- Remove generation counter tracking from the `kv` table, as this
 -- is tracked in the `lease_locks` table.
-DELETE FROM kv WHERE key = "generation-counter";
+DELETE FROM kv WHERE key = 'generation-counter';


### PR DESCRIPTION
Double-quotes are for SQL identifiers, while single-quotes are for string literals. This patch fixes a bug where double-quotes were used for a string literal.

Note: I've carefully reviewed all the other SQL files, and this is the only place where we have this problem.

---

- Fix #6647
- Bug introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/6326 

---

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
