### PR TITLE
test: add integration test for accepting and declining invites to an empty room

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -37,6 +37,52 @@ use tracing::{debug, error, warn};
 use crate::helpers::{TestClientBuilder, wait_for_room};
 
 #[tokio::test]
+async fn test_invite_decline_empty_room() -> Result<()> {
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
+
+    let b = bob.clone();
+    spawn(async move {
+        let bob = b;
+        loop {
+            if let Err(e) = bob.sync(Default::default()).await {
+                error!("bob sync error: {e}");
+            }
+        }
+    });
+
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+
+    let a = alice.clone();
+    spawn(async move {
+        let alice = a;
+        loop {
+            if let Err(e) = alice.sync(Default::default()).await {
+                error!("alice sync error: {e}");
+            }
+        }
+    });
+
+    let room_id = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned()],
+            is_direct: false,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    if let Some(room) = alice.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    if let Some(room) = bob.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_event_with_context() -> Result<()> {
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -37,6 +37,52 @@ use tracing::{debug, error, warn};
 use crate::helpers::{TestClientBuilder, wait_for_room};
 
 #[tokio::test]
+async fn test_invite_accept_empty_room() -> Result<()> {
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
+
+    let b = bob.clone();
+    spawn(async move {
+        let bob = b;
+        loop {
+            if let Err(e) = bob.sync(Default::default()).await {
+                error!("bob sync error: {e}");
+            }
+        }
+    });
+
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+
+    let a = alice.clone();
+    spawn(async move {
+        let alice = a;
+        loop {
+            if let Err(e) = alice.sync(Default::default()).await {
+                error!("alice sync error: {e}");
+            }
+        }
+    });
+
+    let room_id = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned()],
+            is_direct: false,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    if let Some(room) = alice.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    if let Some(room) = bob.get_room(&room_id) {
+        room.join().await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_invite_decline_empty_room() -> Result<()> {
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 


### PR DESCRIPTION
This PR is related to #4642. I have added two integration tests, according to which declining an invite worked just fine, while accepting did not (as expected).

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Paul8711 <154304377+Paulprojects8711@users.noreply.github.com>

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
