### PR TITLE
crypto: Move Signatures types to their own module

### DIFF
--- a/crates/matrix-sdk-crypto/changelog.d/6660.internal
+++ b/crates/matrix-sdk-crypto/changelog.d/6660.internal
@@ -1,0 +1,1 @@
+Move `types::Signature` and `types::Signatures` into submodules of `types`.

--- a/crates/matrix-sdk-crypto/src/types/backup.rs
+++ b/crates/matrix-sdk-crypto/src/types/backup.rs
@@ -122,7 +122,7 @@ mod tests {
     use vodozemac::{Curve25519PublicKey, Ed25519Signature};
 
     use super::RoomKeyBackupInfo;
-    use crate::types::{MegolmV1AuthData, Signature, Signatures};
+    use crate::types::{MegolmV1AuthData, Signatures};
 
     #[test]
     fn serialization() {
@@ -160,15 +160,16 @@ mod tests {
 
     #[test]
     fn snapshot_room_key_backup_info() {
+        let mut signatures = Signatures::new();
+        signatures.add_signature(
+            owned_user_id!("@alice:localhost"),
+            KeyId::from_parts(DeviceKeyAlgorithm::Ed25519, "ABCDEFG".into()),
+            Ed25519Signature::from_slice(&[0u8; 64]).unwrap(),
+        );
+
         let info = RoomKeyBackupInfo::MegolmBackupV1Curve25519AesSha2(MegolmV1AuthData {
             public_key: Curve25519PublicKey::from_bytes([2u8; 32]),
-            signatures: Signatures(BTreeMap::from([(
-                owned_user_id!("@alice:localhost"),
-                BTreeMap::from([(
-                    KeyId::from_parts(DeviceKeyAlgorithm::Ed25519, "ABCDEFG".into()),
-                    Ok(Signature::from(Ed25519Signature::from_slice(&[0u8; 64]).unwrap())),
-                )]),
-            )])),
+            signatures,
             extra: BTreeMap::from([("foo".to_owned(), Value::from("bar"))]),
         });
 

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -33,14 +33,13 @@ use std::{
     },
 };
 
-use as_variant::as_variant;
 use matrix_sdk_common::deserialized_responses::PrivOwnedStr;
 use ruma::{
     DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, RoomId, UserId,
     serde::StringEnum,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, KeyError};
+use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, KeyError};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 mod backup;
@@ -51,8 +50,9 @@ mod one_time_keys;
 pub mod qr_login;
 pub mod requests;
 pub mod room_history;
+mod signatures;
 
-pub use self::{backup::*, cross_signing::*, device_keys::*, one_time_keys::*};
+pub use self::{backup::*, cross_signing::*, device_keys::*, one_time_keys::*, signatures::*};
 use crate::store::types::BackupDecryptionKey;
 
 macro_rules! from_base64 {
@@ -161,25 +161,6 @@ impl BackupSecrets {
     }
 }
 
-/// Represents a potentially decoded signature (but *not* a validated one).
-///
-/// There are two important cases here:
-///
-/// 1. If the claimed algorithm is supported *and* the payload has an expected
-///    format, the signature will be represent by the enum variant corresponding
-///    to that algorithm. For example, decodable Ed25519 signatures are
-///    represented as `Ed25519(...)`.
-/// 2. If the claimed algorithm is unsupported, the signature is represented as
-///    `Other(...)`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Signature {
-    /// A Ed25519 digital signature.
-    Ed25519(Ed25519Signature),
-    /// A digital signature in an unsupported algorithm. The raw signature bytes
-    /// are represented as a base64-encoded string.
-    Other(String),
-}
-
 /// Represents a signature that could not be decoded.
 ///
 /// This will currently only hold invalid Ed25519 signatures.
@@ -188,27 +169,6 @@ pub struct InvalidSignature {
     /// The base64 encoded string that is claimed to contain a signature but
     /// could not be decoded.
     pub source: String,
-}
-
-impl Signature {
-    /// Get the Ed25519 signature, if this is one.
-    pub fn ed25519(&self) -> Option<Ed25519Signature> {
-        as_variant!(self, Self::Ed25519).copied()
-    }
-
-    /// Convert the signature to a base64 encoded string.
-    pub fn to_base64(&self) -> String {
-        match self {
-            Signature::Ed25519(s) => s.to_base64(),
-            Signature::Other(s) => s.to_owned(),
-        }
-    }
-}
-
-impl From<Ed25519Signature> for Signature {
-    fn from(signature: Ed25519Signature) -> Self {
-        Self::Ed25519(signature)
-    }
 }
 
 /// Signatures for a signed object.

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -34,10 +34,7 @@ use std::{
 };
 
 use matrix_sdk_common::deserialized_responses::PrivOwnedStr;
-use ruma::{
-    DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, RoomId, UserId,
-    serde::StringEnum,
-};
+use ruma::{DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, RoomId, serde::StringEnum};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, KeyError};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -158,150 +155,6 @@ impl BackupSecrets {
                 "m.megolm_backup.v1.curve25519-aes-sha2"
             }
         }
-    }
-}
-
-/// Represents a signature that could not be decoded.
-///
-/// This will currently only hold invalid Ed25519 signatures.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidSignature {
-    /// The base64 encoded string that is claimed to contain a signature but
-    /// could not be decoded.
-    pub source: String,
-}
-
-/// Signatures for a signed object.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Signatures(
-    BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>>,
-);
-
-impl Signatures {
-    /// Create a new, empty, signatures collection.
-    pub fn new() -> Self {
-        Signatures(Default::default())
-    }
-
-    /// Add the given signature from the given signer and the given key_id to
-    /// the collection.
-    pub fn add_signature(
-        &mut self,
-        signer: OwnedUserId,
-        key_id: OwnedDeviceKeyId,
-        signature: Ed25519Signature,
-    ) -> Option<Result<Signature, InvalidSignature>> {
-        self.0.entry(signer).or_default().insert(key_id, Ok(signature.into()))
-    }
-
-    /// Try to find an Ed25519 signature from the given signer with the given
-    /// key id.
-    pub fn get_signature(&self, signer: &UserId, key_id: &DeviceKeyId) -> Option<Ed25519Signature> {
-        self.get(signer)?.get(key_id)?.as_ref().ok()?.ed25519()
-    }
-
-    /// Get the map of signatures that belong to the given user.
-    pub fn get(
-        &self,
-        signer: &UserId,
-    ) -> Option<&BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>> {
-        self.0.get(signer)
-    }
-
-    /// Remove all the signatures we currently hold.
-    pub fn clear(&mut self) {
-        self.0.clear()
-    }
-
-    /// Do we hold any signatures or is our collection completely empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// How many signatures do we currently hold.
-    pub fn signature_count(&self) -> usize {
-        self.0.values().map(|u| u.len()).sum()
-    }
-}
-
-impl Default for Signatures {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl IntoIterator for Signatures {
-    type Item = (OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>);
-
-    type IntoIter =
-        IntoIter<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'de> Deserialize<'de> for Signatures {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let map: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> =
-            Deserialize::deserialize(deserializer)?;
-
-        let map = map
-            .into_iter()
-            .map(|(user, signatures)| {
-                let signatures = signatures
-                    .into_iter()
-                    .map(|(key_id, s)| {
-                        let algorithm = key_id.algorithm();
-                        let signature = match algorithm {
-                            DeviceKeyAlgorithm::Ed25519 => Ed25519Signature::from_base64(&s)
-                                .map(|s| s.into())
-                                .map_err(|_| InvalidSignature { source: s }),
-                            _ => Ok(Signature::Other(s)),
-                        };
-
-                        Ok((key_id, signature))
-                    })
-                    .collect::<Result<BTreeMap<_, _>, _>>()?;
-
-                Ok((user, signatures))
-            })
-            .collect::<Result<_, _>>()?;
-
-        Ok(Signatures(map))
-    }
-}
-
-impl Serialize for Signatures {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let signatures: BTreeMap<&OwnedUserId, BTreeMap<&OwnedDeviceKeyId, String>> = self
-            .0
-            .iter()
-            .map(|(u, m)| {
-                (
-                    u,
-                    m.iter()
-                        .map(|(d, s)| {
-                            (
-                                d,
-                                match s {
-                                    Ok(s) => s.to_base64(),
-                                    Err(i) => i.source.to_owned(),
-                                },
-                            )
-                        })
-                        .collect(),
-                )
-            })
-            .collect();
-
-        Serialize::serialize(&signatures, serializer)
     }
 }
 
@@ -518,8 +371,7 @@ pub trait RoomKeyExport {
 
 #[cfg(test)]
 mod test {
-    use insta::{assert_debug_snapshot, assert_json_snapshot, with_settings};
-    use ruma::{device_id, owned_user_id};
+    use insta::{assert_debug_snapshot, assert_json_snapshot};
     use serde_json::json;
     use similar_asserts::assert_eq;
 
@@ -556,42 +408,6 @@ mod test {
 
         // should not log the key !
         assert_debug_snapshot!(decryption_key);
-    }
-
-    #[test]
-    fn snapshot_signatures() {
-        let signatures = Signatures(BTreeMap::from([
-            (
-                owned_user_id!("@alice:localhost"),
-                BTreeMap::from([
-                    (
-                        DeviceKeyId::from_parts(
-                            DeviceKeyAlgorithm::Ed25519,
-                            device_id!("ABCDEFGH"),
-                        ),
-                        Ok(Signature::from(Ed25519Signature::from_slice(&[0u8; 64]).unwrap())),
-                    ),
-                    (
-                        DeviceKeyId::from_parts(
-                            DeviceKeyAlgorithm::Curve25519,
-                            device_id!("IJKLMNOP"),
-                        ),
-                        Ok(Signature::from(Ed25519Signature::from_slice(&[1u8; 64]).unwrap())),
-                    ),
-                ]),
-            ),
-            (
-                owned_user_id!("@bob:localhost"),
-                BTreeMap::from([(
-                    DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, device_id!("ABCDEFGH")),
-                    Err(InvalidSignature { source: "SOME+B64+SOME+B64+SOME+B64+==".to_owned() }),
-                )]),
-            ),
-        ]));
-
-        with_settings!({sort_maps =>true}, {
-            assert_json_snapshot!(signatures)
-        });
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod signature;
+
+pub use self::signature::Signature;

--- a/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Matrix.org Foundation C.I.C.
+Copyright 2022-2026 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,4 +16,198 @@ limitations under the License.
 
 mod signature;
 
+use std::collections::{BTreeMap, btree_map::IntoIter};
+
+use ruma::{DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use vodozemac::Ed25519Signature;
+
 pub use self::signature::Signature;
+
+/// Represents a signature that could not be decoded.
+///
+/// This will currently only hold invalid Ed25519 signatures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSignature {
+    /// The base64 encoded string that is claimed to contain a signature but
+    /// could not be decoded.
+    pub source: String,
+}
+
+/// Signatures for a signed object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signatures(
+    BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>>,
+);
+
+impl Signatures {
+    /// Create a new, empty, signatures collection.
+    pub fn new() -> Self {
+        Signatures(Default::default())
+    }
+
+    /// Add the given signature from the given signer and the given key_id to
+    /// the collection.
+    pub fn add_signature(
+        &mut self,
+        signer: OwnedUserId,
+        key_id: OwnedDeviceKeyId,
+        signature: Ed25519Signature,
+    ) -> Option<Result<Signature, InvalidSignature>> {
+        self.0.entry(signer).or_default().insert(key_id, Ok(signature.into()))
+    }
+
+    /// Try to find an Ed25519 signature from the given signer with the given
+    /// key id.
+    pub fn get_signature(&self, signer: &UserId, key_id: &DeviceKeyId) -> Option<Ed25519Signature> {
+        self.get(signer)?.get(key_id)?.as_ref().ok()?.ed25519()
+    }
+
+    /// Get the map of signatures that belong to the given user.
+    pub fn get(
+        &self,
+        signer: &UserId,
+    ) -> Option<&BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>> {
+        self.0.get(signer)
+    }
+
+    /// Remove all the signatures we currently hold.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    /// Do we hold any signatures or is our collection completely empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How many signatures do we currently hold.
+    pub fn signature_count(&self) -> usize {
+        self.0.values().map(|u| u.len()).sum()
+    }
+}
+
+impl Default for Signatures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoIterator for Signatures {
+    type Item = (OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>);
+
+    type IntoIter =
+        IntoIter<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Result<Signature, InvalidSignature>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for Signatures {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> =
+            Deserialize::deserialize(deserializer)?;
+
+        let map = map
+            .into_iter()
+            .map(|(user, signatures)| {
+                let signatures = signatures
+                    .into_iter()
+                    .map(|(key_id, s)| {
+                        let algorithm = key_id.algorithm();
+                        let signature = match algorithm {
+                            DeviceKeyAlgorithm::Ed25519 => Ed25519Signature::from_base64(&s)
+                                .map(|s| s.into())
+                                .map_err(|_| InvalidSignature { source: s }),
+                            _ => Ok(Signature::Other(s)),
+                        };
+
+                        Ok((key_id, signature))
+                    })
+                    .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+                Ok((user, signatures))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Signatures(map))
+    }
+}
+
+impl Serialize for Signatures {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let signatures: BTreeMap<&OwnedUserId, BTreeMap<&OwnedDeviceKeyId, String>> = self
+            .0
+            .iter()
+            .map(|(u, m)| {
+                (
+                    u,
+                    m.iter()
+                        .map(|(d, s)| {
+                            (
+                                d,
+                                match s {
+                                    Ok(s) => s.to_base64(),
+                                    Err(i) => i.source.to_owned(),
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        Serialize::serialize(&signatures, serializer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use insta::{assert_json_snapshot, with_settings};
+    use ruma::{device_id, owned_user_id};
+
+    use super::*;
+
+    #[test]
+    fn snapshot_signatures() {
+        let signatures = Signatures(BTreeMap::from([
+            (
+                owned_user_id!("@alice:localhost"),
+                BTreeMap::from([
+                    (
+                        DeviceKeyId::from_parts(
+                            DeviceKeyAlgorithm::Ed25519,
+                            device_id!("ABCDEFGH"),
+                        ),
+                        Ok(Signature::from(Ed25519Signature::from_slice(&[0u8; 64]).unwrap())),
+                    ),
+                    (
+                        DeviceKeyId::from_parts(
+                            DeviceKeyAlgorithm::Curve25519,
+                            device_id!("IJKLMNOP"),
+                        ),
+                        Ok(Signature::from(Ed25519Signature::from_slice(&[1u8; 64]).unwrap())),
+                    ),
+                ]),
+            ),
+            (
+                owned_user_id!("@bob:localhost"),
+                BTreeMap::from([(
+                    DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, device_id!("ABCDEFGH")),
+                    Err(InvalidSignature { source: "SOME+B64+SOME+B64+SOME+B64+==".to_owned() }),
+                )]),
+            ),
+        ]));
+
+        with_settings!({sort_maps => true, prepend_module_to_snapshot => false}, {
+            assert_json_snapshot!(signatures)
+        });
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/signatures/signature.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/signature.rs
@@ -1,0 +1,57 @@
+/*
+Copyright 2022-2026 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use as_variant::as_variant;
+use vodozemac::Ed25519Signature;
+
+/// Represents a potentially decoded signature (but *not* a validated one).
+///
+/// There are two important cases here:
+///
+/// 1. If the claimed algorithm is supported *and* the payload has an expected
+///    format, the signature will be represent by the enum variant corresponding
+///    to that algorithm. For example, decodable Ed25519 signatures are
+///    represented as `Ed25519(...)`.
+/// 2. If the claimed algorithm is unsupported, the signature is represented as
+///    `Other(...)`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Signature {
+    /// A Ed25519 digital signature.
+    Ed25519(Ed25519Signature),
+    /// A digital signature in an unsupported algorithm. The raw signature bytes
+    /// are represented as a base64-encoded string.
+    Other(String),
+}
+
+impl Signature {
+    /// Get the Ed25519 signature, if this is one.
+    pub fn ed25519(&self) -> Option<Ed25519Signature> {
+        as_variant!(self, Self::Ed25519).copied()
+    }
+
+    /// Convert the signature to a base64 encoded string.
+    pub fn to_base64(&self) -> String {
+        match self {
+            Signature::Ed25519(s) => s.to_base64(),
+            Signature::Other(s) => s.to_owned(),
+        }
+    }
+}
+
+impl From<Ed25519Signature> for Signature {
+    fn from(signature: Ed25519Signature) -> Self {
+        Self::Ed25519(signature)
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/signatures/snapshots/snapshot_signatures.snap
+++ b/crates/matrix-sdk-crypto/src/types/signatures/snapshots/snapshot_signatures.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/matrix-sdk-crypto/src/types/mod.rs
+source: crates/matrix-sdk-crypto/src/types/signatures/mod.rs
 expression: signatures
 ---
 {


### PR DESCRIPTION
We're shortly going to be extending `Signature` and `Signatures`, and `types/mod.rs` is already somewhat unwieldy. Move them into their own modules.