### PR TITLE
fix(ffi): Fix attachment upload failing when blurhash isn't present

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6662.fixed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6662.fixed.md
@@ -1,0 +1,1 @@
+Fixed attachment upload failing when blurhash isn't present.

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -717,13 +717,11 @@ impl TryFrom<&ImageInfo> for BaseImageInfo {
             .map_err(|_| MediaInfoError::InvalidField)?;
         let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
             .map_err(|_| MediaInfoError::InvalidField)?;
-        let blurhash = value.blurhash.clone().ok_or(MediaInfoError::MissingField)?;
-
         Ok(BaseImageInfo {
             height: Some(height),
             width: Some(width),
             size: Some(size),
-            blurhash: Some(blurhash),
+            blurhash: value.blurhash.clone(),
             is_animated: value.is_animated,
         })
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
