### PR TITLE
Remove panic in `IdentityBasedStrategy`

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
@@ -769,6 +769,9 @@ async fn test_share_strategy_prevents_encryption() {
         .await
         .unwrap();
 
+    // Dan has cross-signing keys, but a device that is not cross-signed. When
+    // we try to send to the unsigned device, we should get an error under the
+    // `OnlyTrustedDevices` and `IdentityBasedStrategy` strategies.
     let keys_query = DataSet::dan_keys_query_response();
     let txn_id = TransactionId::new();
     machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
@@ -786,6 +789,51 @@ async fn test_share_strategy_prevents_encryption() {
         .unwrap()
         .unwrap()
         .encrypt_event_raw(custom_event_type, &custom_content, CollectStrategy::OnlyTrustedDevices)
+        .await;
+
+    assert_matches!(encryption_result, Err(OlmError::Withheld(WithheldCode::Unverified)));
+
+    let encryption_result = machine
+        .get_device(DataSet::dan_id(), DataSet::dan_unsigned_device_id(), None)
+        .await
+        .unwrap()
+        .unwrap()
+        .encrypt_event_raw(
+            custom_event_type,
+            &custom_content,
+            CollectStrategy::IdentityBasedStrategy,
+        )
+        .await;
+
+    assert_matches!(encryption_result, Err(OlmError::Withheld(WithheldCode::Unverified)));
+
+    // Dave has no cross-signing keys. When we try to send to his device, we
+    // should get an error under the `OnlyTrustedDevices` and
+    // `IdentityBasedStrategy` strategies.
+    let keys_query = DataSet::dave_keys_query_response();
+    let txn_id = TransactionId::new();
+    machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
+
+    let encryption_result = machine
+        .get_device(DataSet::dave_id(), DataSet::dave_device_id(), None)
+        .await
+        .unwrap()
+        .unwrap()
+        .encrypt_event_raw(custom_event_type, &custom_content, CollectStrategy::OnlyTrustedDevices)
+        .await;
+
+    assert_matches!(encryption_result, Err(OlmError::Withheld(WithheldCode::Unverified)));
+
+    let encryption_result = machine
+        .get_device(DataSet::dave_id(), DataSet::dave_device_id(), None)
+        .await
+        .unwrap()
+        .unwrap()
+        .encrypt_event_raw(
+            custom_event_type,
+            &custom_content,
+            CollectStrategy::IdentityBasedStrategy,
+        )
         .await;
 
     assert_matches!(encryption_result, Err(OlmError::Withheld(WithheldCode::Unverified)));

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -616,7 +616,9 @@ pub(crate) async fn split_devices_for_share_strategy(
                         allowed_devices.push(device.clone());
                     }
                 } else {
-                    panic!("Should have verification violation if device_owner_identity is None")
+                    // Device owner has no identity, so the device is considered
+                    // to be unverified
+                    blocked_devices.push((device.clone(), WithheldCode::Unverified));
                 }
             }
         }
@@ -726,7 +728,9 @@ pub(crate) async fn withheld_code_for_device_for_share_strategy(
                     device_owner_identity,
                 ))
             } else {
-                panic!("Should have verification violation if device_owner_identity is None")
+                // Device owner has no identity, so the device is considered
+                // to be unverified
+                Ok(Some(WithheldCode::Unverified))
             }
         }
         CollectStrategy::OnlyTrustedDevices => {


### PR DESCRIPTION
Removes possible panics when encrypting to-device events with `IdentityBasedStrategy`.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files
      (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
