### PR TITLE
crypto: Move logic for parsing base64-encoded signatures into `Signature`

### DIFF
--- a/crates/matrix-sdk-crypto/changelog.d/6673.internal
+++ b/crates/matrix-sdk-crypto/changelog.d/6673.internal
@@ -1,0 +1,1 @@
+Move logic for parsing base64-encoded signatures into `Signature`.

--- a/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
@@ -18,7 +18,7 @@ mod signature;
 
 use std::collections::{BTreeMap, btree_map::IntoIter};
 
-use ruma::{DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId};
+use ruma::{DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vodozemac::Ed25519Signature;
 
@@ -119,13 +119,7 @@ impl<'de> Deserialize<'de> for Signatures {
                     .into_iter()
                     .map(|(key_id, s)| {
                         let algorithm = key_id.algorithm();
-                        let signature = match algorithm {
-                            DeviceKeyAlgorithm::Ed25519 => Ed25519Signature::from_base64(&s)
-                                .map(|s| s.into())
-                                .map_err(|_| InvalidSignature { source: s }),
-                            _ => Ok(Signature::Other(s)),
-                        };
-
+                        let signature = Signature::from_base64(algorithm, s);
                         Ok((key_id, signature))
                     })
                     .collect::<Result<BTreeMap<_, _>, _>>()?;
@@ -171,7 +165,7 @@ impl Serialize for Signatures {
 #[cfg(test)]
 mod test {
     use insta::{assert_json_snapshot, with_settings};
-    use ruma::{device_id, owned_user_id};
+    use ruma::{DeviceKeyAlgorithm, device_id, owned_user_id};
 
     use super::*;
 

--- a/crates/matrix-sdk-crypto/src/types/signatures/signature.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/signature.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use as_variant::as_variant;
+use ruma::DeviceKeyAlgorithm;
 use vodozemac::Ed25519Signature;
+
+use crate::types::InvalidSignature;
 
 /// Represents a potentially decoded signature (but *not* a validated one).
 ///
@@ -41,6 +44,17 @@ impl Signature {
         as_variant!(self, Self::Ed25519).copied()
     }
 
+    /// Decode a signature from the Base64-encoded format used in Matrix
+    /// `signatures` maps.
+    pub fn from_base64(algorithm: DeviceKeyAlgorithm, s: String) -> Result<Self, InvalidSignature> {
+        match algorithm {
+            DeviceKeyAlgorithm::Ed25519 => Ed25519Signature::from_base64(&s)
+                .map(|s| s.into())
+                .map_err(|_| InvalidSignature { source: s }),
+            _ => Ok(Signature::Other(s)),
+        }
+    }
+
     /// Convert the signature to a base64 encoded string.
     pub fn to_base64(&self) -> String {
         match self {
@@ -53,5 +67,47 @@ impl Signature {
 impl From<Ed25519Signature> for Signature {
     fn from(signature: Ed25519Signature) -> Self {
         Self::Ed25519(signature)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn roundtrip_ed25519_signature() {
+        const BASE64_SIG: &str = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ";
+
+        let parsed = Signature::from_base64(DeviceKeyAlgorithm::Ed25519, BASE64_SIG.to_owned())
+            .expect("Failed to parse");
+
+        let ed25519 = parsed.ed25519().expect("Not parsed as Ed25519");
+        assert_eq!(ed25519.to_base64(), BASE64_SIG);
+
+        let encoded = parsed.to_base64();
+        assert_eq!(encoded, BASE64_SIG)
+    }
+
+    #[test]
+    fn parse_invalid_ed25519_signature() {
+        const BASE64_SIG: &str = "XXXX";
+
+        let parsed = Signature::from_base64(DeviceKeyAlgorithm::Ed25519, BASE64_SIG.to_owned())
+            .expect_err("Expected an invalid signature");
+        assert_eq!(parsed.source, BASE64_SIG);
+    }
+
+    #[test]
+    fn roundtrip_other_signature() {
+        const TEXT: &str = "abcd";
+
+        let parsed = Signature::from_base64(DeviceKeyAlgorithm::from("foo"), TEXT.to_owned())
+            .expect("Failed to parse");
+
+        let other = as_variant!(&parsed, Signature::Other).expect("Not parsed as Other");
+        assert_eq!(other, TEXT);
+
+        let encoded = parsed.to_base64();
+        assert_eq!(encoded, TEXT)
     }
 }


### PR DESCRIPTION
I'm going to need to add some more logic here soon, so having it as a separate method (with tests!) will help that.