### PR TITLE
doc: Forgejo's AI policy has changed, stop mentioning it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,7 +366,7 @@ git rebase --signoff origin/main
 
 ## AI policy
 
-This policy is a copy of the [Forgejo's AI agreement][Forgejo].
+Let's define terminology before defining the policy.
 
 ### Terminology
 
@@ -408,5 +408,3 @@ with little to no human supervision.
 6. It is **not allowed** to use AI in an autonomous-looking way to contribute to
    the Matrix Rust SDK. This also applies when someone engages in _vibe coding_
    or uses so-called _agent mode_.
-
-[Forgejo]: https://codeberg.org/forgejo/governance/src/branch/main/AIAgreement.md


### PR DESCRIPTION
What it says on the tin!

---

- Close https://github.com/matrix-org/matrix-rust-sdk/issues/6657

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
