### PR TITLE
Fix potential deadlock in SessionVerificationController

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6669.fixed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6669.fixed.md
@@ -1,0 +1,1 @@
+Fixed a potential deadlock in `SessionVerificationController` where delegate callbacks were invoked while the delegate `RwLock` read guard was held, so a delegate that detached itself via `set_delegate` would deadlock.

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -77,7 +77,7 @@ pub trait SessionVerificationControllerDelegate: SyncOutsideWasm + SendOutsideWa
     fn did_finish(&self);
 }
 
-pub type Delegate = Arc<RwLock<Option<Box<dyn SessionVerificationControllerDelegate>>>>;
+pub type Delegate = Arc<RwLock<Option<Arc<dyn SessionVerificationControllerDelegate>>>>;
 
 #[derive(Clone, uniffi::Object)]
 pub struct SessionVerificationController {
@@ -92,7 +92,7 @@ pub struct SessionVerificationController {
 #[matrix_sdk_ffi_macros::export]
 impl SessionVerificationController {
     pub fn set_delegate(&self, delegate: Option<Box<dyn SessionVerificationControllerDelegate>>) {
-        *self.delegate.write().unwrap() = delegate;
+        *self.delegate.write().unwrap() = delegate.map(Arc::from);
     }
 
     /// Set this particular request as the currently active one and register for
@@ -170,7 +170,7 @@ impl SessionVerificationController {
             Ok(Some(verification)) => {
                 *self.sas_verification.write().unwrap() = Some(verification.clone());
 
-                if let Some(delegate) = &*self.delegate.read().unwrap() {
+                if let Some(delegate) = Self::current_delegate(&self.delegate) {
                     delegate.did_start_sas_verification()
                 }
 
@@ -179,7 +179,7 @@ impl SessionVerificationController {
                     .spawn(Self::listen_to_sas_verification_changes(verification, delegate));
             }
             _ => {
-                if let Some(delegate) = &*self.delegate.read().unwrap() {
+                if let Some(delegate) = Self::current_delegate(&self.delegate) {
                     delegate.did_fail()
                 }
             }
@@ -272,7 +272,7 @@ impl SessionVerificationController {
             return;
         };
 
-        if let Some(delegate) = &*self.delegate.read().unwrap() {
+        if let Some(delegate) = Self::current_delegate(&self.delegate) {
             delegate.did_receive_verification_request(SessionVerificationRequestDetails {
                 sender_profile,
                 flow_id: request.flow_id().into(),
@@ -306,6 +306,16 @@ impl SessionVerificationController {
         Ok(())
     }
 
+    /// Clone the current delegate out of the lock, releasing the read guard
+    /// before it is returned. Callbacks must never be invoked while the guard
+    /// is held: a delegate that detaches itself via `set_delegate` (which takes
+    /// the write guard) would otherwise deadlock. See issue #6669.
+    fn current_delegate(
+        delegate: &Delegate,
+    ) -> Option<Arc<dyn SessionVerificationControllerDelegate>> {
+        delegate.read().unwrap().clone()
+    }
+
     async fn listen_to_verification_request_changes(
         verification_request: VerificationRequest,
         sas_verification: Arc<RwLock<Option<SasVerification>>>,
@@ -324,27 +334,26 @@ impl SessionVerificationController {
                     *sas_verification.write().unwrap() = Some(verification.clone());
 
                     if verification.accept().await.is_ok() {
-                        if let Some(delegate) = &*delegate.read().unwrap() {
-                            delegate.did_start_sas_verification()
+                        if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                            current_delegate.did_start_sas_verification()
                         }
 
-                        let delegate = delegate.clone();
                         get_runtime_handle().spawn(Self::listen_to_sas_verification_changes(
                             verification,
-                            delegate,
+                            delegate.clone(),
                         ));
-                    } else if let Some(delegate) = &*delegate.read().unwrap() {
-                        delegate.did_fail()
+                    } else if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                        current_delegate.did_fail()
                     }
                 }
                 VerificationRequestState::Ready { .. } => {
-                    if let Some(delegate) = &*delegate.read().unwrap() {
-                        delegate.did_accept_verification_request()
+                    if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                        current_delegate.did_accept_verification_request()
                     }
                 }
                 VerificationRequestState::Cancelled(..) => {
-                    if let Some(delegate) = &*delegate.read().unwrap() {
-                        delegate.did_cancel();
+                    if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                        current_delegate.did_cancel();
                     }
                 }
                 _ => {}
@@ -358,9 +367,9 @@ impl SessionVerificationController {
         while let Some(state) = stream.next().await {
             match state {
                 SasState::KeysExchanged { emojis, decimals } => {
-                    if let Some(delegate) = &*delegate.read().unwrap() {
+                    if let Some(current_delegate) = Self::current_delegate(&delegate) {
                         if let Some(emojis) = emojis {
-                            delegate.did_receive_verification_data(
+                            current_delegate.did_receive_verification_data(
                                 SessionVerificationData::Emojis {
                                     emojis: emojis
                                         .emojis
@@ -376,7 +385,7 @@ impl SessionVerificationController {
                                 },
                             );
                         } else {
-                            delegate.did_receive_verification_data(
+                            current_delegate.did_receive_verification_data(
                                 SessionVerificationData::Decimals {
                                     values: vec![decimals.0, decimals.1, decimals.2],
                                 },
@@ -385,16 +394,16 @@ impl SessionVerificationController {
                     }
                 }
                 SasState::Done { .. } => {
-                    if let Some(delegate) = &*delegate.read().unwrap() {
-                        delegate.did_finish()
+                    if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                        current_delegate.did_finish()
                     }
                     break;
                 }
                 SasState::Cancelled(_cancel_info) => {
                     // TODO: The cancel_info is usable, we should tell the user why we were
                     // cancelled.
-                    if let Some(delegate) = &*delegate.read().unwrap() {
-                        delegate.did_cancel()
+                    if let Some(current_delegate) = Self::current_delegate(&delegate) {
+                        current_delegate.did_cancel()
                     }
                     break;
                 }
@@ -404,5 +413,49 @@ impl SessionVerificationController {
                 | SasState::Confirmed => (),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+
+    use super::{
+        Delegate, SessionVerificationController, SessionVerificationControllerDelegate,
+        SessionVerificationData, SessionVerificationRequestDetails,
+    };
+
+    /// A delegate that detaches itself from within a callback. The only
+    /// documented way to detach is `set_delegate(None)`, which takes the
+    /// delegate write guard. Mirrors the deadlock repro from issue #6669.
+    struct ReentrantDelegate {
+        slot: Delegate,
+    }
+
+    impl SessionVerificationControllerDelegate for ReentrantDelegate {
+        fn did_cancel(&self) {
+            *self.slot.write().unwrap() = None;
+        }
+        fn did_receive_verification_request(&self, _: SessionVerificationRequestDetails) {}
+        fn did_accept_verification_request(&self) {}
+        fn did_start_sas_verification(&self) {}
+        fn did_receive_verification_data(&self, _: SessionVerificationData) {}
+        fn did_fail(&self) {}
+        fn did_finish(&self) {}
+    }
+
+    #[test]
+    fn invoking_a_callback_does_not_hold_the_delegate_read_guard() {
+        let slot: Delegate = Arc::new(RwLock::new(None));
+        *slot.write().unwrap() = Some(Arc::new(ReentrantDelegate { slot: slot.clone() }));
+
+        // `current_delegate` must release the read guard before the callback
+        // runs. If it held the guard, the re-entrant `set_delegate` (write
+        // guard) inside `did_cancel` would deadlock here.
+        if let Some(delegate) = SessionVerificationController::current_delegate(&slot) {
+            delegate.did_cancel();
+        }
+
+        assert!(slot.read().unwrap().is_none(), "delegate should have detached itself");
     }
 }


### PR DESCRIPTION
Delegate callbacks were dispatched while holding the delegate RwLock read guard. A delegate detaching itself via set_delegate (which needs the write guard) would deadlock. Store the delegate as an Arc and clone it out of the lock before invoking, releasing the guard first. Fixes #6669.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
