### PR TITLE
fix(ffi): Match `Base*Info` metadata fields requirement to the spec

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6683.fixed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6683.fixed.md
@@ -1,0 +1,1 @@
+Fixed upload failures for attachments when `height`, `width`, `size`, `duration`, or `blurhash` fields are not present.

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -711,16 +711,22 @@ impl TryFrom<&ImageInfo> for BaseImageInfo {
     type Error = MediaInfoError;
 
     fn try_from(value: &ImageInfo) -> Result<Self, MediaInfoError> {
-        let height = UInt::try_from(value.height.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let width = UInt::try_from(value.width.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
         Ok(BaseImageInfo {
-            height: Some(height),
-            width: Some(width),
-            size: Some(size),
+            height: value
+                .height
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            width: value
+                .width
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            size: value
+                .size
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
             blurhash: value.blurhash.clone(),
             is_animated: value.is_animated,
         })
@@ -748,11 +754,15 @@ impl TryFrom<&AudioInfo> for BaseAudioInfo {
     type Error = MediaInfoError;
 
     fn try_from(value: &AudioInfo) -> Result<Self, MediaInfoError> {
-        let duration = value.duration.ok_or(MediaInfoError::MissingField)?;
-        let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-
-        Ok(BaseAudioInfo { duration: Some(duration), size: Some(size), waveform: None })
+        Ok(BaseAudioInfo {
+            duration: value.duration,
+            size: value
+                .size
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            waveform: None,
+        })
     }
 }
 
@@ -830,21 +840,24 @@ impl TryFrom<&VideoInfo> for BaseVideoInfo {
     type Error = MediaInfoError;
 
     fn try_from(value: &VideoInfo) -> Result<Self, MediaInfoError> {
-        let duration = value.duration.ok_or(MediaInfoError::MissingField)?;
-        let height = UInt::try_from(value.height.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let width = UInt::try_from(value.width.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-        let blurhash = value.blurhash.clone().ok_or(MediaInfoError::MissingField)?;
-
         Ok(BaseVideoInfo {
-            duration: Some(duration),
-            height: Some(height),
-            width: Some(width),
-            size: Some(size),
-            blurhash: Some(blurhash),
+            duration: value.duration,
+            height: value
+                .height
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            width: value
+                .width
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            size: value
+                .size
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+            blurhash: value.blurhash.clone(),
         })
     }
 }
@@ -872,10 +885,13 @@ impl TryFrom<&FileInfo> for BaseFileInfo {
     type Error = MediaInfoError;
 
     fn try_from(value: &FileInfo) -> Result<Self, MediaInfoError> {
-        let size = UInt::try_from(value.size.ok_or(MediaInfoError::MissingField)?)
-            .map_err(|_| MediaInfoError::InvalidField)?;
-
-        Ok(BaseFileInfo { size: Some(size) })
+        Ok(BaseFileInfo {
+            size: value
+                .size
+                .map(UInt::try_from)
+                .transpose()
+                .map_err(|_| MediaInfoError::InvalidField)?,
+        })
     }
 }
 


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-rust-sdk/pull/6662#discussion_r3459985786 and the Matrix spec.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
