### PR TITLE
fix(sdk): Introduce `SubscribersHandle` and `SubscriberHandle`

### DIFF
--- a/crates/matrix-sdk/changelog.d/6684.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6684.fixed.md
@@ -1,0 +1,7 @@
+Ensure a `VectorDiff` is not emitted to subscribers when an event cache is
+shrunk because no subscribers is listening to it. If there is no subscribers,
+it's useless to send it anyway, and if in the future, a race happens and a
+subscriber exists, it must not receive this diff.
+
+At the same time, the way the subscribers are tracked and counted have been
+revisited to use less space in memory and use less atomic operations.

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -22,13 +22,14 @@ use matrix_sdk_base::{
     linked_chunk::Position,
     sync::{JoinedRoomUpdate, LeftRoomUpdate},
 };
-use ruma::{OwnedEventId, OwnedRoomId, RoomId, room_version_rules::RoomVersionRules};
+use ruma::{OwnedEventId, RoomId, room_version_rules::RoomVersionRules};
 use tokio::sync::{
     OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, broadcast::Sender, mpsc,
 };
 
 use super::{
-    EventCacheError, EventsOrigin, Result, automatic_pagination::AutomaticPagination, states,
+    AutoShrinkChannelPayload, EventCacheError, EventsOrigin, Result,
+    automatic_pagination::AutomaticPagination, states,
 };
 use crate::{client::WeakClient, room::WeakRoom};
 
@@ -85,7 +86,7 @@ impl Caches {
         room_id: &RoomId,
         generic_update_sender: Sender<room::RoomEventCacheGenericUpdate>,
         linked_chunk_update_sender: Sender<room::RoomEventCacheLinkedChunkUpdate>,
-        auto_shrink_sender: mpsc::Sender<OwnedRoomId>,
+        auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
         state: &states::StateLock,
         automatic_pagination: Option<AutomaticPagination>,
     ) -> Result<Self> {

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -1857,6 +1857,12 @@ mod timed_tests {
         assert_eq!(events2[1].event_id(), Some(evid2));
         assert!(stream2.is_empty());
 
+        // Grab a receiver for testing no diffs is sent.
+        let subscriber = {
+            let state = room_event_cache.inner.state.read().await.unwrap();
+            state.update_sender.new_room_receiver()
+        };
+
         // Drop the first stream, and wait a bit.
         drop(stream1);
         yield_now().await;
@@ -1874,6 +1880,10 @@ mod timed_tests {
             // Check the inner state: there's no more shared auto-shrinker.
             let state = room_event_cache.inner.state.read().await.unwrap();
             assert_eq!(state.subscribers_handle().count(), 0);
+
+            // No diff is sent when the linked chunk has auto-shrunk.
+            assert!(subscriber.is_empty());
+            assert!(generic_stream.is_empty());
         }
 
         // Getting the events will only give us the latest chunk.

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -17,11 +17,7 @@ mod state;
 mod subscriber;
 mod updates;
 
-use std::{
-    collections::BTreeMap,
-    fmt,
-    sync::{Arc, atomic::Ordering},
-};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use eyeball::SharedObservable;
 use matrix_sdk_base::{
@@ -132,16 +128,16 @@ impl RoomEventCache {
         let events =
             state.room_linked_chunk().events().map(|(_position, item)| item.clone()).collect();
 
-        let subscriber_count = state.subscriber_count();
-        let previous_subscriber_count = subscriber_count.fetch_add(1, Ordering::SeqCst);
-        trace!("added a room event cache subscriber; new count: {}", previous_subscriber_count + 1);
+        let subscribers_handle = state.subscribers_handle();
 
         let subscriber = RoomEventCacheSubscriber::new(
             self.inner.update_sender.new_room_receiver(),
             self.inner.room_id.clone(),
             self.inner.auto_shrink_sender.clone(),
-            subscriber_count.clone(),
+            subscribers_handle,
         );
+
+        trace!("added a room event cache subscriber; new count: {}", subscribers_handle.count());
 
         Ok((events, subscriber))
     }
@@ -1877,7 +1873,7 @@ mod timed_tests {
         {
             // Check the inner state: there's no more shared auto-shrinker.
             let state = room_event_cache.inner.state.read().await.unwrap();
-            assert_eq!(state.subscriber_count().load(std::sync::atomic::Ordering::SeqCst), 0);
+            assert_eq!(state.subscribers_handle().count(), 0);
         }
 
         // Getting the events will only give us the latest chunk.

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -398,6 +398,11 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         if number_of_subscribers == 0 {
             // There is no more subscribers listening to this cache, we can shrink the state
             // to its last chunk to save memory.
+            //
+            // In theory, between the condition (`… == 0`) and this instruction, a new
+            // subscriber could be created, creating a race, except that this method takes a
+            // `&mut`, ensuring an exclusive access to the state, ensuring no other
+            // subscribers can be created.
             self.shrink_to_last_chunk().await?;
 
             Ok(Some(self.state.room_linked_chunk.updates_as_vector_diffs()))

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
-
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
@@ -62,6 +57,7 @@ use super::{
         read_receipts::compute_unread_counts,
     },
     RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdateSender, sort_positions_descending,
+    subscriber::SubscribersHandle,
 };
 use crate::room::WeakRoom;
 
@@ -103,9 +99,8 @@ pub struct RoomEventCacheState {
     /// that upon clearing the timeline events.
     waited_for_initial_prev_token: bool,
 
-    /// An atomic count of the current number of subscriber of the
-    /// [`super::RoomEventCache`].
-    subscriber_count: Arc<AtomicUsize>,
+    /// A handle for subscribers.
+    subscribers_handle: SubscribersHandle,
 
     /// A copy of the automatic pagination API object.
     automatic_pagination: Option<AutomaticPagination>,
@@ -192,7 +187,7 @@ impl RoomEventCacheState {
             linked_chunk_update_sender,
             room_version_rules,
             waited_for_initial_prev_token: false,
-            subscriber_count: Default::default(),
+            subscribers_handle: Default::default(),
             automatic_pagination,
         })
     }
@@ -204,9 +199,9 @@ impl RoomEventCacheState {
 }
 
 impl<'a> StateLockReadGuard<'a, RoomEventCacheState> {
-    /// Return the subscriber count.
-    pub fn subscriber_count(&self) -> &Arc<AtomicUsize> {
-        &self.state.subscriber_count
+    /// Return a reference to subscribers handle.
+    pub fn subscribers_handle(&self) -> &SubscribersHandle {
+        &self.state.subscribers_handle
     }
 
     /// See documentation of [`find_event`].
@@ -396,13 +391,13 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     pub async fn auto_shrink_if_no_subscribers(
         &mut self,
     ) -> Result<Option<Vec<VectorDiff<Event>>>, EventCacheError> {
-        let subscriber_count = self.state.subscriber_count.load(Ordering::SeqCst);
+        let number_of_subscribers = self.state.subscribers_handle.count();
 
-        trace!(subscriber_count, "received request to auto-shrink");
+        trace!(number_of_subscribers, "received request to auto-shrink");
 
-        if subscriber_count == 0 {
-            // If we are the last strong reference to the auto-shrinker, we can shrink the
-            // events data structure to its last chunk.
+        if number_of_subscribers == 0 {
+            // There is no more subscribers listening to this cache, we can shrink the state
+            // to its last chunk to save memory.
             self.shrink_to_last_chunk().await?;
 
             Ok(Some(self.state.room_linked_chunk.updates_as_vector_diffs()))

--- a/crates/matrix-sdk/src/event_cache/caches/room/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/subscriber.rs
@@ -16,10 +16,7 @@
 
 use std::{
     ops::{Deref, DerefMut},
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, Weak},
 };
 
 use ruma::OwnedRoomId;
@@ -27,6 +24,47 @@ use tokio::sync::{broadcast::Receiver, mpsc};
 use tracing::{trace, warn};
 
 use super::{AutoShrinkChannelPayload, RoomEventCacheUpdate};
+
+/// A structure that can generate handles for subscribers, and count them. See
+/// [`SubscriberHandle`] to learn more.
+#[derive(Default)]
+pub struct SubscribersHandle(Arc<()>);
+
+impl SubscribersHandle {
+    /// Count the number of subscribers.
+    ///
+    /// Similar to [`SubscriberHandle::count`].
+    pub fn count(&self) -> usize {
+        Arc::weak_count(&self.0)
+    }
+
+    /// Generate a handle for a subscriber.
+    pub fn new_subscriber_handle(&self) -> SubscriberHandle {
+        SubscriberHandle(Arc::downgrade(&self.0))
+    }
+}
+
+/// A handle for a subscriber.
+///
+/// A cache might need to track/count the number of subscribers. When the number
+/// of subscribers reach zero, it means no more code is listening to it. That's
+/// an opportunity to free some memory by shrinking the cache for example!
+/// Shrinking means forgetting about “old” events, keeping events from the last
+/// chunk for example.
+///
+/// Every time a subscriber is created,
+/// [`SubscribersHandle::new_subscriber_handle`] is called. The resulting value
+/// must be kept by the subscriber for its entire lifetime.
+pub struct SubscriberHandle(Weak<()>);
+
+impl SubscriberHandle {
+    /// Count the number of subscribers.
+    ///
+    /// Similar to [`SubscribersHandle::count`].
+    pub fn count(&self) -> usize {
+        Weak::weak_count(&self.0)
+    }
+}
 
 /// Thin wrapper for a room event cache subscriber, so as to trigger
 /// side-effects when all subscribers are gone.
@@ -50,8 +88,10 @@ pub struct RoomEventCacheSubscriber {
     /// Sender to the auto-shrink channel.
     auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
 
-    /// Shared instance of the auto-shrinker.
-    subscriber_count: Arc<AtomicUsize>,
+    /// The subscribers handle shared by all subscribers.
+    ///
+    /// It comes from [`super::RoomEventCacheState::subscribers_handle`].
+    subscriber_handle: Option<SubscriberHandle>,
 }
 
 impl RoomEventCacheSubscriber {
@@ -60,21 +100,30 @@ impl RoomEventCacheSubscriber {
         recv: Receiver<RoomEventCacheUpdate>,
         room_id: OwnedRoomId,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
-        subscriber_count: Arc<AtomicUsize>,
+        subscribers_handle: &SubscribersHandle,
     ) -> Self {
-        Self { recv, room_id, auto_shrink_sender, subscriber_count }
+        Self {
+            recv,
+            room_id,
+            auto_shrink_sender,
+            subscriber_handle: Some(subscribers_handle.new_subscriber_handle()),
+        }
     }
 }
 
 impl Drop for RoomEventCacheSubscriber {
     fn drop(&mut self) {
-        let previous_subscriber_count = self.subscriber_count.fetch_sub(1, Ordering::SeqCst);
+        let number_of_subscribers = self
+            .subscriber_handle
+            // Ensure the handle is dropped before sending the message to the
+            // auto shrink task.
+            .take()
+            .expect("Unreachable: `subscriber_handle` must be `Some`")
+            .count();
 
-        trace!(
-            "dropping a room event cache subscriber; previous count: {previous_subscriber_count}"
-        );
+        trace!("dropping a room event cache subscriber; count: {number_of_subscribers}");
 
-        if previous_subscriber_count == 1 {
+        if number_of_subscribers == 1 {
             // We were the last instance of the subscriber; let the auto-shrinker know by
             // notifying it of our room id.
 
@@ -124,5 +173,48 @@ impl Deref for RoomEventCacheSubscriber {
 impl DerefMut for RoomEventCacheSubscriber {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.recv
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubscribersHandle;
+
+    #[test]
+    fn test_subscribers_handle() {
+        let subscribers_handle = SubscribersHandle::default();
+
+        // No subscribers.
+        assert_eq!(subscribers_handle.count(), 0);
+
+        // Pretend a new subscriber exists!
+        let handle0 = subscribers_handle.new_subscriber_handle();
+        assert_eq!(subscribers_handle.count(), 1);
+        assert_eq!(handle0.count(), 1);
+
+        // Pretend another new subscriber exists!
+        let handle1 = subscribers_handle.new_subscriber_handle();
+        assert_eq!(subscribers_handle.count(), 2);
+        assert_eq!(handle0.count(), 2);
+        assert_eq!(handle1.count(), 2);
+
+        // A subscriber dies. RIP.
+        drop(handle0);
+        assert_eq!(subscribers_handle.count(), 1);
+        assert_eq!(handle1.count(), 1);
+
+        // Another subscriber dies. RIP.
+        drop(handle1);
+        assert_eq!(subscribers_handle.count(), 0);
+
+        // Create a new subscriber, for the last test.
+        let handle2 = subscribers_handle.new_subscriber_handle();
+
+        // We can even drop the `SubscribersHandle`!
+        drop(subscribers_handle);
+        assert_eq!(handle2.count(), 0);
+        // ZERO, yes, not 1.
+        // If the state containing the `SubscribersHandle` drops, there is no
+        // more update, and no auto-shrink, so it's fine to get a zero here.
     }
 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -580,7 +580,7 @@ struct EventCacheInner {
     /// It's a `OnceLock` because its initialization is deferred to
     /// [`EventCache::subscribe`].
     ///
-    /// See doc comment of [`EventCache::auto_shrink_linked_chunk_task`].
+    /// See doc comment of [`tasks::auto_shrink_linked_chunk_task`].
     auto_shrink_sender: OnceLock<mpsc::Sender<AutoShrinkChannelPayload>>,
 
     /// A sender for room generic update.

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -118,8 +118,8 @@ pub(super) async fn ignore_user_list_update_task(
 /// The auto-shrink mechanism works this way:
 ///
 /// - Each time there's a new subscriber to a [`RoomEventCache`], it will
-///   increment the active number of subscribers to that room, aka
-///   `RoomEventCacheState::subscriber_count`.
+///   increment the active number of subscribers to that room, see
+///   `RoomEventCacheState::subscribers_handle`.
 /// - When that subscriber is dropped, it will decrement that count; and notify
 ///   the task below if it reached 0.
 /// - The task spawned here, owned by the [`EventCacheInner`], will listen to

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -33,8 +33,7 @@ use tokio::{
 use tracing::{Instrument as _, Span, debug, error, info, info_span, instrument, trace, warn};
 
 use super::{
-    AutoShrinkChannelPayload, EventCacheError, EventCacheInner, EventsOrigin,
-    RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdate, TimelineVectorDiffs,
+    AutoShrinkChannelPayload, EventCacheError, EventCacheInner, RoomEventCacheLinkedChunkUpdate,
 };
 use crate::{
     client::WeakClient,
@@ -164,26 +163,18 @@ pub(super) async fn auto_shrink_linked_chunk_task(
         };
 
         match state.auto_shrink_if_no_subscribers().await {
-            Ok(diffs) => {
-                if let Some(diffs) = diffs {
-                    // Hey, fun stuff: we shrunk the linked chunk, so there shouldn't be any
-                    // subscribers, right? RIGHT? Especially because the state is guarded behind
-                    // a lock.
-                    //
-                    // However, better safe than sorry, and it's cheap to send an update here,
-                    // so let's do it!
-                    if !diffs.is_empty() {
-                        room.update_sender().send(
-                            RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
-                                diffs,
-                                origin: EventsOrigin::Cache,
-                            }),
-                            None,
-                        );
-                    }
-                } else {
-                    debug!("auto-shrinking didn't happen");
-                }
+            Ok(_diffs) => {
+                // Two situations here:
+                //
+                // 1. No race, no subscribers have been registered, so it's safe
+                //    to do nothing,
+                // 2. A race, a subscriber has been created meanwhile, we **must
+                //    not** send the diff to it, otherwise it can create an
+                //    invalid state.
+                //
+                // Note that a race shouldn't be possible as we have acquired an
+                // exclusive access to the state, ensuring no subscriber can be
+                // created.
             }
 
             Err(err) => {


### PR DESCRIPTION
This PR is twofold.

When a cache (from the Event Cache) has no more subscribers, it auto-shrinks to its last chunk to save memory. That's great! The way it counts/tracks the number of subscribers isn't efficient though. It uses an `Arc<AtomicU32>`. `Arc` in itself is already an atomic counter. We can use `Arc<()>` directly, saving the cost of more atomic operations.

The first main patch introduces `SubscribersHandle` that is owned by the cache state (like `RoomEventCacheState`). When a subscriber is created, `SubscribersHandle::new_subscriber_handle` (note the singular form) is called, and produces a `SubscriberHandle` (still singular form).

A `SubscriberHandle` is a thin type around `Weak<()>`. The state has an `Arc`, the subscribers have a `Weak`. The number of subscribers is calculated by `(Arc|Weak)::weak_count`. That way, no need to `fetch_add` or `load` to calculate the count.

The second main patch removes the sending of the `VectorDiff`s updates when the cache is shrunk. The documentation said:

> Hey, fun stuff: we shrunk the linked chunk, so there shouldn't be any subscribers, right? RIGHT? Especially because the state is guarded behind a lock.
>
> However, better safe than sorry, and it's cheap to send an update here, so let's do it!

I think that's an error. Two situations here:

1. No race, no subscribers have been registered, so it's safe to do nothing,
2. A race, a subscriber has been created meanwhile, we **must not** send the diff to it, otherwise it can create an invalid state.

Note that a race shouldn't be possible as we have acquired an exclusive access to the state, ensuring no subscriber can be created, so technically the diff should be sent to nowhere, but it's really important to **not** send it :-].

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/6152

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
