### PR TITLE
test: add integration test for declining an invite to an empty room

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -71,9 +71,8 @@ async fn test_empty_room_decline_invite() -> Result<()> {
         .room_id()
         .to_owned();
 
-    if let Some(room) = alice.get_room(&room_id) {
-        room.leave().await?;
-    }
+    let room = alice.get_room(&room_id).expect("Alice should see the room");
+    room.leave().await?;
 
     let mut bob_declined = false;
     for i in 1..=5 {

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -37,6 +37,52 @@ use tracing::{debug, error, warn};
 use crate::helpers::{TestClientBuilder, wait_for_room};
 
 #[tokio::test]
+async fn test_empty_room_decline_invite() -> Result<()> {
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
+
+    let b = bob.clone();
+    spawn(async move {
+        let bob = b;
+        loop {
+            if let Err(e) = bob.sync(Default::default()).await {
+                error!("bob sync error: {e}");
+            }
+        }
+    });
+
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+
+    let a = alice.clone();
+    spawn(async move {
+        let alice = a;
+        loop {
+            if let Err(e) = alice.sync(Default::default()).await {
+                error!("alice sync error: {e}");
+            }
+        }
+    });
+
+    let room_id = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned()],
+            is_direct: false,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    if let Some(room) = alice.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    if let Some(room) = bob.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_event_with_context() -> Result<()> {
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -75,9 +75,18 @@ async fn test_empty_room_decline_invite() -> Result<()> {
         room.leave().await?;
     }
 
-    if let Some(room) = bob.get_room(&room_id) {
-        room.leave().await?;
+    let mut bob_declined = false;
+    for i in 1..=5 {
+        if let Some(room) = bob.get_room(&room_id)
+            && matches!(room.state(), RoomState::Invited)
+        {
+            room.leave().await?;
+            bob_declined = true;
+            break;
+        }
+        sleep(Duration::from_millis(500 * i)).await;
     }
+    anyhow::ensure!(bob_declined, "bob couldn't find the invite after ~8 seconds");
 
     Ok(())
 }


### PR DESCRIPTION
This PR is related to #4642. I have added the first of two integration tests (as requested), according to which declining an invite worked just fine.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Paul8711 <154304377+paul8711-code@users.noreply.github.com>
