### PR TITLE
test: add integration test for accepting an invite to an empty room

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use assert_matches2::{assert_let, assert_matches};
 use eyeball::Subscriber;
 use futures::FutureExt as _;
+use http::StatusCode;
 use matrix_sdk::{
     Room, RoomMemberships, RoomState, assert_let_timeout,
     encryption::{BackupDownloadStrategy, EncryptionSettings, recovery::RecoveryState},
@@ -133,7 +134,21 @@ async fn test_empty_room_accept_invite() -> Result<()> {
         if let Some(room) = bob.get_room(&room_id)
             && matches!(room.state(), RoomState::Invited)
         {
-            room.join().await?;
+            if let Err(err) = room.join().await {
+                if let Some(api_err) = err.as_client_api_error() {
+                    if api_err.status_code == StatusCode::NOT_FOUND {
+                        // leave first
+                        room.leave().await?;
+
+                        // then forget
+                        room.forget().await?;
+                    } else {
+                        return Err(err.into());
+                    }
+                } else {
+                    return Err(err.into());
+                }
+            }
             bob_accepted = true;
             break;
         }

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -91,6 +91,52 @@ async fn test_empty_room_decline_invite() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_empty_room_accept_invite() -> Result<()> {
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
+
+    let b = bob.clone();
+    spawn(async move {
+        let bob = b;
+        loop {
+            if let Err(e) = bob.sync(Default::default()).await {
+                error!("bob sync error: {e}");
+            }
+        }
+    });
+
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+
+    let a = alice.clone();
+    spawn(async move {
+        let alice = a;
+        loop {
+            if let Err(e) = alice.sync(Default::default()).await {
+                error!("alice sync error: {e}");
+            }
+        }
+    });
+
+    let room_id = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned()],
+            is_direct: false,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    if let Some(room) = alice.get_room(&room_id) {
+        room.leave().await?;
+    }
+
+    if let Some(room) = bob.get_room(&room_id) {
+        room.join().await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_event_with_context() -> Result<()> {
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -129,9 +129,18 @@ async fn test_empty_room_accept_invite() -> Result<()> {
         room.leave().await?;
     }
 
-    if let Some(room) = bob.get_room(&room_id) {
-        room.join().await?;
+    let mut bob_accepted = false;
+    for i in 1..=5 {
+        if let Some(room) = bob.get_room(&room_id)
+            && matches!(room.state(), RoomState::Invited)
+        {
+            room.join().await?;
+            bob_accepted = true;
+            break;
+        }
+        sleep(Duration::from_millis(500 * i)).await;
     }
+    anyhow::ensure!(bob_accepted, "bob couldn't find the invite after ~8 seconds");
 
     Ok(())
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -129,7 +129,6 @@ async fn test_empty_room_accept_invite() -> Result<()> {
     let room = alice.get_room(&room_id).expect("Alice should see the room");
     room.leave().await?;
 
-    let mut bob_accepted = false;
     for i in 1..=5 {
         if let Some(room) = bob.get_room(&room_id)
             && matches!(room.state(), RoomState::Invited)
@@ -137,11 +136,7 @@ async fn test_empty_room_accept_invite() -> Result<()> {
             if let Err(err) = room.join().await {
                 if let Some(api_err) = err.as_client_api_error() {
                     if api_err.status_code == StatusCode::NOT_FOUND {
-                        // leave first
-                        room.leave().await?;
-
-                        // then forget
-                        room.forget().await?;
+                        return Ok(());
                     } else {
                         return Err(err.into());
                     }
@@ -149,14 +144,11 @@ async fn test_empty_room_accept_invite() -> Result<()> {
                     return Err(err.into());
                 }
             }
-            bob_accepted = true;
             break;
         }
         sleep(Duration::from_millis(500 * i)).await;
     }
-    anyhow::ensure!(bob_accepted, "bob couldn't find the invite after ~8 seconds");
-
-    Ok(())
+    Err(anyhow::anyhow!("bob couldn't find the invite after ~8 seconds"))
 }
 
 #[tokio::test]

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -125,9 +125,8 @@ async fn test_empty_room_accept_invite() -> Result<()> {
         .room_id()
         .to_owned();
 
-    if let Some(room) = alice.get_room(&room_id) {
-        room.leave().await?;
-    }
+    let room = alice.get_room(&room_id).expect("Alice should see the room");
+    room.leave().await?;
 
     let mut bob_accepted = false;
     for i in 1..=5 {


### PR DESCRIPTION
This PR is related to #4642. I have added the second of the two requested integration tests, according to which accepting an invite did indeed not work, but instead threw a completely different error than mentioned.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Paul8711 <154304377+paul8711-code@users.noreply.github.com>
