### PR TITLE
feat(ffi): enable content scanner by passing an existing instance

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6689.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6689.changed.md
@@ -1,0 +1,3 @@
+[**Breaking**]: instead of setting up a `ContentScanner` in `ClientBuilder`,
+using `ClientBuilder::set_content_scanner`, it can now be enabled and disabled at any time using 
+`Client::set_content_scanner` and you can check if content scanning is enabled using `Client::content_scanner`.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3470,4 +3470,39 @@ mod tests {
             .join()
             .expect("Client::drop panicked on a non-tokio thread");
     }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn test_set_content_scanner_sets_media_fetcher() {
+        let client = crate::client_builder::ClientBuilder::new()
+            .homeserver_url("https://example.com".to_owned())
+            .build()
+            .await
+            .expect("build client");
+
+        // No content scanner set, the media fetcher is the default one
+        assert!(client.content_scanner().await.is_none());
+        assert_eq!(format!("{:?}", client.inner.get_media_fetcher().await), "DefaultMediaFetcher");
+
+        // We set a content scanner instance
+        client
+            .set_content_scanner(Some(crate::content_scanner::ContentScanner::new(
+                "https://scanner_url.com".to_owned(),
+            )))
+            .await;
+
+        // Content scanner is present, media fetcher is now based on it
+        assert!(client.content_scanner().await.is_some());
+        assert_eq!(
+            format!("{:?}", client.inner.get_media_fetcher().await),
+            "ContentScannerMediaFetcher"
+        );
+
+        // We remove the content scanner
+        client.set_content_scanner(None).await;
+
+        // We're back to the initial state: no content scanner, default fetcher
+        assert!(client.content_scanner().await.is_none());
+        assert_eq!(format!("{:?}", client.inner.get_media_fetcher().await), "DefaultMediaFetcher");
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -33,7 +33,10 @@ use matrix_sdk::{
     },
     deserialized_responses::RawAnySyncOrStrippedTimelineEvent,
     executor::AbortOnDrop,
-    media::{MediaFormat, MediaRequestParameters, MediaRetentionPolicy, MediaThumbnailSettings},
+    media::{
+        DefaultMediaFetcher, MediaFormat, MediaRequestParameters, MediaRetentionPolicy,
+        MediaThumbnailSettings,
+    },
     ruma::{
         EventEncryptionAlgorithm, RoomId, TransactionId, UInt, UserId,
         api::client::{
@@ -114,7 +117,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{RwLock, broadcast::error::RecvError};
 use tracing::{debug, error, warn};
 use url::Url;
 
@@ -128,6 +131,7 @@ use crate::{
         HomeserverLoginDetails, OAuthConfiguration, OAuthError, SsoError, SsoHandler,
     },
     client,
+    content_scanner::ContentScanner,
     encryption::Encryption,
     live_locations_observer::BeaconInfoUpdate,
     notification::{
@@ -374,6 +378,8 @@ pub struct Client {
     /// SQLite or IndexedDB).
     #[cfg_attr(not(feature = "sqlite"), allow(unused))]
     store_path: Option<PathBuf>,
+
+    content_scanner: RwLock<Option<Arc<ContentScanner>>>,
 }
 
 impl Client {
@@ -418,6 +424,7 @@ impl Client {
             utd_hook_manager: OnceLock::new(),
             session_verification_controller,
             store_path,
+            content_scanner: Default::default(),
         };
 
         match store_mode {
@@ -2236,6 +2243,24 @@ impl Client {
 
     pub fn homeserver_capabilities(&self) -> HomeserverCapabilities {
         HomeserverCapabilities::new(self.inner.homeserver_capabilities())
+    }
+
+    /// Enables or disables the content scanner feature using the provided
+    /// [`ContentScanner`] instance.
+    pub async fn set_content_scanner(&self, content_scanner: Option<Arc<ContentScanner>>) {
+        let media_fetcher = if let Some(content_scanner) = &content_scanner {
+            content_scanner.media_fetcher()
+        } else {
+            Arc::new(DefaultMediaFetcher)
+        };
+        self.inner.set_media_fetcher(media_fetcher).await;
+
+        *self.content_scanner.write().await = content_scanner;
+    }
+
+    /// Returns the currently used [`ContentScanner`] instance, if any.
+    pub async fn content_scanner(&self) -> Option<Arc<ContentScanner>> {
+        self.content_scanner.read().await.clone()
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -40,7 +40,6 @@ use matrix_sdk_base::{
     DmRoomDefinition,
     crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
 };
-use matrix_sdk_contentscanner::ContentScannerMediaFetcher;
 use ruma::api::error::{DeserializationError, FromHttpResponseError};
 use tracing::debug;
 
@@ -215,12 +214,6 @@ impl ClientBuilder {
             dm_room_definition: DmRoomDefinition::MatrixSpec,
             media_fetcher: None,
         })
-    }
-
-    pub fn enable_content_scanner(self: Arc<Self>, scanner_url: String) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.media_fetcher = Some(Arc::new(ContentScannerMediaFetcher::new(scanner_url)));
-        Arc::new(builder)
     }
 
     pub fn dm_room_definition(self: Arc<Self>, dm_room_definition: DmRoomDefinition) -> Arc<Self> {

--- a/bindings/matrix-sdk-ffi/src/content_scanner.rs
+++ b/bindings/matrix-sdk-ffi/src/content_scanner.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use matrix_sdk::media::MediaFetcher;
+use matrix_sdk_contentscanner::{ContentScannerMediaFetcher, MediaScanResponse};
+
+use crate::{client::Client, error::ClientError, ruma::MediaSource};
+
+#[derive(Debug, uniffi::Object)]
+pub struct ContentScanner {
+    pub(crate) inner: Arc<matrix_sdk_contentscanner::ContentScanner>,
+}
+
+impl ContentScanner {
+    pub(crate) fn media_fetcher(&self) -> Arc<dyn MediaFetcher> {
+        Arc::new(ContentScannerMediaFetcher::with_content_scanner(self.inner.clone()))
+    }
+}
+
+#[matrix_sdk_ffi_macros::export]
+impl ContentScanner {
+    /// Instantiate a new [`ContentScanner`] using the `scanner_url`.
+    #[uniffi::constructor]
+    pub fn new(scanner_url: String) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Arc::new(matrix_sdk_contentscanner::ContentScanner::new(scanner_url)),
+        })
+    }
+
+    /// Scan a media source, returning a [`MediaScanResponse`] with the scan
+    /// result, or an error if something failed when trying to scan the media.
+    pub async fn scan(
+        &self,
+        client: Arc<Client>,
+        media_source: Arc<MediaSource>,
+    ) -> Result<MediaScanResponse, ClientError> {
+        Ok(self.inner.scan(&client.inner, &media_source.media_source).await?)
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -6,6 +6,7 @@ mod authentication;
 mod chunk_iterator;
 mod client;
 mod client_builder;
+mod content_scanner;
 mod encryption;
 mod error;
 mod event;

--- a/crates/matrix-sdk-contentscanner/changelog.d/6689.added.md
+++ b/crates/matrix-sdk-contentscanner/changelog.d/6689.added.md
@@ -1,0 +1,3 @@
+`MediaScanResponse` is now exposed in the FFI layer too, and there is a new
+`ContentScannerMediaFetcher::with_content_scanner(Arc<ContentScanner>)` method that allows you to create a media fetcher
+that will reuse an existing `ContentScanner` instance instead of creating a new one.

--- a/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
@@ -24,6 +24,7 @@ pub mod unencrypted;
 
 /// A media scan response containing the result of the scan.
 /// Spec: <https://github.com/element-hq/matrix-content-scanner-python/blob/main/docs/api.md#get-_matrixmedia_proxyunstablescanservernamemediaid>
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 #[derive(Debug, Deserialize)]
 pub struct MediaScanResponse {
     /// Whether the media is clean or contained something dangerous.

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -189,13 +189,17 @@ impl EncryptedFileRequest {
 
 /// A media fetcher that uses the content scanner to download and scan media.
 pub struct ContentScannerMediaFetcher {
-    pub content_scanner: ContentScanner,
+    pub content_scanner: Arc<ContentScanner>,
 }
 
 impl ContentScannerMediaFetcher {
     /// Instantiate a new [`MediaFetcher`] using the provided `scanner_url`.
     pub fn new(scanner_url: impl Into<String>) -> Self {
-        Self { content_scanner: ContentScanner::new(scanner_url.into()) }
+        Self { content_scanner: Arc::new(ContentScanner::new(scanner_url.into())) }
+    }
+
+    pub fn with_content_scanner(content_scanner: Arc<ContentScanner>) -> Self {
+        Self { content_scanner }
     }
 }
 

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 
 use api::{
     download::{
@@ -212,6 +215,12 @@ impl MediaFetcher for ContentScannerMediaFetcher {
         Box::pin(async move {
             Ok(self.content_scanner.get_media(client, &request.source).await?.content)
         })
+    }
+}
+
+impl Debug for ContentScannerMediaFetcher {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ContentScannerMediaFetcher")
     }
 }
 

--- a/crates/matrix-sdk/changelog.d/6689.changed.md
+++ b/crates/matrix-sdk/changelog.d/6689.changed.md
@@ -1,0 +1,2 @@
+Put `ClientInner::MediaFetcher` behind a `RwLock` so it can be replaced at any time from any thread, 
+without having a mutable `ClientInner` reference around.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -513,10 +513,6 @@ impl ClientInner {
 
         client
     }
-
-    pub async fn set_media_fetcher(&self, media_fetcher: Arc<dyn MediaFetcher>) {
-        *self.media_fetcher.write().await = media_fetcher;
-    }
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -3617,7 +3613,13 @@ impl Client {
     /// Replaces the [`MediaFetcher`] used to download media from the media
     /// server with the provided one.
     pub async fn set_media_fetcher(&self, media_fetcher: Arc<dyn MediaFetcher>) {
-        self.inner.set_media_fetcher(media_fetcher).await;
+        *self.inner.media_fetcher.write().await = media_fetcher;
+    }
+
+    /// Returns the currently used [`MediaFetcher`] used to download media from
+    /// the media server.
+    pub async fn get_media_fetcher(&self) -> Arc<dyn MediaFetcher> {
+        self.inner.media_fetcher.read().await.clone()
     }
 }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -418,7 +418,7 @@ pub(crate) struct ClientInner {
     pub(crate) duplicate_key_upload_error_sender:
         broadcast::Sender<Option<DuplicateOneTimeKeyErrorMessage>>,
 
-    pub(crate) media_fetcher: Arc<dyn MediaFetcher>,
+    pub(crate) media_fetcher: RwLock<Arc<dyn MediaFetcher>>,
 }
 
 impl ClientInner {
@@ -492,7 +492,7 @@ impl ClientInner {
             task_monitor: TaskMonitor::new(),
             #[cfg(feature = "e2e-encryption")]
             duplicate_key_upload_error_sender: broadcast::channel(1).0,
-            media_fetcher,
+            media_fetcher: RwLock::new(media_fetcher),
         };
 
         #[allow(clippy::let_and_return)]
@@ -512,6 +512,10 @@ impl ClientInner {
         let _ = join!(init_event_cache, init_thread_subscription_catchup);
 
         client
+    }
+
+    pub async fn set_media_fetcher(&self, media_fetcher: Arc<dyn MediaFetcher>) {
+        *self.media_fetcher.write().await = media_fetcher;
     }
 }
 
@@ -844,7 +848,7 @@ impl Client {
 
     /// Get the media manager of the client.
     pub fn media(&self) -> Media {
-        Media::new(self.clone(), self.inner.media_fetcher.clone())
+        Media::new(self.clone())
     }
 
     /// Get the pusher manager of the client.
@@ -3307,7 +3311,7 @@ impl Client {
                 #[cfg(feature = "experimental-search")]
                 self.inner.search_index.clone(),
                 self.inner.thread_subscription_catchup.clone(),
-                self.inner.media_fetcher.clone(),
+                (*self.inner.media_fetcher.read().await).clone(),
             )
             .await,
         };
@@ -3608,6 +3612,12 @@ impl Client {
     /// a DM.
     pub fn dm_room_definition(&self) -> &DmRoomDefinition {
         &self.inner.base_client.dm_room_definition
+    }
+
+    /// Replaces the [`MediaFetcher`] used to download media from the media
+    /// server with the provided one.
+    pub async fn set_media_fetcher(&self, media_fetcher: Arc<dyn MediaFetcher>) {
+        self.inner.set_media_fetcher(media_fetcher).await;
     }
 }
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -163,7 +163,7 @@ pub enum MediaError {
 }
 
 /// A generic trait for fetching media content.
-pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm {
+pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm + fmt::Debug {
     /// Fetches the media content for the given [`MediaRequestParameters`].
     /// Returns either a byte array or an [`crate::Error`].
     fn fetch_media_content<'a>(
@@ -171,12 +171,6 @@ pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm {
         client: &'a Client,
         request: &'a MediaRequestParameters,
     ) -> BoxFuture<'a, Result<Vec<u8>, Error>>;
-}
-
-impl fmt::Debug for dyn MediaFetcher {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("MediaFetcher")
-    }
 }
 
 impl Media {

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -17,7 +17,7 @@
 
 #[cfg(feature = "e2e-encryption")]
 use std::io::Read;
-use std::{fmt, sync::Arc, time::Duration};
+use std::{fmt, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use std::{fs::File, path::Path};
 
@@ -66,7 +66,6 @@ const LOCAL_MXC_SERVER_NAME: &str = "send-queue.localhost";
 pub struct Media {
     /// The underlying HTTP client.
     client: Client,
-    media_fetcher: Arc<dyn MediaFetcher>,
 }
 
 /// A file handle that takes ownership of a media file on disk. When the handle
@@ -181,8 +180,8 @@ impl fmt::Debug for dyn MediaFetcher {
 }
 
 impl Media {
-    pub(crate) fn new(client: Client, media_fetcher: Arc<dyn MediaFetcher>) -> Self {
-        Self { client, media_fetcher: media_fetcher.clone() }
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
     }
 
     /// Upload some media to the server.
@@ -453,7 +452,14 @@ impl Media {
             return Ok(content);
         }
 
-        let content = self.media_fetcher.fetch_media_content(&self.client, request).await?;
+        let content = self
+            .client
+            .inner
+            .media_fetcher
+            .read()
+            .await
+            .fetch_media_content(&self.client, request)
+            .await?;
 
         if use_cache {
             self.client
@@ -729,7 +735,7 @@ impl Media {
 /// A [`MediaFetcher`] that uses the default media/authenticated media endpoints
 /// to fetch new media.
 #[derive(Debug, Clone)]
-pub(crate) struct DefaultMediaFetcher;
+pub struct DefaultMediaFetcher;
 
 impl MediaFetcher for DefaultMediaFetcher {
     fn fetch_media_content<'a>(


### PR DESCRIPTION
Replace setting up the content scanner at the `ClientBuilder` to being able to set it on the fly when needed.

It's a lot easier for the clients to enable/disable this on the fly than having to create the client with the value ahead of time.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
