### PR TITLE
feat(sdk): All caches have an auto-shrink mechanism

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -28,7 +28,7 @@ use matrix_sdk::{
     deserialized_responses::TimelineEvent,
     event_cache::{
         DecryptionRetryRequest, EventCache, EventFocusedCache, PaginationStatus, PinnedEventsCache,
-        RoomEventCache, ThreadEventCache, TimelineVectorDiffs,
+        RoomEventCache, Subscriber as EventCacheSubscriber, ThreadEventCache, TimelineVectorDiffs,
     },
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendHandle, SendReactionHandle,
@@ -52,7 +52,7 @@ use ruma::{
     room_version_rules::RoomVersionRules,
     serde::Raw,
 };
-use tokio::sync::{RwLock, RwLockWriteGuard, broadcast};
+use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{
     Instrument as _, Span, debug, error, field::debug, info, info_span, instrument, trace, warn,
 };
@@ -1417,7 +1417,7 @@ impl TimelineController {
             }
 
             TimelineFocusKind::Thread { event_cache, .. } => {
-                let (has_events, receiver) = self.init_with_thread_root(event_cache).await?;
+                let (has_events, subscriber) = self.init_with_thread_root(event_cache).await?;
 
                 let room = &self.room_data_provider;
                 let span = info_span!(
@@ -1432,7 +1432,7 @@ impl TimelineController {
                     .task_monitor()
                     .spawn_infinite_task(
                         "timeline::thread_event_cache_updates",
-                        thread_updates_task(receiver, event_cache.clone(), self.clone())
+                        thread_updates_task(subscriber, event_cache.clone(), self.clone())
                             .instrument(span),
                     )
                     .abort_on_drop();
@@ -1475,8 +1475,8 @@ impl TimelineController {
     pub(super) async fn init_with_thread_root(
         &self,
         event_cache: &ThreadEventCache,
-    ) -> Result<(bool, broadcast::Receiver<TimelineVectorDiffs>), Error> {
-        let (events, receiver) = event_cache.subscribe().await?;
+    ) -> Result<(bool, EventCacheSubscriber<TimelineVectorDiffs>), Error> {
+        let (events, subscriber) = event_cache.subscribe().await?;
         let has_events = !events.is_empty();
 
         // For each event, we also need to find the related events, as they don't
@@ -1502,7 +1502,7 @@ impl TimelineController {
             .await;
         }
 
-        Ok((has_events, receiver))
+        Ok((has_events, subscriber))
     }
 
     /// Given an event identifier, will fetch the details for the event it's

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -138,7 +138,7 @@ pub(in crate::timeline) async fn event_focused_task(
 /// For a thread-focused timeline, a long-lived task that will listen to the
 /// underlying thread updates.
 pub(in crate::timeline) async fn thread_updates_task(
-    mut receiver: Receiver<TimelineVectorDiffs>,
+    mut thread_event_cache_subscriber: Subscriber<TimelineVectorDiffs>,
     event_cache: ThreadEventCache,
     timeline_controller: TimelineController,
 ) {
@@ -147,7 +147,7 @@ pub(in crate::timeline) async fn thread_updates_task(
     loop {
         trace!("Waiting for an event.");
 
-        let update = match receiver.recv().await {
+        let update = match thread_event_cache_subscriber.recv().await {
             Ok(up) => up,
             Err(RecvError::Closed) => break,
             Err(RecvError::Lagged(num_skipped)) => {

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeSet;
 use matrix_sdk::{
     event_cache::{
         EventFocusThreadMode, EventFocusedCache, EventsOrigin, PinnedEventsCache, RoomEventCache,
-        RoomEventCacheSubscriber, RoomEventCacheUpdate, ThreadEventCache, TimelineVectorDiffs,
+        RoomEventCacheUpdate, Subscriber, ThreadEventCache, TimelineVectorDiffs,
     },
     send_queue::RoomSendQueueUpdate,
 };
@@ -187,7 +187,7 @@ pub(in crate::timeline) async fn thread_updates_task(
 pub(in crate::timeline) async fn room_event_cache_updates_task(
     room_event_cache: RoomEventCache,
     timeline_controller: TimelineController,
-    mut room_event_cache_subscriber: RoomEventCacheSubscriber,
+    mut room_event_cache_subscriber: Subscriber<RoomEventCacheUpdate>,
     timeline_focus: TimelineFocus,
 ) {
     trace!("Spawned the event subscriber task.");

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -21,7 +21,7 @@ use imbl::Vector;
 use matrix_sdk::{
     Result, Room,
     deserialized_responses::TimelineEvent,
-    event_cache::{RoomEventCacheSubscriber, RoomEventCacheUpdate},
+    event_cache::{RoomEventCacheUpdate, Subscriber as EventCacheSubscriber},
     locks::Mutex,
     paginators::PaginationToken,
     room::ListThreadsOptions,
@@ -383,7 +383,7 @@ impl ThreadListService {
     /// [`ThreadListItem`]'s `latest_event` and `num_replies`.
     async fn event_cache_listener_loop(
         room: &Room,
-        subscriber: &mut RoomEventCacheSubscriber,
+        subscriber: &mut EventCacheSubscriber<RoomEventCacheUpdate>,
         items: Arc<Mutex<ObservableVector<ThreadListItem>>>,
     ) {
         use tokio::sync::broadcast::error::RecvError;

--- a/crates/matrix-sdk/changelog.d/6690.added.md
+++ b/crates/matrix-sdk/changelog.d/6690.added.md
@@ -1,0 +1,5 @@
+`ThreadEventCache` auto-shrinks when no more subscribers are alive. Subscribers
+are returned by [`ThreadEventCache::subscribe`]. When the last subscriber is
+dropped, it means no external API are listening to this cache, and thus it
+shrinks to its last chunk of events, to save memory. This behaviour was already
+present for `RoomEventCache`.

--- a/crates/matrix-sdk/changelog.d/6690.changed.md
+++ b/crates/matrix-sdk/changelog.d/6690.changed.md
@@ -1,0 +1,4 @@
+The `event_cache::RoomEventCacheSubscriber` type has been renamed to
+`event_cache::Subscriber<RoomEventCacheUpdate>`. The type has been made generic
+to be reused by `ThreadEventCache`. The behaviour is exactly the same as it
+keeps `Deref` and `DerefMut` to `tokio::sync::mpsc::Receiver`.

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -40,6 +40,7 @@ pub mod pagination;
 pub mod pinned_events;
 mod read_receipts;
 pub mod room;
+mod subscriber;
 pub mod thread;
 
 /// A type to hold all the caches for a given room.

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -76,6 +76,7 @@ pub(super) struct Caches {
 #[derive(Debug)]
 struct CachesInternals {
     state: states::StateLock,
+    auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
     linked_chunk_update_sender: Sender<room::RoomEventCacheLinkedChunkUpdate>,
     room_version_rules: RoomVersionRules,
 }
@@ -143,7 +144,7 @@ impl Caches {
             own_user_id,
             room_state,
             pagination_status,
-            auto_shrink_sender,
+            auto_shrink_sender.clone(),
             update_sender,
         );
 
@@ -161,6 +162,7 @@ impl Caches {
             event_focused: Arc::new(RwLock::new(HashMap::new())),
             internals: CachesInternals {
                 state: state.clone(),
+                auto_shrink_sender,
                 linked_chunk_update_sender,
                 room_version_rules,
             },
@@ -207,6 +209,7 @@ impl Caches {
                         self.internals.room_version_rules.clone(),
                         room.weak_room().to_owned(),
                         &self.internals.state,
+                        self.internals.auto_shrink_sender.clone(),
                         room.update_sender().generic_update_sender().clone(),
                         self.internals.linked_chunk_update_sender.clone(),
                     )

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -27,9 +27,9 @@ use tokio::sync::{
     OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, broadcast::Sender, mpsc,
 };
 
+use self::subscriber::AutoShrinkChannelPayload;
 use super::{
-    AutoShrinkChannelPayload, EventCacheError, EventsOrigin, Result,
-    automatic_pagination::AutomaticPagination, states,
+    EventCacheError, EventsOrigin, Result, automatic_pagination::AutomaticPagination, states,
 };
 use crate::{client::WeakClient, room::WeakRoom};
 

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -40,7 +40,7 @@ pub mod pagination;
 pub mod pinned_events;
 mod read_receipts;
 pub mod room;
-mod subscriber;
+pub mod subscriber;
 pub mod thread;
 
 /// A type to hold all the caches for a given room.

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -27,7 +27,7 @@ use tokio::sync::{
     OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, broadcast::Sender, mpsc,
 };
 
-use self::subscriber::AutoShrinkChannelPayload;
+use self::subscriber::AutoShrinkMessage;
 use super::{
     EventCacheError, EventsOrigin, Result, automatic_pagination::AutomaticPagination, states,
 };
@@ -87,7 +87,7 @@ impl Caches {
         room_id: &RoomId,
         generic_update_sender: Sender<room::RoomEventCacheGenericUpdate>,
         linked_chunk_update_sender: Sender<room::RoomEventCacheLinkedChunkUpdate>,
-        auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+        auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
         state: &states::StateLock,
         automatic_pagination: Option<AutomaticPagination>,
     ) -> Result<Self> {

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -14,7 +14,6 @@
 
 pub mod pagination;
 mod state;
-mod subscriber;
 mod updates;
 
 use std::{collections::BTreeMap, fmt, sync::Arc};
@@ -36,7 +35,6 @@ use tracing::{instrument, trace, warn};
 use self::pagination::RoomPagination;
 pub use self::{
     state::RoomEventCacheState,
-    subscriber::RoomEventCacheSubscriber,
     updates::{
         RoomEventCacheGenericUpdate, RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdate,
         RoomEventCacheUpdateSender,
@@ -50,6 +48,7 @@ use super::{
     TimelineVectorDiffs,
     event_linked_chunk::sort_positions_descending,
     pagination::SharedPaginationStatus,
+    subscriber::RoomEventCacheSubscriber,
 };
 use crate::room::WeakRoom;
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -48,7 +48,7 @@ use super::{
     TimelineVectorDiffs,
     event_linked_chunk::sort_positions_descending,
     pagination::SharedPaginationStatus,
-    subscriber::{AutoShrinkChannelPayload, Subscriber},
+    subscriber::{AutoShrinkMessage, Subscriber},
 };
 use crate::room::WeakRoom;
 
@@ -74,7 +74,7 @@ impl RoomEventCache {
         own_user_id: OwnedUserId,
         state: CacheStateLock<RoomStateSelector>,
         shared_pagination_status: SharedObservable<SharedPaginationStatus>,
-        auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+        auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
         update_sender: RoomEventCacheUpdateSender,
     ) -> Self {
         Self {
@@ -329,7 +329,7 @@ pub(super) struct RoomEventCacheInner {
     ///
     /// See doc comment around [`EventCache::auto_shrink_linked_chunk_task`] for
     /// more details.
-    auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+    auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
 
     /// Update sender for this room.
     update_sender: RoomEventCacheUpdateSender,

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -48,7 +48,7 @@ use super::{
     TimelineVectorDiffs,
     event_linked_chunk::sort_positions_descending,
     pagination::SharedPaginationStatus,
-    subscriber::RoomEventCacheSubscriber,
+    subscriber::Subscriber,
 };
 use crate::room::WeakRoom;
 
@@ -120,16 +120,16 @@ impl RoomEventCache {
     /// events.
     ///
     /// Use [`RoomEventCache::events`] to get all current events without the
-    /// subscriber. Creating, and especially dropping, a
-    /// [`RoomEventCacheSubscriber`] isn't free, as it triggers side-effects.
-    pub async fn subscribe(&self) -> Result<(Vec<Event>, RoomEventCacheSubscriber)> {
+    /// subscriber. Creating, and especially dropping, a [`Subscriber`] isn't
+    /// free, as it triggers side-effects.
+    pub async fn subscribe(&self) -> Result<(Vec<Event>, Subscriber<RoomEventCacheUpdate>)> {
         let state = self.inner.state.read().await?;
         let events =
             state.room_linked_chunk().events().map(|(_position, item)| item.clone()).collect();
 
         let subscribers_handle = state.subscribers_handle();
 
-        let subscriber = RoomEventCacheSubscriber::new(
+        let subscriber = Subscriber::new(
             self.inner.update_sender.new_room_receiver(),
             self.inner.room_id.clone(),
             self.inner.auto_shrink_sender.clone(),

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -131,7 +131,7 @@ impl RoomEventCache {
 
         let subscriber = Subscriber::new(
             self.inner.update_sender.new_room_receiver(),
-            self.inner.room_id.clone(),
+            AutoShrinkMessage::Room { room_id: self.inner.room_id.clone() },
             self.inner.auto_shrink_sender.clone(),
             subscribers_handle,
         );

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -42,13 +42,13 @@ pub use self::{
 };
 use super::{
     super::{
-        AutoShrinkChannelPayload, EventsOrigin, Result,
+        EventsOrigin, Result,
         states::{CacheStateLock, StateLockWriteGuard, selectors::RoomStateSelector},
     },
     TimelineVectorDiffs,
     event_linked_chunk::sort_positions_descending,
     pagination::SharedPaginationStatus,
-    subscriber::Subscriber,
+    subscriber::{AutoShrinkChannelPayload, Subscriber},
 };
 use crate::room::WeakRoom;
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -55,9 +55,9 @@ use super::{
         event_linked_chunk::EventLinkedChunk,
         pagination::SharedPaginationStatus,
         read_receipts::compute_unread_counts,
+        subscriber::SubscribersHandle,
     },
     RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdateSender, sort_positions_descending,
-    subscriber::SubscribersHandle,
 };
 use crate::room::WeakRoom;
 

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -182,14 +182,22 @@ impl<T> DerefMut for Subscriber<T> {
     }
 }
 
-pub type AutoShrinkMessage = OwnedRoomId;
+/// Type of messages exchanged between [`Subscriber`] and the
+/// [`auto_shrink_linked_chunk_task`] task.
+///
+/// [`auto_shrink_linked_chunk_task`]: super::super::tasks::auto_shrink_linked_chunk_task
+#[derive(Debug)]
+pub enum AutoShrinkMessage {
+    Room { room_id: OwnedRoomId },
+}
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use ruma::owned_room_id;
     use tokio::sync::{broadcast, mpsc};
 
-    use super::{Subscriber, SubscribersHandle};
+    use super::{AutoShrinkMessage, Subscriber, SubscribersHandle};
 
     #[test]
     fn test_subscribers_handle() {
@@ -237,7 +245,7 @@ mod tests {
 
         let mut subscriber = Subscriber::new(
             subscriber_receiver,
-            owned_room_id!("!r0"),
+            AutoShrinkMessage::Room { room_id: owned_room_id!("!r0") },
             auto_shrink_sender,
             &subscribers_handle,
         );
@@ -256,18 +264,19 @@ mod tests {
         let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_message = owned_room_id!("!r0");
+        let room_id = owned_room_id!("!r0");
+        let auto_shrink_message = AutoShrinkMessage::Room { room_id: room_id.clone() };
 
         let subscriber0 = Subscriber::new(
             subscriber_receiver.resubscribe(),
-            auto_shrink_message.clone(),
+            AutoShrinkMessage::Room { room_id: room_id.clone() },
             auto_shrink_sender.clone(),
             &subscribers_handle,
         );
 
         let subscriber1 = Subscriber::new(
             subscriber_receiver,
-            auto_shrink_message.clone(),
+            auto_shrink_message,
             auto_shrink_sender,
             &subscribers_handle,
         );
@@ -278,7 +287,12 @@ mod tests {
 
         // Drop the last subscriber. Side-effect should… take effect!
         drop(subscriber1);
-        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_message);
+        assert_matches!(
+            auto_shrink_receiver.try_recv().unwrap(),
+            AutoShrinkMessage::Room { room_id: expected_room_id } => {
+                assert_eq!(expected_room_id, room_id);
+            }
+        );
         assert!(auto_shrink_receiver.is_empty());
     }
 
@@ -287,11 +301,13 @@ mod tests {
         let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_noisy_message = owned_room_id!("!r1");
-        let auto_shrink_message = owned_room_id!("!r0");
+        let noisy_room_id = owned_room_id!("!r1");
+        let auto_shrink_noisy_message = AutoShrinkMessage::Room { room_id: noisy_room_id.clone() };
+        let room_id = owned_room_id!("!r0");
+        let auto_shrink_message = AutoShrinkMessage::Room { room_id };
 
         // Saturate the `auto_shrink` channel.
-        auto_shrink_sender.try_send(auto_shrink_noisy_message.clone()).unwrap();
+        auto_shrink_sender.try_send(auto_shrink_noisy_message).unwrap();
 
         let subscriber = Subscriber::new(
             subscriber_receiver,
@@ -307,7 +323,12 @@ mod tests {
 
         // We receive the noisy message: **not** the message from the subscriber under
         // testing.
-        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_noisy_message);
+        assert_matches!(
+            auto_shrink_receiver.try_recv().unwrap(),
+            AutoShrinkMessage::Room { room_id: expected_room_id } => {
+                assert_eq!(expected_room_id, noisy_room_id);
+            }
+        );
 
         // Then, we receive nothing, i.e. `subscriber` dropped without any side-effect.
         assert!(auto_shrink_receiver.is_empty());
@@ -318,7 +339,8 @@ mod tests {
         let (auto_shrink_sender, auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_message = owned_room_id!("!r0");
+        let room_id = owned_room_id!("!r0");
+        let auto_shrink_message = AutoShrinkMessage::Room { room_id };
 
         let subscriber = Subscriber::new(
             subscriber_receiver,

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -254,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subscriber_deref() {
+    fn test_subscriber_t_derefs_to_t() {
         let (auto_shrink_sender, _auto_shrink_receiver) = mpsc::channel(1);
         let (subscriber_sender, subscriber_receiver) = broadcast::channel(1);
         let subscribers_handle = SubscribersHandle::default();

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -19,10 +19,9 @@ use std::{
     sync::{Arc, Weak},
 };
 
+use ruma::OwnedRoomId;
 use tokio::sync::{broadcast::Receiver, mpsc};
 use tracing::{trace, warn};
-
-use super::super::AutoShrinkChannelPayload;
 
 /// A structure that can generate handles for subscribers, and count them. See
 /// [`SubscriberHandle`] to learn more.
@@ -182,6 +181,8 @@ impl<T> DerefMut for Subscriber<T> {
         &mut self.subscriber_receiver
     }
 }
+
+pub type AutoShrinkChannelPayload = OwnedRoomId;
 
 #[cfg(test)]
 mod tests {

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -19,7 +19,7 @@ use std::{
     sync::{Arc, Weak},
 };
 
-use ruma::OwnedRoomId;
+use ruma::{OwnedEventId, OwnedRoomId};
 use tokio::sync::{broadcast::Receiver, mpsc};
 use tracing::{trace, warn};
 
@@ -188,7 +188,23 @@ impl<T> DerefMut for Subscriber<T> {
 /// [`auto_shrink_linked_chunk_task`]: super::super::tasks::auto_shrink_linked_chunk_task
 #[derive(Debug)]
 pub enum AutoShrinkMessage {
-    Room { room_id: OwnedRoomId },
+    /// Ask to automatically shrink a [`RoomEventCache`].
+    ///
+    /// [`RoomEventCache`]: super::room::RoomEventCache
+    Room {
+        /// The ID of the room.
+        room_id: OwnedRoomId,
+    },
+
+    /// Ask to automatically shrink a [`ThreadEventCache`].
+    ///
+    /// [`ThreadEventCache`]: super::thread::ThreadEventCache
+    Thread {
+        /// The room ID of the thread.
+        room_id: OwnedRoomId,
+        /// The thread ID (root).
+        thread_id: OwnedEventId,
+    },
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -76,8 +76,8 @@ impl SubscriberHandle {
 /// The side-effect takes effect on `Drop`.
 #[allow(missing_debug_implementations)]
 pub struct Subscriber<T> {
-    /// Underlying receiver of the room event cache's updates.
-    recv: Receiver<T>,
+    /// Underlying receiver of the cache's updates.
+    subscriber_receiver: Receiver<T>,
 
     /// The payload that is going to be sent to [`Self::auto_shrink_sender`].
     ///
@@ -102,13 +102,13 @@ pub struct Subscriber<T> {
 impl<T> Subscriber<T> {
     /// Create a new [`Subscriber`].
     pub(super) fn new(
-        recv: Receiver<T>,
+        subscriber_receiver: Receiver<T>,
         auto_shrink_payload: AutoShrinkChannelPayload,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
         subscribers_handle: &SubscribersHandle,
     ) -> Self {
         Self {
-            recv,
+            subscriber_receiver,
             auto_shrink_payload: Some(auto_shrink_payload),
             auto_shrink_sender,
             subscriber_handle: Some(subscribers_handle.new_subscriber_handle()),
@@ -173,19 +173,22 @@ impl<T> Deref for Subscriber<T> {
     type Target = Receiver<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.recv
+        &self.subscriber_receiver
     }
 }
 
 impl<T> DerefMut for Subscriber<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.recv
+        &mut self.subscriber_receiver
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SubscribersHandle;
+    use ruma::owned_room_id;
+    use tokio::sync::{broadcast, mpsc};
+
+    use super::{Subscriber, SubscribersHandle};
 
     #[test]
     fn test_subscribers_handle() {
@@ -223,5 +226,115 @@ mod tests {
         // ZERO, yes, not 1.
         // If the state containing the `SubscribersHandle` drops, there is no
         // more update, and no auto-shrink, so it's fine to get a zero here.
+    }
+
+    #[test]
+    fn test_subscriber_deref() {
+        let (auto_shrink_sender, _auto_shrink_receiver) = mpsc::channel(1);
+        let (subscriber_sender, subscriber_receiver) = broadcast::channel(1);
+        let subscribers_handle = SubscribersHandle::default();
+
+        let mut subscriber = Subscriber::new(
+            subscriber_receiver,
+            owned_room_id!("!r0"),
+            auto_shrink_sender,
+            &subscribers_handle,
+        );
+
+        subscriber_sender.send('a').unwrap();
+
+        // `DerefMut` with `try_recv(&mut self)`.
+        assert_eq!(subscriber.try_recv().unwrap(), 'a');
+
+        // `Deref` with `is_empty(&self)`.
+        assert!(subscriber.is_empty());
+    }
+
+    #[test]
+    fn test_subscriber_send_auto_shrink_payload_on_last_drop() {
+        let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
+        let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
+        let subscribers_handle = SubscribersHandle::default();
+        let auto_shrink_payload = owned_room_id!("!r0");
+
+        let subscriber0 = Subscriber::new(
+            subscriber_receiver.resubscribe(),
+            auto_shrink_payload.clone(),
+            auto_shrink_sender.clone(),
+            &subscribers_handle,
+        );
+
+        let subscriber1 = Subscriber::new(
+            subscriber_receiver,
+            auto_shrink_payload.clone(),
+            auto_shrink_sender,
+            &subscribers_handle,
+        );
+
+        // Drop a subscriber. No side-effect because there is still one alive!
+        drop(subscriber0);
+        assert!(auto_shrink_receiver.is_empty());
+
+        // Drop the last subscriber. Side-effect should… take effect!
+        drop(subscriber1);
+        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_payload);
+        assert!(auto_shrink_receiver.is_empty());
+    }
+
+    #[test]
+    fn test_subscriber_send_auto_shrink_payload_with_full_channel() {
+        let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
+        let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
+        let subscribers_handle = SubscribersHandle::default();
+        let auto_shrink_noisy_payload = owned_room_id!("!r1");
+        let auto_shrink_payload = owned_room_id!("!r0");
+
+        // Saturate the `auto_shrink` channel.
+        auto_shrink_sender.try_send(auto_shrink_noisy_payload.clone()).unwrap();
+
+        let subscriber = Subscriber::new(
+            subscriber_receiver,
+            auto_shrink_payload,
+            auto_shrink_sender,
+            &subscribers_handle,
+        );
+
+        // Drop the last subscriber. Side-effect should… take effect, but (!) the
+        // channel is full, so it's going to retry many times and will fail, resulting
+        // in no side-effect.
+        drop(subscriber);
+
+        // We receive the noisy payload: **not** the payload from the subscriber under
+        // testing.
+        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_noisy_payload);
+
+        // Then, we receive nothing, i.e. `subscriber` dropped without any side-effect.
+        assert!(auto_shrink_receiver.is_empty());
+    }
+
+    #[test]
+    fn test_subscriber_send_auto_shrink_payload_with_closed_channel() {
+        let (auto_shrink_sender, auto_shrink_receiver) = mpsc::channel(1);
+        let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
+        let subscribers_handle = SubscribersHandle::default();
+        let auto_shrink_payload = owned_room_id!("!r0");
+
+        let subscriber = Subscriber::new(
+            subscriber_receiver,
+            auto_shrink_payload,
+            auto_shrink_sender,
+            &subscribers_handle,
+        );
+
+        // Close the `auto_shrink` channel.
+        drop(auto_shrink_receiver);
+
+        // Drop the last subscriber. Side-effect should… take effect, but (!) the
+        // channel is closed, so it's going to stop immediately, resulting in no
+        // side-effect.
+        drop(subscriber);
+
+        // Sadly, nothing to assert because we are now blind, but at least the
+        // system shouldn't explode!
     }
 }

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The [`RoomEventCacheSubscriber`] implementation.
+//! The [`Subscriber`] implementation.
 
 use std::{
     ops::{Deref, DerefMut},
     sync::{Arc, Weak},
 };
 
-use ruma::OwnedRoomId;
 use tokio::sync::{broadcast::Receiver, mpsc};
 use tracing::{trace, warn};
 
-use super::{super::AutoShrinkChannelPayload, room::RoomEventCacheUpdate};
+use super::super::AutoShrinkChannelPayload;
 
 /// A structure that can generate handles for subscribers, and count them. See
 /// [`SubscriberHandle`] to learn more.
@@ -66,52 +65,58 @@ impl SubscriberHandle {
     }
 }
 
-/// Thin wrapper for a room event cache subscriber, so as to trigger
-/// side-effects when all subscribers are gone.
+/// Thin wrapper for a cache subscriber, so as to trigger side-effects when all
+/// subscribers are gone.
 ///
-/// The current side-effect is: auto-shrinking the [`RoomEventCache`] when no
-/// more subscribers are active. This is an optimisation to reduce the number of
-/// data held in memory by a [`RoomEventCache`]: when no more subscribers are
-/// active, all data are reduced to the minimum.
+/// The current side-effect is: auto-shrinking the cache when no more
+/// subscribers are active. This is an optimisation to reduce the number of data
+/// held in memory by the cache: when no more subscribers are active, all data
+/// are reduced to the minimum.
 ///
 /// The side-effect takes effect on `Drop`.
-///
-/// [`RoomEventCache`]: super::RoomEventCache
 #[allow(missing_debug_implementations)]
-pub struct RoomEventCacheSubscriber {
+pub struct Subscriber<T> {
     /// Underlying receiver of the room event cache's updates.
-    recv: Receiver<RoomEventCacheUpdate>,
+    recv: Receiver<T>,
 
-    /// To which room are we listening?
-    room_id: OwnedRoomId,
+    /// The payload that is going to be sent to [`Self::auto_shrink_sender`].
+    ///
+    /// This is an `Option` to take/own the value in the `Drop` implementation
+    /// without cloning it.
+    auto_shrink_payload: Option<AutoShrinkChannelPayload>,
 
-    /// Sender to the auto-shrink channel.
+    /// The sender side of the auto-shrink channel.
     auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
 
     /// The subscribers handle shared by all subscribers.
     ///
-    /// It comes from [`super::RoomEventCacheState::subscribers_handle`].
+    /// This is used to detect when no more subscribers are active, and trigger
+    /// side-effect.
+    ///
+    /// This is an `Option` to take/own the value in the `Drop` implementation
+    /// without cloning it. Being able to own it helps to control when the value
+    /// is dropped.
     subscriber_handle: Option<SubscriberHandle>,
 }
 
-impl RoomEventCacheSubscriber {
-    /// Create a new [`RoomEventCacheSubscriber`].
+impl<T> Subscriber<T> {
+    /// Create a new [`Subscriber`].
     pub(super) fn new(
-        recv: Receiver<RoomEventCacheUpdate>,
-        room_id: OwnedRoomId,
+        recv: Receiver<T>,
+        auto_shrink_payload: AutoShrinkChannelPayload,
         auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
         subscribers_handle: &SubscribersHandle,
     ) -> Self {
         Self {
             recv,
-            room_id,
+            auto_shrink_payload: Some(auto_shrink_payload),
             auto_shrink_sender,
             subscriber_handle: Some(subscribers_handle.new_subscriber_handle()),
         }
     }
 }
 
-impl Drop for RoomEventCacheSubscriber {
+impl<T> Drop for Subscriber<T> {
     fn drop(&mut self) {
         let number_of_subscribers = self
             .subscriber_handle
@@ -125,18 +130,20 @@ impl Drop for RoomEventCacheSubscriber {
 
         if number_of_subscribers == 1 {
             // We were the last instance of the subscriber; let the auto-shrinker know by
-            // notifying it of our room id.
+            // notifying it.
 
-            let mut room_id = self.room_id.clone();
+            // Try to send without waiting for channel capacity, and restart in a loop if it
+            // failed (until a maximum number of attempts is reached, or the send was
+            // successful). The channel shouldn't be super busy in general, so this should
+            // resolve quickly enough.
 
-            // Try to send without waiting for channel capacity, and restart in a spin-loop
-            // if it failed (until a maximum number of attempts is reached, or
-            // the send was successful). The channel shouldn't be super busy in
-            // general, so this should resolve quickly enough.
-
+            let mut payload = self
+                .auto_shrink_payload
+                .take()
+                .expect("Unreachable: `auto_shrink_payload` must be `Some`");
             let mut num_attempts = 0;
 
-            while let Err(err) = self.auto_shrink_sender.try_send(room_id) {
+            while let Err(err) = self.auto_shrink_sender.try_send(payload) {
                 num_attempts += 1;
 
                 if num_attempts > 1024 {
@@ -150,8 +157,8 @@ impl Drop for RoomEventCacheSubscriber {
                 }
 
                 match err {
-                    mpsc::error::TrySendError::Full(stolen_room_id) => {
-                        room_id = stolen_room_id;
+                    mpsc::error::TrySendError::Full(stolen_payload) => {
+                        payload = stolen_payload;
                     }
                     mpsc::error::TrySendError::Closed(_) => return,
                 }
@@ -162,15 +169,15 @@ impl Drop for RoomEventCacheSubscriber {
     }
 }
 
-impl Deref for RoomEventCacheSubscriber {
-    type Target = Receiver<RoomEventCacheUpdate>;
+impl<T> Deref for Subscriber<T> {
+    type Target = Receiver<T>;
 
     fn deref(&self) -> &Self::Target {
         &self.recv
     }
 }
 
-impl DerefMut for RoomEventCacheSubscriber {
+impl<T> DerefMut for Subscriber<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.recv
     }

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -23,7 +23,7 @@ use ruma::OwnedRoomId;
 use tokio::sync::{broadcast::Receiver, mpsc};
 use tracing::{trace, warn};
 
-use super::{AutoShrinkChannelPayload, RoomEventCacheUpdate};
+use super::{super::AutoShrinkChannelPayload, room::RoomEventCacheUpdate};
 
 /// A structure that can generate handles for subscribers, and count them. See
 /// [`SubscriberHandle`] to learn more.

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -78,14 +78,14 @@ pub struct Subscriber<T> {
     /// Underlying receiver of the cache's updates.
     subscriber_receiver: Receiver<T>,
 
-    /// The payload that is going to be sent to [`Self::auto_shrink_sender`].
+    /// The message that is going to be sent to [`Self::auto_shrink_sender`].
     ///
     /// This is an `Option` to take/own the value in the `Drop` implementation
     /// without cloning it.
-    auto_shrink_payload: Option<AutoShrinkChannelPayload>,
+    auto_shrink_message: Option<AutoShrinkMessage>,
 
     /// The sender side of the auto-shrink channel.
-    auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+    auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
 
     /// The subscribers handle shared by all subscribers.
     ///
@@ -102,13 +102,13 @@ impl<T> Subscriber<T> {
     /// Create a new [`Subscriber`].
     pub(super) fn new(
         subscriber_receiver: Receiver<T>,
-        auto_shrink_payload: AutoShrinkChannelPayload,
-        auto_shrink_sender: mpsc::Sender<AutoShrinkChannelPayload>,
+        auto_shrink_message: AutoShrinkMessage,
+        auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
         subscribers_handle: &SubscribersHandle,
     ) -> Self {
         Self {
             subscriber_receiver,
-            auto_shrink_payload: Some(auto_shrink_payload),
+            auto_shrink_message: Some(auto_shrink_message),
             auto_shrink_sender,
             subscriber_handle: Some(subscribers_handle.new_subscriber_handle()),
         }
@@ -136,13 +136,13 @@ impl<T> Drop for Subscriber<T> {
             // successful). The channel shouldn't be super busy in general, so this should
             // resolve quickly enough.
 
-            let mut payload = self
-                .auto_shrink_payload
+            let mut message = self
+                .auto_shrink_message
                 .take()
-                .expect("Unreachable: `auto_shrink_payload` must be `Some`");
+                .expect("Unreachable: `auto_shrink_message` must be `Some`");
             let mut num_attempts = 0;
 
-            while let Err(err) = self.auto_shrink_sender.try_send(payload) {
+            while let Err(err) = self.auto_shrink_sender.try_send(message) {
                 num_attempts += 1;
 
                 if num_attempts > 1024 {
@@ -156,8 +156,8 @@ impl<T> Drop for Subscriber<T> {
                 }
 
                 match err {
-                    mpsc::error::TrySendError::Full(stolen_payload) => {
-                        payload = stolen_payload;
+                    mpsc::error::TrySendError::Full(stolen_message) => {
+                        message = stolen_message;
                     }
                     mpsc::error::TrySendError::Closed(_) => return,
                 }
@@ -182,7 +182,7 @@ impl<T> DerefMut for Subscriber<T> {
     }
 }
 
-pub type AutoShrinkChannelPayload = OwnedRoomId;
+pub type AutoShrinkMessage = OwnedRoomId;
 
 #[cfg(test)]
 mod tests {
@@ -252,22 +252,22 @@ mod tests {
     }
 
     #[test]
-    fn test_subscriber_send_auto_shrink_payload_on_last_drop() {
+    fn test_subscriber_send_auto_shrink_message_on_last_drop() {
         let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_payload = owned_room_id!("!r0");
+        let auto_shrink_message = owned_room_id!("!r0");
 
         let subscriber0 = Subscriber::new(
             subscriber_receiver.resubscribe(),
-            auto_shrink_payload.clone(),
+            auto_shrink_message.clone(),
             auto_shrink_sender.clone(),
             &subscribers_handle,
         );
 
         let subscriber1 = Subscriber::new(
             subscriber_receiver,
-            auto_shrink_payload.clone(),
+            auto_shrink_message.clone(),
             auto_shrink_sender,
             &subscribers_handle,
         );
@@ -278,24 +278,24 @@ mod tests {
 
         // Drop the last subscriber. Side-effect should… take effect!
         drop(subscriber1);
-        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_payload);
+        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_message);
         assert!(auto_shrink_receiver.is_empty());
     }
 
     #[test]
-    fn test_subscriber_send_auto_shrink_payload_with_full_channel() {
+    fn test_subscriber_send_auto_shrink_message_with_full_channel() {
         let (auto_shrink_sender, mut auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_noisy_payload = owned_room_id!("!r1");
-        let auto_shrink_payload = owned_room_id!("!r0");
+        let auto_shrink_noisy_message = owned_room_id!("!r1");
+        let auto_shrink_message = owned_room_id!("!r0");
 
         // Saturate the `auto_shrink` channel.
-        auto_shrink_sender.try_send(auto_shrink_noisy_payload.clone()).unwrap();
+        auto_shrink_sender.try_send(auto_shrink_noisy_message.clone()).unwrap();
 
         let subscriber = Subscriber::new(
             subscriber_receiver,
-            auto_shrink_payload,
+            auto_shrink_message,
             auto_shrink_sender,
             &subscribers_handle,
         );
@@ -305,24 +305,24 @@ mod tests {
         // in no side-effect.
         drop(subscriber);
 
-        // We receive the noisy payload: **not** the payload from the subscriber under
+        // We receive the noisy message: **not** the message from the subscriber under
         // testing.
-        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_noisy_payload);
+        assert_eq!(auto_shrink_receiver.try_recv().unwrap(), auto_shrink_noisy_message);
 
         // Then, we receive nothing, i.e. `subscriber` dropped without any side-effect.
         assert!(auto_shrink_receiver.is_empty());
     }
 
     #[test]
-    fn test_subscriber_send_auto_shrink_payload_with_closed_channel() {
+    fn test_subscriber_send_auto_shrink_message_with_closed_channel() {
         let (auto_shrink_sender, auto_shrink_receiver) = mpsc::channel(1);
         let (_subscriber_sender, subscriber_receiver) = broadcast::channel::<()>(1);
         let subscribers_handle = SubscribersHandle::default();
-        let auto_shrink_payload = owned_room_id!("!r0");
+        let auto_shrink_message = owned_room_id!("!r0");
 
         let subscriber = Subscriber::new(
             subscriber_receiver,
-            auto_shrink_payload,
+            auto_shrink_message,
             auto_shrink_sender,
             &subscribers_handle,
         );

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -28,10 +28,7 @@ use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, events::relation::RelationType,
     room_version_rules::RoomVersionRules,
 };
-use tokio::sync::{
-    Notify,
-    broadcast::{Receiver, Sender},
-};
+use tokio::sync::{Notify, broadcast::Sender, mpsc};
 use tracing::{instrument, trace};
 
 use self::pagination::ThreadPagination;
@@ -46,6 +43,7 @@ use super::{
     },
     EventsOrigin, TimelineVectorDiffs,
     room::{RoomEventCacheGenericUpdate, RoomEventCacheLinkedChunkUpdate},
+    subscriber::{AutoShrinkMessage, Subscriber},
 };
 use crate::room::WeakRoom;
 
@@ -74,6 +72,12 @@ struct ThreadEventCacheInner {
     /// A notifier that we received a new pagination token.
     pagination_batch_token_notifier: Notify,
 
+    /// Sender to the auto-shrink channel.
+    ///
+    /// See doc comment around [`EventCache::auto_shrink_linked_chunk_task`] for
+    /// more details.
+    auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
+
     /// Update sender for this thread.
     update_sender: ThreadEventCacheUpdateSender,
 }
@@ -94,6 +98,7 @@ impl ThreadEventCache {
         room_version_rules: RoomVersionRules,
         weak_room: WeakRoom,
         state: &StateLock,
+        auto_shrink_sender: mpsc::Sender<AutoShrinkMessage>,
         generic_update_sender: Sender<RoomEventCacheGenericUpdate>,
         linked_chunk_update_sender: Sender<RoomEventCacheLinkedChunkUpdate>,
     ) -> Result<Self> {
@@ -126,6 +131,7 @@ impl ThreadEventCache {
                 weak_room,
                 state: cache_state,
                 pagination_batch_token_notifier: Notify::new(),
+                auto_shrink_sender,
                 update_sender,
             }),
         };
@@ -150,16 +156,31 @@ impl ThreadEventCache {
         &self.inner.thread_id
     }
 
-    /// Subscribe to live events from this thread.
-    pub async fn subscribe(&self) -> Result<(Vec<Event>, Receiver<TimelineVectorDiffs>)> {
+    /// Subscribe to this thread updates, after getting the initial list of
+    /// events.
+    ///
+    /// Creating, and especially dropping, a [`Subscriber`] isn't free, as it
+    /// triggers side-effects.
+    pub async fn subscribe(&self) -> Result<(Vec<Event>, Subscriber<TimelineVectorDiffs>)> {
         let state = self.inner.state.read().await?;
-
         let events =
             state.thread_linked_chunk().events().map(|(_position, item)| item.clone()).collect();
 
-        let recv = state.update_sender.new_thread_receiver();
+        let subscribers_handle = state.subscribers_handle();
 
-        Ok((events, recv))
+        let subscriber = Subscriber::new(
+            self.inner.update_sender.new_thread_receiver(),
+            AutoShrinkMessage::Thread {
+                room_id: self.inner.room_id.clone(),
+                thread_id: self.inner.thread_id.clone(),
+            },
+            self.inner.auto_shrink_sender.clone(),
+            subscribers_handle,
+        );
+
+        trace!("added a thread event cache subscriber; new count: {}", subscribers_handle.count());
+
+        Ok((events, subscriber))
     }
 
     /// Return a [`ThreadPagination`] useful for running back-pagination queries
@@ -312,15 +333,16 @@ mod timed_tests {
         store::StoreConfig,
         sync::{JoinedRoomUpdate, Timeline},
     };
-    use matrix_sdk_test::{async_test, event_factory::EventFactory};
+    use matrix_sdk_test::{ALICE, async_test, event_factory::EventFactory};
     use ruma::{
         event_id,
         events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent},
         room_id, user_id,
     };
+    use tokio::task::yield_now;
 
     use super::super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs};
-    use crate::test_utils::client::MockClientBuilder;
+    use crate::{assert_let_timeout, test_utils::client::MockClientBuilder};
 
     #[async_test]
     async fn test_write_to_storage() {
@@ -1195,5 +1217,156 @@ mod timed_tests {
                 );
             }
         }
+    }
+
+    #[async_test]
+    async fn test_auto_shrink_after_all_subscribers_are_gone() {
+        let room_id = room_id!("!r0");
+        let thread_id = event_id!("$t0");
+
+        let client = MockClientBuilder::new(None).build().await;
+
+        let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+        let event_id_0 = event_id!("$ev0");
+        let event_id_1 = event_id!("$ev1");
+
+        let thread_root =
+            f.text_msg("gr00t").event_id(thread_id).in_thread(thread_id, thread_id).into_event();
+        let event_0 =
+            f.text_msg("hello").event_id(event_id_0).in_thread(thread_id, event_id_0).into_event();
+        let event_1 =
+            f.text_msg("world").event_id(event_id_1).in_thread(thread_id, event_id_1).into_event();
+
+        // Fill the event cache store with an initial linked chunk with 2 events chunks.
+        {
+            client
+                .event_cache_store()
+                .lock()
+                .await
+                .expect("Could not acquire the event cache lock")
+                .as_clean()
+                .expect("Could not acquire a clean event cache lock")
+                .handle_linked_chunk_updates(
+                    LinkedChunkId::Thread(room_id, thread_id),
+                    vec![
+                        Update::NewItemsChunk {
+                            previous: None,
+                            new: ChunkIdentifier::new(0),
+                            next: None,
+                        },
+                        Update::PushItems {
+                            at: Position::new(ChunkIdentifier::new(0), 0),
+                            items: vec![thread_root, event_0],
+                        },
+                        Update::NewItemsChunk {
+                            previous: Some(ChunkIdentifier::new(0)),
+                            new: ChunkIdentifier::new(1),
+                            next: None,
+                        },
+                        Update::PushItems {
+                            at: Position::new(ChunkIdentifier::new(1), 0),
+                            items: vec![event_1],
+                        },
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+        let (thread_event_cache, _drop_handles) =
+            event_cache.thread(room_id, thread_id).await.unwrap();
+
+        // Sanity check: lazily loaded, so only includes one item at start.
+        let (events1, mut stream1) = thread_event_cache.subscribe().await.unwrap();
+        assert_eq!(events1.len(), 1);
+        assert_eq!(events1[0].event_id(), Some(event_id_1));
+        assert!(stream1.is_empty());
+
+        let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
+
+        // Force loading the full linked chunk by back-paginating.
+        let outcome = thread_event_cache.pagination().run_backwards_once(20).await.unwrap();
+        assert_eq!(outcome.events.len(), 2);
+        assert_eq!(outcome.events[0].event_id(), Some(event_id_0));
+        assert_eq!(outcome.events[1].event_id(), Some(thread_id));
+        assert!(outcome.reached_start);
+
+        // We also get an update about the loading from the store. Ignore it, for this
+        // test's sake.
+        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = stream1.recv());
+        assert_eq!(diffs.len(), 2);
+        assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value } => {
+            assert_eq!(value.event_id(), Some(thread_id));
+        });
+        assert_matches!(&diffs[1], VectorDiff::Insert { index: 1, value } => {
+            assert_eq!(value.event_id(), Some(event_id_0));
+        });
+
+        assert!(stream1.is_empty());
+
+        assert_let_timeout!(
+            Ok(RoomEventCacheGenericUpdate { room_id: expected_room_id }) = generic_stream.recv()
+        );
+        assert_eq!(expected_room_id, room_id);
+        assert!(generic_stream.is_empty());
+
+        // Have another subscriber.
+        // Since it's not the first one, and the previous one loaded some more events,
+        // the second subscribers sees them all.
+        let (events2, stream2) = thread_event_cache.subscribe().await.unwrap();
+        assert_eq!(events2.len(), 3);
+        assert_eq!(events2[0].event_id(), Some(thread_id));
+        assert_eq!(events2[1].event_id(), Some(event_id_0));
+        assert_eq!(events2[2].event_id(), Some(event_id_1));
+        assert!(stream2.is_empty());
+
+        // Grab a receiver for testing no diffs is sent.
+        let subscriber = {
+            let state = thread_event_cache.inner.state.read().await.unwrap();
+            state.update_sender.new_thread_receiver()
+        };
+
+        // Drop the first stream, and wait a bit.
+        drop(stream1);
+        yield_now().await;
+
+        // The second stream remains undisturbed.
+        assert!(stream2.is_empty());
+
+        // Now drop the second stream, and wait a bit.
+        drop(stream2);
+        yield_now().await;
+
+        // The linked chunk must have auto-shrunk by now.
+
+        {
+            // Check the inner state: there's no more shared auto-shrinker.
+            let state = thread_event_cache.inner.state.read().await.unwrap();
+            assert_eq!(state.subscribers_handle().count(), 0);
+
+            // No diff is sent when the linked chunk has auto-shrunk.
+            assert!(subscriber.is_empty());
+            assert!(generic_stream.is_empty());
+        }
+
+        // Getting the events will only give us the latest chunk.
+        let events3 = thread_event_cache
+            .inner
+            .state
+            .read()
+            .await
+            .unwrap()
+            .thread_linked_chunk()
+            .events()
+            .map(|(_position, item)| item.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(events3.len(), 1);
+        assert_eq!(events3[0].event_id(), Some(event_id_1));
     }
 }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -48,6 +48,7 @@ use super::{
         EventLocation,
         event_linked_chunk::{EventLinkedChunk, sort_positions_descending},
         room::RoomEventCacheLinkedChunkUpdate,
+        subscriber::SubscribersHandle,
     },
     ThreadEventCacheUpdateSender,
 };
@@ -86,6 +87,9 @@ pub struct ThreadEventCacheState {
     /// the first time we try to run backward pagination. We reset
     /// that upon clearing the timeline events.
     waited_for_initial_prev_token: bool,
+
+    /// A handle for subscribers.
+    subscribers_handle: SubscribersHandle,
 }
 
 impl ThreadEventCacheState {
@@ -238,6 +242,7 @@ impl ThreadEventCacheState {
             update_sender,
             linked_chunk_update_sender,
             waited_for_initial_prev_token: false,
+            subscribers_handle: SubscribersHandle::default(),
         })
     }
 }
@@ -246,6 +251,11 @@ impl<'a> StateLockReadGuard<'a, ThreadEventCacheState> {
     /// Return a read-only reference to the underlying thread linked chunk.
     pub fn thread_linked_chunk(&self) -> &EventLinkedChunk {
         &self.state.thread_linked_chunk
+    }
+
+    /// Return a reference to subscribers handle.
+    pub fn subscribers_handle(&self) -> &SubscribersHandle {
+        &self.state.subscribers_handle
     }
 
     /// Compute and return the [`ThreadSummary`] for this thread.
@@ -617,6 +627,32 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             .expect("failed to remove an event");
 
         self.state.propagate_changes(&self.store).await
+    }
+
+    /// Automatically shrink the thread if there are no more subscribers, as
+    /// indicated by the atomic number of active subscribers.
+    #[must_use = "Propagate `VectorDiff` updates via `ThreadEventCacheUpdate`"]
+    pub async fn auto_shrink_if_no_subscribers(
+        &mut self,
+    ) -> Result<Option<Vec<VectorDiff<Event>>>> {
+        let number_of_subscribers = self.state.subscribers_handle.count();
+
+        trace!(number_of_subscribers, "received request to auto-shrink");
+
+        if number_of_subscribers == 0 {
+            // There is no more subscribers listening to this cache, we can shrink the state
+            // to its last chunk to save memory.
+            //
+            // In theory, between the condition (`… == 0`) and this instruction, a new
+            // subscriber could be created, creating a race, except that this method takes a
+            // `&mut`, ensuring an exclusive access to the state, ensuring no other
+            // subscribers can be created.
+            self.state.shrink_to_last_chunk(&self.store).await?;
+
+            Ok(Some(self.state.thread_linked_chunk.updates_as_vector_diffs()))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Apply some updates that are effective only on the store itself.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -83,7 +83,7 @@ pub use self::{
     },
 };
 use self::{
-    caches::{Caches, room::RoomEventCacheLinkedChunkUpdate, subscriber::AutoShrinkChannelPayload},
+    caches::{Caches, room::RoomEventCacheLinkedChunkUpdate, subscriber::AutoShrinkMessage},
     states::StateLock,
 };
 
@@ -582,7 +582,7 @@ struct EventCacheInner {
     /// [`EventCache::subscribe`].
     ///
     /// See doc comment of [`tasks::auto_shrink_linked_chunk_task`].
-    auto_shrink_sender: OnceLock<mpsc::Sender<AutoShrinkChannelPayload>>,
+    auto_shrink_sender: OnceLock<mpsc::Sender<AutoShrinkMessage>>,
 
     /// A sender for room generic update.
     ///

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -83,7 +83,7 @@ pub use self::{
     },
 };
 use self::{
-    caches::{Caches, room::RoomEventCacheLinkedChunkUpdate},
+    caches::{Caches, room::RoomEventCacheLinkedChunkUpdate, subscriber::AutoShrinkChannelPayload},
     states::StateLock,
 };
 
@@ -615,8 +615,6 @@ struct EventCacheInner {
     /// flag to be set at subscription time.
     automatic_pagination: OnceLock<AutomaticPagination>,
 }
-
-type AutoShrinkChannelPayload = OwnedRoomId;
 
 impl EventCacheInner {
     fn client(&self) -> Result<Client> {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -75,8 +75,8 @@ pub use self::{
         pagination::{BackPaginationOutcome, PaginationStatus},
         pinned_events::PinnedEventsCache,
         room::{
-            RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheSubscriber,
-            RoomEventCacheUpdate, pagination::RoomPagination,
+            RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheUpdate,
+            pagination::RoomPagination,
         },
         thread::{ThreadEventCache, pagination::ThreadPagination},
     },

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -78,6 +78,7 @@ pub use self::{
             RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheUpdate,
             pagination::RoomPagination,
         },
+        subscriber::Subscriber,
         thread::{ThreadEventCache, pagination::ThreadPagination},
     },
 };
@@ -469,9 +470,9 @@ impl EventCache {
 
     /// Subscribe to room _generic_ updates.
     ///
-    /// If one wants to listen what has changed in a specific room, the
-    /// [`RoomEventCache::subscribe`] is recommended. However, the
-    /// [`RoomEventCacheSubscriber`] type triggers side-effects.
+    /// If one wants to listen what has changed in a specific room for example,
+    /// the [`RoomEventCache::subscribe`] is recommended. However, the
+    /// [`Subscriber`] type triggers side-effects.
     ///
     /// If one wants to get a high-overview, generic, updates for rooms, and
     /// without side-effects, this method is recommended. Also, dropping the

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -32,9 +32,7 @@ use tokio::{
 };
 use tracing::{Instrument as _, Span, debug, error, info, info_span, instrument, trace, warn};
 
-use super::{
-    AutoShrinkChannelPayload, EventCacheError, EventCacheInner, RoomEventCacheLinkedChunkUpdate,
-};
+use super::{AutoShrinkMessage, EventCacheError, EventCacheInner, RoomEventCacheLinkedChunkUpdate};
 use crate::{
     client::WeakClient,
     send_queue::{LocalEchoContent, RoomSendQueueUpdate, SendQueueUpdate},
@@ -131,7 +129,7 @@ pub(super) async fn ignore_user_list_update_task(
 #[instrument(skip_all)]
 pub(super) async fn auto_shrink_linked_chunk_task(
     inner: Weak<EventCacheInner>,
-    mut rx: mpsc::Receiver<AutoShrinkChannelPayload>,
+    mut rx: mpsc::Receiver<AutoShrinkMessage>,
 ) {
     while let Some(room_id) = rx.recv().await {
         trace!(for_room = %room_id, "received notification to shrink");

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -158,6 +158,26 @@ pub(super) async fn auto_shrink_linked_chunk_task(
                     }
                 }
             }
+
+            AutoShrinkMessage::Thread { room_id, thread_id } => {
+                let ControlFlow::Continue(caches) = all_caches(inner.as_ref(), &room_id).await
+                else {
+                    continue;
+                };
+
+                let Ok(cache) = caches.thread(thread_id.clone()).await else {
+                    warn!(%room_id, %thread_id, "Failed to get the `ThreadEventCache`");
+                    continue;
+                };
+
+                match cache.state().write().await {
+                    Ok(mut state) => state.auto_shrink_if_no_subscribers().await,
+                    Err(err) => {
+                        warn!(%room_id, ?err, "Failed to get the `ThreadEventCacheStateLock`");
+                        continue;
+                    }
+                }
+            }
         };
 
         match maybe_diffs {

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -14,6 +14,7 @@
 
 use std::{
     collections::HashMap,
+    ops::ControlFlow,
     sync::{Arc, Weak},
 };
 
@@ -22,17 +23,21 @@ use matrix_sdk_base::{
     linked_chunk::OwnedLinkedChunkId, serde_helpers::extract_thread_root_from_content,
     sync::RoomUpdates,
 };
-use ruma::{OwnedEventId, OwnedTransactionId};
+use ruma::{OwnedEventId, OwnedTransactionId, RoomId};
 use tokio::{
     select,
     sync::{
+        OwnedRwLockReadGuard,
         broadcast::{Receiver, Sender, error::RecvError},
         mpsc,
     },
 };
 use tracing::{Instrument as _, Span, debug, error, info, info_span, instrument, trace, warn};
 
-use super::{AutoShrinkMessage, EventCacheError, EventCacheInner, RoomEventCacheLinkedChunkUpdate};
+use super::{
+    AutoShrinkMessage, Caches, CachesByRoom, EventCacheError, EventCacheInner,
+    RoomEventCacheLinkedChunkUpdate,
+};
 use crate::{
     client::WeakClient,
     send_queue::{LocalEchoContent, RoomSendQueueUpdate, SendQueueUpdate},
@@ -129,38 +134,33 @@ pub(super) async fn ignore_user_list_update_task(
 #[instrument(skip_all)]
 pub(super) async fn auto_shrink_linked_chunk_task(
     inner: Weak<EventCacheInner>,
-    mut rx: mpsc::Receiver<AutoShrinkMessage>,
+    mut auto_shrink_receiver: mpsc::Receiver<AutoShrinkMessage>,
 ) {
-    while let Some(room_id) = rx.recv().await {
-        trace!(for_room = %room_id, "received notification to shrink");
+    while let Some(message) = auto_shrink_receiver.recv().await {
+        trace!(?message, "received notification to shrink");
 
         let Some(inner) = inner.upgrade() else {
             return;
         };
 
-        let room = {
-            let caches = match inner.all_caches_for_room(&room_id).await {
-                Ok(caches) => caches,
-                Err(err) => {
-                    warn!(for_room = %room_id, "Failed to get the `Caches`: {err}");
+        let maybe_diffs = match message {
+            AutoShrinkMessage::Room { room_id } => {
+                let ControlFlow::Continue(caches) = all_caches(inner.as_ref(), &room_id).await
+                else {
                     continue;
+                };
+
+                match caches.room().state().write().await {
+                    Ok(mut state) => state.auto_shrink_if_no_subscribers().await,
+                    Err(err) => {
+                        warn!(%room_id, ?err, "Failed to get the `RoomEventCacheStateLock`");
+                        continue;
+                    }
                 }
-            };
-
-            caches.room.clone()
-        };
-
-        trace!("Waiting for state lock…");
-
-        let mut state = match room.state().write().await {
-            Ok(state) => state,
-            Err(err) => {
-                warn!(for_room = %room_id, "Failed to get the `RoomEventCacheStateLock`: {err}");
-                continue;
             }
         };
 
-        match state.auto_shrink_if_no_subscribers().await {
+        match maybe_diffs {
             Ok(_diffs) => {
                 // Two situations here:
                 //
@@ -177,12 +177,25 @@ pub(super) async fn auto_shrink_linked_chunk_task(
 
             Err(err) => {
                 // There's not much we can do here, unfortunately.
-                warn!(for_room = %room_id, "error when attempting to shrink linked chunk: {err}");
+                warn!(?err, "error when attempting to shrink linked chunk");
             }
         }
     }
 
     info!("Auto-shrink linked chunk task has been closed, exiting");
+
+    async fn all_caches(
+        inner: &EventCacheInner,
+        room_id: &RoomId,
+    ) -> ControlFlow<(), OwnedRwLockReadGuard<CachesByRoom, Caches>> {
+        match inner.all_caches_for_room(room_id).await {
+            Ok(caches) => ControlFlow::Continue(caches),
+            Err(err) => {
+                warn!(?err, "Failed to get the `Caches`");
+                ControlFlow::Break(())
+            }
+        }
+    }
 }
 
 /// Handle [`SendQueueUpdate`] and [`RoomEventCacheLinkedChunkUpdate`] to update

--- a/crates/matrix-sdk/tests/integration/event_cache/threads.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads.rs
@@ -6,7 +6,7 @@ use imbl::Vector;
 use matrix_sdk::{
     Client, ThreadingSupport, assert_let_timeout,
     deserialized_responses::TimelineEvent,
-    event_cache::{RoomEventCacheSubscriber, RoomEventCacheUpdate, TimelineVectorDiffs},
+    event_cache::{RoomEventCacheUpdate, Subscriber, TimelineVectorDiffs},
     sleep::sleep,
     test_utils::{
         assert_event_matches_msg,
@@ -302,7 +302,7 @@ struct ThreadSubscriptionTestSetup {
     client: Client,
     factory: EventFactory,
     room_id: OwnedRoomId,
-    subscriber: RoomEventCacheSubscriber,
+    subscriber: Subscriber<RoomEventCacheUpdate>,
     /// 3 events: 1 non-mention, 1 mention, and another non-mention.
     events: Vec<Raw<AnySyncTimelineEvent>>,
     mention_event_id: OwnedEventId,


### PR DESCRIPTION
During the big refactoring of the Event Cache, I noticed that the auto-shrink mechanism needs to be implement on all caches now. It was implemented on `RoomEventCache` before, but we want to extend it to `ThreadEventCache` now it supports persistent storage (see #6317), and maybe on `PinnedEventsCache` too since it has its own storage too (note that this is less critical as it seems unlikely we will have that many pinned-events living in memory).

### Tasks

- [x] Move `event_cache/caches/room/subscriber.rs` to `event_cache/caches/subscriber.rs`
- [x] Transform `RoomEventCacheSubscriber` to `Subscriber<RoomEventCacheUpdate>`, i.e. make it generic over any updates,
- [x] Add tests for this `Subscriber` type only,
- [x] Update `AutoSkrinkPayload` to be an enum instead of `OwnedRoomId`, something like:
  ```rust
  enum AutoShrinkPayload {
      Room { room_id: OwnedRoomId },
      Thread { room_id: OwnedRoomId, thread_id: OwnedEventId },
       // etc.
  }
  ```
- [x] Update the `auto_shrink_linked_chunk_task`,
- [x] Update `ThreadEventCache::subscribe` to return a `Subscriber<TimelineVectorDiffs` instead of a `Receiver<TimelinevectorDiffs>`,
- [ ] Update `PinnedEventsCache::subscribe` to return a `Subscriber<TimelineVectorDiffs` instead of a `Receiver<TimelinevectorDiffs>` ▶️  Not doing: I don't think this is relevant for the moment.

---

- Address https://github.com/matrix-org/matrix-rust-sdk/issues/6152

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
