### PR TITLE
MSC4426 :  support set/clear/fetch own user status 

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = [
 ]
 
 [features]
-default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
+default = ["bundled-sqlite", "unstable-msc4274", "unstable-msc4426", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
 experimental-search = ["matrix-sdk/experimental-search", "matrix-sdk-ui/experimental-search"]
 # Use SQLite for the session storage.
 sqlite = ["matrix-sdk/sqlite"]
@@ -33,6 +33,7 @@ bundled-sqlite = ["sqlite", "matrix-sdk/bundled-sqlite"]
 # Use IndexedDB for the session storage.
 indexeddb = ["matrix-sdk/indexeddb"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
+unstable-msc4426 = ["matrix-sdk/unstable-msc4426"]
 # Required when targeting a Javascript environment, like Wasm in a browser.
 js = ["matrix-sdk-ui/js"]
 # Enable sentry error monitoring, not compatible with Wasm platforms.
@@ -90,6 +91,8 @@ ruma = { workspace = true, features = [
     "unstable-msc2545",
     # Room language event type
     "unstable-msc4334",
+    # User status profile fields (m.status, m.call).
+    "unstable-msc4426",
     "unstable-uniffi",
 ] }
 serde.workspace = true

--- a/bindings/matrix-sdk-ffi/changelog.d/6616.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6616.added.md
@@ -1,0 +1,1 @@
+Expose [MSC4426] user-status profile fields through the FFI.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -125,6 +125,8 @@ use super::{
     room::{Room, room_info::RoomInfo},
     session_verification::SessionVerificationController,
 };
+#[cfg(feature = "unstable-msc4426")]
+use crate::ruma::UserStatus;
 use crate::{
     ClientError,
     authentication::{
@@ -2515,6 +2517,32 @@ impl From<&search_users::v3::User> for UserProfile {
             display_name: value.display_name.clone(),
             avatar_url: value.avatar_url.as_ref().map(|url| url.to_string()),
         }
+    }
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[matrix_sdk_ffi_macros::export]
+impl Client {
+    /// Set the current user's status (MSC4426 `m.status` profile field).
+    ///
+    /// Replaces any existing status. Use [`Self::clear_user_status`] to
+    /// remove it.
+    pub async fn set_user_status(&self, status: UserStatus) -> Result<(), ClientError> {
+        self.inner.account().set_status(status.emoji, status.text).await?;
+        Ok(())
+    }
+
+    /// Clear the current user's status (MSC4426).
+    ///
+    /// Deletes both `m.status` and `m.call` concurrently. Clearing `m.status`
+    /// alone would let `m.call` immediately reappear if the user were in a
+    /// call.
+    pub async fn clear_user_status(&self) -> Result<(), ClientError> {
+        let account = self.inner.account();
+        let (status_res, call_res) = tokio::join!(account.clear_status(), account.clear_call());
+        status_res?;
+        call_res?;
+        Ok(())
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -75,6 +75,8 @@ use matrix_sdk_ui::{
 };
 use mime::Mime;
 use oauth2::Scope;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::api::client::profile::{Call, Status};
 use ruma::{
     OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
     api::{
@@ -126,7 +128,7 @@ use super::{
     session_verification::SessionVerificationController,
 };
 #[cfg(feature = "unstable-msc4426")]
-use crate::ruma::UserStatus;
+use crate::ruma::{UserCall, UserStatus};
 use crate::{
     ClientError,
     authentication::{
@@ -2496,6 +2498,17 @@ pub struct UserProfile {
     pub user_id: String,
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
+
+    /// The user's status (MSC4426 `m.status` profile field), if set.
+    #[cfg(feature = "unstable-msc4426")]
+    pub status: Option<UserStatus>,
+
+    /// Set when the user is in a call (MSC4426 `m.call` profile field).
+    ///
+    /// `None` means the user is not in a call. `Some(UserCall { call_joined_ts:
+    /// None })` means the user is in a call but the join time wasn't recorded.
+    #[cfg(feature = "unstable-msc4426")]
+    pub call: Option<UserCall>,
 }
 
 impl UserProfile {
@@ -2506,7 +2519,20 @@ impl UserProfile {
         let display_name = response.get_static::<DisplayName>()?;
         let avatar_url = response.get_static::<AvatarUrl>()?.map(|url| url.to_string());
 
-        Ok(UserProfile { user_id: user_id.to_string(), display_name, avatar_url })
+        #[cfg(feature = "unstable-msc4426")]
+        let status = response.get_static::<Status>()?.map(UserStatus::from);
+        #[cfg(feature = "unstable-msc4426")]
+        let call = response.get_static::<Call>()?.map(UserCall::from);
+
+        Ok(UserProfile {
+            user_id: user_id.to_string(),
+            display_name,
+            avatar_url,
+            #[cfg(feature = "unstable-msc4426")]
+            status,
+            #[cfg(feature = "unstable-msc4426")]
+            call,
+        })
     }
 }
 
@@ -2516,6 +2542,10 @@ impl From<&search_users::v3::User> for UserProfile {
             user_id: value.user_id.to_string(),
             display_name: value.display_name.clone(),
             avatar_url: value.avatar_url.as_ref().map(|url| url.to_string()),
+            #[cfg(feature = "unstable-msc4426")]
+            status: None,
+            #[cfg(feature = "unstable-msc4426")]
+            call: None,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -20,6 +20,8 @@ use std::{
 
 use extension_trait::extension_trait;
 use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVideoInfo};
+#[cfg(feature = "unstable-msc4426")]
+use ruma::profile::StatusProfileField;
 use ruma::{
     KeyDerivationAlgorithm as RumaKeyDerivationAlgorithm, MatrixToUri, MatrixUri as RumaMatrixUri,
     OwnedRoomId, OwnedUserId, UInt, UserId, assign,
@@ -217,6 +219,28 @@ impl From<RumaPresenceState> for PresenceState {
             RumaPresenceState::Unavailable => Self::Unavailable,
             _ => Self::default(),
         }
+    }
+}
+
+/// A user-set status (MSC4426 `m.status` profile field value).
+#[cfg(feature = "unstable-msc4426")]
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct UserStatus {
+    pub emoji: String,
+    pub text: String,
+}
+
+#[cfg(feature = "unstable-msc4426")]
+impl From<UserStatus> for StatusProfileField {
+    fn from(value: UserStatus) -> Self {
+        Self::new(value.text, value.emoji)
+    }
+}
+
+#[cfg(feature = "unstable-msc4426")]
+impl From<StatusProfileField> for UserStatus {
+    fn from(value: StatusProfileField) -> Self {
+        Self { emoji: value.emoji, text: value.text }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -20,8 +20,6 @@ use std::{
 
 use extension_trait::extension_trait;
 use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVideoInfo};
-#[cfg(feature = "unstable-msc4426")]
-use ruma::profile::StatusProfileField;
 use ruma::{
     KeyDerivationAlgorithm as RumaKeyDerivationAlgorithm, MatrixToUri, MatrixUri as RumaMatrixUri,
     OwnedRoomId, OwnedUserId, UInt, UserId, assign,
@@ -86,6 +84,11 @@ use ruma::{
         Ruleset as RumaRuleset, SimplePushRule as RumaSimplePushRule,
     },
     serde::JsonObject,
+};
+#[cfg(feature = "unstable-msc4426")]
+use ruma::{
+    SecondsSinceUnixEpoch,
+    profile::{CallProfileField, StatusProfileField},
 };
 use tracing::info;
 
@@ -241,6 +244,34 @@ impl From<UserStatus> for StatusProfileField {
 impl From<StatusProfileField> for UserStatus {
     fn from(value: StatusProfileField) -> Self {
         Self { emoji: value.emoji, text: value.text }
+    }
+}
+
+/// The user's call indicator (MSC4426 `m.call` profile field value).
+///
+/// Presence of a `UserCall` value means the user is in a call. The optional
+/// `call_joined_ts` is the Unix-epoch seconds when they joined, if known.
+#[cfg(feature = "unstable-msc4426")]
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct UserCall {
+    pub call_joined_ts: Option<u64>,
+}
+
+#[cfg(feature = "unstable-msc4426")]
+impl From<CallProfileField> for UserCall {
+    fn from(value: CallProfileField) -> Self {
+        Self { call_joined_ts: value.call_joined_ts.map(|ts| u64::from(ts.get())) }
+    }
+}
+
+#[cfg(feature = "unstable-msc4426")]
+impl From<UserCall> for CallProfileField {
+    fn from(value: UserCall) -> Self {
+        let mut field = CallProfileField::new();
+        field.call_joined_ts = value
+            .call_joined_ts
+            .map(|secs| SecondsSinceUnixEpoch(UInt::try_from(secs).unwrap_or_default()));
+        field
     }
 }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -90,6 +90,9 @@ docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "feder
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
 
+# Add support for user status profile fields (m.status, m.call).
+unstable-msc4426 = ["ruma/unstable-msc4426"]
+
 experimental-search = ["matrix-sdk-search"]
 
 experimental-element-recent-emojis = ["matrix-sdk-base/experimental-element-recent-emojis"]

--- a/crates/matrix-sdk/changelog.d/6616.added.md
+++ b/crates/matrix-sdk/changelog.d/6616.added.md
@@ -1,0 +1,3 @@
+Added `Account::set_status`, `Account::clear_status`, `Account::set_call`, and
+`Account::clear_call` to write [MSC4426] user-status profile fields (`m.status`
+and `m.call`). All four are gated behind the new `unstable-msc4426` feature.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -28,8 +28,12 @@ use matrix_sdk_base::{
     store::StateStoreExt,
 };
 use mime::Mime;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::SecondsSinceUnixEpoch;
 #[cfg(feature = "experimental-element-recent-emojis")]
 use ruma::api::client::config::set_global_account_data::v3::Request as UpdateGlobalAccountDataRequest;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::profile::{CallProfileField, StatusProfileField};
 use ruma::{
     ClientSecret, MxcUri, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, SessionId, UInt, UserId,
     api::{
@@ -444,6 +448,48 @@ impl Account {
             .await?;
 
         Ok(response.value)
+    }
+
+    /// Set the user's status (MSC4426 `m.status` profile field).
+    ///
+    /// Replaces any existing status. Use [`Self::clear_status`] to remove it.
+    ///
+    /// # Arguments
+    ///
+    /// * `emoji` - the status emoji. The MSC limits this to 32 bytes; not
+    ///   enforced client-side.
+    /// * `text` - the status text. The MSC limits this to 256 bytes; not
+    ///   enforced client-side.
+    #[cfg(feature = "unstable-msc4426")]
+    pub async fn set_status(&self, emoji: String, text: String) -> Result<()> {
+        let value = StatusProfileField::new(text, emoji);
+        self.set_profile_field(ProfileFieldValue::Status(value)).await
+    }
+
+    /// Clear the user's status (deletes the MSC4426 `m.status` profile field).
+    #[cfg(feature = "unstable-msc4426")]
+    pub async fn clear_status(&self) -> Result<()> {
+        self.delete_profile_field(ProfileFieldName::Status).await
+    }
+
+    /// Set the user's call indicator (MSC4426 `m.call` profile field).
+    ///
+    /// # Arguments
+    ///
+    /// * `call_joined_ts` - when the user joined the current call, in seconds
+    ///   since the Unix epoch. `None` if the joined time isn't known.
+    #[cfg(feature = "unstable-msc4426")]
+    pub async fn set_call(&self, call_joined_ts: Option<SecondsSinceUnixEpoch>) -> Result<()> {
+        let mut value = CallProfileField::new();
+        value.call_joined_ts = call_joined_ts;
+        self.set_profile_field(ProfileFieldValue::Call(value)).await
+    }
+
+    /// Clear the user's call indicator (deletes the MSC4426 `m.call` profile
+    /// field).
+    #[cfg(feature = "unstable-msc4426")]
+    pub async fn clear_call(&self) -> Result<()> {
+        self.delete_profile_field(ProfileFieldName::Call).await
     }
 
     /// Set the given field of our own user's profile.

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -5022,6 +5022,13 @@ impl<'a> MockEndpoint<'a, SetProfileFieldEndpoint> {
     pub fn ok(self) -> MatrixMock<'a> {
         self.ok_empty_json()
     }
+
+    /// Expect the request body to set the given [`ProfileFieldValue`].
+    pub fn expect_field_value(mut self, value: ProfileFieldValue) -> Self {
+        let body = BTreeMap::from([(value.field_name(), value.value())]);
+        self.mock = self.mock.and(body_json(body));
+        self
+    }
 }
 
 /// A prebuilt mock for `DELETE /_matrix/client/*/profile/{user_id}/{key_name}`.

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -322,3 +322,108 @@ async fn test_get_cached_avatar_url() {
     let res_avatar_url = account.get_cached_avatar_url().await.unwrap();
     assert_eq!(res_avatar_url, None);
 }
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_set_status() {
+    use ruma::profile::StatusProfileField;
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    let user_id = client.user_id().unwrap();
+
+    server
+        .mock_set_profile_field(user_id, ProfileFieldName::Status)
+        .expect_field_value(ProfileFieldValue::Status(StatusProfileField::new(
+            "Away".to_owned(),
+            "🌴".to_owned(),
+        )))
+        .ok()
+        .mock_once()
+        .named("set org.matrix.msc4426.status profile field")
+        .mount()
+        .await;
+
+    let account = client.account();
+    account.set_status("🌴".to_owned(), "Away".to_owned()).await.unwrap();
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_clear_status() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    let user_id = client.user_id().unwrap();
+
+    server
+        .mock_delete_profile_field(user_id, ProfileFieldName::Status)
+        .ok()
+        .mock_once()
+        .named("delete org.matrix.msc4426.status profile field")
+        .mount()
+        .await;
+
+    let account = client.account();
+    account.clear_status().await.unwrap();
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_set_call() {
+    use ruma::{SecondsSinceUnixEpoch, profile::CallProfileField, uint};
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    let user_id = client.user_id().unwrap();
+    let account = client.account();
+
+    // With a `call_joined_ts`.
+    {
+        let mut call_field = CallProfileField::new();
+        call_field.call_joined_ts = Some(SecondsSinceUnixEpoch(uint!(1_770_140_640)));
+
+        let _guard = server
+            .mock_set_profile_field(user_id, ProfileFieldName::Call)
+            .expect_field_value(ProfileFieldValue::Call(call_field))
+            .ok()
+            .mock_once()
+            .named("set org.matrix.msc4426.call profile field with joined ts")
+            .mount_as_scoped()
+            .await;
+
+        account.set_call(Some(SecondsSinceUnixEpoch(uint!(1_770_140_640)))).await.unwrap();
+    }
+
+    // Without a `call_joined_ts`.
+    {
+        let _guard = server
+            .mock_set_profile_field(user_id, ProfileFieldName::Call)
+            .expect_field_value(ProfileFieldValue::Call(CallProfileField::new()))
+            .ok()
+            .mock_once()
+            .named("set org.matrix.msc4426.call profile field without joined ts")
+            .mount_as_scoped()
+            .await;
+
+        account.set_call(None).await.unwrap();
+    }
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_clear_call() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    let user_id = client.user_id().unwrap();
+
+    server
+        .mock_delete_profile_field(user_id, ProfileFieldName::Call)
+        .ok()
+        .mock_once()
+        .named("delete org.matrix.msc4426.call profile field")
+        .mount()
+        .await;
+
+    let account = client.account();
+    account.clear_call().await.unwrap();
+}

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -427,3 +427,73 @@ async fn test_clear_call() {
     let account = client.account();
     account.clear_call().await.unwrap();
 }
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_fetch_user_profile_with_status() {
+    use ruma::{
+        SecondsSinceUnixEpoch,
+        api::client::profile::{Call, Status},
+        profile::{CallProfileField, StatusProfileField},
+        uint,
+    };
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let user_id = client.user_id().unwrap();
+
+    let mut call_field = CallProfileField::new();
+    call_field.call_joined_ts = Some(SecondsSinceUnixEpoch(uint!(1_770_140_640)));
+
+    server
+        .mock_get_profile(user_id)
+        .ok_with_fields(vec![
+            ProfileFieldValue::DisplayName("Alice".to_owned()),
+            ProfileFieldValue::AvatarUrl(mxc_uri!("mxc://localhost/abc").to_owned()),
+            ProfileFieldValue::Status(StatusProfileField::new("Away".to_owned(), "🌴".to_owned())),
+            ProfileFieldValue::Call(call_field),
+        ])
+        .mock_once()
+        .named("get profile with status and call")
+        .mount()
+        .await;
+
+    let profile = client.account().fetch_user_profile().await.unwrap();
+
+    assert_eq!(profile.get_static::<DisplayName>().unwrap().as_deref(), Some("Alice"));
+    let status = profile.get_static::<Status>().unwrap().unwrap();
+    assert_eq!(status.emoji, "🌴");
+    assert_eq!(status.text, "Away");
+    let call = profile.get_static::<Call>().unwrap().unwrap();
+    assert_eq!(call.call_joined_ts, Some(SecondsSinceUnixEpoch(uint!(1_770_140_640))));
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_fetch_user_profile_call_without_ts() {
+    use ruma::{
+        api::client::profile::{Call, Status},
+        profile::CallProfileField,
+    };
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let user_id = client.user_id().unwrap();
+
+    server
+        .mock_get_profile(user_id)
+        .ok_with_fields(vec![
+            ProfileFieldValue::DisplayName("Bob".to_owned()),
+            ProfileFieldValue::Call(CallProfileField::new()),
+        ])
+        .mock_once()
+        .named("get profile with call but no ts")
+        .mount()
+        .await;
+
+    let profile = client.account().fetch_user_profile().await.unwrap();
+
+    assert_eq!(profile.get_static::<Status>().unwrap(), None);
+    let call = profile.get_static::<Call>().unwrap().unwrap();
+    assert_eq!(call.call_joined_ts, None);
+}


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Adds support for MSC4426 (user status profile fields). Two new profile fields are exposed end-to-end behind a new `unstable-msc4426`.

  - `m.status` : user-set emoji + text.
  - `m.call` : call indicator with an optional `call_joined_ts`.

  **SDK**:  four new methods on `Account` : `set_status` / `clear_status` / `set_call` / `clear_call` 

  **FFI** : two uniffi records `UserStatus { emoji, text }` and `UserCall { call_joined_ts }`

  - `Client::set_user_status(UserStatus)` : writes `m.status`.
  - `Client::clear_user_status()` :  concurrently clears both `m.status` and `m.call` (the latter prevents the call indicator from reappearing immediately after a manual clear).
  - `Client::get_profile(user_id)` now returns `status: Option<UserStatus>` and `call: Option<UserCall>` alongside the existing fields.

  The FFI keeps the precedence rule (m.status over m.call) out of the API.

  Handles part of #6616.
- [X] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
