### PR TITLE
Profiles: Add status and call fields to `RoomMember` and the UI crate's `Profile`.

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -33,7 +33,7 @@ bundled-sqlite = ["sqlite", "matrix-sdk/bundled-sqlite"]
 # Use IndexedDB for the session storage.
 indexeddb = ["matrix-sdk/indexeddb"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
-unstable-msc4426 = ["matrix-sdk/unstable-msc4426"]
+unstable-msc4426 = ["matrix-sdk-ui/unstable-msc4426"]
 # Required when targeting a Javascript environment, like Wasm in a browser.
 js = ["matrix-sdk-ui/js"]
 # Enable sentry error monitoring, not compatible with Wasm platforms.

--- a/bindings/matrix-sdk-ffi/changelog.d/6704.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6704.added.md
@@ -1,0 +1,4 @@
+Add `status` and `call` fields to the FFI `RoomMember` and `ProfileDetails`,
+exposing the user's
+[MSC4426](https://github.com/matrix-org/matrix-spec-proposals/pull/4426) user
+status and call indicator from their global profile.

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -2,6 +2,8 @@ use matrix_sdk::room::{RoomMember as SdkRoomMember, RoomMemberRole};
 use ruma::{UserId, events::room::power_levels::UserPowerLevel};
 
 use crate::error::{ClientError, NotYetImplemented};
+#[cfg(feature = "unstable-msc4426")]
+use crate::ruma::{UserCall, UserStatus};
 
 #[derive(Clone, uniffi::Enum)]
 pub enum MembershipState {
@@ -90,6 +92,10 @@ pub struct RoomMember {
     pub user_id: String,
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
+    #[cfg(feature = "unstable-msc4426")]
+    pub status: Option<UserStatus>,
+    #[cfg(feature = "unstable-msc4426")]
+    pub call: Option<UserCall>,
     pub membership: MembershipState,
     pub is_name_ambiguous: bool,
     pub power_level: PowerLevel,
@@ -107,6 +113,10 @@ impl TryFrom<SdkRoomMember> for RoomMember {
             user_id: m.user_id().to_string(),
             display_name: m.display_name().map(|s| s.to_owned()),
             avatar_url: m.avatar_url().map(|a| a.to_string()),
+            #[cfg(feature = "unstable-msc4426")]
+            status: m.status().cloned().map(UserStatus::from),
+            #[cfg(feature = "unstable-msc4426")]
+            call: m.call().cloned().map(UserCall::from),
             membership: m.membership().clone().try_into()?,
             is_name_ambiguous: m.name_ambiguous(),
             power_level: m.power_level().try_into()?,

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -61,6 +61,8 @@ use tracing::{error, warn};
 use uuid::Uuid;
 
 pub use self::{content::TimelineItemContent, msg_like::MessageContent};
+#[cfg(feature = "unstable-msc4426")]
+use crate::ruma::{UserCall, UserStatus};
 use crate::{
     error::{ClientError, RoomError},
     event::EventOrTransactionId,
@@ -1075,8 +1077,18 @@ pub struct EventTimelineItemDebugInfo {
 pub enum ProfileDetails {
     Unavailable,
     Pending,
-    Ready { display_name: Option<String>, display_name_ambiguous: bool, avatar_url: Option<String> },
-    Error { message: String },
+    Ready {
+        display_name: Option<String>,
+        display_name_ambiguous: bool,
+        avatar_url: Option<String>,
+        #[cfg(feature = "unstable-msc4426")]
+        status: Option<UserStatus>,
+        #[cfg(feature = "unstable-msc4426")]
+        call: Option<UserCall>,
+    },
+    Error {
+        message: String,
+    },
 }
 
 impl From<TimelineDetails<Profile>> for ProfileDetails {
@@ -1088,6 +1100,10 @@ impl From<TimelineDetails<Profile>> for ProfileDetails {
                 display_name: profile.display_name,
                 display_name_ambiguous: profile.display_name_ambiguous,
                 avatar_url: profile.avatar_url.as_ref().map(ToString::to_string),
+                #[cfg(feature = "unstable-msc4426")]
+                status: profile.status.map(UserStatus::from),
+                #[cfg(feature = "unstable-msc4426")]
+                call: profile.call.map(UserCall::from),
             },
             TimelineDetails::Error(e) => Self::Error { message: e.to_string() },
         }
@@ -1103,6 +1119,10 @@ impl From<&TimelineDetails<Profile>> for ProfileDetails {
                 display_name: profile.display_name.clone(),
                 display_name_ambiguous: profile.display_name_ambiguous,
                 avatar_url: profile.avatar_url.as_ref().map(ToString::to_string),
+                #[cfg(feature = "unstable-msc4426")]
+                status: profile.status.clone().map(UserStatus::from),
+                #[cfg(feature = "unstable-msc4426")]
+                call: profile.call.clone().map(UserCall::from),
             },
             TimelineDetails::Error(e) => Self::Error { message: e.to_string() },
         }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -68,6 +68,9 @@ testing = [
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = []
 
+# Add support for user status profile fields (m.status, m.call).
+unstable-msc4426 = ["ruma/unstable-msc4426"]
+
 experimental-element-recent-emojis = []
 
 [dependencies]

--- a/crates/matrix-sdk-base/changelog.d/6704.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6704.added.md
@@ -1,0 +1,3 @@
+Surface the [MSC4426](https://github.com/matrix-org/matrix-spec-proposals/pull/4426)
+user status and call indicator on `RoomMember`, sourced from the user's global
+profile. Read them with `RoomMember::status()` and `RoomMember::call()`.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1263,6 +1263,8 @@ mod tests {
         BOB, InvitedRoomBuilder, LeftRoomBuilder, SyncResponseBuilder, async_test,
         event_factory::EventFactory, ruma_response_from_json,
     };
+    #[cfg(feature = "unstable-msc4426")]
+    use ruma::profile::{ProfileFieldValue, StatusProfileField, UserProfileUpdate};
     use ruma::{
         api::client::{self as api, sync::sync_events::v5},
         event_id,
@@ -1280,6 +1282,8 @@ mod tests {
         store::{RoomLoadSettings, StateStoreExt, StoreConfig},
         test_utils::logged_in_base_client,
     };
+    #[cfg(feature = "unstable-msc4426")]
+    use crate::{RoomMemberships, store::StateChanges};
 
     #[test]
     fn test_requested_required_states() {
@@ -1754,6 +1758,69 @@ mod tests {
         assert_eq!(member.user_id(), user_id);
         assert_eq!(member.display_name().unwrap(), "Invited Alice");
         assert_eq!(member.avatar_url().unwrap().to_string(), "mxc://localhost/fewjilfewjil42");
+    }
+
+    #[cfg(feature = "unstable-msc4426")]
+    #[async_test]
+    async fn test_room_member_carries_global_profile_status() {
+        let user_id = user_id!("@alice:example.org");
+        let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
+
+        let client = BaseClient::new(
+            StoreConfig::new(CrossProcessLockConfig::SingleProcess),
+            ThreadingSupport::Disabled,
+            DmRoomDefinition::default(),
+        );
+        client
+            .activate(
+                SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() },
+                RoomLoadSettings::default(),
+                #[cfg(feature = "e2e-encryption")]
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Let the SDK know about the room, with the user as a joined member.
+        let f = EventFactory::new().sender(user_id);
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(
+                matrix_sdk_test::JoinedRoomBuilder::new(room_id).add_state_event(f.member(user_id)),
+            )
+            .build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        let room = client.get_room(room_id).unwrap();
+
+        // Without a global profile, the member has no status.
+        let member = room.get_member(user_id).await.expect("ok").expect("exists");
+        assert!(member.status().is_none());
+
+        // Save a global profile carrying an `m.status` for the member.
+        let mut changes = StateChanges::default();
+        changes.global_profiles.insert(
+            user_id.to_owned(),
+            UserProfileUpdate::from_iter([ProfileFieldValue::Status(StatusProfileField::new(
+                "Working".to_owned(),
+                "💻".to_owned(),
+            ))]),
+        );
+        client.state_store().save_changes(&changes).await.unwrap();
+
+        // `get_member` surfaces the status from the global profile.
+        let member = room.get_member(user_id).await.expect("ok").expect("exists");
+        let status = member.status().expect("status is set");
+        assert_eq!(status.text, "Working");
+        assert_eq!(status.emoji, "💻");
+
+        // `members` surfaces it too.
+        let members = room.members(RoomMemberships::JOIN).await.unwrap();
+        let member =
+            members.iter().find(|m| m.user_id() == user_id).expect("member is in the list");
+        let status = member.status().expect("status is set");
+        assert_eq!(status.text, "Working");
+        assert_eq!(status.emoji, "💻");
     }
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -119,6 +119,10 @@ pub struct BaseClient {
     /// Observable of when a user is ignored/unignored.
     pub(crate) ignore_user_list_changes: SharedObservable<Vec<String>>,
 
+    /// Broadcasts the user IDs whose global profile changed during a sync.
+    /// Requires the Profiles sliding sync extension to be enabled.
+    pub(crate) global_profile_updates_sender: broadcast::Sender<BTreeSet<OwnedUserId>>,
+
     /// The strategy to use for picking recipient devices, when sending an
     /// encrypted message.
     #[cfg(feature = "e2e-encryption")]
@@ -198,6 +202,7 @@ impl BaseClient {
             #[cfg(feature = "e2e-encryption")]
             olm_machine: Default::default(),
             ignore_user_list_changes: Default::default(),
+            global_profile_updates_sender: broadcast::Sender::new(16),
             #[cfg(feature = "e2e-encryption")]
             room_key_recipient_strategy: Default::default(),
             #[cfg(feature = "e2e-encryption")]
@@ -235,6 +240,7 @@ impl BaseClient {
             crypto_store: self.crypto_store.clone(),
             olm_machine: self.olm_machine.clone(),
             ignore_user_list_changes: Default::default(),
+            global_profile_updates_sender: broadcast::Sender::new(16),
             room_key_recipient_strategy: self.room_key_recipient_strategy.clone(),
             decryption_settings: self.decryption_settings.clone(),
             handle_verification_events,
@@ -1112,6 +1118,17 @@ impl BaseClient {
     /// Learn more by reading the [`RoomInfoNotableUpdate`] type.
     pub fn room_info_notable_update_receiver(&self) -> broadcast::Receiver<RoomInfoNotableUpdate> {
         self.state_store.room_info_notable_update_sender.subscribe()
+    }
+
+    /// Returns a receiver of the user IDs whose global profile changed during a
+    /// sync. Consumers can use this as a trigger to e.g. merge any global
+    /// fields into a user's room profile.
+    ///
+    /// Requires the Profiles sliding sync extension to be enabled.
+    pub fn subscribe_to_global_profile_updates(
+        &self,
+    ) -> broadcast::Receiver<BTreeSet<OwnedUserId>> {
+        self.global_profile_updates_sender.subscribe()
     }
 
     /// Checks whether the provided `user_id` belongs to an ignored user.

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -20,6 +20,8 @@ use std::{
 
 use bitflags::bitflags;
 use futures_util::future;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::profile::{Call, CallProfileField, Status, StatusProfileField, UserProfile};
 use ruma::{
     Int, MxcUri, OwnedUserId, UserId,
     events::{
@@ -93,6 +95,9 @@ impl Room {
 
         let mut profiles = self.store.get_profiles(self.room_id(), &user_ids).await?;
 
+        #[cfg(feature = "unstable-msc4426")]
+        let mut global_profiles = self.store.get_global_profiles(&user_ids).await?;
+
         let mut presences = self
             .store
             .get_presence_events(&user_ids)
@@ -110,8 +115,17 @@ impl Room {
 
         for event in member_events {
             let profile = profiles.remove(event.user_id());
+            #[cfg(feature = "unstable-msc4426")]
+            let global_profile = global_profiles.remove(event.user_id());
             let presence = presences.remove(event.user_id());
-            members.push(RoomMember::from_parts(event, profile, presence, &room_info))
+            members.push(RoomMember::from_parts(
+                event,
+                profile,
+                #[cfg(feature = "unstable-msc4426")]
+                global_profile,
+                presence,
+                &room_info,
+            ))
         }
 
         Ok(members)
@@ -157,6 +171,16 @@ impl Room {
 
         let profile = async { self.store.get_profile(self.room_id(), user_id).await };
 
+        #[cfg(feature = "unstable-msc4426")]
+        let (Some(event), presence, profile, global_profile) =
+            future::try_join4(event, presence, profile, async {
+                self.store.get_global_profile(user_id).await
+            })
+            .await?
+        else {
+            return Ok(None);
+        };
+        #[cfg(not(feature = "unstable-msc4426"))]
         let (Some(event), presence, profile) = future::try_join3(event, presence, profile).await?
         else {
             return Ok(None);
@@ -165,7 +189,14 @@ impl Room {
         let display_names = [event.display_name()];
         let room_info = self.member_room_info(&display_names).await?;
 
-        Ok(Some(RoomMember::from_parts(event, profile, presence, &room_info)))
+        Ok(Some(RoomMember::from_parts(
+            event,
+            profile,
+            #[cfg(feature = "unstable-msc4426")]
+            global_profile,
+            presence,
+            &room_info,
+        )))
     }
 
     /// The current `MemberRoomInfo` for this room.
@@ -212,6 +243,12 @@ pub struct RoomMember {
     // Stored in addition to the latest member event overall to get displayname
     // and avatar from, which should be ignored on events sent by others.
     pub(crate) profile: Arc<Option<MinimalRoomMemberEvent>>,
+    // The user's status, taken from their global profile.
+    #[cfg(feature = "unstable-msc4426")]
+    pub(crate) status: Option<StatusProfileField>,
+    // The user's call indicator, taken from their global profile.
+    #[cfg(feature = "unstable-msc4426")]
+    pub(crate) call: Option<CallProfileField>,
     #[allow(dead_code)]
     pub(crate) presence: Arc<Option<PresenceEvent>>,
     pub(crate) power_levels: Arc<RoomPowerLevels>,
@@ -225,6 +262,7 @@ impl RoomMember {
     pub(crate) fn from_parts(
         event: MemberEvent,
         profile: Option<MinimalRoomMemberEvent>,
+        #[cfg(feature = "unstable-msc4426")] global_profile: Option<UserProfile>,
         presence: Option<PresenceEvent>,
         room_info: &MemberRoomInfo<'_>,
     ) -> Self {
@@ -244,9 +282,19 @@ impl RoomMember {
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
         let is_service_member = service_members.as_ref().is_some_and(|s| s.contains(&user_id));
 
+        // Extract global profile fields, swallowing any deserialization errors.
+        #[cfg(feature = "unstable-msc4426")]
+        let status = global_profile.as_ref().and_then(|p| p.get_static::<Status>().ok().flatten());
+        #[cfg(feature = "unstable-msc4426")]
+        let call = global_profile.as_ref().and_then(|p| p.get_static::<Call>().ok().flatten());
+
         Self {
             event: event.into(),
             profile: profile.into(),
+            #[cfg(feature = "unstable-msc4426")]
+            status,
+            #[cfg(feature = "unstable-msc4426")]
+            call,
             presence: presence.into(),
             power_levels: power_levels.clone(),
             max_power_level: *max_power_level,
@@ -290,6 +338,30 @@ impl RoomMember {
         } else {
             self.event.avatar_url()
         }
+    }
+
+    /// Get the user's status, if any.
+    ///
+    /// This is the user-set status (emoji + text) taken from the user's global
+    /// profile.
+    ///
+    /// Global profiles are only populated when syncing via sliding sync with
+    /// the profiles extension enabled; this is always `None` under sync v2.
+    #[cfg(feature = "unstable-msc4426")]
+    pub fn status(&self) -> Option<&StatusProfileField> {
+        self.status.as_ref()
+    }
+
+    /// Get the user's call indicator, if any.
+    ///
+    /// This indicates the user is currently in a call (and optionally how long
+    /// they've been in it). It is taken from the user's global profile.
+    ///
+    /// Global profiles are only populated when syncing via sliding sync with
+    /// the profiles extension enabled; this is always `None` under sync v2.
+    #[cfg(feature = "unstable-msc4426")]
+    pub fn call(&self) -> Option<&CallProfileField> {
+        self.call.as_ref()
     }
 
     /// Get the normalized power level of this member.
@@ -509,7 +581,16 @@ pub fn normalize_power_level(power_level: Int, max_power_level: i64) -> Int {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "unstable-msc4426")]
+    use matrix_sdk_common::ROOM_VERSION_RULES_FALLBACK;
+    #[cfg(feature = "unstable-msc4426")]
+    use matrix_sdk_test::event_factory::EventFactory;
     use proptest::prelude::*;
+    #[cfg(feature = "unstable-msc4426")]
+    use ruma::{
+        SecondsSinceUnixEpoch, events::room::power_levels::RoomPowerLevelsSource,
+        profile::ProfileFieldValue, user_id,
+    };
 
     use super::*;
 
@@ -556,5 +637,50 @@ mod tests {
         let normalized = i64::from(normalized);
         assert!(normalized >= 0);
         assert!(normalized <= 100);
+    }
+
+    #[cfg(feature = "unstable-msc4426")]
+    #[test]
+    fn test_global_profile_fields() {
+        let user_id = user_id!("@alice:example.org");
+        let event = MemberEvent::Sync(EventFactory::new().sender(user_id).member(user_id).into());
+        let room_info = MemberRoomInfo {
+            power_levels: Arc::new(RoomPowerLevels::new(
+                RoomPowerLevelsSource::None,
+                &ROOM_VERSION_RULES_FALLBACK.authorization,
+                std::iter::empty::<OwnedUserId>(),
+            )),
+            max_power_level: 100,
+            users_display_names: HashMap::new(),
+            ignored_users: None,
+            service_members: None,
+        };
+
+        // Without a global profile, neither field is set.
+        let member = RoomMember::from_parts(event.clone(), None, None, None, &room_info);
+        assert!(member.status().is_none());
+        assert!(member.call().is_none());
+
+        // A global profile carrying both m.status and m.call is extracted into
+        // both fields.
+        let mut call = CallProfileField::new();
+        call.call_joined_ts = Some(SecondsSinceUnixEpoch(1_700_000_000u32.into()));
+        let global_profile = UserProfile::from_iter([
+            ProfileFieldValue::Status(StatusProfileField::new(
+                "Working".to_owned(),
+                "💻".to_owned(),
+            )),
+            ProfileFieldValue::Call(call),
+        ]);
+
+        let member = RoomMember::from_parts(event, None, Some(global_profile), None, &room_info);
+
+        let status = member.status().expect("status is set");
+        assert_eq!(status.text, "Working");
+        assert_eq!(status.emoji, "💻");
+        assert_eq!(
+            member.call().expect("call is set").call_joined_ts,
+            Some(SecondsSinceUnixEpoch(1_700_000_000u32.into()))
+        );
     }
 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -219,6 +219,14 @@ impl BaseClient {
         )
         .await?;
 
+        // Notify subscribers (e.g. open timelines) about global profile updates, which
+        // don't otherwise touch any room and so trigger no other broadcast.
+        if !extensions.profiles.is_empty() {
+            let _ = self
+                .global_profile_updates_sender
+                .send(extensions.profiles.keys().cloned().collect());
+        }
+
         let mut context = processors::Context::default();
 
         // Now that all the rooms information have been saved, update the display name
@@ -518,6 +526,64 @@ mod tests {
             .expect("Bob's profile should still be saved");
         let bob_map: BTreeMap<String, serde_json::Value> = bob_profile.into_iter().collect();
         assert_eq!(bob_map.get("displayname"), Some(&json!("Bob")));
+    }
+
+    #[async_test]
+    async fn test_profiles_extension_broadcasts_global_profile_updates() {
+        let client = logged_in_base_client(None).await;
+
+        let alice = user_id!("@alice:e.uk");
+        let bob = user_id!("@bob:e.uk");
+
+        // Given a subscriber to global profile updates.
+        let mut global_profile_updates = client.subscribe_to_global_profile_updates();
+
+        // When a sliding sync response carries the profiles extension for two users.
+        let mut response = http::Response::new("0".to_owned());
+        response.extensions.profiles.insert(
+            alice.to_owned(),
+            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice"))]),
+        );
+        response.extensions.profiles.insert(
+            bob.to_owned(),
+            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Bob"))]),
+        );
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // Then the changed user IDs are broadcast.
+        let users =
+            global_profile_updates.recv().await.expect("should receive a global profile update");
+        assert_eq!(users.len(), 2);
+        assert!(users.contains(alice));
+        assert!(users.contains(bob));
+
+        // When a subsequent response only carries an update for Alice.
+        let mut response = http::Response::new("1".to_owned());
+        response.extensions.profiles.insert(
+            alice.to_owned(),
+            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice Updated"))]),
+        );
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // Then only Alice is broadcast.
+        let users =
+            global_profile_updates.recv().await.expect("should receive a global profile update");
+        assert_eq!(users.len(), 1);
+        assert!(users.contains(alice));
     }
 
     #[async_test]

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -23,6 +23,9 @@ unstable-msc3956 = ["ruma/unstable-msc3956"]
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["matrix-sdk/unstable-msc4274"]
 
+# Add support for user status profile fields (m.status, m.call).
+unstable-msc4426 = ["matrix-sdk/unstable-msc4426"]
+
 # Enable the global, reactive search service built on top of the SDK's
 # message search.
 experimental-search = ["matrix-sdk/experimental-search"]

--- a/crates/matrix-sdk-ui/changelog.d/6704.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6704.added.md
@@ -1,0 +1,3 @@
+Add `status` and `call` fields to the timeline `Profile`, carrying the sender's
+[MSC4426](https://github.com/matrix-org/matrix-spec-proposals/pull/4426) user
+status and call indicator from their global profile.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -23,6 +23,8 @@ use super::{
     DateDividerMode, Error, Timeline, TimelineDropHandle, TimelineFocus,
     controller::{TimelineController, TimelineSettings},
 };
+#[cfg(feature = "unstable-msc4426")]
+use crate::timeline::tasks::global_profile_updates_task;
 use crate::{
     timeline::{
         TimelineReadReceiptTracking,
@@ -243,6 +245,19 @@ impl TimelineBuilder {
                 .abort_on_drop()
         };
 
+        #[cfg(feature = "unstable-msc4426")]
+        let global_profile_updates_handle = room
+            .client()
+            .task_monitor()
+            .spawn_infinite_task(
+                "timeline::global_profile_updates",
+                global_profile_updates_task(
+                    room.client().subscribe_to_global_profile_updates(),
+                    controller.clone(),
+                ),
+            )
+            .abort_on_drop();
+
         let initial_active_call_info = ActiveCallInfo::from_info(initial_info, owned_user_id);
         if initial_active_call_info.is_some() {
             controller.handle_active_call_update(initial_active_call_info).await;
@@ -272,6 +287,8 @@ impl TimelineBuilder {
             drop_handle: Arc::new(TimelineDropHandle {
                 _crypto_drop_handles: crypto_drop_handles,
                 _room_update_join_handle: room_update_join_handle,
+                #[cfg(feature = "unstable-msc4426")]
+                _global_profile_updates_handle: global_profile_updates_handle,
                 _local_echo_listener_handle: local_echo_listener_handle,
                 _rtc_membership_listener_handle: rtc_membership_listener_handle,
                 _focus_drop_handle: focus_task,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -25,6 +25,8 @@ use matrix_sdk::{
     send_queue::{SendHandle, SendReactionHandle},
 };
 use matrix_sdk_base::deserialized_responses::ShieldStateCode;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::profile::{CallProfileField, StatusProfileField};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
     OwnedUserId, TransactionId, UserId,
@@ -701,6 +703,14 @@ pub struct Profile {
 
     /// The avatar URL, if set.
     pub avatar_url: Option<OwnedMxcUri>,
+
+    /// The user's status, taken from their global profile, if set.
+    #[cfg(feature = "unstable-msc4426")]
+    pub status: Option<StatusProfileField>,
+
+    /// The user's call indicator, taken from their global profile, if set.
+    #[cfg(feature = "unstable-msc4426")]
+    pub call: Option<CallProfileField>,
 }
 
 impl Profile {
@@ -710,6 +720,10 @@ impl Profile {
                 display_name: member.display_name().map(ToOwned::to_owned),
                 display_name_ambiguous: member.name_ambiguous(),
                 avatar_url: member.avatar_url().map(ToOwned::to_owned),
+                #[cfg(feature = "unstable-msc4426")]
+                status: member.status().cloned(),
+                #[cfg(feature = "unstable-msc4426")]
+                call: member.call().cloned(),
             }),
             Ok(None) if room.are_members_synced() => Some(Profile::default()),
             Ok(None) => None,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -885,6 +885,8 @@ impl Timeline {
 #[derive(Debug)]
 struct TimelineDropHandle {
     _room_update_join_handle: BackgroundTaskHandle,
+    #[cfg(feature = "unstable-msc4426")]
+    _global_profile_updates_handle: BackgroundTaskHandle,
     _local_echo_listener_handle: BackgroundTaskHandle,
     _rtc_membership_listener_handle: BackgroundTaskHandle,
     _event_cache_drop_handle: Arc<EventCacheDropHandles>,

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -26,6 +26,8 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::RoomInfo;
 use ruma::OwnedEventId;
+#[cfg(feature = "unstable-msc4426")]
+use ruma::{OwnedUserId, UserId};
 use tokio::sync::broadcast::{Receiver, error::RecvError};
 use tracing::{error, instrument, trace, warn};
 
@@ -286,6 +288,35 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
                     }
                     timeline_controller.force_update_sender_profiles(&user_ids_to_update).await;
                 }
+            }
+        }
+    }
+}
+
+/// Long-lived task that refreshes displayed sender profiles when the users'
+/// global profiles change. The controller filters to the senders it shows.
+#[cfg(feature = "unstable-msc4426")]
+pub(in crate::timeline) async fn global_profile_updates_task(
+    mut global_profile_updates_stream: Receiver<BTreeSet<OwnedUserId>>,
+    timeline_controller: TimelineController,
+) {
+    trace!("spawned the global profile updates task!");
+
+    loop {
+        match global_profile_updates_stream.recv().await {
+            Ok(user_ids) => {
+                let sender_ids: BTreeSet<&UserId> =
+                    user_ids.iter().map(|user_id| user_id.as_ref()).collect();
+                timeline_controller.force_update_sender_profiles(&sender_ids).await;
+            }
+
+            Err(RecvError::Lagged(num_missed)) => {
+                warn!("missed {num_missed} global profile updates, ignoring those missed");
+            }
+
+            Err(RecvError::Closed) => {
+                trace!("channel closed, exiting the global profile updates handler");
+                break;
             }
         }
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -649,3 +649,109 @@ async fn test_timeline_read_receipts_are_updated_live() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_timeline_refreshes_sender_profile_on_global_profile_update() -> Result<()> {
+    use matrix_sdk_ui::timeline::TimelineDetails;
+    use ruma::profile::StatusProfileField;
+
+    let (client, server, sliding_sync) = new_sliding_sync(vec![
+        SlidingSyncList::builder("foo")
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+    ])
+    .await?;
+
+    let stream = sliding_sync.sync();
+    pin_mut!(stream);
+
+    let room_id = room_id!("!foo:bar.org");
+
+    create_one_room(&server, &mut stream, room_id, "Room Name".to_owned()).await?;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let sdk_room = client.get_room(room_id).context("room should exist")?;
+    let timeline = TimelineBuilder::new(&sdk_room)
+        .track_read_marker_and_receipts(TimelineReadReceiptTracking::AllEvents)
+        .build()
+        .await?;
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    // Alice is a member of the room and has sent a message.
+    receive_response! {
+        [server.server(), stream]
+        {
+            "pos": "1",
+            "lists": {},
+            "rooms": {
+                room_id: {
+                    "required_state": [
+                        {
+                            "type": "m.room.member",
+                            "state_key": "@alice:bar.org",
+                            "sender": "@alice:bar.org",
+                            "content": { "membership": "join", "displayname": "Alice" },
+                            "event_id": "$alice_member:bar.org",
+                            "origin_server_ts": 0
+                        }
+                    ],
+                    "timeline": [ timeline_event!("$msg:bar.org" at 1 sec) ]
+                }
+            }
+        }
+    };
+
+    // Consume the initial updates for Alice's message.
+    assert_timeline_stream! {
+        [timeline_stream]
+        append  "$msg:bar.org";
+        prepend --- date divider ---;
+    };
+
+    // Baseline: Alice's profile is known, but carries no status yet.
+    let items = timeline.items().await;
+    let alice_message = items
+        .iter()
+        .filter_map(|item| item.as_event())
+        .find(|event| event.event_id().map(|id| id.as_str()) == Some("$msg:bar.org"))
+        .context("Alice's message should be in the timeline")?;
+    assert_let!(TimelineDetails::Ready(profile) = alice_message.sender_profile());
+    assert!(profile.status.is_none(), "The status should be unset before the profile update.");
+
+    // A sync carrying only a global profiles update for Alice with a new status.
+    receive_response! {
+        [server.server(), stream]
+        {
+            "pos": "2",
+            "lists": {},
+            "rooms": {},
+            "extensions": {
+                "users": {
+                    "@alice:bar.org": {
+                        "org.matrix.msc4426.status": { "text": "Away", "emoji": "🌴" }
+                    }
+                }
+            }
+        }
+    };
+
+    // Wait for the sync response to be processed.
+    assert_let_timeout!(Some(_) = timeline_stream.next());
+
+    // The same message now carries Alice's new status.
+    let items = timeline.items().await;
+    let alice_message = items
+        .iter()
+        .filter_map(|item| item.as_event())
+        .find(|event| event.event_id().map(|id| id.as_str()) == Some("$msg:bar.org"))
+        .context("Alice's message should be in the timeline")?;
+    assert_let!(TimelineDetails::Ready(profile) = alice_message.sender_profile());
+    assert_eq!(
+        profile.status.as_ref(),
+        Some(&StatusProfileField::new("Away".to_owned(), "🌴".to_owned())),
+        "The timeline should refresh Alice's sender profile with the new status."
+    );
+
+    Ok(())
+}

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -91,7 +91,7 @@ docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "feder
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
 
 # Add support for user status profile fields (m.status, m.call).
-unstable-msc4426 = ["ruma/unstable-msc4426"]
+unstable-msc4426 = ["matrix-sdk-base/unstable-msc4426"]
 
 experimental-search = ["matrix-sdk-search"]
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -709,6 +709,17 @@ impl Client {
         self.base_client().room_info_notable_update_receiver()
     }
 
+    /// Returns a receiver of the user IDs whose global profile changed during a
+    /// sync. Consumers can use this as a trigger to e.g. merge any global
+    /// fields into a user's room profile.
+    ///
+    /// Requires the Profiles sliding sync extension to be enabled.
+    pub fn subscribe_to_global_profile_updates(
+        &self,
+    ) -> broadcast::Receiver<BTreeSet<ruma::OwnedUserId>> {
+        self.base_client().subscribe_to_global_profile_updates()
+    }
+
     /// Performs a search for users.
     /// The search is performed case-insensitively on user IDs and display names
     ///


### PR DESCRIPTION
Builds on top of #6685, this PR reads the stored global profiles and combines the user status fields into the various room member profile types in the SDK.

Built on top of the feature from #6703 (although I've rejigged things a bit).

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries