### PR TITLE
fix(sdk): Introduce a new default feature flag which can be deactivated to avoid pulling aws-lc-rs

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -17,7 +17,7 @@ codspeed = []
 assert_matches.workspace = true
 criterion = { version = "4.2.1", features = ["async", "async_tokio", "html_reports"], package = "codspeed-criterion-compat" }
 futures-util.workspace = true
-matrix-sdk = { workspace = true, features = ["e2e-encryption", "sqlite", "testing"] }
+matrix-sdk = { workspace = true, features = ["e2e-encryption", "sqlite", "testing", "rustls-aws-lc-rs"] }
 matrix-sdk-base.workspace = true
 matrix-sdk-crypto.workspace = true
 matrix-sdk-sqlite = { workspace = true, features = ["crypto-store"] }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = [
 ]
 
 [features]
-default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search"]
+default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
 experimental-search = ["matrix-sdk/experimental-search", "matrix-sdk-ui/experimental-search"]
 # Use SQLite for the session storage.
 sqlite = ["matrix-sdk/sqlite"]
@@ -40,6 +40,8 @@ sentry = ["dep:sentry", "dep:sentry-tracing"]
 
 experimental-element-recent-emojis = ["matrix-sdk/experimental-element-recent-emojis"]
 experimental-push-secrets = ["matrix-sdk/experimental-push-secrets"]
+
+rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs", "matrix-sdk-ui/rustls-aws-lc-rs", "matrix-sdk-contentscanner/rustls-aws-lc-rs"]
 
 [dependencies]
 anyhow.workspace = true
@@ -136,7 +138,7 @@ once_cell = "1.21.4"
 jvm-getter = "0.1.0"
 
 [dev-dependencies]
-matrix-sdk = { workspace = true, features = ["testing"] }
+matrix-sdk = { workspace = true, features = ["testing", "rustls-aws-lc-rs"] }
 similar-asserts.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }

--- a/crates/matrix-sdk-contentscanner/Cargo.toml
+++ b/crates/matrix-sdk-contentscanner/Cargo.toml
@@ -8,7 +8,10 @@ license = "Apache-2.0"
 rust-version.workspace = true
 
 [features]
+default = ["rustls-aws-lc-rs"]
 uniffi = ["dep:uniffi", "matrix-sdk/uniffi"]
+
+rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs"]
 
 [dependencies]
 assert_matches2.workspace = true

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -11,9 +11,11 @@ rust-version.workspace = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
 js = ["matrix-sdk/js"]
 uniffi = ["dep:uniffi", "matrix-sdk/uniffi", "matrix-sdk-base/uniffi"]
+
+rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs"]
 
 # Add support for encrypted extensible events.
 unstable-msc3956 = ["ruma/unstable-msc3956"]
@@ -72,7 +74,7 @@ assert-json-diff.workspace = true
 assert_matches.workspace = true
 assert_matches2.workspace = true
 eyeball-im-util.workspace = true
-matrix-sdk = { workspace = true, features = ["testing", "sqlite"] }
+matrix-sdk = { workspace = true, features = ["testing", "sqlite", "rustls-aws-lc-rs"] }
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
 proptest.workspace = true

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -16,7 +16,7 @@ features = ["docsrs"]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [features]
-default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite"]
+default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "rustls-aws-lc-rs"]
 testing = [
     "matrix-sdk-sqlite?/testing",
     "matrix-sdk-indexeddb?/testing",
@@ -49,6 +49,9 @@ indexeddb = [
     "matrix-sdk-indexeddb/event-cache-store",
     "matrix-sdk-indexeddb/media-store"
 ]
+# If enabled, reqwest depends on and installs aws-lc-rs as the default crypto
+# provider for rustls
+rustls-aws-lc-rs = ["reqwest/rustls"]
 
 qrcode = ["e2e-encryption", "matrix-sdk-base/qrcode"]
 automatic-room-key-forwarding = ["e2e-encryption", "matrix-sdk-base/automatic-room-key-forwarding"]
@@ -160,13 +163,13 @@ zeroize.workspace = true
 backon = "1.6.0"
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
-reqwest = { workspace = true, features = ["stream", "gzip", "http2", "rustls"] }
+reqwest = { workspace = true, features = ["stream", "gzip", "http2", "rustls-no-provider"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 wiremock = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo-timers = { workspace = true, features = ["futures"] }
-reqwest = { workspace = true, features = ["gzip", "http2", "rustls"] }
+reqwest = { workspace = true, features = ["gzip", "http2", "rustls-no-provider"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]
@@ -180,6 +183,7 @@ insta.workspace = true
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
+reqwest = { workspace = true, features = ["rustls"] }
 serde_urlencoded = "0.7.1"
 similar-asserts.workspace = true
 stream_assert.workspace = true

--- a/crates/matrix-sdk/changelog.d/6705.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6705.fixed.md
@@ -1,0 +1,1 @@
+It is now possible to prevent `matrix-sdk` from pulling in `aws-lc-rs` as a transitive dependency by deactivating the newly introduced `rustls-aws-lc-rs` default feature. This is a breaking change for downstream users relying on `matrix-sdk` without default features, who now have to explicitly enable `rustls-aws-lc-rs` or register a rustls provider explicitly.


### PR DESCRIPTION
Previously, matrix-sdk would pull aws-lc-sys as a transitive dependency via reqwest's rustls feature, even if downstream users otherwise rely on ring. rustls-no-provider is the provider-agnostic alternative, which is now used instead.

This is a breaking change because downstream users now have to pick a provider explicitly, via a reqwest feature flag or by manually registering a rustls provider.

If preferred, we can introduce a new feature flag for the previous behavior, and make it a default. That way it can be deselected manually.

- [X] I've documented the public API changes in the appropriate changelog files
- [X] This PR was made with the help of AI.