### PR TITLE
feat(qr-code): Add continuation sender to WaitingForAuth

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6711.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6711.changed.md
@@ -1,0 +1,14 @@
+[**breaking**] `GrantQrLoginProgress::WaitingForAuth` and
+`GrantGeneratedQrLoginProgress::WaitingForAuth` now have a
+`continuation_sender: ContinuationMessageSender` field. Applications must call
+`continuation_sender.confirm()` once the verification URI has been opened in
+the browser and the application is ready to proceed, or
+`continuation_sender.cancel()` to abort; previously it proceeded automatically
+as soon as this state was reached. This lets applications that suspend or
+navigate away while the verification URI is open to resume the process
+explicitly.
+
+`HumanQrLoginError` has two new variants, `ContinuationAlreadySent` and
+`ContinuationCannotBeSent`, which `ContinuationMessageSender.confirm()` and
+`.cancel()` return instead of the check-code-specific `CheckCodeAlreadySent` /
+`CheckCodeCannotBeSent` variants.

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -17,8 +17,9 @@ use std::sync::Arc;
 use matrix_sdk::authentication::oauth::{
     OAuth,
     qrcode::{
-        self, CheckCodeSender as SdkCheckCodeSender, CheckCodeSenderError,
-        DeviceCodeErrorResponseType, GeneratedQrProgress, LoginFailureReason, QrProgress,
+        self, CheckCodeSender as SdkCheckCodeSender,
+        ContinuationMessageSender as SdkContinuationMessageSender, DeviceCodeErrorResponseType,
+        GeneratedQrProgress, LoginFailureReason, QrProgress, SenderError,
     },
 };
 use matrix_sdk_base::crypto::types::qr_login::{self, QrCodeIntent};
@@ -330,6 +331,10 @@ pub enum HumanQrLoginError {
     CheckCodeAlreadySent,
     #[error("The check code could not be sent.")]
     CheckCodeCannotBeSent,
+    #[error("The continuation was already confirmed or cancelled.")]
+    ContinuationAlreadySent,
+    #[error("The continuation could no longer be confirmed or cancelled.")]
+    ContinuationCannotBeSent,
     #[error("The rendezvous session was not found and might have expired")]
     NotFound,
     #[error("The QR code specifies an unsupported protocol version")]
@@ -386,15 +391,6 @@ impl From<qrcode::QRCodeLoginError> for HumanQrLoginError {
             | QRCodeLoginError::ServerReset(_) => HumanQrLoginError::Unknown,
 
             QRCodeLoginError::NotFound => HumanQrLoginError::NotFound,
-        }
-    }
-}
-
-impl From<CheckCodeSenderError> for HumanQrLoginError {
-    fn from(value: CheckCodeSenderError) -> Self {
-        match value {
-            CheckCodeSenderError::AlreadySent => HumanQrLoginError::CheckCodeAlreadySent,
-            CheckCodeSenderError::CannotSend => HumanQrLoginError::CheckCodeCannotBeSent,
         }
     }
 }
@@ -614,6 +610,12 @@ pub enum GrantQrLoginProgress {
     WaitingForAuth {
         /// A URI to open in a (secure) system browser to verify the new login.
         verification_uri: String,
+        /// A sender to confirm that the authorization using the verification
+        /// URI has been started in the browser and that the application is
+        /// ready to proceed. This allows applications that suspend or navigate
+        /// away while the verification URI is open to resume the process
+        /// explicitly.
+        continuation_sender: Arc<ContinuationMessageSender>,
     },
     /// We are syncing secrets.
     SyncingSecrets,
@@ -640,8 +642,11 @@ impl From<qrcode::GrantLoginProgress<QrProgress>> for GrantQrLoginProgress {
                     check_code_string: format!("{check_code:02}"),
                 }
             }
-            GrantLoginProgress::WaitingForAuth { verification_uri } => {
-                Self::WaitingForAuth { verification_uri: verification_uri.into() }
+            GrantLoginProgress::WaitingForAuth { verification_uri, continuation_sender } => {
+                Self::WaitingForAuth {
+                    verification_uri: verification_uri.into(),
+                    continuation_sender: Arc::new(continuation_sender.into()),
+                }
             }
             GrantLoginProgress::SyncingSecrets => Self::SyncingSecrets,
             GrantLoginProgress::Done => Self::Done,
@@ -668,6 +673,12 @@ pub enum GrantGeneratedQrLoginProgress {
     WaitingForAuth {
         /// A URI to open in a (secure) system browser to verify the new login.
         verification_uri: String,
+        /// A sender to confirm that the authorization using the verification
+        /// URI has been started in the browser and that the application is
+        /// ready to proceed. This allows applications that suspend or navigate
+        /// away while the verification URI is open to resume the process
+        /// explicitly.
+        continuation_sender: Arc<ContinuationMessageSender>,
     },
     /// We are syncing secrets.
     SyncingSecrets,
@@ -692,8 +703,11 @@ impl From<qrcode::GrantLoginProgress<GeneratedQrProgress>> for GrantGeneratedQrL
             GrantLoginProgress::EstablishingSecureChannel(GeneratedQrProgress::QrScanned(
                 inner,
             )) => Self::QrScanned { check_code_sender: Arc::new(CheckCodeSender { inner }) },
-            GrantLoginProgress::WaitingForAuth { verification_uri } => {
-                Self::WaitingForAuth { verification_uri: verification_uri.into() }
+            GrantLoginProgress::WaitingForAuth { verification_uri, continuation_sender } => {
+                Self::WaitingForAuth {
+                    verification_uri: verification_uri.into(),
+                    continuation_sender: Arc::new(continuation_sender.into()),
+                }
             }
             GrantLoginProgress::SyncingSecrets => Self::SyncingSecrets,
             GrantLoginProgress::Done => Self::Done,
@@ -701,9 +715,9 @@ impl From<qrcode::GrantLoginProgress<GeneratedQrProgress>> for GrantGeneratedQrL
     }
 }
 
-#[derive(Debug, uniffi::Object)]
 /// Used to pass back the [`CheckCode`] entered by the user to verify that the
 /// secure channel is indeed secure.
+#[derive(Debug, uniffi::Object)]
 pub struct CheckCodeSender {
     inner: SdkCheckCodeSender,
 }
@@ -718,6 +732,50 @@ impl CheckCodeSender {
     ///
     /// * `check_code` - The check code in digits representation.
     pub async fn send(&self, code: u8) -> Result<(), HumanQrLoginError> {
-        self.inner.send(code).await.map_err(HumanQrLoginError::from)
+        self.inner.send(code).await.map_err(check_code_error)
+    }
+}
+
+/// Struct used to let the QR code granting logic know that it can continue with
+/// the process since applications might suspend things while the verification
+/// URI is open.
+#[derive(Debug, Clone, uniffi::Object)]
+pub struct ContinuationMessageSender {
+    inner: SdkContinuationMessageSender,
+}
+
+#[matrix_sdk_ffi_macros::export]
+impl ContinuationMessageSender {
+    /// Confirm the continuation of the login granting process.
+    pub async fn confirm(&self) -> Result<(), HumanQrLoginError> {
+        self.inner.confirm().await.map_err(continuation_error)
+    }
+
+    /// Cancel the login granting process.
+    pub async fn cancel(&self) -> Result<(), HumanQrLoginError> {
+        self.inner.cancel().await.map_err(continuation_error)
+    }
+}
+
+/// Map a [`SenderError`] from the check code sender to a human-readable error.
+fn check_code_error(value: SenderError) -> HumanQrLoginError {
+    match value {
+        SenderError::AlreadySent => HumanQrLoginError::CheckCodeAlreadySent,
+        SenderError::CannotSend => HumanQrLoginError::CheckCodeCannotBeSent,
+    }
+}
+
+/// Map a [`SenderError`] from the continuation sender to a human-readable
+/// error.
+fn continuation_error(value: SenderError) -> HumanQrLoginError {
+    match value {
+        SenderError::AlreadySent => HumanQrLoginError::ContinuationAlreadySent,
+        SenderError::CannotSend => HumanQrLoginError::ContinuationCannotBeSent,
+    }
+}
+
+impl From<SdkContinuationMessageSender> for ContinuationMessageSender {
+    fn from(value: SdkContinuationMessageSender) -> Self {
+        Self { inner: value }
     }
 }

--- a/crates/matrix-sdk/changelog.d/6711.changed.md
+++ b/crates/matrix-sdk/changelog.d/6711.changed.md
@@ -1,0 +1,11 @@
+[**breaking**] `GrantLoginProgress::WaitingForAuth` now has a
+`continuation_sender: ContinuationMessageSender` field. Applications must call
+`continuation_sender.confirm()` once the verification URI has been opened in
+the browser and the application is ready to proceed, or
+`continuation_sender.cancel()` to abort; previously it proceeded automatically
+as soon as this state was reached. This lets applications that suspend or
+navigate away while the verification URI is open to resume the process
+explicitly.
+
+[**breaking**] `qrcode::CheckCodeSenderError` has been renamed to
+`qrcode::SenderError`, since it is now shared with `ContinuationMessageSender`.

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -1619,8 +1619,12 @@ impl<'a> GrantLoginWithQrCodeBuilder<'a> {
     ///             GrantLoginProgress::EstablishingSecureChannel(QrProgress { check_code }) => {
     ///                 println!("Please enter the checkcode on your other device: {:?}", check_code);
     ///             }
-    ///             GrantLoginProgress::WaitingForAuth { verification_uri } => {
-    ///                 println!("Please open {verification_uri} to confirm the new login")
+    ///             GrantLoginProgress::WaitingForAuth { verification_uri, continuation_sender } => {
+    ///                 println!("Please open {verification_uri} to confirm the new login");
+    ///
+    ///                 // Once the new login has been confirmed in the browser, we can let the
+    ///                 // client continue with the process.
+    ///                 continuation_sender.confirm().await?;
     ///             },
     ///             GrantLoginProgress::Done => break,
     ///         }
@@ -1696,8 +1700,12 @@ impl<'a> GrantLoginWithQrCodeBuilder<'a> {
     ///                 let check_code = s.trim().parse::<u8>()?;
     ///                 checkcode_sender.send(check_code).await?;
     ///             }
-    ///             GrantLoginProgress::WaitingForAuth { verification_uri } => {
-    ///                 println!("Please open {verification_uri} to confirm the new login")
+    ///             GrantLoginProgress::WaitingForAuth { verification_uri, continuation_sender } => {
+    ///                 println!("Please open {verification_uri} to confirm the new login");
+    ///
+    ///                 // Once the new login has been confirmed in the browser, we can let the
+    ///                 // client continue with the process.
+    ///                 continuation_sender.confirm().await?;
     ///             },
     ///             GrantLoginProgress::Done => break,
     ///         }

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -36,8 +36,9 @@ use super::{
 use crate::{
     Client,
     authentication::oauth::qrcode::{
-        CheckCodeSender, GeneratedQrProgress, LoginFailureReason, QRCodeGrantLoginError,
-        QrProgress, SecureChannelError,
+        CheckCodeSender, CloneableSender, ContinuationMessage, ContinuationMessageSender,
+        GeneratedQrProgress, LoginFailureReason, QRCodeGrantLoginError, QrProgress,
+        SecureChannelError,
     },
 };
 
@@ -116,8 +117,29 @@ async fn finish_login_grant<Q>(
             .as_str(),
     )
     .map_err(|e| QRCodeGrantLoginError::Unknown(e.to_string()))?;
-    state.set(GrantLoginProgress::WaitingForAuth { verification_uri });
 
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    state.set(GrantLoginProgress::WaitingForAuth {
+        verification_uri,
+        continuation_sender: ContinuationMessageSender(CloneableSender::new(sender)),
+    });
+
+    // We wait for this device to confirm that the authorization using the
+    // verification URI has succeeded.
+    match receiver.await {
+        Ok(ContinuationMessage::Confirm) => {}
+        Ok(ContinuationMessage::Cancel) | Err(_) => {
+            channel
+                .send_json(QrAuthMessage::LoginFailure {
+                    reason: LoginFailureReason::UserCancelled,
+                    homeserver: None,
+                })
+                .await?;
+            return Err(QRCodeGrantLoginError::LoginFailure {
+                reason: LoginFailureReason::UserCancelled,
+            });
+        }
+    }
     // We send the new device the m.login.protocol_accepted message to let it know
     // that the consent process is in progress.
     // -- MSC4108 OAuth 2.0 login step 4 continued
@@ -196,6 +218,12 @@ pub enum GrantLoginProgress<Q> {
     WaitingForAuth {
         /// A URI to open in a (secure) system browser to verify the new login.
         verification_uri: Url,
+        /// A sender to confirm that the authorization using the verification
+        /// URI has been started in the browser and that the application is
+        /// ready to proceed. This allows applications that suspend or navigate
+        /// away while the verification URI is open to resume the process
+        /// explicitly.
+        continuation_sender: ContinuationMessageSender,
     },
     /// The new device has been granted access and this device is sending the
     /// secrets to it.
@@ -425,6 +453,7 @@ mod test {
         DeviceAlreadyExists,
         DeviceNotCreated,
         InvalidJsonMessage,
+        CancelledWhileWaitingForAuth,
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -507,6 +536,27 @@ mod test {
                     .expect("Bob should receive the LoginFailure message from Alice");
                 assert_let!(QrAuthMessage::LoginFailure { reason, .. } = message);
                 assert_matches!(reason, LoginFailureReason::DeviceAlreadyExists);
+
+                return; // Exit.
+            }
+            BobBehaviour::CancelledWhileWaitingForAuth => {
+                // Send the LoginProtocol message.
+                let message = QrAuthMessage::LoginProtocol {
+                    protocol: LoginProtocolType::DeviceAuthorizationGrant,
+                    device_authorization_grant: device_authorization_grant
+                        .expect("Bob needs the device authorization grant"),
+                    device_id: "wjLpTLRqbqBzLs63aYaEv2Boi6cFEbbM/sSRQ2oAKk4".to_owned(),
+                };
+                bob.send_json(message).await.unwrap();
+
+                // Alice cancels while waiting for the authorization and should fail the login
+                // with the appropriate reason.
+                let message = bob
+                    .receive_json()
+                    .await
+                    .expect("Bob should receive the LoginFailure message from Alice");
+                assert_let!(QrAuthMessage::LoginFailure { reason, .. } = message);
+                assert_matches!(reason, LoginFailureReason::UserCancelled);
 
                 return; // Exit.
             }
@@ -682,6 +732,27 @@ mod test {
                     .expect("Bob should receive the LoginFailure message from Alice");
                 assert_let!(QrAuthMessage::LoginFailure { reason, .. } = message);
                 assert_matches!(reason, LoginFailureReason::DeviceAlreadyExists);
+
+                return; // Exit.
+            }
+            BobBehaviour::CancelledWhileWaitingForAuth => {
+                // Send the LoginProtocol message.
+                let message = QrAuthMessage::LoginProtocol {
+                    protocol: LoginProtocolType::DeviceAuthorizationGrant,
+                    device_authorization_grant: device_authorization_grant
+                        .expect("Bob needs the device authorization grant"),
+                    device_id: "wjLpTLRqbqBzLs63aYaEv2Boi6cFEbbM/sSRQ2oAKk4".to_owned(),
+                };
+                bob.send_json(message).await.unwrap();
+
+                // Alice cancels while waiting for the authorization and should fail the login
+                // with the appropriate reason.
+                let message = bob
+                    .receive_json()
+                    .await
+                    .expect("Bob should receive the LoginFailure message from Alice");
+                assert_let!(QrAuthMessage::LoginFailure { reason, .. } = message);
+                assert_matches!(reason, LoginFailureReason::UserCancelled);
 
                 return; // Exit.
             }
@@ -875,7 +946,10 @@ mod test {
                             .await
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(
@@ -883,6 +957,7 @@ mod test {
                             )
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     GrantLoginProgress::SyncingSecrets => {
                         assert_matches!(state, GrantLoginProgress::WaitingForAuth { .. });
@@ -1003,12 +1078,16 @@ mod test {
                             .send(check_code.to_digit())
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     GrantLoginProgress::SyncingSecrets => {
                         assert_matches!(state, GrantLoginProgress::WaitingForAuth { .. });
@@ -1132,12 +1211,16 @@ mod test {
                             .send(check_code.to_digit())
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     GrantLoginProgress::SyncingSecrets => {
                         assert_matches!(state, GrantLoginProgress::WaitingForAuth { .. });
@@ -1763,7 +1846,10 @@ mod test {
                             .await
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(
@@ -1771,6 +1857,7 @@ mod test {
                             )
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -1887,12 +1974,16 @@ mod test {
                             .send(check_code.to_digit())
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -2413,7 +2504,10 @@ mod test {
                             .await
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(
@@ -2421,6 +2515,7 @@ mod test {
                             )
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -2542,12 +2637,16 @@ mod test {
                             .send(check_code.to_digit())
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -2686,7 +2785,10 @@ mod test {
                             .await
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(
@@ -2694,6 +2796,7 @@ mod test {
                             )
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -2820,12 +2923,16 @@ mod test {
                             .send(check_code.to_digit())
                             .expect("Alice should be able to forward the checkcode");
                     }
-                    GrantLoginProgress::WaitingForAuth { verification_uri } => {
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
                         assert_matches!(
                             state,
                             GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
                         );
                         assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        continuation_sender.confirm().await.expect("should be able to confirm");
                     }
                     _ => {
                         panic!("Alice should abort the process");
@@ -3094,6 +3201,283 @@ mod test {
             grant.await,
             Err(QRCodeGrantLoginError::SecureChannel(SecureChannelError::Json(_))),
             "Alice should abort the login with a SecureChannel error"
+        );
+        updates_task.await.expect("Alice should run through all progress states");
+        bob_task.await.expect("Bob's task should finish");
+    }
+
+    #[async_test]
+    async fn test_grant_login_with_generated_qr_code_cancelled_while_waiting_for_auth() {
+        let server = MatrixMockServer::new().await;
+        let rendezvous_server =
+            MockedRendezvousServer::new(server.server(), "abcdEFG12345", Duration::MAX).await;
+        debug!("Set up rendezvous server mock at {}", rendezvous_server.rendezvous_url);
+
+        let device_authorization_grant = AuthorizationGrant {
+            verification_uri_complete: Some(VerificationUriComplete::new(
+                "https://id.matrix.org/device/abcde".to_owned(),
+            )),
+            verification_uri: EndUserVerificationUrl::new(
+                "https://id.matrix.org/device/abcde?code=ABCDE".to_owned(),
+            )
+            .unwrap(),
+        };
+
+        server.mock_upload_keys().ok().expect(1).named("upload_keys").mount().await;
+        server
+            .mock_upload_cross_signing_keys()
+            .ok()
+            .expect(1)
+            .named("upload_xsigning_keys")
+            .mount()
+            .await;
+        server
+            .mock_upload_cross_signing_signatures()
+            .ok()
+            .expect(1)
+            .named("upload_xsigning_signatures")
+            .mount()
+            .await;
+
+        // Create the existing client (Alice).
+        let user_id = owned_user_id!("@alice:example.org");
+        let device_id = owned_device_id!("ALICE_DEVICE");
+        let alice = server
+            .client_builder_for_crypto_end_to_end(&user_id, &device_id)
+            .logged_in_with_oauth()
+            .build()
+            .await;
+        alice
+            .encryption()
+            .bootstrap_cross_signing(None)
+            .await
+            .expect("Alice should be able to set up cross signing");
+
+        // Prepare the login granting future.
+        let oauth = alice.oauth();
+        let grant = oauth
+            .grant_login_with_qr_code()
+            .device_creation_timeout(Duration::from_secs(2))
+            .generate();
+        let (qr_code_tx, qr_code_rx) = oneshot::channel();
+        let (checkcode_tx, checkcode_rx) = oneshot::channel();
+
+        // Spawn the updates task.
+        let mut updates = grant.subscribe_to_progress();
+        let mut state = grant.state.get();
+        let verification_uri_complete =
+            device_authorization_grant.clone().verification_uri_complete.unwrap().into_secret();
+        assert_matches!(state.clone(), GrantLoginProgress::Starting);
+        let updates_task = spawn(async move {
+            let mut qr_code_tx = Some(qr_code_tx);
+            let mut checkcode_rx = Some(checkcode_rx);
+
+            while let Some(update) = updates.next().await {
+                match &update {
+                    GrantLoginProgress::Starting => {
+                        assert_matches!(state, GrantLoginProgress::Starting);
+                    }
+                    GrantLoginProgress::EstablishingSecureChannel(
+                        GeneratedQrProgress::QrReady(qr_code_data),
+                    ) => {
+                        assert_matches!(state, GrantLoginProgress::Starting);
+                        qr_code_tx
+                            .take()
+                            .expect("The QR code should only be forwarded once")
+                            .send(qr_code_data.clone())
+                            .expect("Alice should be able to forward the QR code");
+                    }
+                    GrantLoginProgress::EstablishingSecureChannel(
+                        GeneratedQrProgress::QrScanned(checkcode_sender),
+                    ) => {
+                        assert_matches!(
+                            state,
+                            GrantLoginProgress::EstablishingSecureChannel(
+                                GeneratedQrProgress::QrReady(_)
+                            )
+                        );
+                        let checkcode = checkcode_rx
+                            .take()
+                            .expect("The checkcode should only be forwarded once")
+                            .await
+                            .expect("Alice should receive the checkcode");
+                        checkcode_sender
+                            .send(checkcode)
+                            .await
+                            .expect("Alice should be able to forward the checkcode");
+                    }
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
+                        assert_matches!(
+                            state,
+                            GrantLoginProgress::EstablishingSecureChannel(
+                                GeneratedQrProgress::QrScanned(_)
+                            )
+                        );
+                        assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        // The user cancels the login instead of confirming it.
+                        continuation_sender.cancel().await.expect("should be able to cancel");
+                        break;
+                    }
+                    _ => {
+                        panic!("Alice should abort the process after being cancelled");
+                    }
+                }
+                state = update;
+            }
+        });
+
+        // Let Bob request the login and run through the process.
+        let bob_task = spawn(async move {
+            request_login_with_scanned_qr_code(
+                BobBehaviour::CancelledWhileWaitingForAuth,
+                qr_code_rx,
+                checkcode_tx,
+                Some(server),
+                &rendezvous_server,
+                Some(device_authorization_grant),
+                None,
+            )
+            .await;
+        });
+
+        // Wait for all tasks to finish / fail.
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::LoginFailure { reason: LoginFailureReason::UserCancelled }),
+            "Alice should abort the login with expected error"
+        );
+        updates_task.await.expect("Alice should run through all progress states");
+        bob_task.await.expect("Bob's task should finish");
+    }
+
+    #[async_test]
+    async fn test_grant_login_with_scanned_qr_code_cancelled_while_waiting_for_auth() {
+        let server = MatrixMockServer::new().await;
+        let rendezvous_server =
+            MockedRendezvousServer::new(server.server(), "abcdEFG12345", Duration::MAX).await;
+        debug!("Set up rendezvous server mock at {}", rendezvous_server.rendezvous_url);
+
+        let device_authorization_grant = AuthorizationGrant {
+            verification_uri_complete: Some(VerificationUriComplete::new(
+                "https://id.matrix.org/device/abcde".to_owned(),
+            )),
+            verification_uri: EndUserVerificationUrl::new(
+                "https://id.matrix.org/device/abcde?code=ABCDE".to_owned(),
+            )
+            .unwrap(),
+        };
+
+        server.mock_upload_keys().ok().expect(1).named("upload_keys").mount().await;
+        server
+            .mock_upload_cross_signing_keys()
+            .ok()
+            .expect(1)
+            .named("upload_xsigning_keys")
+            .mount()
+            .await;
+        server
+            .mock_upload_cross_signing_signatures()
+            .ok()
+            .expect(1)
+            .named("upload_xsigning_signatures")
+            .mount()
+            .await;
+
+        // Create a secure channel on the new client (Bob) and extract the QR code.
+        let client = HttpClient::new(reqwest::Client::new(), Default::default());
+        let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
+            .await
+            .expect("Bob should be able to create a secure channel.");
+        let qr_code_data = channel.qr_code_data().clone();
+
+        // Create the existing client (Alice).
+        let user_id = owned_user_id!("@alice:example.org");
+        let device_id = owned_device_id!("ALICE_DEVICE");
+        let alice = server
+            .client_builder_for_crypto_end_to_end(&user_id, &device_id)
+            .logged_in_with_oauth()
+            .build()
+            .await;
+        alice
+            .encryption()
+            .bootstrap_cross_signing(None)
+            .await
+            .expect("Alice should be able to set up cross signing");
+
+        // Prepare the login granting future using the QR code.
+        let oauth = alice.oauth();
+        let grant = oauth
+            .grant_login_with_qr_code()
+            .device_creation_timeout(Duration::from_secs(2))
+            .scan(&qr_code_data);
+        let (checkcode_tx, checkcode_rx) = oneshot::channel();
+
+        // Spawn the updates task.
+        let mut updates = grant.subscribe_to_progress();
+        let mut state = grant.state.get();
+        let verification_uri_complete =
+            device_authorization_grant.clone().verification_uri_complete.unwrap().into_secret();
+        assert_matches!(state.clone(), GrantLoginProgress::Starting);
+        let updates_task = spawn(async move {
+            let mut checkcode_tx = Some(checkcode_tx);
+
+            while let Some(update) = updates.next().await {
+                match &update {
+                    GrantLoginProgress::Starting => {
+                        assert_matches!(state, GrantLoginProgress::Starting);
+                    }
+                    GrantLoginProgress::EstablishingSecureChannel(QrProgress { check_code }) => {
+                        assert_matches!(state, GrantLoginProgress::Starting);
+                        checkcode_tx
+                            .take()
+                            .expect("The checkcode should only be forwarded once")
+                            .send(check_code.to_digit())
+                            .expect("Alice should be able to forward the checkcode");
+                    }
+                    GrantLoginProgress::WaitingForAuth {
+                        verification_uri,
+                        continuation_sender,
+                    } => {
+                        assert_matches!(
+                            state,
+                            GrantLoginProgress::EstablishingSecureChannel(QrProgress { .. })
+                        );
+                        assert_eq!(verification_uri.as_str(), verification_uri_complete);
+                        // The user cancels the login instead of confirming it.
+                        continuation_sender.cancel().await.expect("should be able to cancel");
+                        break;
+                    }
+                    _ => {
+                        panic!("Alice should abort the process after being cancelled");
+                    }
+                }
+                state = update;
+            }
+        });
+
+        // Let Bob request the login and run through the process.
+        let bob_task = spawn(async move {
+            request_login_with_generated_qr_code(
+                BobBehaviour::CancelledWhileWaitingForAuth,
+                channel,
+                checkcode_rx,
+                Some(server),
+                &rendezvous_server,
+                alice.homeserver(),
+                Some(device_authorization_grant),
+                None,
+            )
+            .await;
+        });
+
+        // Wait for all tasks to finish / fail.
+        assert_matches!(
+            grant.await,
+            Err(QRCodeGrantLoginError::LoginFailure { reason: LoginFailureReason::UserCancelled }),
+            "Alice should abort the login with expected error"
         );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -329,7 +329,7 @@ pub struct QrProgress {
 ///
 /// We have established the secure channel, but we need to let the
 /// other device know about the [`QrCodeData`] so they can connect to the
-/// channel and let us know about the checkcode so we can verify that the
+/// channel and let us know about the check code so we can verify that the
 /// channel is indeed secure.
 #[derive(Clone, Debug)]
 pub enum GeneratedQrProgress {
@@ -337,45 +337,81 @@ pub enum GeneratedQrProgress {
     /// device to scan it.
     QrReady(QrCodeData),
     /// The QR code has been scanned by the other device and this device is
-    /// waiting for the user to put in the checkcode displayed on the
+    /// waiting for the user to put in the check code displayed on the
     /// other device.
     QrScanned(CheckCodeSender),
 }
 
-/// Used to pass back the checkcode entered by the user to verify that the
-/// secure channel is indeed secure.
-#[derive(Clone, Debug)]
-pub struct CheckCodeSender {
-    inner: Arc<Mutex<Option<tokio::sync::oneshot::Sender<u8>>>>,
-}
+/// A oneshot sender used to send the check code back to the device that
+/// generated the QR code.
+pub type CheckCodeSender = CloneableSender<u8>;
 
 impl CheckCodeSender {
-    pub(crate) fn new(tx: tokio::sync::oneshot::Sender<u8>) -> Self {
-        Self { inner: Arc::new(Mutex::new(Some(tx))) }
-    }
-
-    /// Send the checkcode.
+    /// Send the check code.
     ///
     /// Calling this method more than once will result in an error.
     ///
     /// # Arguments
     ///
     /// * `check_code` - The check code in digits representation.
-    pub async fn send(&self, check_code: u8) -> Result<(), CheckCodeSenderError> {
+    pub async fn send(&self, check_code: u8) -> Result<(), SenderError> {
+        self.send_impl(check_code).await
+    }
+}
+
+/// The internal message of the [`ContinuationMessageSender`] to either continue
+/// the login granting process or to cancel it.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ContinuationMessage {
+    Confirm,
+    Cancel,
+}
+
+/// Struct used to let the QR code granting logic know that it can continue with
+/// the process since applications might suspend things while the verification
+/// URI is open.
+#[derive(Clone, Debug)]
+pub struct ContinuationMessageSender(CloneableSender<ContinuationMessage>);
+
+impl ContinuationMessageSender {
+    /// Confirm the continuation of the login granting process.
+    pub async fn confirm(&self) -> Result<(), SenderError> {
+        self.0.send_impl(ContinuationMessage::Confirm).await
+    }
+
+    /// Cancel the login granting process.
+    pub async fn cancel(&self) -> Result<(), SenderError> {
+        self.0.send_impl(ContinuationMessage::Cancel).await
+    }
+}
+
+/// A oneshot sender we are able to clone so we can put it into a
+/// [`SharedObservable`](eyeball::SharedObservable).
+#[derive(Clone, Debug)]
+pub struct CloneableSender<T> {
+    inner: Arc<Mutex<Option<tokio::sync::oneshot::Sender<T>>>>,
+}
+
+impl<T> CloneableSender<T> {
+    pub(crate) fn new(tx: tokio::sync::oneshot::Sender<T>) -> Self {
+        Self { inner: Arc::new(Mutex::new(Some(tx))) }
+    }
+
+    async fn send_impl(&self, message: T) -> Result<(), SenderError> {
         match self.inner.lock().await.take() {
-            Some(tx) => tx.send(check_code).map_err(|_| CheckCodeSenderError::CannotSend),
-            None => Err(CheckCodeSenderError::AlreadySent),
+            Some(tx) => tx.send(message).map_err(|_| SenderError::CannotSend),
+            None => Err(SenderError::AlreadySent),
         }
     }
 }
 
-/// Possible errors when calling [`CheckCodeSender::send`].
+/// Possible errors when calling [`CloneableSender::send`].
 #[derive(Debug, thiserror::Error)]
-pub enum CheckCodeSenderError {
-    /// The check code has already been sent.
-    #[error("check code already sent.")]
+pub enum SenderError {
+    /// The message has already been sent.
+    #[error("message already sent.")]
     AlreadySent,
-    /// The check code cannot be sent.
-    #[error("check code cannot be sent.")]
+    /// The message cannot be sent.
+    #[error("message cannot be sent.")]
     CannotSend,
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

This PR adds a continuation sender to the `WaitingForAuth` enums so that applications which suspend or navigate away while the verification URI is open (e.g. on Android) can resume the process explicitly.

This is based on @poljar's work in https://github.com/matrix-org/matrix-rust-sdk/pull/6173

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Hugh Nimmo-Smith <hughns@element.io>
