### PR TITLE
chore(xtask): add size-optimized apple-release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,12 @@ lto = true
 # Use binary size optimization, since this is intended for distributed copies of the SDK
 opt-level = "s"
 
+# Profile for the distributed Apple framework. `opt-level = "s"` measured ~33%
+# smaller linked code than `release`.
+[profile.apple-release]
+inherits = "release"
+opt-level = "s"
+
 [profile.profiling]
 inherits = "release"
 # LTO is too slow to compile.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ opt-level = "s"
 
 # Profile for the distributed Apple framework. `opt-level = "s"` measured ~33%
 # smaller linked code than `release`.
-[profile.apple-release]
+[profile.small-release]
 inherits = "release"
 opt-level = "s"
 

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -91,7 +91,7 @@ impl SwiftArgs {
                 // The dev profile seems to cause crashes on some platforms so we default to
                 // reldbg (https://github.com/matrix-org/matrix-rust-sdk/issues/4009)
                 let profile =
-                    profile.as_deref().unwrap_or(if release { "apple-release" } else { "reldbg" });
+                    profile.as_deref().unwrap_or(if release { "small-release" } else { "reldbg" });
                 build_xcframework(
                     profile,
                     targets,

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -91,7 +91,7 @@ impl SwiftArgs {
                 // The dev profile seems to cause crashes on some platforms so we default to
                 // reldbg (https://github.com/matrix-org/matrix-rust-sdk/issues/4009)
                 let profile =
-                    profile.as_deref().unwrap_or(if release { "release" } else { "reldbg" });
+                    profile.as_deref().unwrap_or(if release { "apple-release" } else { "reldbg" });
                 build_xcframework(
                     profile,
                     targets,


### PR DESCRIPTION
Distributed Apple framework built with release links ~33% more code than necessary. Add an apple-release profile using opt-level = "s", which measured ~33% smaller linked code with no behavior change.

This is to address "This [binary] exceeds the cellular network download size limit and may require your app to be downloaded over Wi-Fi. Users running iOS 13 or later can choose to use cellular data to download apps that exceed this limit." AppStore warnings.