### PR TITLE
X.509 Preparation

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -76,6 +76,14 @@ pub enum DecryptionError {
     Store { error: String },
 }
 
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum BootstrapCrossSigningError {
+    #[error(transparent)]
+    CryptoStore(CryptoStoreError),
+    #[error(transparent)]
+    Signature(SignatureError),
+}
+
 /// Error describing what went wrong when exporting a [`SecretsBundle`].
 ///
 /// The [`SecretsBundle`] can only be exported if we have all cross-signing
@@ -146,6 +154,16 @@ impl From<IdParseError> for DecryptionError {
 impl From<InnerStoreError> for DecryptionError {
     fn from(err: InnerStoreError) -> Self {
         Self::Store { error: err.to_string() }
+    }
+}
+
+impl From<matrix_sdk_crypto::BootstrapCrossSigningError> for BootstrapCrossSigningError {
+    fn from(err: matrix_sdk_crypto::BootstrapCrossSigningError) -> Self {
+        use matrix_sdk_crypto::BootstrapCrossSigningError as BCSE;
+        match err {
+            BCSE::CryptoStore(e) => Self::CryptoStore(e.into()),
+            BCSE::Signature(e) => Self::Signature(e.into()),
+        }
     }
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -28,7 +28,8 @@ pub use backup_recovery_key::{
 };
 pub use device::Device;
 pub use error::{
-    CryptoStoreError, DecryptionError, KeyImportError, SecretImportError, SignatureError,
+    BootstrapCrossSigningError, CryptoStoreError, DecryptionError, KeyImportError,
+    SecretImportError, SignatureError,
 };
 use js_int::UInt;
 pub use logger::{Logger, set_logger};

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -52,11 +52,12 @@ use tokio::runtime::Runtime;
 use zeroize::Zeroize;
 
 use crate::{
-    BackupKeys, BackupRecoveryKey, BootstrapCrossSigningResult, CrossSigningKeyExport,
-    CrossSigningStatus, DecodeError, DecryptedEvent, Device, DeviceLists, EncryptionSettings,
-    EventEncryptionAlgorithm, KeyImportError, KeysImportResult, MegolmV1BackupKey,
-    ProgressListener, Request, RequestType, RequestVerificationResult, RoomKeyCounts, RoomSettings,
-    Sas, SignatureUploadRequest, StartSasResult, UserIdentity, Verification, VerificationRequest,
+    BackupKeys, BackupRecoveryKey, BootstrapCrossSigningError, BootstrapCrossSigningResult,
+    CrossSigningKeyExport, CrossSigningStatus, DecodeError, DecryptedEvent, Device, DeviceLists,
+    EncryptionSettings, EventEncryptionAlgorithm, KeyImportError, KeysImportResult,
+    MegolmV1BackupKey, ProgressListener, Request, RequestType, RequestVerificationResult,
+    RoomKeyCounts, RoomSettings, Sas, SignatureUploadRequest, StartSasResult, UserIdentity,
+    Verification, VerificationRequest,
     dehydrated_devices::DehydratedDevices,
     error::{
         CryptoStoreError, DecryptionError, SecretImportError, SecretsBundleExportError,
@@ -1376,7 +1377,9 @@ impl OlmMachine {
 
     /// Create a new private cross signing identity and create a request to
     /// upload the public part of it to the server.
-    pub fn bootstrap_cross_signing(&self) -> Result<BootstrapCrossSigningResult, CryptoStoreError> {
+    pub fn bootstrap_cross_signing(
+        &self,
+    ) -> Result<BootstrapCrossSigningResult, BootstrapCrossSigningError> {
         Ok(self.runtime.block_on(self.inner.bootstrap_cross_signing(true))?.into())
     }
 

--- a/bindings/matrix-sdk-ffi/changelog.d/6715.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6715.changed.md
@@ -1,0 +1,4 @@
+[**breaking**] Adjust `OlmMachine::bootstrap_cross_signing` to return
+a new `BootstrapCrossSigningError` enum covering both crypto store
+and signing failures. This replaces the previous `CryptoStoreError`
+return type.

--- a/crates/matrix-sdk-crypto/changelog.d/6715.changed
+++ b/crates/matrix-sdk-crypto/changelog.d/6715.changed
@@ -1,0 +1,9 @@
+Accept `impl Into<Signature>` in `Signatures::add_signature`.
+
+[**breaking**] Make `OlmMachine::bootstrap_cross_signing` fallible to
+allow future signing implementations to produce errors. Further
+introduces `CrossSigningBootstrapError` to enumerate possible failure
+cases.
+
+[**breaking**] Removed `Account::sign_master_key`, as the master key
+is signed automatically when calling `OwnUserIdentity::verify`

--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -1112,7 +1112,7 @@ mod tests {
         let account = Account::with_device_id(user_id, &device_id);
 
         let private_identity =
-            Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account)));
+            Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account).unwrap()));
 
         let other_user_identity_data =
             OtherUserIdentityData::from_private(&*private_identity.lock().await).await;
@@ -1152,7 +1152,7 @@ mod tests {
         let account = Account::with_device_id(user_id, &device_id);
 
         let private_identity =
-            Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account)));
+            Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account).unwrap()));
 
         let own_user_identity_data =
             OwnUserIdentityData::from_private(&*private_identity.lock().await).await;

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -2023,7 +2023,7 @@ pub(crate) mod tests {
      * Creates a new private user identity for the account.
      */
     fn get_verification_machine(account: &Account) -> VerificationMachine {
-        let private_identity = PrivateCrossSigningIdentity::for_account(account);
+        let private_identity = PrivateCrossSigningIdentity::for_account(account).unwrap();
         VerificationMachine::new(
             account.static_data().clone(),
             Arc::new(Mutex::new(private_identity)),

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -25,7 +25,7 @@ use as_variant::as_variant;
 use matrix_sdk_common::locks::RwLock;
 use ruma::{
     DeviceId, EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
-    api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
+    api::client::keys::upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
     events::{key::verification::VerificationMethod, room::message::MessageType},
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -40,7 +40,8 @@ use crate::{
         types::{Changes, IdentityChanges},
     },
     types::{
-        MasterPubkey, SelfSigningPubkey, UserSigningPubkey, requests::OutgoingVerificationRequest,
+        CrossSigningKey, MasterPubkey, SelfSigningPubkey, UserSigningPubkey,
+        requests::OutgoingVerificationRequest,
     },
     verification::VerificationMachine,
 };
@@ -230,7 +231,23 @@ impl OwnUserIdentity {
 
         let cache = self.store.cache().await?;
         let account = cache.account().await?;
-        account.sign_master_key(&self.master_key)
+
+        let public_key = self
+            .master_key
+            .get_first_key()
+            .ok_or(SignatureError::MissingSigningKey)?
+            .to_base64()
+            .into();
+
+        let mut cross_signing_key: CrossSigningKey = (*self.master_key).as_ref().clone();
+        cross_signing_key.signatures.clear();
+        account.sign_cross_signing_key(&mut cross_signing_key)?;
+
+        let mut user_signed_keys = SignedKeys::new();
+        user_signed_keys.add_cross_signing_keys(public_key, cross_signing_key.to_raw());
+
+        let signed_keys = [(self.user_id().to_owned(), user_signed_keys)].into();
+        Ok(SignatureUploadRequest::new(signed_keys))
     }
 
     /// Send a verification request to our other devices.

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -91,7 +91,8 @@ pub use identities::{
     OwnUserIdentityData, UserDevices, UserIdentity, UserIdentityData,
 };
 pub use machine::{
-    CrossSigningBootstrapRequests, EncryptionSyncChanges, OlmMachine, OlmMachineBuilder,
+    BootstrapCrossSigningError, CrossSigningBootstrapRequests, EncryptionSyncChanges, OlmMachine,
+    OlmMachineBuilder,
 };
 use matrix_sdk_common::deserialized_responses::{DecryptedRoomEvent, UnableToDecryptInfo};
 #[cfg(feature = "qrcode")]

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -717,7 +717,7 @@ impl OlmMachine {
     pub async fn bootstrap_cross_signing(
         &self,
         reset: bool,
-    ) -> StoreResult<CrossSigningBootstrapRequests> {
+    ) -> Result<CrossSigningBootstrapRequests, BootstrapCrossSigningError> {
         // Don't hold the lock, otherwise we might deadlock in
         // `bootstrap_cross_signing()` on `account` if a sync task is already
         // running (which locks `account`), or we will deadlock
@@ -731,7 +731,7 @@ impl OlmMachine {
             let (identity, upload_signing_keys_req, upload_signatures_req) = {
                 let cache = self.inner.store.cache().await?;
                 let account = cache.account().await?;
-                account.bootstrap_cross_signing().await
+                account.bootstrap_cross_signing().await?
             };
 
             let public = identity.to_public_identity().await.expect(
@@ -3191,6 +3191,22 @@ pub struct CrossSigningBootstrapRequests {
     ///
     /// Should be sent last.
     pub upload_signatures_req: UploadSignaturesRequest,
+}
+
+/// An error that can occur during [`OlmMachine::bootstrap_cross_signing`]:
+///
+/// * because a failure with the store occurred, or
+///
+/// * because the new cross-signing identity could not be signed.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapCrossSigningError {
+    /// A failure with the store occurred.
+    #[error(transparent)]
+    CryptoStore(#[from] CryptoStoreError),
+
+    /// The new cross-signing identity could not be signed
+    #[error(transparent)]
+    Signature(#[from] SignatureError),
 }
 
 /// Data contained from a sync response and that needs to be processed by the

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -817,17 +817,17 @@ impl Account {
     ///   this device to the server.
     pub async fn bootstrap_cross_signing(
         &self,
-    ) -> (PrivateCrossSigningIdentity, UploadSigningKeysRequest, SignatureUploadRequest) {
-        let identity = PrivateCrossSigningIdentity::for_account(self);
+    ) -> Result<
+        (PrivateCrossSigningIdentity, UploadSigningKeysRequest, SignatureUploadRequest),
+        SignatureError,
+    > {
+        let identity = PrivateCrossSigningIdentity::for_account(self)?;
 
-        let signature_request = identity
-            .sign_account(self.static_data())
-            .await
-            .expect("Can't sign own device with new cross signing keys");
+        let signature_request = identity.sign_account(self.static_data()).await?;
 
         let upload_request = identity.as_upload_request().await;
 
-        (identity, upload_request, signature_request)
+        Ok((identity, upload_request, signature_request))
     }
 
     /// Sign the given CrossSigning Key in place

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -31,10 +31,7 @@ use ruma::{
     OwnedUserId, RoomId, SecondsSinceUnixEpoch, UInt, UserId,
     api::client::{
         dehydrated_device::{DehydratedDeviceData, DehydratedDeviceV2},
-        keys::{
-            upload_keys,
-            upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
-        },
+        keys::{upload_keys, upload_signatures::v3::Request as SignatureUploadRequest},
     },
     canonical_json::to_canonical_value,
     events::{AnyToDeviceEvent, room::history_visibility::HistoryVisibility},
@@ -70,7 +67,7 @@ use crate::{
         types::{Changes, DeviceChanges},
     },
     types::{
-        CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, MasterPubkey, OneTimeKey, SignedKey,
+        CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, OneTimeKey, SignedKey,
         events::{
             olm_v1::AnyDecryptedOlmEvent,
             room::encrypted::{
@@ -844,25 +841,6 @@ impl Account {
         );
 
         Ok(())
-    }
-
-    /// Sign the given Master Key
-    pub fn sign_master_key(
-        &self,
-        master_key: &MasterPubkey,
-    ) -> Result<SignatureUploadRequest, SignatureError> {
-        let public_key =
-            master_key.get_first_key().ok_or(SignatureError::MissingSigningKey)?.to_base64().into();
-
-        let mut cross_signing_key: CrossSigningKey = master_key.as_ref().clone();
-        cross_signing_key.signatures.clear();
-        self.sign_cross_signing_key(&mut cross_signing_key)?;
-
-        let mut user_signed_keys = SignedKeys::new();
-        user_signed_keys.add_cross_signing_keys(public_key, cross_signing_key.to_raw());
-
-        let signed_keys = [(self.user_id().to_owned(), user_signed_keys)].into();
-        Ok(SignatureUploadRequest::new(signed_keys))
     }
 
     /// Convert a JSON value to the canonical representation and sign the JSON

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -796,7 +796,7 @@ mod tests {
     async fn test_from_device_for_verified_user() {
         let alice_account =
             Account::with_device_id(user_id!("@alice:example.com"), device_id!("ALICE_DEVICE"));
-        let alice_identity = PrivateCrossSigningIdentity::for_account(&alice_account);
+        let alice_identity = PrivateCrossSigningIdentity::for_account(&alice_account).unwrap();
 
         let bob_identity = PrivateCrossSigningIdentity::new(owned_user_id!("@bob:example.com"));
         let bob_account =

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -914,7 +914,7 @@ mod tests {
             let account = Account::with_device_id(user_id, device_id);
             let user_id = user_id.to_owned();
             let private_identity =
-                Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account)));
+                Arc::new(Mutex::new(PrivateCrossSigningIdentity::for_account(&account).unwrap()));
 
             let user_identity =
                 create_user_identity(&*private_identity.lock().await, is_me, is_verified, signer)

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -564,14 +564,14 @@ impl PrivateCrossSigningIdentity {
      *
      * * `account` - The Olm account that is creating the new identity.
      */
-    pub(crate) fn for_account(account: &Account) -> PrivateCrossSigningIdentity {
+    pub(crate) fn for_account(
+        account: &Account,
+    ) -> Result<PrivateCrossSigningIdentity, SignatureError> {
         let mut master = MasterSigning::new(account.user_id().into());
 
-        account
-            .sign_cross_signing_key(master.public_key_mut().as_mut())
-            .expect("Can't sign our freshly created master key with our account");
+        account.sign_cross_signing_key(master.public_key_mut().as_mut())?;
 
-        Self::new_helper(account.user_id(), master)
+        Ok(Self::new_helper(account.user_id(), master))
     }
 
     #[cfg(any(test, feature = "testing"))]
@@ -749,7 +749,7 @@ mod tests {
     #[async_test]
     async fn test_private_identity_signed_by_account() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
-        let identity = PrivateCrossSigningIdentity::for_account(&account);
+        let identity = PrivateCrossSigningIdentity::for_account(&account).unwrap();
         let master = identity.master_key.lock().await;
         let master = master.as_ref().unwrap();
 
@@ -772,7 +772,7 @@ mod tests {
     #[async_test]
     async fn test_sign_device() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
-        let identity = PrivateCrossSigningIdentity::for_account(&account);
+        let identity = PrivateCrossSigningIdentity::for_account(&account).unwrap();
 
         let mut device = DeviceData::from_account(&account);
         let self_signing = identity.self_signing_key.lock().await;
@@ -789,11 +789,11 @@ mod tests {
     #[async_test]
     async fn test_sign_user_identity() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
-        let identity = PrivateCrossSigningIdentity::for_account(&account);
+        let identity = PrivateCrossSigningIdentity::for_account(&account).unwrap();
 
         let bob_account =
             Account::with_device_id(user_id!("@bob:localhost"), device_id!("DEVICEID"));
-        let bob_private = PrivateCrossSigningIdentity::for_account(&bob_account);
+        let bob_private = PrivateCrossSigningIdentity::for_account(&bob_account).unwrap();
         let mut bob_public = OtherUserIdentityData::from_private(&bob_private).await;
 
         let user_signing = identity.user_signing_key.lock().await;

--- a/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
@@ -52,7 +52,7 @@ impl Signatures {
         &mut self,
         signer: OwnedUserId,
         key_id: OwnedDeviceKeyId,
-        signature: Ed25519Signature,
+        signature: impl Into<Signature>,
     ) -> Option<Result<Signature, InvalidSignature>> {
         self.0.entry(signer).or_default().insert(key_id, Ok(signature.into()))
     }

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -830,12 +830,12 @@ pub(crate) mod tests {
     pub(crate) async fn setup_stores() -> (Account, VerificationStore, Account, VerificationStore) {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_store = MemoryStore::new();
-        let alice_private_identity = PrivateCrossSigningIdentity::for_account(&alice);
+        let alice_private_identity = PrivateCrossSigningIdentity::for_account(&alice).unwrap();
         let alice_private_identity = Mutex::new(alice_private_identity);
 
         let bob = Account::with_device_id(bob_id(), bob_device_id());
         let bob_store = MemoryStore::new();
-        let bob_private_identity = PrivateCrossSigningIdentity::for_account(&bob);
+        let bob_private_identity = PrivateCrossSigningIdentity::for_account(&bob).unwrap();
         let bob_private_identity = Mutex::new(bob_private_identity);
 
         let alice_public_identity =

--- a/crates/matrix-sdk/changelog.d/6715.added.md
+++ b/crates/matrix-sdk/changelog.d/6715.added.md
@@ -1,0 +1,2 @@
+Added a new top-level `Error` variant, `SignatureError` representing
+errors that occurred signing or verifying cryptographic data.

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -22,7 +22,8 @@ use http::StatusCode;
 use matrix_sdk_base::crypto::ScanError;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::{
-    CryptoStoreError, DecryptorError, KeyExportError, MegolmError, OlmError,
+    BootstrapCrossSigningError, CryptoStoreError, DecryptorError, KeyExportError, MegolmError,
+    OlmError, SignatureError,
 };
 use matrix_sdk_base::{
     Error as SdkBaseError, QueueWedgeError, RoomState, StoreError,
@@ -302,6 +303,11 @@ pub enum Error {
     #[error(transparent)]
     DecryptorError(#[from] DecryptorError),
 
+    /// An error occurred during signing or verifying.
+    #[cfg(feature = "e2e-encryption")]
+    #[error(transparent)]
+    SignatureError(#[from] SignatureError),
+
     /// An error occurred in the state store.
     #[error(transparent)]
     StateStore(Box<StoreError>),
@@ -523,6 +529,16 @@ impl From<EventCacheError> for Error {
 impl From<QueueWedgeError> for Error {
     fn from(error: QueueWedgeError) -> Self {
         Error::SendQueueWedgeError(Box::new(error))
+    }
+}
+
+#[cfg(feature = "e2e-encryption")]
+impl From<BootstrapCrossSigningError> for Error {
+    fn from(error: BootstrapCrossSigningError) -> Self {
+        match error {
+            BootstrapCrossSigningError::CryptoStore(e) => e.into(),
+            BootstrapCrossSigningError::Signature(e) => e.into(),
+        }
     }
 }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

This PR extracts three of the more general changes made in [`andyrich/x509`](https://github.com/matrix-org/matrix-rust-sdk/commits/andyrich/x509/) (the X.509 development branch) and applies them independently. In summary:

- Adjusts `Sugnatures::add_signature` to accept any type implementing `Into<Signature>` - done in advance of adding X.509-specific signature structs;
- Makes `bootstrap_cross_signing` falliable, since X.509 signature setup can fail;
- Inlines `Account::sign_master_key`, as this is only used in one place, and will be touched by X.509 anyway.

PR checklist:

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Skye Elliot <actuallyori@gmail.com>
