### PR TITLE
fix(base): Ensure `unicode-perl` is enabled for `regex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ proc-macro2 = { version = "1.0.106", default-features = false }
 proptest = { version = "1.9.0", default-features = false, features = ["std"] }
 quote = { version = "1.0.37", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-regex = { version = "1.12.2", default-features = false }
+regex = { version = "1.12.2", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
 ruma = { git = "https://github.com/ruma/ruma", rev = "8beb557b466a43b057c9c155277c77fe8766fadf", features = [

--- a/crates/matrix-sdk-base/changelog.d/6718.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6718.fixed.md
@@ -1,0 +1,2 @@
+The `unicode-perl` feature flag is always enabled on the `regex` crate, ensuring
+the `RoomDisplayName` works as expected.


### PR DESCRIPTION
The `RoomDisplayName` API needs to support `\s`, which is behind the `unicode-perl` feature.

Note for the reviewer: we already have a test for that (`test_room_alias_from_room_display_name_removes_whitespace`). I didn't check exactly how it is possible to use `matrix-sdk-base` to trigger the error in #6716, but the fix is simple enough.

---

* Fix https://github.com/matrix-org/matrix-rust-sdk/issues/6716

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
