### PR TITLE
fix(matrix-rust-sdk/encryption): use common timeout helper for CrossSigningResetHandle::auth instead of tokio::time directly

### DIFF
--- a/crates/matrix-sdk/changelog.d/6719.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6719.fixed.md
@@ -1,0 +1,1 @@
+ `CrossSigningResetHandle::auth` now uses the common timeout helper (from `matrix-sdk-base`) instead of `tokio::time` directly.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -53,6 +53,7 @@ use matrix_sdk_base::{
         },
     },
     sleep::sleep,
+    timeout::timeout,
 };
 use matrix_sdk_common::{executor::spawn, locks::Mutex as StdMutex};
 use ruma::{
@@ -361,43 +362,46 @@ impl CrossSigningResetHandle {
         // Give up after two minutes of polling.
         const TIMEOUT: Duration = Duration::from_mins(2);
 
-        tokio::time::timeout(TIMEOUT, async {
-            let mut upload_request = self.upload_request.clone();
-            upload_request.auth = auth;
-
-            debug!(
-                "Repeatedly PUTting to keys/device_signing/upload until it works \
-                or we hit a permanent failure."
-            );
-            while let Err(e) = self.client.send(upload_request.clone()).await {
-                if *self.is_cancelled.lock().await {
-                    return Ok(());
-                }
-
-                match e.as_uiaa_response() {
-                    Some(uiaa_info) => {
-                        // Return the error except if we are at the `m.oauth` stage where we want to
-                        // keep polling.
-                        if !matches!(self.auth_type, CrossSigningResetAuthType::OAuth(_))
-                            && uiaa_info.auth_error.is_some()
-                        {
-                            return Err(e.into());
-                        }
-                    }
-                    None => return Err(e.into()),
-                }
+        timeout(
+            async {
+                let mut upload_request = self.upload_request.clone();
+                upload_request.auth = auth;
 
                 debug!(
-                    "PUT to keys/device_signing/upload failed with 401. Retrying after \
-                    a short delay."
+                    "Repeatedly PUTting to keys/device_signing/upload until it works \
+                    or we hit a permanent failure."
                 );
-                sleep(RETRY_EVERY).await;
-            }
+                while let Err(e) = self.client.send(upload_request.clone()).await {
+                    if *self.is_cancelled.lock().await {
+                        return Ok(());
+                    }
 
-            self.client.send(self.signatures_request.clone()).await?;
+                    match e.as_uiaa_response() {
+                        Some(uiaa_info) => {
+                            // Return the error except if we are at the `m.oauth` stage where we
+                            // want to keep polling.
+                            if !matches!(self.auth_type, CrossSigningResetAuthType::OAuth(_))
+                                && uiaa_info.auth_error.is_some()
+                            {
+                                return Err(e.into());
+                            }
+                        }
+                        None => return Err(e.into()),
+                    }
 
-            Ok(())
-        })
+                    debug!(
+                        "PUT to keys/device_signing/upload failed with 401. Retrying after \
+                        a short delay."
+                    );
+                    sleep(RETRY_EVERY).await;
+                }
+
+                self.client.send(self.signatures_request.clone()).await?;
+
+                Ok(())
+            },
+            TIMEOUT,
+        )
         .await
         .unwrap_or_else(|_| {
             warn!("Timed out waiting for keys/device_signing/upload to succeed.");


### PR DESCRIPTION
Hello! This PR changes `CrossSigningResetHandle::auth` to uses the common timeout helper from `matrix-sdk-base` instead of tokio::time directly, allowing the method to work in WASM/Typescript.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
