### PR TITLE
Profiles: Allow building a sync service with support for the profiles extension.

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6726.feature.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6726.feature.md
@@ -1,0 +1,1 @@
+Add `SyncServiceBuilder::with_profiles_extension` to enable the Profiles sliding sync extension, which syncs global profile fields such as `m.status` and `m.call`.

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -128,6 +128,16 @@ impl SyncServiceBuilder {
         Arc::new(Self { builder, ..this })
     }
 
+    /// Enable the Profiles sliding sync extension for the room list service.
+    ///
+    /// Required to merge the global `m.status` and `m.call` fields into the
+    /// room members and profiles read from the SDK.
+    pub fn with_profiles_extension(self: Arc<Self>) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_profiles_extension();
+        Arc::new(Self { builder, ..this })
+    }
+
     /// Set a custom Sliding Sync connection ID for the room list service.
     ///
     /// By default [`matrix_sdk_ui::room_list_service::DEFAULT_CONNECTION_ID`]

--- a/crates/matrix-sdk-ui/changelog.d/6726.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6726.added.md
@@ -1,0 +1,1 @@
+Add `SyncServiceBuilder::with_profiles_extension` to enable the Profiles sliding sync extension, which syncs global profile fields such as `m.status` and `m.call`.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -141,7 +141,8 @@ impl RoomListService {
     /// to create one in this case using
     /// [`EncryptionSyncService`][crate::encryption_sync_service::EncryptionSyncService].
     pub async fn new(client: Client) -> Result<Self, Error> {
-        Self::new_with(client, true, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT).await
+        Self::new_with(client, true, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT, false)
+            .await
     }
 
     /// Like [`RoomListService::new`] but with additional configuration options.
@@ -150,6 +151,9 @@ impl RoomListService {
     ///   cross-process position sharing.
     /// - `connection_id`: the Sliding Sync connection ID
     /// - `timeline_limit`: the timeline limit
+    /// - `profiles_extension`: enables the Profiles extension, required to
+    ///   merge the global `m.status` and `m.call` fields into room members and
+    ///   profiles
     ///
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub async fn new_with(
@@ -157,6 +161,7 @@ impl RoomListService {
         share_pos: bool,
         connection_id: &str,
         timeline_limit: u32,
+        profiles_extension: bool,
     ) -> Result<Self, Error> {
         let mut builder = client
             .sliding_sync(connection_id)
@@ -196,6 +201,14 @@ impl RoomListService {
                     "Failed to check whether the client requested thread subscriptions extension: not enabling."
                 );
             }
+        }
+
+        if profiles_extension {
+            debug!("Enabling the profiles extension for the room list sliding sync");
+            builder = builder.with_profiles_extension(assign!(
+                http::request::Profiles::default(),
+                { enabled: Some(true) }
+            ));
         }
 
         if share_pos {

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -775,6 +775,13 @@ pub struct SyncServiceBuilder {
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     with_share_pos: bool,
 
+    /// Whether to enable the Profiles sliding sync extension for the room list
+    /// service.
+    ///
+    /// Required to merge the global `m.status` and `m.call` fields into the
+    /// room members and profiles read from this crate.
+    with_profiles_extension: bool,
+
     /// Custom connection ID for the room list service.
     /// Defaults to [`room_list_service::DEFAULT_CONNECTION_ID`]. Use a
     /// different value for secondary processes such as iOS share extensions
@@ -799,6 +806,7 @@ impl SyncServiceBuilder {
             client,
             with_offline_mode: false,
             with_share_pos: true,
+            with_profiles_extension: false,
             room_list_conn_id: DEFAULT_CONNECTION_ID.to_owned(),
             room_list_timeline_limit: DEFAULT_LIST_TIMELINE_LIMIT,
             parent_span: Span::none(),
@@ -819,6 +827,15 @@ impl SyncServiceBuilder {
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub fn with_share_pos(mut self, enable: bool) -> Self {
         self.with_share_pos = enable;
+        self
+    }
+
+    /// Enable the Profiles sliding sync extension for the room list service.
+    ///
+    /// Required to merge the global `m.status` and `m.call` fields into the
+    /// room members and profiles read from this crate.
+    pub fn with_profiles_extension(mut self) -> Self {
+        self.with_profiles_extension = true;
         self
     }
 
@@ -851,6 +868,7 @@ impl SyncServiceBuilder {
             client,
             with_offline_mode,
             with_share_pos,
+            with_profiles_extension,
             room_list_conn_id,
             room_list_timeline_limit,
             parent_span,
@@ -863,6 +881,7 @@ impl SyncServiceBuilder {
             with_share_pos,
             &room_list_conn_id,
             room_list_timeline_limit,
+            with_profiles_extension,
         )
         .await?;
 


### PR DESCRIPTION
Follow-up to #6685, this PR adds support for building a sync service with the profiles extension enabled.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
