### PR TITLE
fix(search): wait for merge threads before dropping the bulk writer

### DIFF
--- a/crates/matrix-sdk-search/changelog.d/6731.fixed.md
+++ b/crates/matrix-sdk-search/changelog.d/6731.fixed.md
@@ -1,0 +1,1 @@
+`RoomIndex::bulk_execute` now waits for the index writers merge threads before dropping it, avoiding spurious "couldn't find segment in SegmentManager" warnings and index fragmentation

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -342,6 +342,9 @@ impl RoomIndex {
     ///
     /// This which will add/remove/edit an events in the index based on the
     /// operations.
+    ///
+    /// Waits for background merge threads to prevent racing with subsequent
+    /// calls.
     pub fn bulk_execute(&mut self, operations: Vec<RoomIndexOperation>) -> Result<(), IndexError> {
         let mut writer = self.writer()?;
         let mut operations = operations.into_iter();
@@ -353,6 +356,7 @@ impl RoomIndex {
         }
 
         self.commit_and_reload(&mut writer)?;
+        writer.wait_merging_threads()?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-search/src/writer.rs
+++ b/crates/matrix-sdk-search/src/writer.rs
@@ -33,8 +33,7 @@ impl SearchIndexWriter {
     }
 
     pub(crate) fn add(&self, document: TantivyDocument) -> Result<OpStamp, IndexError> {
-        Ok(self.inner.add_document(document)?) // TODO: This is blocking. Handle
-        // it.
+        Ok(self.inner.add_document(document)?) // TODO: This is blocking. Handle it.
     }
 
     pub(crate) fn remove(&self, event_id: &EventId) {
@@ -45,5 +44,9 @@ impl SearchIndexWriter {
     pub(crate) fn commit(&mut self) -> Result<OpStamp, TantivyError> {
         self.last_commit_opstamp = self.inner.commit()?; // TODO: This is blocking. Handle it.
         Ok(self.last_commit_opstamp)
+    }
+
+    pub(crate) fn wait_merging_threads(self) -> Result<(), TantivyError> {
+        self.inner.wait_merging_threads()
     }
 }


### PR DESCRIPTION
`RoomIndex::bulk_execute` oepns a tantivy `IndexWriter`, commits, and then lets it drop without calling `wait_merging_threads()`. The writers background merge threads can outlive it and still be running when the next `bulk_execute` opens a new writer on the same index, so the two race over the same segments

During bulk indexing (e.g. backfilling a room history) this surfaces as

          tantivy::indexer::segment_manager: couldn't find segment in SegmentManager

warnings and leaves the index more fragmented than necessary

To fix this, we wait for the writers merge threads to finish before it is dropped at the end of `bulk_execute`. No public api change

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.