### PR TITLE
fix(sdk): export SupportedPathBuilder and SupportedAuthScheme

### DIFF
--- a/crates/matrix-sdk/changelog.d/6734.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6734.fixed.md
@@ -1,0 +1,1 @@
+Export SupportedPathBuilder and SupportedAuthScheme Client::send uses these in it's trait bounds, but because they were private it wasn't possible to write dependent code that is generic over request types.

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -258,8 +258,7 @@ async fn response_to_http_response(
 /// Marker trait to identify the authentication schemes that the
 /// [`Client`](crate::Client) supports.
 ///
-/// This trait can also be implemented for custom
-/// [`PathBuilder`](path_builder::PathBuilder)s if necessary.
+/// This trait can also be implemented for custom [`AuthScheme`]s if necessary.
 pub trait SupportedAuthScheme: AuthScheme {
     fn authentication_input(access_token: SendAccessToken<'_>) -> Self::Input<'_>;
 }

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -304,7 +304,7 @@ impl SupportedAuthScheme for auth_scheme::NoAuthentication {
 /// This trait can also be implemented for custom
 /// [`PathBuilder`](path_builder::PathBuilder)s if necessary.
 pub trait SupportedPathBuilder: path_builder::PathBuilder {
-    /// Get the [`PathBuilder::Input`](path_builder::Pathbuilder::Input) from
+    /// Get the [`PathBuilder::Input`](path_builder::PathBuilder::Input) from
     /// the [`Client`](crate::Client).
     fn get_path_builder_input(
         client: &crate::Client,

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -260,6 +260,7 @@ async fn response_to_http_response(
 ///
 /// This trait can also be implemented for custom [`AuthScheme`]s if necessary.
 pub trait SupportedAuthScheme: AuthScheme {
+    /// Get the [`AuthScheme::Input`] from the access token.
     fn authentication_input(access_token: SendAccessToken<'_>) -> Self::Input<'_>;
 }
 
@@ -303,6 +304,8 @@ impl SupportedAuthScheme for auth_scheme::NoAuthentication {
 /// This trait can also be implemented for custom
 /// [`PathBuilder`](path_builder::PathBuilder)s if necessary.
 pub trait SupportedPathBuilder: path_builder::PathBuilder {
+    /// Get the [`PathBuilder::Input`](path_builder::Pathbuilder::Input) from
+    /// the [`Client`](crate::Client).
     fn get_path_builder_input(
         client: &crate::Client,
         skip_auth: bool,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -80,7 +80,7 @@ pub use error::{
     BeaconError, Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError,
     Result, RumaApiError,
 };
-pub use http_client::{TransmissionProgress, SupportedPathBuilder, SupportedAuthScheme};
+pub use http_client::{SupportedAuthScheme, SupportedPathBuilder, TransmissionProgress};
 #[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -80,7 +80,7 @@ pub use error::{
     BeaconError, Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError,
     Result, RumaApiError,
 };
-pub use http_client::TransmissionProgress;
+pub use http_client::{TransmissionProgress, SupportedPathBuilder, SupportedAuthScheme};
 #[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
 pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]


### PR DESCRIPTION
`Client::send` uses these in it's trait bounds, but because they are private it isn't currently possible to write dependent code that is generic over request types.

Also fixes a small typo in the existing `SupportedAuthScheme` docstring.

Fixes #6732

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI. (absolutely not... *sigh*)
