### PR TITLE
Fix #6707 by using `OnceCell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "matrix-sdk-test",
+ "once_cell",
  "pbkdf2",
  "rand 0.10.1",
  "ruma",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ js-sys = { version = "0.3.82", default-features = false, features = ["std"] }
 mime = { version = "0.3.17", default-features = false }
 oauth2 = { version = "5.0.0", default-features = false, features = ["timing-resistant-secret-traits"] }
 oauth2-reqwest = { version = "0.1.0-alpha.3", default-features = false }
+once_cell = { version = "1.21", default-features = false, features = ["std"] }
 pbkdf2 = { version = "0.12.2", default-features = false }
 pin-project-lite = { version = "0.2.16", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false }

--- a/crates/matrix-sdk-search/Cargo.toml
+++ b/crates/matrix-sdk-search/Cargo.toml
@@ -21,6 +21,7 @@ ctr = { version = "0.9.2", default-features = false}
 hmac = { workspace = true, features = ["reset"] }
 hkdf.workspace = true
 matrix-sdk-test = { workspace = true, optional = true }
+once_cell.workspace = true
 pbkdf2.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 sha2.workspace = true

--- a/crates/matrix-sdk-search/changelog.d/6707.changed.md
+++ b/crates/matrix-sdk-search/changelog.d/6707.changed.md
@@ -1,0 +1,2 @@
+Performance optimisation: Cache the Tantivy `IndexReader` on `RoomIndex` because
+creating it is costly.

--- a/crates/matrix-sdk-search/changelog.d/6707.fixed.md
+++ b/crates/matrix-sdk-search/changelog.d/6707.fixed.md
@@ -1,1 +1,0 @@
-Performance optimization: Cache the tantivy IndexReader on RoomIndex.

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -17,6 +17,7 @@ pub mod builder;
 
 use std::{collections::HashSet, fmt};
 
+use once_cell::sync::OnceCell;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, RoomId, events::room::message::OriginalSyncRoomMessageEvent,
 };
@@ -58,7 +59,11 @@ pub struct RoomIndex {
     room_id: OwnedRoomId,
     uncommitted_adds: HashSet<OwnedEventId>,
     uncommitted_removes: HashSet<OwnedEventId>,
-    reader: Option<IndexReader>,
+    /// Cached [`IndexReader`].
+    ///
+    /// It is costly to create one, so let's keep it in memory when needed; see
+    /// [`RoomIndex::get_reader`] to learn more.
+    reader: OnceCell<IndexReader>,
 }
 
 impl fmt::Debug for RoomIndex {
@@ -80,7 +85,7 @@ impl RoomIndex {
             room_id: room_id.to_owned(),
             uncommitted_adds: HashSet::new(),
             uncommitted_removes: HashSet::new(),
-            reader: None,
+            reader: OnceCell::new(),
         }
     }
 
@@ -91,14 +96,8 @@ impl RoomIndex {
     }
 
     /// Get or create the cached [`IndexReader`] for this index.
-    fn get_reader(&mut self) -> Result<&IndexReader, IndexError> {
-        Ok(match self.reader {
-            Some(ref reader) => reader,
-            None => {
-                let reader = self.index.reader_builder().try_into()?;
-                self.reader.insert(reader)
-            }
-        })
+    fn get_reader(&self) -> Result<&IndexReader, IndexError> {
+        self.reader.get_or_try_init(|| Ok(self.index.reader_builder().try_into()?))
     }
 
     /// Commit added events to [`RoomIndex`]. The changes are not reflected in
@@ -140,7 +139,7 @@ impl RoomIndex {
     /// (and there are a surplus of results)
     /// then this will return results `11, 12, 13`
     pub fn search(
-        &mut self,
+        &self,
         query: &str,
         max_number_of_results: usize,
         pagination_offset: Option<usize>,
@@ -172,7 +171,7 @@ impl RoomIndex {
     }
 
     fn get_events_to_be_removed(
-        &mut self,
+        &self,
         event_id: &EventId,
     ) -> Result<Vec<OwnedEventId>, IndexError> {
         Ok(self
@@ -321,7 +320,7 @@ impl RoomIndex {
         Ok(())
     }
 
-    fn contains(&mut self, event_id: &EventId) -> bool {
+    fn contains(&self, event_id: &EventId) -> bool {
         let search_result = self.search(
             format!("{}:\"{event_id}\"", self.schema.get_field_name(self.schema.primary_key()))
                 .as_str(),
@@ -453,7 +452,7 @@ mod tests {
     #[test]
     fn test_search_empty_index() -> Result<(), Box<dyn Error>> {
         let room_id = room_id!("!room_id:localhost");
-        let mut index = RoomIndexBuilder::new_in_memory(room_id).build();
+        let index = RoomIndexBuilder::new_in_memory(room_id).build();
 
         let result = index.search("sentence", 10, None).expect("search failed with: {result:?}");
 
@@ -465,7 +464,7 @@ mod tests {
     #[test]
     fn test_index_contains_false() {
         let room_id = room_id!("!room_id:localhost");
-        let mut index = RoomIndexBuilder::new_in_memory(room_id).build();
+        let index = RoomIndexBuilder::new_in_memory(room_id).build();
 
         let event_id = event_id!("$event_id:localhost");
 

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -62,7 +62,7 @@ pub struct RoomIndex {
     /// Cached [`IndexReader`].
     ///
     /// It is costly to create one, so let's keep it in memory when needed; see
-    /// [`RoomIndex::get_reader`] to learn more.
+    /// [`RoomIndex::reader`] to learn more.
     reader: OnceCell<IndexReader>,
 }
 
@@ -90,13 +90,13 @@ impl RoomIndex {
     }
 
     /// Get a [`SearchIndexWriter`] for this index.
-    fn get_writer(&self) -> Result<SearchIndexWriter, IndexError> {
+    fn writer(&self) -> Result<SearchIndexWriter, IndexError> {
         let writer = self.index.writer(TANTIVY_INDEX_MEMORY_BUDGET)?;
         Ok(SearchIndexWriter::new(writer, self.schema.clone()))
     }
 
     /// Get or create the cached [`IndexReader`] for this index.
-    fn get_reader(&self) -> Result<&IndexReader, IndexError> {
+    fn reader(&self) -> Result<&IndexReader, IndexError> {
         self.reader.get_or_try_init(|| Ok(self.index.reader_builder().try_into()?))
     }
 
@@ -127,7 +127,7 @@ impl RoomIndex {
             self.uncommitted_adds, self.uncommitted_removes
         );
         let last_commit_opstamp = self.commit(writer)?;
-        self.get_reader()?.reload()?;
+        self.reader()?.reload()?;
         Ok(last_commit_opstamp)
     }
 
@@ -145,7 +145,7 @@ impl RoomIndex {
         pagination_offset: Option<usize>,
     ) -> Result<Vec<(f32, OwnedEventId)>, IndexError> {
         let query = self.query_parser.parse_query(query)?;
-        let searcher = self.get_reader()?.searcher();
+        let searcher = self.reader()?.searcher();
 
         let offset = pagination_offset.unwrap_or(0);
 
@@ -170,10 +170,7 @@ impl RoomIndex {
         Ok(ret)
     }
 
-    fn get_events_to_be_removed(
-        &self,
-        event_id: &EventId,
-    ) -> Result<Vec<OwnedEventId>, IndexError> {
+    fn events_to_be_removed(&self, event_id: &EventId) -> Result<Vec<OwnedEventId>, IndexError> {
         Ok(self
             .search(
                 format!(
@@ -207,7 +204,7 @@ impl RoomIndex {
         writer: &mut SearchIndexWriter,
         event_id: OwnedEventId,
     ) -> Result<(), IndexError> {
-        let events = self.get_events_to_be_removed(&event_id)?;
+        let events = self.events_to_be_removed(&event_id)?;
 
         writer.remove(&event_id);
 
@@ -293,7 +290,7 @@ impl RoomIndex {
     ///
     /// Prefer [`RoomIndex::bulk_execute`] for multiple operations.
     pub fn execute(&mut self, operation: RoomIndexOperation) -> Result<(), IndexError> {
-        let mut writer = self.get_writer()?;
+        let mut writer = self.writer()?;
         self.execute_with_retry(&mut writer, &operation, 5)?;
         self.commit_and_reload(&mut writer)?;
         Ok(())
@@ -306,7 +303,7 @@ impl RoomIndex {
     /// This which will add/remove/edit an events in the index based on the
     /// operations.
     pub fn bulk_execute(&mut self, operations: Vec<RoomIndexOperation>) -> Result<(), IndexError> {
-        let mut writer = self.get_writer()?;
+        let mut writer = self.writer()?;
         let mut operations = operations.into_iter();
         let mut next_operation = operations.next();
 


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-rust-sdk/pull/6707, the `RoomIndex::reader` field has been introduced to improve performance by building the index reader only once. Good idea, but using an `Option` for that isn't appropriate as it requires an exclusive reference (`&mut`) which propagates everywhere. It is better to use a `OnceCell` for that. The standard `OnceCell` type is great, except it doesn't have standardised the `get_or_try_init` method yet: let's use the `once_cell` crate (already present in our dependency tree).

This patch also fixes the changelog file that is not using the right category.

cc @stefanceriu @procr1337

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
