### PR TITLE
fix(sqlite): Encrypt `EventId`s in the Event Cache SQLite database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8192,18 +8192,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ wasm-bindgen = { version = "0.2.105", default-features = false }
 wasm-bindgen-test = { version = "0.3.55", default-features = false, features = ["std"] }
 web-sys = { version = "0.3.82", default-features = false }
 wiremock = { version = "0.6.5", default-features = false }
-zeroize = { version = "1.8.2", default-features = false }
+zeroize = { version = "1.9", default-features = false, features = ["alloc"] }
 zxcvbn = { git = "https://github.com/shssoichiro/zxcvbn-rs", rev = "4e8e784b23541d118800df84feedf8160879d1af", default-features = false }
 
 matrix-sdk = { path = "crates/matrix-sdk", version = "0.18.0", default-features = false }

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1511,7 +1511,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Now let's find the event.
         let event = self
-            .find_event(room_id, event_comte.event_id().unwrap().as_ref())
+            .find_event(room_id, event_comte.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find an event");
@@ -1520,7 +1520,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Now let's try to find an event that exists, but not in the expected room.
         assert!(
-            self.find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
+            self.find_event(room_id, event_gruyere.event_id().unwrap())
                 .await
                 .expect("failed to query for finding an event")
                 .is_none()
@@ -1529,7 +1529,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Clearing the rooms also clears the event's storage.
         self.clear_all_events().await.expect("failed to clear all rooms chunks");
         assert!(
-            self.find_event(room_id, event_comte.event_id().unwrap().as_ref())
+            self.find_event(room_id, event_comte.event_id().unwrap())
                 .await
                 .expect("failed to query for finding an event")
                 .is_none()
@@ -2042,14 +2042,14 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // Events can be found, when searched in their own rooms.
         let event = self
-            .find_event(room_id, event_comte.event_id().unwrap().as_ref())
+            .find_event(room_id, event_comte.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find an event");
         assert_eq!(event.event_id(), event_comte.event_id());
 
         let event = self
-            .find_event(another_room_id, event_gruyere.event_id().unwrap().as_ref())
+            .find_event(another_room_id, event_gruyere.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find an event");
@@ -2057,13 +2057,13 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         // But they won't be returned when searching in the wrong room.
         assert!(
-            self.find_event(another_room_id, event_comte.event_id().unwrap().as_ref())
+            self.find_event(another_room_id, event_comte.event_id().unwrap())
                 .await
                 .expect("failed to query for finding an event")
                 .is_none()
         );
         assert!(
-            self.find_event(room_id, event_gruyere.event_id().unwrap().as_ref())
+            self.find_event(room_id, event_gruyere.event_id().unwrap())
                 .await
                 .expect("failed to query for finding an event")
                 .is_none()
@@ -2186,22 +2186,22 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // All the events can be found with `find_event()` for the room.
-        self.find_event(room_id, thread2_ev.event_id().unwrap().as_ref())
+        self.find_event(room_id, thread2_ev.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find thread1_ev");
 
-        self.find_event(room_id, thread2_ev.event_id().unwrap().as_ref())
+        self.find_event(room_id, thread2_ev.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find thread2_ev");
 
-        self.find_event(room_id, thread2_ev2.event_id().unwrap().as_ref())
+        self.find_event(room_id, thread2_ev2.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find thread2_ev2");
 
-        self.find_event(room_id, room_ev.event_id().unwrap().as_ref())
+        self.find_event(room_id, room_ev.event_id().unwrap())
             .await
             .expect("failed to query for finding an event")
             .expect("failed to find room_ev");

--- a/crates/matrix-sdk-sqlite/changelog.d/6739.changed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/6739.changed.md
@@ -1,0 +1,8 @@
+The `EventId`s stored in the Event Cache database are now encrypted as hashes,
+they cannot be decrypted.
+
+The gap `prev_batch_token` is also encoded from a Rust `String` instead of a
+JSON representation of a `String`, saving a bit of computation and storage
+space.
+
+The Event Cache database is reset.

--- a/crates/matrix-sdk-sqlite/migrations/NOTES.md
+++ b/crates/matrix-sdk-sqlite/migrations/NOTES.md
@@ -16,6 +16,22 @@ migration scripts, with the hope that future us won't replicate these errors.
    $ # Enjoy
    ```
 
+2. Writing comments in SQL is great! Every comments outside tables are not part
+   of the schema, but all comments inside the tables _are_ part of the schema.
+   It means that if a column has a comment, it will be displayed with the
+   `.schema` command for example. However, if one needs to add a comment for a
+   table (which is very recommended), the comment must be inside the table, like
+   so:
+
+   ```sql
+   CREATE TABLE IF NOT EXISTS "foo" (
+      --- This table exists to address this and that.
+
+      --- First column!
+      foo BLOB NOT NULL
+   );
+   ```
+
 ## Errors
 
 1. _Identifiers_ can be delimited by double-quotes, while _string literals_ must

--- a/crates/matrix-sdk-sqlite/migrations/NOTES.md
+++ b/crates/matrix-sdk-sqlite/migrations/NOTES.md
@@ -1,7 +1,22 @@
 # Notes about migration scripts
 
-This document aims at listing all errors we made in the past with the migration
-scripts, with the hope that future us won't replicate these errors.
+This document aims at listing all tips and errors we made in the past with the
+migration scripts, with the hope that future us won't replicate these errors.
+
+## Tips
+
+1. Determining the up-to-date schema after all the migrations can be hard to
+   track by hand. Here is the trick: create a temporary database, apply all the
+   migration scripts, and then query the database, like so:
+
+   ```shell
+   $ cd <migration-directory>;
+   $ for i in $(/bin/ls -1); sqlite3 temporary.db < $i; end
+   $ sqlite3 temporary.db '.schema'
+   $ # Enjoy
+   ```
+
+## Errors
 
 1. _Identifiers_ can be delimited by double-quotes, while _string literals_ must
    be delimited by single-quotes. Even if SQLite has a compile-time

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/015_event_ids_are_encoded.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/015_event_ids_are_encoded.sql
@@ -1,0 +1,16 @@
+-- The following columns now contain encoded data:
+-- 
+-- - `event_chunks.event_id`,
+-- - `events.event_id`,
+-- - `events.relates_to`.
+-- 
+-- Nothing to do except clearing all the data.
+-- 
+-- Event IDs are encoded as _keys_: They cannot be decoded. However, keep in
+-- mind that the event's content is encoded as a _value_ and can be decoded: it
+-- contains the event ID. However, it is not possible to query it.
+
+DELETE FROM linked_chunks;
+DELETE FROM event_chunks;  -- should be done by cascading
+DELETE FROM gap_chunks;    -- should be done by cascading
+DELETE FROM events;

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -91,6 +91,9 @@ pub enum Error {
     Decode(rmp_serde::decode::Error),
 
     #[error(transparent)]
+    DecodeString(#[from] std::string::FromUtf8Error),
+
+    #[error(transparent)]
     Json(#[from] serde_json::Error),
 
     #[error(transparent)]

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -94,6 +94,12 @@ pub enum Error {
     DecodeString(#[from] std::string::FromUtf8Error),
 
     #[error(transparent)]
+    DecodeStr(#[from] std::str::Utf8Error),
+
+    #[error(transparent)]
+    DecodeRuma(#[from] ruma::IdParseError),
+
+    #[error(transparent)]
     Json(#[from] serde_json::Error),
 
     #[error(transparent)]

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -18,6 +18,7 @@ use std::{
     collections::HashMap,
     fmt,
     iter::once,
+    ops::{Deref, Not},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -98,12 +99,24 @@ impl Encryption {
         Ok(EncodedEvent {
             content,
             rel_type,
-            relates_to: relates_to.map(|relates_to| relates_to.to_string()),
+            relates_to: relates_to.map(|relates_to| self.encode_event_id(&relates_to)),
         })
     }
 
     fn decode_event(&self, raw_encoded_event: &[u8]) -> Result<Event> {
         Ok(serde_json::from_slice(&self.decode_value(raw_encoded_event)?)?)
+    }
+
+    /// Encode the event ID as a _key_: it cannot be decoded, but this is
+    /// stable.
+    fn encode_event_id(&self, event_id: &EventId) -> Key {
+        self.encode_key(keys::EVENTS, event_id)
+    }
+
+    /// Encode the room ID as a _key_: it cannot be decoded, but this is
+    /// stable.
+    fn encode_room_id(&self, room_id: &RoomId) -> Key {
+        self.encode_key(keys::EVENTS, room_id)
     }
 }
 
@@ -316,7 +329,7 @@ impl SqliteEventCacheStore {
 struct EncodedEvent {
     content: Vec<u8>,
     rel_type: Option<String>,
-    relates_to: Option<String>,
+    relates_to: Option<Key>,
 }
 
 trait TransactionExtForLinkedChunks {
@@ -587,6 +600,17 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         .await?;
     }
 
+    if version < 15 {
+        debug!("Upgrading database to version 15");
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/event_cache_store/015_event_ids_are_encoded.sql"
+            ))?;
+            txn.set_db_version(15)
+        })
+        .await?;
+    }
+
     Ok(())
 }
 
@@ -650,6 +674,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let hashed_linked_chunk_id =
             self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
         let linked_chunk_id = linked_chunk_id.to_owned();
+        let hashed_room_id = self.encryption.encode_room_id(linked_chunk_id.room_id());
         let encryption = self.encryption.clone();
 
         // Use a single transaction throughout this function, so that either all updates
@@ -769,35 +794,46 @@ impl EventCacheStore for SqliteEventCacheStore {
                                 return None;
                             };
 
-                            Some((event_id.to_string(), event_type, event))
+                            Some((event_id.to_owned(), event_type, event))
                         };
 
-                        let room_id = linked_chunk_id.room_id();
-                        let hashed_room_id = encryption.encode_key(keys::LINKED_CHUNKS, room_id);
-
                         for (i, (event_id, event_type, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
-                            // Insert the location information into the database.
-                            let index = at.index() + i;
-                            chunk_statement.execute((chunk_id, &hashed_linked_chunk_id, &event_id, index))?;
+                            let hashed_event_id = encryption.encode_event_id(&event_id);
 
-                            let session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
-                            let event_type = encryption.encode_key(keys::EVENTS, event_type);
+                            // Table `event_chunks`.
+                            {
+                                let index = at.index() + i;
 
-                            // Now, insert the event content into the database.
-                            let encoded_event = encryption.encode_event(&event)?;
-                            content_statement.execute((&hashed_room_id, event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                                chunk_statement.execute((chunk_id, &hashed_linked_chunk_id, &hashed_event_id, index))?;
+                            }
+
+                            // Table `events`.
+                            {
+                                let hashed_session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
+                                let hashed_event_type = encryption.encode_key(keys::EVENTS, event_type);
+                                let encoded_event = encryption.encode_event(&event)?;
+
+                                content_statement.execute((
+                                    &hashed_room_id,
+                                    &hashed_event_id,
+                                    hashed_event_type,
+                                    hashed_session_id,
+                                    encoded_event.content,
+                                    encoded_event.relates_to,
+                                    encoded_event.rel_type
+                                ))?;
+                            }
                         }
                     }
 
                     Update::ReplaceItem { at, item: event } => {
                         let chunk_id = at.chunk_identifier().index();
-
                         let index = at.index();
 
                         trace!(%linked_chunk_id, "replacing item @ {chunk_id}:{index}");
 
-                        // The event id should be the same, but just in case it changed…
-                        let Some(event_id) = event.event_id().map(|event_id| event_id.to_string()) else {
+                        // The event ID should be the same, but just in case it changed…
+                        let Some(event_id) = event.event_id().map(|event_id| event_id.to_owned()) else {
                             error!(%linked_chunk_id, "Trying to replace an event with a new one that has no ID");
                             continue;
                         };
@@ -807,24 +843,41 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
-                        let session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
-                        let event_type = encryption.encode_key(keys::EVENTS, event_type);
+                        let hashed_event_id = encryption.encode_event_id(&event_id);
 
-                        // Replace the event's content. Really we'd like to update, but in case the
-                        // event id changed, we are a bit lenient here and will allow an insertion
-                        // of the new event.
-                        let encoded_event = encryption.encode_event(&event)?;
-                        let room_id = linked_chunk_id.room_id();
-                        let hashed_room_id = encryption.encode_key(keys::LINKED_CHUNKS, room_id);
-                        txn.execute(
-                            "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                            (&hashed_room_id, &event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                        // Before updating the event in its chunk, we must ensure the event exists:
+                        // either we insert it, or we update it. Note that it's possible to replace
+                        // an event by itself (with different encryption info for example, or from
+                        // UTD to decrypted, stuff like that).
 
-                        // Replace the event id in the linked chunk, in case it changed.
-                        txn.execute(
-                            r#"UPDATE event_chunks SET event_id = ? WHERE linked_chunk_id = ? AND chunk_id = ? AND position = ?"#,
-                            (event_id, &hashed_linked_chunk_id, chunk_id, index)
-                        )?;
+                        // Table `events`.
+                        {
+                            let hashed_session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
+                            let hashed_event_type = encryption.encode_key(keys::EVENTS, event_type);
+                            let encoded_event = encryption.encode_event(&event)?;
+
+                            txn.execute(
+                                "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                                (
+                                    &hashed_room_id,
+                                    &hashed_event_id,
+                                    hashed_event_type,
+                                    hashed_session_id,
+                                    encoded_event.content,
+                                    encoded_event.relates_to,
+                                    encoded_event.rel_type
+                                ),
+                            )?;
+                        }
+
+                        // Table `event_chunks`.
+                        {
+                            // Replace the event at position `index` in chunk `chunk_id` by updating the event ID.
+                            txn.execute(
+                                r#"UPDATE event_chunks SET event_id = ? WHERE linked_chunk_id = ? AND chunk_id = ? AND position = ?"#,
+                                (&hashed_event_id, &hashed_linked_chunk_id, chunk_id, index)
+                            )?;
+                        }
                     }
 
                     Update::RemoveItem { at } => {
@@ -1300,86 +1353,109 @@ impl EventCacheStore for SqliteEventCacheStore {
         Ok(())
     }
 
-    #[instrument(skip(self, events))]
+    #[instrument(skip(self, event_ids))]
     async fn filter_duplicated_events(
         &self,
         linked_chunk_id: LinkedChunkId<'_>,
-        events: Vec<OwnedEventId>,
+        event_ids: Vec<OwnedEventId>,
     ) -> Result<Vec<(OwnedEventId, Position)>, Self::Error> {
         let _timer = timer!("method");
 
         // If there's no events for which we want to check duplicates, we can return
         // early. It's not only an optimization to do so: it's required, otherwise the
         // `repeat_vars` call below will panic.
-        if events.is_empty() {
+        if event_ids.is_empty() {
             return Ok(Vec::new());
         }
 
         // Select all events that exist in the store, i.e. the duplicates.
         let hashed_linked_chunk_id =
             self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
-        let linked_chunk_id = linked_chunk_id.to_owned();
+        let event_ids_and_hashed_event_ids = event_ids
+            .into_iter()
+            .map(|event_id| {
+                let hashed_event_id = self.encryption.encode_event_id(&event_id);
 
-        let encryption = self.encryption.clone();
+                (event_id, hashed_event_id)
+            })
+            .collect::<Vec<_>>();
 
         self.read()
             .await?
             .with_transaction(move |txn| -> Result<_> {
-                txn.chunk_large_query_over(events, None, move |txn, events| {
-                    let query = format!(
-                        r#"
-                            SELECT event_id, chunk_id, position
-                            FROM event_chunks
-                            WHERE linked_chunk_id = ? AND event_id IN ({})
-                            ORDER BY chunk_id ASC, position ASC
-                        "#,
-                        repeat_vars(events.len()),
-                    );
+                txn.chunk_large_query_over(
+                    event_ids_and_hashed_event_ids,
+                    None,
+                    move |txn, event_ids_and_hashed_event_ids| {
+                        let query = format!(
+                            "SELECT event_id, chunk_id, position \
+                            FROM event_chunks \
+                            WHERE linked_chunk_id = ? AND event_id IN ({}) \
+                            ORDER BY chunk_id ASC, position ASC",
+                            repeat_vars(event_ids_and_hashed_event_ids.len()),
+                        );
 
-                    let parameters = params_from_iter(
-                        // parameter for `linked_chunk_id = ?`
-                        once(
-                            hashed_linked_chunk_id
-                                .to_sql()
-                                // SAFETY: it cannot fail since `Key::to_sql` never fails
-                                .unwrap(),
-                        )
-                        // parameters for `event_id IN (…)`
-                        .chain(events.iter().map(|event| {
-                            event
-                                .as_str()
-                                .to_sql()
-                                // SAFETY: it cannot fail since `str::to_sql` never fails
-                                .unwrap()
-                        })),
-                    );
+                        let parameters = params_from_iter(
+                            // parameter for `linked_chunk_id = ?`
+                            once(
+                                hashed_linked_chunk_id
+                                    .to_sql()
+                                    // SAFETY: it cannot fail since `Key::to_sql` never fails
+                                    .unwrap(),
+                            )
+                            // parameters for `event_id IN (…)`
+                            .chain(
+                                event_ids_and_hashed_event_ids.iter().map(
+                                    |(_event_id, hashed_event_id)| {
+                                        hashed_event_id
+                                            .to_sql()
+                                            // SAFETY: it cannot fail since `Vec::<u8>::to_sql`
+                                            // never fails
+                                            .unwrap()
+                                    },
+                                ),
+                            ),
+                        );
 
-                    let mut duplicated_events = Vec::new();
+                        let mut duplicated_events = Vec::new();
 
-                    for duplicated_event in txn.prepare(&query)?.query_map(parameters, |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, u64>(1)?,
-                            row.get::<_, usize>(2)?,
-                        ))
-                    })? {
-                        let (duplicated_event, chunk_identifier, index) = duplicated_event?;
+                        for duplicated_event in
+                            txn.prepare(&query)?.query_map(parameters, |row| {
+                                Ok((
+                                    row.get::<_, Vec<u8>>(0)?,
+                                    row.get::<_, u64>(1)?,
+                                    row.get::<_, usize>(2)?,
+                                ))
+                            })?
+                        {
+                            let (duplicated_hashed_event_id, chunk_identifier, index) =
+                                duplicated_event?;
 
-                        let Ok(duplicated_event) = EventId::parse(duplicated_event.clone()) else {
-                            // Normally unreachable, but the event ID has been stored even if it is
-                            // malformed, let's skip it.
-                            error!(%duplicated_event, %linked_chunk_id, "Reading an malformed event ID");
-                            continue;
-                        };
+                            // The event ID is encoded in the database. We can't decode it. However,
+                            // we can find the original event ID with the `event_ids` parameter of
+                            // this method by comparing the encoded event ID!
+                            let Some(duplicated_event_id) = event_ids_and_hashed_event_ids
+                                .iter()
+                                .find_map(|(event_id, hashed_event_id)| {
+                                    (hashed_event_id.deref() == duplicated_hashed_event_id)
+                                        .then_some(event_id.clone())
+                                })
+                            else {
+                                error!(
+                                    "Unreachable: found a duplicated event that was not requested"
+                                );
+                                continue;
+                            };
 
-                        duplicated_events.push((
-                            duplicated_event,
-                            Position::new(ChunkIdentifier::new(chunk_identifier), index),
-                        ));
-                    }
+                            duplicated_events.push((
+                                duplicated_event_id,
+                                Position::new(ChunkIdentifier::new(chunk_identifier), index),
+                            ));
+                        }
 
-                    Ok(duplicated_events)
-                })
+                        Ok(duplicated_events)
+                    },
+                )
             })
             .await
     }
@@ -1392,17 +1468,17 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Option<Event>, Self::Error> {
         let _timer = timer!("method");
 
-        let event_id = event_id.to_owned();
         let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_room_id = self.encryption.encode_room_id(room_id);
+        let hashed_event_id = self.encryption.encode_event_id(event_id);
 
         self.read()
             .await?
             .with_transaction(move |txn| -> Result<_> {
                 let Some(event) = txn
                     .prepare("SELECT content FROM events WHERE event_id = ? AND room_id = ?")?
-                    .query_row((event_id.as_str(), hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
+                    .query_row((hashed_event_id, hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
                     .optional()?
                 else {
                     // Event is not found.
@@ -1423,13 +1499,12 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error> {
         let _timer = timer!("method");
 
-        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
-
+        let hashed_room_id = self.encryption.encode_room_id(room_id);
         let hashed_linked_chunk_id = self
             .encryption
             .encode_key(keys::LINKED_CHUNKS, LinkedChunkId::Room(room_id).storage_key());
+        let hashed_event_id = self.encryption.encode_event_id(event_id);
 
-        let event_id = event_id.to_owned();
         let filters = filters.map(ToOwned::to_owned);
         let encryption = self.encryption.clone();
 
@@ -1440,7 +1515,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     &encryption,
                     hashed_room_id,
                     hashed_linked_chunk_id,
-                    event_id,
+                    hashed_event_id,
                     filters,
                     txn,
                 )
@@ -1459,7 +1534,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_room_id = self.encryption.encode_room_id(room_id);
         let hashed_event_type = event_type.map(|e| self.encryption.encode_key(keys::EVENTS, e));
         let hashed_session_id = session_id.map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
@@ -1514,12 +1589,12 @@ impl EventCacheStore for SqliteEventCacheStore {
             return Ok(());
         };
 
-        let event_type = self.encryption.encode_key(keys::EVENTS, event_type);
-        let session_id =
+        let hashed_event_type = self.encryption.encode_key(keys::EVENTS, event_type);
+        let hashed_session_id =
             event.kind.session_id().map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
-        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
-        let event_id = event_id.to_string();
+        let hashed_room_id = self.encryption.encode_room_id(room_id);
+        let hashed_event_id = self.encryption.encode_event_id(event_id);
         let encoded_event = self.encryption.encode_event(&event)?;
 
         self.write()
@@ -1527,7 +1602,16 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| -> Result<_> {
                 txn.execute(
                     "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                    (&hashed_room_id, &event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
+                    (
+                        &hashed_room_id,
+                        hashed_event_id,
+                        hashed_event_type,
+                        hashed_session_id,
+                        encoded_event.content,
+                        encoded_event.relates_to,
+                        encoded_event.rel_type
+                    )
+                )?;
 
                 Ok(())
             })
@@ -1555,7 +1639,7 @@ fn find_event_relations_transaction(
     encryption: &Encryption,
     hashed_room_id: Key,
     hashed_linked_chunk_id: Key,
-    event_id: OwnedEventId,
+    hashed_event_id: Key,
     filters: Option<Vec<RelationType>>,
     txn: &Transaction<'_>,
 ) -> Result<Vec<(Event, Option<Position>)>> {
@@ -1613,8 +1697,7 @@ fn find_event_relations_transaction(
                 hashed_linked_chunk_id.to_sql().expect(
                     "We should be able to convert a hashed linked chunk ID to a SQLite value",
                 ),
-                event_id
-                    .as_str()
+                hashed_event_id
                     .to_sql()
                     .expect("We should be able to convert an event ID to a SQLite value"),
                 hashed_room_id
@@ -1630,12 +1713,11 @@ fn find_event_relations_transaction(
 
         collect_results(transaction)
     } else {
-        let query =
-            "SELECT events.content, event_chunks.chunk_id, event_chunks.position
-            FROM events
-            LEFT JOIN event_chunks ON events.event_id = event_chunks.event_id AND event_chunks.linked_chunk_id = ?
-            WHERE relates_to = ? AND room_id = ?";
-        let parameters = (hashed_linked_chunk_id, event_id.as_str(), hashed_room_id);
+        let query = "SELECT events.content, event_chunks.chunk_id, event_chunks.position \
+            FROM events \
+            LEFT JOIN event_chunks ON events.event_id = event_chunks.event_id AND event_chunks.linked_chunk_id = ? \
+            WHERE events.relates_to = ? AND events.room_id = ?";
+        let parameters = (hashed_linked_chunk_id, hashed_event_id, hashed_room_id);
 
         let mut transaction = txn.prepare(query)?;
         let transaction = transaction.query_map(parameters, get_rows)?;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -385,7 +385,7 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
             |row| row.get(0),
         )?;
         let prev_token_bytes = store.decode_value(&encoded_prev_token)?;
-        let prev_token = serde_json::from_slice(&prev_token_bytes)?;
+        let prev_token = String::from_utf8(prev_token_bytes.into_owned())?;
         Ok(Gap { token: prev_token })
     }
 
@@ -670,8 +670,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     }
 
                     Update::NewGapChunk { previous, new, next, gap } => {
-                        let serialized = serde_json::to_vec(&gap.token)?;
-                        let prev_token = this.encode_value(serialized)?;
+                        let hashed_prev_token = this.encode_value(gap.token)?;
 
                         let previous = previous.as_ref().map(ChunkIdentifier::index);
                         let new = new.index();
@@ -698,7 +697,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                             INSERT INTO gap_chunks(chunk_id, linked_chunk_id, prev_token)
                             VALUES (?, ?, ?)
                         "#,
-                            (new, &hashed_linked_chunk_id, prev_token),
+                            (new, &hashed_linked_chunk_id, hashed_prev_token),
                         )?;
                     }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -99,7 +99,8 @@ impl Encryption {
         Ok(EncodedEvent {
             content,
             rel_type,
-            relates_to: relates_to.map(|relates_to| self.encode_event_id(&relates_to)),
+            relates_to: relates_to
+                .map(|relates_to| self.encode_event_id(keys::EVENTS, &relates_to)),
         })
     }
 
@@ -109,14 +110,14 @@ impl Encryption {
 
     /// Encode the event ID as a _key_: it cannot be decoded, but this is
     /// stable.
-    fn encode_event_id(&self, event_id: &EventId) -> Key {
-        self.encode_key(keys::EVENTS, event_id)
+    fn encode_event_id(&self, table_name: &str, event_id: &EventId) -> Key {
+        self.encode_key(table_name, event_id)
     }
 
     /// Encode the room ID as a _key_: it cannot be decoded, but this is
     /// stable.
-    fn encode_room_id(&self, room_id: &RoomId) -> Key {
-        self.encode_key(keys::EVENTS, room_id)
+    fn encode_room_id(&self, table_name: &str, room_id: &RoomId) -> Key {
+        self.encode_key(table_name, room_id)
     }
 }
 
@@ -674,7 +675,8 @@ impl EventCacheStore for SqliteEventCacheStore {
         let hashed_linked_chunk_id =
             self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
         let linked_chunk_id = linked_chunk_id.to_owned();
-        let hashed_room_id = self.encryption.encode_room_id(linked_chunk_id.room_id());
+        let hashed_room_id =
+            self.encryption.encode_room_id(keys::EVENTS, linked_chunk_id.room_id());
         let encryption = self.encryption.clone();
 
         // Use a single transaction throughout this function, so that either all updates
@@ -798,7 +800,14 @@ impl EventCacheStore for SqliteEventCacheStore {
                         };
 
                         for (i, (event_id, event_type, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
-                            let hashed_event_id = encryption.encode_event_id(&event_id);
+                            let hashed_event_id = encryption.encode_event_id(
+                                // For the event ID, we need a stable hash between the `events`
+                                // and `event_chunks` tables. That's why we use `keys::EVENTS`
+                                // even if `hashed_event_id` is sometimes only used in
+                                // `events_chunks`.
+                                keys::EVENTS,
+                                &event_id,
+                            );
 
                             // Table `event_chunks`.
                             {
@@ -843,7 +852,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
-                        let hashed_event_id = encryption.encode_event_id(&event_id);
+                        let hashed_event_id = encryption.encode_event_id(keys::EVENTS, &event_id);
 
                         // Before updating the event in its chunk, we must ensure the event exists:
                         // either we insert it, or we update it. Note that it's possible to replace
@@ -1374,7 +1383,14 @@ impl EventCacheStore for SqliteEventCacheStore {
         let event_ids_and_hashed_event_ids = event_ids
             .into_iter()
             .map(|event_id| {
-                let hashed_event_id = self.encryption.encode_event_id(&event_id);
+                let hashed_event_id = self.encryption.encode_event_id(
+                    // For the event ID, we need a stable hash between the
+                    // `events` and `event_chunks` tables. That's why we use
+                    // `keys::EVENTS` even if `hashed_event_id` is only used in
+                    // `events_chunks`.
+                    keys::EVENTS,
+                    &event_id,
+                );
 
                 (event_id, hashed_event_id)
             })
@@ -1470,8 +1486,8 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encryption.encode_room_id(room_id);
-        let hashed_event_id = self.encryption.encode_event_id(event_id);
+        let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
+        let hashed_event_id = self.encryption.encode_event_id(keys::EVENTS, event_id);
 
         self.read()
             .await?
@@ -1499,11 +1515,11 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error> {
         let _timer = timer!("method");
 
-        let hashed_room_id = self.encryption.encode_room_id(room_id);
+        let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
         let hashed_linked_chunk_id = self
             .encryption
             .encode_key(keys::LINKED_CHUNKS, LinkedChunkId::Room(room_id).storage_key());
-        let hashed_event_id = self.encryption.encode_event_id(event_id);
+        let hashed_event_id = self.encryption.encode_event_id(keys::EVENTS, event_id);
 
         let filters = filters.map(ToOwned::to_owned);
         let encryption = self.encryption.clone();
@@ -1534,7 +1550,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encryption.encode_room_id(room_id);
+        let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
         let hashed_event_type = event_type.map(|e| self.encryption.encode_key(keys::EVENTS, e));
         let hashed_session_id = session_id.map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
@@ -1593,8 +1609,8 @@ impl EventCacheStore for SqliteEventCacheStore {
         let hashed_session_id =
             event.kind.session_id().map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
-        let hashed_room_id = self.encryption.encode_room_id(room_id);
-        let hashed_event_id = self.encryption.encode_event_id(event_id);
+        let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
+        let hashed_event_id = self.encryption.encode_event_id(keys::EVENTS, event_id);
         let encoded_event = self.encryption.encode_event(&event)?;
 
         self.write()

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -76,10 +76,48 @@ const CHUNK_TYPE_EVENT_TYPE_STRING: &str = "E";
 /// database.
 const CHUNK_TYPE_GAP_TYPE_STRING: &str = "G";
 
+/// Type to support (de)encryption of keys and values for the
+/// [`SqliteEventCacheStore`].
+///
+/// See the [`SqliteEventCacheStore::encryption`] field.
+struct Encryption {
+    cipher: Option<StoreCipher>,
+}
+
+impl Encryption {
+    fn encode_event(&self, event: &TimelineEvent) -> Result<EncodedEvent> {
+        let serialized = serde_json::to_vec(event)?;
+
+        // Extract the relationship info here.
+        let raw_event = event.raw();
+        let (relates_to, rel_type) = extract_event_relation(raw_event).unzip();
+
+        // The content may be encrypted.
+        let content = self.encode_value(serialized)?;
+
+        Ok(EncodedEvent {
+            content,
+            rel_type,
+            relates_to: relates_to.map(|relates_to| relates_to.to_string()),
+        })
+    }
+
+    fn decode_event(&self, raw_encoded_event: &[u8]) -> Result<Event> {
+        Ok(serde_json::from_slice(&self.decode_value(raw_encoded_event)?)?)
+    }
+}
+
+impl EncryptableStore for Encryption {
+    fn get_cypher(&self) -> Option<&StoreCipher> {
+        self.cipher.as_ref()
+    }
+}
+
 /// An SQLite-based event cache store.
 #[derive(Clone)]
 pub struct SqliteEventCacheStore {
-    store_cipher: Option<Arc<StoreCipher>>,
+    /// Type to encrypt keys and values.
+    encryption: Arc<Encryption>,
 
     /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
@@ -98,12 +136,6 @@ pub struct SqliteEventCacheStore {
 impl fmt::Debug for SqliteEventCacheStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SqliteEventCacheStore").finish_non_exhaustive()
-    }
-}
-
-impl EncryptableStore for SqliteEventCacheStore {
-    fn get_cypher(&self) -> Option<&StoreCipher> {
-        self.store_cipher.as_deref()
     }
 }
 
@@ -168,8 +200,8 @@ impl SqliteEventCacheStore {
 
         conn.wal_checkpoint().await;
 
-        let store_cipher = match secret {
-            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
+        let cipher = match secret {
+            Some(s) => Some(conn.get_or_create_store_cipher(s).await?),
             None => None,
         };
 
@@ -180,7 +212,7 @@ impl SqliteEventCacheStore {
         };
 
         Ok(Self {
-            store_cipher,
+            encryption: Arc::new(Encryption { cipher }),
             connections: Arc::new(Mutex::new(Some(connections))),
             db_path,
             pool_config,
@@ -239,23 +271,6 @@ impl SqliteEventCacheStore {
         ))
     }
 
-    fn encode_event(&self, event: &TimelineEvent) -> Result<EncodedEvent> {
-        let serialized = serde_json::to_vec(event)?;
-
-        // Extract the relationship info here.
-        let raw_event = event.raw();
-        let (relates_to, rel_type) = extract_event_relation(raw_event).unzip();
-
-        // The content may be encrypted.
-        let content = self.encode_value(serialized)?;
-
-        Ok(EncodedEvent {
-            content,
-            rel_type,
-            relates_to: relates_to.map(|relates_to| relates_to.to_string()),
-        })
-    }
-
     pub async fn vacuum(&self) -> Result<()> {
         let write_connection = {
             let guard = self.connections.lock().await;
@@ -307,7 +322,7 @@ struct EncodedEvent {
 trait TransactionExtForLinkedChunks {
     fn rebuild_chunk(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         previous: Option<u64>,
         index: u64,
@@ -317,14 +332,14 @@ trait TransactionExtForLinkedChunks {
 
     fn load_gap_content(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Gap>;
 
     fn load_events_content(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Vec<Event>>;
@@ -333,7 +348,7 @@ trait TransactionExtForLinkedChunks {
 impl TransactionExtForLinkedChunks for Transaction<'_> {
     fn rebuild_chunk(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         previous: Option<u64>,
         id: u64,
@@ -347,13 +362,13 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         match chunk_type {
             CHUNK_TYPE_GAP_TYPE_STRING => {
                 // It's a gap!
-                let gap = self.load_gap_content(store, linked_chunk_id, id)?;
+                let gap = self.load_gap_content(encryption, linked_chunk_id, id)?;
                 Ok(RawChunk { content: ChunkContent::Gap(gap), previous, identifier: id, next })
             }
 
             CHUNK_TYPE_EVENT_TYPE_STRING => {
                 // It's events!
-                let events = self.load_events_content(store, linked_chunk_id, id)?;
+                let events = self.load_events_content(encryption, linked_chunk_id, id)?;
                 Ok(RawChunk {
                     content: ChunkContent::Items(events),
                     previous,
@@ -373,7 +388,7 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
 
     fn load_gap_content(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Gap> {
@@ -384,14 +399,14 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
             (chunk_id.index(), &linked_chunk_id),
             |row| row.get(0),
         )?;
-        let prev_token_bytes = store.decode_value(&encoded_prev_token)?;
+        let prev_token_bytes = encryption.decode_value(&encoded_prev_token)?;
         let prev_token = String::from_utf8(prev_token_bytes.into_owned())?;
         Ok(Gap { token: prev_token })
     }
 
     fn load_events_content(
         &self,
-        store: &SqliteEventCacheStore,
+        encryption: &Encryption,
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Vec<Event>> {
@@ -409,11 +424,7 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
             )?
             .query_map((chunk_id.index(), &linked_chunk_id), |row| row.get::<_, Vec<u8>>(0))?
         {
-            let encoded_content = event_data?;
-            let serialized_content = store.decode_value(&encoded_content)?;
-            let event = serde_json::from_slice(&serialized_content)?;
-
-            events.push(event);
+            events.push(encryption.decode_event(&event_data?)?);
         }
 
         Ok(events)
@@ -642,9 +653,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         // Use a single transaction throughout this function, so that either all updates
         // work, or none is taken into account.
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
         let linked_chunk_id = linked_chunk_id.to_owned();
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
         with_immediate_transaction(self, move |txn| {
             for up in updates {
@@ -670,7 +681,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     }
 
                     Update::NewGapChunk { previous, new, next, gap } => {
-                        let hashed_prev_token = this.encode_value(gap.token)?;
+                        let hashed_prev_token = encryption.encode_value(gap.token)?;
 
                         let previous = previous.as_ref().map(ChunkIdentifier::index);
                         let new = new.index();
@@ -765,18 +776,18 @@ impl EventCacheStore for SqliteEventCacheStore {
                         };
 
                         let room_id = linked_chunk_id.room_id();
-                        let hashed_room_id = this.encode_key(keys::LINKED_CHUNKS, room_id);
+                        let hashed_room_id = encryption.encode_key(keys::LINKED_CHUNKS, room_id);
 
                         for (i, (event_id, event_type, event)) in items.into_iter().filter_map(invalid_event).enumerate() {
                             // Insert the location information into the database.
                             let index = at.index() + i;
                             chunk_statement.execute((chunk_id, &hashed_linked_chunk_id, &event_id, index))?;
 
-                            let session_id = event.kind.session_id().map(|s| this.encode_key(keys::EVENTS, s));
-                            let event_type = this.encode_key(keys::EVENTS, event_type);
+                            let session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
+                            let event_type = encryption.encode_key(keys::EVENTS, event_type);
 
                             // Now, insert the event content into the database.
-                            let encoded_event = this.encode_event(&event)?;
+                            let encoded_event = encryption.encode_event(&event)?;
                             content_statement.execute((&hashed_room_id, event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
                         }
                     }
@@ -799,15 +810,15 @@ impl EventCacheStore for SqliteEventCacheStore {
                             continue;
                         };
 
-                        let session_id = event.kind.session_id().map(|s| this.encode_key(keys::EVENTS, s));
-                        let event_type = this.encode_key(keys::EVENTS, event_type);
+                        let session_id = event.kind.session_id().map(|s| encryption.encode_key(keys::EVENTS, s));
+                        let event_type = encryption.encode_key(keys::EVENTS, event_type);
 
                         // Replace the event's content. Really we'd like to update, but in case the
                         // event id changed, we are a bit lenient here and will allow an insertion
                         // of the new event.
-                        let encoded_event = this.encode_event(&event)?;
+                        let encoded_event = encryption.encode_event(&event)?;
                         let room_id = linked_chunk_id.room_id();
-                        let hashed_room_id = this.encode_key(keys::LINKED_CHUNKS, room_id);
+                        let hashed_room_id = encryption.encode_key(keys::LINKED_CHUNKS, room_id);
                         txn.execute(
                             "INSERT OR REPLACE INTO events(room_id, event_id, event_type, session_id, content, relates_to, rel_type) VALUES (?, ?, ?, ?, ?, ?, ?)",
                             (&hashed_room_id, &event_id, event_type, session_id, encoded_event.content, encoded_event.relates_to, encoded_event.rel_type))?;
@@ -985,9 +996,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
 
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
         let result = self
             .read()
@@ -1004,7 +1015,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                 {
                     let (id, previous, next, chunk_type) = data?;
                     let new = txn.rebuild_chunk(
-                        &this,
+                        &encryption,
                         &hashed_linked_chunk_id,
                         previous,
                         id,
@@ -1029,7 +1040,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
 
         self.read()
             .await?
@@ -1127,9 +1138,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
 
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
         self
             .read()
@@ -1201,7 +1212,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                 // Build the chunk.
                 let last_chunk = txn.rebuild_chunk(
-                    &this,
+                    &encryption,
                     &hashed_linked_chunk_id,
                     previous_chunk,
                     chunk_identifier,
@@ -1223,9 +1234,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
 
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
         self
             .read()
@@ -1255,7 +1266,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                 // Build the chunk.
                 let last_chunk = txn.rebuild_chunk(
-                    &this,
+                    &encryption,
                     &hashed_linked_chunk_id,
                     previous_chunk,
                     chunk_identifier,
@@ -1302,8 +1313,10 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         // Select all events that exist in the store, i.e. the duplicates.
         let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
         let linked_chunk_id = linked_chunk_id.to_owned();
+
+        let encryption = self.encryption.clone();
 
         self.read()
             .await?
@@ -1376,9 +1389,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let event_id = event_id.to_owned();
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
 
         self.read()
             .await?
@@ -1392,9 +1405,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     return Ok(None);
                 };
 
-                let event = serde_json::from_slice(&this.decode_value(&event)?)?;
-
-                Ok(Some(event))
+                Ok(Some(encryption.decode_event(&event)?))
             })
             .await
     }
@@ -1408,20 +1419,21 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Vec<(Event, Option<Position>)>, Self::Error> {
         let _timer = timer!("method");
 
-        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
 
-        let hashed_linked_chunk_id =
-            self.encode_key(keys::LINKED_CHUNKS, LinkedChunkId::Room(room_id).storage_key());
+        let hashed_linked_chunk_id = self
+            .encryption
+            .encode_key(keys::LINKED_CHUNKS, LinkedChunkId::Room(room_id).storage_key());
 
         let event_id = event_id.to_owned();
         let filters = filters.map(ToOwned::to_owned);
-        let store = self.clone();
+        let encryption = self.encryption.clone();
 
         self.read()
             .await?
             .with_transaction(move |txn| -> Result<_> {
                 find_event_relations_transaction(
-                    store,
+                    &encryption,
                     hashed_room_id,
                     hashed_linked_chunk_id,
                     event_id,
@@ -1441,11 +1453,11 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Vec<Event>, Self::Error> {
         let _timer = timer!("method");
 
-        let this = self.clone();
+        let encryption = self.encryption.clone();
 
-        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
-        let hashed_event_type = event_type.map(|e| self.encode_key(keys::EVENTS, e));
-        let hashed_session_id = session_id.map(|s| self.encode_key(keys::EVENTS, s));
+        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_event_type = event_type.map(|e| self.encryption.encode_key(keys::EVENTS, e));
+        let hashed_session_id = session_id.map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
         self.read()
             .await?
@@ -1473,15 +1485,13 @@ impl EventCacheStore for SqliteEventCacheStore {
                 };
 
                 let mut statement = txn.prepare(query)?;
-                let maybe_events = statement.query_map(keys, |row| row.get::<_, Vec<u8>>(0))?;
 
-                let mut events = Vec::new();
-                for ev in maybe_events {
-                    let event = serde_json::from_slice(&this.decode_value(&ev?)?)?;
-                    events.push(event);
-                }
-
-                Ok(events)
+                statement
+                    .query_map(keys, |row| row.get::<_, Vec<u8>>(0))?
+                    .map(|maybe_encoded_event| {
+                        encryption.decode_event(&maybe_encoded_event?)
+                    })
+                    .collect::<Result<Vec<_>>>()
             })
             .await
     }
@@ -1500,12 +1510,13 @@ impl EventCacheStore for SqliteEventCacheStore {
             return Ok(());
         };
 
-        let event_type = self.encode_key(keys::EVENTS, event_type);
-        let session_id = event.kind.session_id().map(|s| self.encode_key(keys::EVENTS, s));
+        let event_type = self.encryption.encode_key(keys::EVENTS, event_type);
+        let session_id =
+            event.kind.session_id().map(|s| self.encryption.encode_key(keys::EVENTS, s));
 
-        let hashed_room_id = self.encode_key(keys::LINKED_CHUNKS, room_id);
+        let hashed_room_id = self.encryption.encode_key(keys::LINKED_CHUNKS, room_id);
         let event_id = event_id.to_string();
-        let encoded_event = self.encode_event(&event)?;
+        let encoded_event = self.encryption.encode_event(&event)?;
 
         self.write()
             .await?
@@ -1537,7 +1548,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 }
 
 fn find_event_relations_transaction(
-    store: SqliteEventCacheStore,
+    encryption: &Encryption,
     hashed_room_id: Key,
     hashed_linked_chunk_id: Key,
     event_id: OwnedEventId,
@@ -1559,7 +1570,7 @@ fn find_event_relations_transaction(
         for result in transaction {
             let (event_blob, chunk_id, index): (Vec<u8>, Option<u64>, _) = result?;
 
-            let event: Event = serde_json::from_slice(&store.decode_value(&event_blob)?)?;
+            let event = encryption.decode_event(&event_blob)?;
 
             // Only build the position if both the chunk_id and position were present; in
             // theory, they should either be present at the same time, or not at all.
@@ -1829,7 +1840,7 @@ mod tests {
             .with_transaction(move |txn| {
                 txn.query_row(
                     "SELECT COUNT(*) FROM event_chunks WHERE chunk_id = 42 AND linked_chunk_id = ? AND position IN (2, 3, 4)",
-                    (store.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key()),),
+                    (store.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key()),),
                     |row| row.get(0),
                 )
             })

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -415,12 +415,10 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
 
         for event_data in self
             .prepare(
-                r#"
-                    SELECT events.content
-                    FROM event_chunks ec, events
-                    WHERE events.event_id = ec.event_id AND ec.chunk_id = ? AND ec.linked_chunk_id = ?
-                    ORDER BY ec.position ASC
-                "#,
+                "SELECT events.content \
+                    FROM event_chunks ec, events \
+                    WHERE events.event_id = ec.event_id AND ec.chunk_id = ? AND ec.linked_chunk_id = ? \
+                    ORDER BY ec.position ASC",
             )?
             .query_map((chunk_id.index(), &linked_chunk_id), |row| row.get::<_, Vec<u8>>(0))?
         {
@@ -615,23 +613,22 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await?
             .with_transaction(move |txn| {
                 txn.query_row(
-                    "INSERT INTO lease_locks (key, holder, expiration)
-                    VALUES (?1, ?2, ?3)
-                    ON CONFLICT (key)
-                    DO
-                        UPDATE SET
-                            holder = excluded.holder,
-                            expiration = excluded.expiration,
-                            generation =
-                                CASE holder
-                                    WHEN excluded.holder THEN generation
-                                    ELSE generation + 1
-                                END
-                        WHERE
-                            holder = excluded.holder
-                            OR expiration < ?4
-                    RETURNING generation
-                    ",
+                    "INSERT INTO lease_locks (key, holder, expiration) \
+                    VALUES (?1, ?2, ?3) \
+                    ON CONFLICT (key) \
+                    DO \
+                        UPDATE SET \
+                            holder = excluded.holder, \
+                            expiration = excluded.expiration, \
+                            generation = \
+                                CASE holder \
+                                    WHEN excluded.holder THEN generation \
+                                    ELSE generation + 1 \
+                                END \
+                        WHERE \
+                            holder = excluded.holder \
+                            OR expiration < ?4 \
+                    RETURNING generation",
                     (key, holder, expiration, now),
                     |row| row.get(0),
                 )
@@ -650,16 +647,16 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<(), Self::Error> {
         let _timer = timer!("method");
 
-        // Use a single transaction throughout this function, so that either all updates
-        // work, or none is taken into account.
         let hashed_linked_chunk_id =
             self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
         let linked_chunk_id = linked_chunk_id.to_owned();
         let encryption = self.encryption.clone();
 
+        // Use a single transaction throughout this function, so that either all updates
+        // work, or none is taken into account.
         with_immediate_transaction(self, move |txn| {
-            for up in updates {
-                match up {
+            for update in updates {
+                match update {
                     Update::NewItemsChunk { previous, new, next } => {
                         let previous = previous.as_ref().map(ChunkIdentifier::index);
                         let new = new.index();
@@ -953,6 +950,9 @@ impl EventCacheStore for SqliteEventCacheStore {
                             "#,
                             (&hashed_linked_chunk_id, chunk_id)
                         )?;
+
+                        // We don't remove the events from `events` purposely
+                        // because they can be used by another `LinkedChunkId`.
                     }
 
                     Update::DetachLastItems { at } => {
@@ -963,6 +963,9 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         // Remove these entries.
                         txn.execute("DELETE FROM event_chunks WHERE linked_chunk_id = ? AND chunk_id = ? AND position >= ?", (&hashed_linked_chunk_id, chunk_id, index))?;
+
+                        // We don't remove the events from `events` purposely
+                        // because they can be used by another `LinkedChunkId`.
                     }
 
                     Update::Clear => {
@@ -973,6 +976,9 @@ impl EventCacheStore for SqliteEventCacheStore {
                             "DELETE FROM linked_chunks WHERE linked_chunk_id = ?",
                             (&hashed_linked_chunk_id,),
                         )?;
+
+                        // We don't remove the events from `events` purposely
+                        // because they can be used by another `LinkedChunkId`.
                     }
 
                     Update::StartReattachItems | Update::EndReattachItems => {
@@ -1073,12 +1079,10 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                 let num_events_by_chunk_ids = txn
                     .prepare(
-                        r#"
-                            SELECT ec.chunk_id, COUNT(ec.event_id)
-                            FROM event_chunks as ec
-                            WHERE ec.linked_chunk_id = ?
-                            GROUP BY ec.chunk_id
-                        "#,
+                        "SELECT ec.chunk_id, COUNT(ec.event_id) \
+                        FROM event_chunks as ec \
+                        WHERE ec.linked_chunk_id = ? \
+                        GROUP BY ec.chunk_id",
                     )?
                     .query_map((&hashed_linked_chunk_id,), |row| {
                         Ok((row.get::<_, u64>(0)?, row.get::<_, usize>(1)?))
@@ -1086,15 +1090,14 @@ impl EventCacheStore for SqliteEventCacheStore {
                     .collect::<Result<HashMap<_, _>, _>>()?;
 
                 txn.prepare(
-                    r#"
-                        SELECT
-                            lc.id,
-                            lc.previous,
-                            lc.next,
-                            lc.type
-                        FROM linked_chunks as lc
-                        WHERE lc.linked_chunk_id = ?
-                        ORDER BY lc.id"#,
+                    "SELECT \
+                        lc.id, \
+                        lc.previous, \
+                        lc.next, \
+                        lc.type \
+                    FROM linked_chunks as lc \
+                    WHERE lc.linked_chunk_id = ? \
+                    ORDER BY lc.id",
                 )?
                 .query_map((&hashed_linked_chunk_id,), |row| {
                     Ok((
@@ -1288,7 +1291,8 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| {
                 // Remove all the chunks, and let cascading do its job.
                 txn.execute("DELETE FROM linked_chunks", ())?;
-                // Also clear all the events' contents.
+
+                // Also clear all the events' contents, and let cascading do its job.
                 txn.execute("DELETE FROM events", ())
             })
             .await?;
@@ -1568,9 +1572,8 @@ fn find_event_relations_transaction(
         let mut related = Vec::new();
 
         for result in transaction {
-            let (event_blob, chunk_id, index): (Vec<u8>, Option<u64>, _) = result?;
-
-            let event = encryption.decode_event(&event_blob)?;
+            let (event, chunk_id, index): (Vec<u8>, Option<u64>, _) = result?;
+            let event = encryption.decode_event(&event)?;
 
             // Only build the position if both the chunk_id and position were present; in
             // theory, they should either be present at the same time, or not at all.
@@ -1584,13 +1587,15 @@ fn find_event_relations_transaction(
         Ok(related)
     };
 
-    if let Some(filters) = filters {
-        let question_marks = repeat_vars(filters.len());
+    if let Some(filters) = filters
+        && filters.is_empty().not()
+    {
         let query = format!(
-            "SELECT events.content, event_chunks.chunk_id, event_chunks.position
-            FROM events
-            LEFT JOIN event_chunks ON events.event_id = event_chunks.event_id AND event_chunks.linked_chunk_id = ?
-            WHERE relates_to = ? AND room_id = ? AND rel_type IN ({question_marks})"
+            "SELECT events.content, event_chunks.chunk_id, event_chunks.position \
+            FROM events \
+            LEFT JOIN event_chunks ON events.event_id = event_chunks.event_id AND event_chunks.linked_chunk_id = ? \
+            WHERE events.relates_to = ? AND events.room_id = ? AND events.rel_type IN ({})",
+            repeat_vars(filters.len())
         );
 
         // First the filters need to be stringified; because `.to_sql()` will borrow

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -23,7 +23,7 @@ use std::{
 use async_trait::async_trait;
 use deadpool_sync::InteractError;
 use itertools::Itertools;
-use matrix_sdk_store_encryption::StoreCipher;
+use matrix_sdk_store_encryption::{EncryptableValue, StoreCipher};
 use ruma::{OwnedEventId, OwnedRoomId, serde::Raw, time::SystemTime};
 use rusqlite::{OptionalExtension, Params, Row, Statement, Transaction, limits::Limit};
 use serde::{Serialize, de::DeserializeOwned};
@@ -641,12 +641,15 @@ pub(crate) trait EncryptableStore {
         }
     }
 
-    fn encode_value(&self, value: Vec<u8>) -> Result<Vec<u8>> {
+    fn encode_value<V>(&self, value: V) -> Result<Vec<u8>>
+    where
+        V: EncryptableValue + Into<Vec<u8>>,
+    {
         if let Some(key) = self.get_cypher() {
             let encrypted = key.encrypt_value_data(value)?;
             Ok(rmp_serde::to_vec_named(&encrypted)?)
         } else {
-            Ok(value)
+            Ok(value.into())
         }
     }
 

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -448,13 +448,16 @@ impl StoreCipher {
     /// assert_eq!(value, decrypted);
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn encrypt_value_data(&self, mut data: Vec<u8>) -> Result<EncryptedValue, Error> {
+    pub fn encrypt_value_data<D>(&self, mut data: D) -> Result<EncryptedValue, Error>
+    where
+        D: EncryptableValue,
+    {
         let nonce = Keys::get_nonce();
         let cipher = XChaCha20Poly1305::new(self.inner.encryption_key());
 
-        let ciphertext = cipher.encrypt(XNonce::from_slice(&nonce), data.as_ref())?;
+        let ciphertext = cipher.encrypt(XNonce::from_slice(&nonce), data.as_bytes())?;
 
-        data.zeroize();
+        data.zeroiize();
         Ok(EncryptedValue { version: VERSION, ciphertext, nonce })
     }
 
@@ -806,6 +809,53 @@ struct EncryptedStoreCipher {
     /// The ciphertext with it's accompanying additional data that is needed to
     /// decrypt the store cipher.
     pub ciphertext_info: CipherTextInfo,
+}
+
+/// A trait to get a slice of bytes and to zeroize a data, which are the
+/// required operations for [`StoreCipher::encrypt_value_data`].
+///
+/// The goal of this trait was to call [`Zeroize`] efficiently on `Vec<u8>` and
+/// `&[u8]`. We could call `vec.iter_mut().zeroize()` but the implementation of
+/// `Zeroize` on `Vec<u8>` does a bit more than that as it clears the vector and
+/// zeroizes the spare capacity as a best effort.
+pub trait EncryptableValue {
+    /// Get the encodable value as bytes.
+    fn as_bytes(&self) -> &[u8];
+
+    /// Zeroize the encodable value.
+    ///
+    /// Called `zeroiize` to avoid clashes with [`Zeroize::zeroize`].
+    fn zeroiize(&mut self);
+}
+
+impl EncryptableValue for Vec<u8> {
+    fn as_bytes(&self) -> &[u8] {
+        AsRef::as_ref(self)
+    }
+
+    fn zeroiize(&mut self) {
+        Zeroize::zeroize(self);
+    }
+}
+
+impl EncryptableValue for String {
+    fn as_bytes(&self) -> &[u8] {
+        str::as_bytes(self)
+    }
+
+    fn zeroiize(&mut self) {
+        Zeroize::zeroize(self);
+    }
+}
+
+impl EncryptableValue for &mut [u8] {
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn zeroiize(&mut self) {
+        self.iter_mut().zeroize();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This patch aims at encrypting the `EventId` value in the Event Cache database (in the SQLite backend).

Best to review this PR one patch at a time.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
