### PR TITLE
feat(ffi): expose beacon and beacon info events

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -319,6 +319,7 @@ pub enum StateEventContent {
     RoomTopic { topic: String },
     SpaceChild,
     SpaceParent,
+    BeaconInfo,
 }
 
 impl TryFrom<AnySyncStateEvent> for StateEventContent {
@@ -357,6 +358,7 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
             }
             AnySyncStateEvent::SpaceChild(_) => StateEventContent::SpaceChild,
             AnySyncStateEvent::SpaceParent(_) => StateEventContent::SpaceParent,
+            AnySyncStateEvent::BeaconInfo(_) => StateEventContent::BeaconInfo,
             _ => bail!("Unsupported state event: {:?}", value.event_type()),
         };
         Ok(event)
@@ -407,6 +409,7 @@ pub enum MessageLikeEventContent {
         reason: Option<String>,
     },
     Sticker,
+    Beacon,
 }
 
 impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
@@ -486,6 +489,7 @@ impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
                 MessageLikeEventContent::RoomRedaction { redacted_event_id, reason }
             }
             AnySyncMessageLikeEvent::Sticker(_) => MessageLikeEventContent::Sticker,
+            AnySyncMessageLikeEvent::Beacon(_) => MessageLikeEventContent::Beacon,
             _ => bail!("Unsupported Event Type: {:?}", value.event_type()),
         };
         Ok(content)


### PR DESCRIPTION
<!-- description of the changes in this PR -->
What the title says.
- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
