### PR TITLE
fix(wasm): replace tokio::time::sleep with matrix_sdk_common::sleep

### DIFF
--- a/crates/matrix-sdk/changelog.d/6743.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6743.fixed.md
@@ -1,1 +1,1 @@
-Replace `tokio::time::sleep` with `matrix_sdk_common::sleep::sleep` to ensure wasm
+Replace `tokio::time::sleep` with `matrix_sdk_common::sleep::sleep` to ensure wasm compatibility.

--- a/crates/matrix-sdk/changelog.d/6743.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6743.fixed.md
@@ -1,1 +1,1 @@
-Replace `tokio::time::sleep` with `matrix_sdk_common::sleep::sleep` to ensure wasm compatibility.
+Replace `tokio::time::sleep` with `matrix_sdk_common::sleep::sleep` to ensure QRCode auth compiles to WebAssembly.

--- a/crates/matrix-sdk/changelog.d/6743.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6743.fixed.md
@@ -1,0 +1,1 @@
+Replace `tokio::time::sleep` with `matrix_sdk_common::sleep::sleep` to ensure wasm

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -1116,7 +1116,7 @@ impl OAuth {
         let response = OAuthClient::new(client_id)
             .set_token_uri(token_uri)
             .exchange_device_access_token(device_authorization_response)
-            .request_async(self.http_client(), tokio::time::sleep, None)
+            .request_async(self.http_client(), matrix_sdk_common::sleep::sleep, None)
             .await?;
 
         self.client.auth_ctx().set_session_tokens(SessionTokens {

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -155,7 +155,7 @@ async fn finish_login_grant<Q>(
         } else {
             // If the deadline hasn't yet passed, give it some time and retry the request.
             if Instant::now() < deadline {
-                tokio::time::sleep(Duration::from_millis(500)).await;
+                matrix_sdk_common::sleep::sleep(Duration::from_millis(500)).await;
                 continue;
             } else {
                 // The deadline has passed. Let's fail the login process.


### PR DESCRIPTION
I was trying to do the QR code auth in wasm and ran into issues with it because of SDK's usage of tokio, I believe these should be simple drop-in replacements with `matrix_sdk_common::sleep`. This is building on top of work like https://github.com/matrix-org/matrix-rust-sdk/pull/4573

Disclosure: the issue was found during development with an AI agent but I manually reviewed the needed patch and created this upstream PR.