### PR TITLE
feat(sdk): Loop over and delete all backup versions on identity reset

### DIFF
--- a/crates/matrix-sdk/changelog.d/6744.changed.md
+++ b/crates/matrix-sdk/changelog.d/6744.changed.md
@@ -1,1 +1,3 @@
-Resetting your cryptographic identity now iteratively deletes all server-side key backup versions.
+Methods that delete key backup versions, such as resetting your
+cryptographic identity now iteratively delete all server-side key
+backup versions.

--- a/crates/matrix-sdk/changelog.d/6744.changed.md
+++ b/crates/matrix-sdk/changelog.d/6744.changed.md
@@ -1,0 +1,1 @@
+Resetting your cryptographic identity now iteratively deletes all server-side key backup versions.

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -247,16 +247,17 @@ impl Backups {
         result
     }
 
-    /// Completely disable and delete the active backup both locally
-    /// and from the backend no matter if previously setup locally
+    /// Completely disable and delete all backup versions, both locally
+    /// and from the server, no matter if they were previously setup locally
     /// or not.
     ///
     /// ⚠️ This method is mainly used when resetting the crypto identity
     /// and for most other use cases its safer [`Backups::disable`] counterpart
     /// should be used.
     ///
-    /// It will fetch the current backup version from the backend and delete it
-    /// before proceeding to disabling local backups as well
+    /// It will fetch the current backup version from the server, delete it,
+    /// then repeat this until no backups remain, before proceeding to
+    /// disabling local backups as well
     ///
     /// # Examples
     ///

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -279,9 +279,7 @@ impl Backups {
 
         // Create a future so we can catch errors and go back to the `Unknown` state.
         let future = async {
-            let response = self.get_current_version().await?;
-
-            if let Some(response) = response {
+            while let Some(response) = self.get_current_version().await? {
                 self.delete_backup_from_server(response.version).await?;
             }
 

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -842,6 +842,7 @@ async fn test_recover_and_reset() {
 #[async_test]
 async fn test_reset_identity() {
     let user_id = user_id!("@example:morpheus.localhost");
+    let backup_count = 4;
     let (client, server) = test_client(user_id).await;
 
     enable(user_id, &client, &server, true).await;
@@ -850,16 +851,16 @@ async fn test_reset_identity() {
     assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
     assert_eq!(client.encryption().recovery().state(), RecoveryState::Enabled);
 
-    let did_delete_backup = Arc::new(Mutex::new(false));
+    let backups_remaining = Arc::new(Mutex::new(backup_count));
 
     // Disabling backups
     Mock::given(method("GET"))
         .and(path("_matrix/client/r0/room_keys/version"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with({
-            let did_delete_backup = did_delete_backup.clone();
+            let backups_remaining = backups_remaining.clone();
             move |_: &wiremock::Request| {
-                if *did_delete_backup.lock().unwrap() {
+                if *backups_remaining.lock().unwrap() == 0 {
                     ResponseTemplate::new(404).set_body_json(json!({
                         "errcode": "M_NOT_FOUND",
                         "error": "No current backup version"
@@ -878,7 +879,7 @@ async fn test_reset_identity() {
                 }
             }
         })
-        .expect(3)
+        .expect(backup_count + 3)
         .named("room_keys/version GET")
         .mount(&server)
         .await;
@@ -887,13 +888,13 @@ async fn test_reset_identity() {
         .and(path("_matrix/client/r0/room_keys/version/1"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with({
-            let did_delete_backup = did_delete_backup.clone();
+            let did_delete_backup = backups_remaining.clone();
             move |_: &wiremock::Request| {
-                *did_delete_backup.lock().unwrap() = true;
+                *did_delete_backup.lock().unwrap() -= 1;
                 ResponseTemplate::new(200).set_body_json(json!({}))
             }
         })
-        .expect(1)
+        .expect(backup_count)
         .mount(&server)
         .await;
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

 This PR adjusts the identity reset logic to loop on `GET  /_matrix/client/v3/room_keys/version`, deleting all backups until none remain.

When we reset our identity, we delete the current backup version, but not any other versions if they happen to exist. This can leave clients in a broken state where they are unable to enable key backup since one already exists server-side. Deleting all backup versions on reset should fix this issue.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Skye Elliot <actuallyori@gmail.com>
