### PR TITLE
Test `--all-features` on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,12 @@ jobs:
       fail-fast: true
       matrix:
         name:
+          - all
           - no-encryption
           - no-sqlite
           - no-encryption-and-sqlite
           - sqlite-cryptostore
           - experimental-encrypted-state-events
-          - markdown
-          - socks
-          - sso-login
-          - search
 
     steps:
       - name: Checkout

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1216,7 +1216,7 @@ impl MatrixMockServer {
     /// .mount()
     /// .await;
     ///
-    /// client.account().fetch_media_preview_config_event_content().await.unwrap();
+    /// client.account().get_recent_emojis(true).await.unwrap();
     ///
     /// # anyhow::Ok(()) });
     /// ```
@@ -1241,11 +1241,12 @@ impl MatrixMockServer {
     /// let client = mock_server.client_builder().build().await;
     /// let user_id = client.user_id().unwrap();
     ///
-    /// mock.server.mock_get_recent_emojis()
+    /// mock_server.mock_get_recent_emojis()
     /// .ok(user_id, vec![(":D".to_string(), uint!(1))])
     /// .mock_once()
     /// .mount()
     /// .await;
+    ///
     /// mock_server.mock_add_recent_emojis()
     /// .ok(user_id)
     /// .mock_once()

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -202,8 +202,18 @@ To use this module, two structs are needed:
     the widget via `postMessage`.
 
 ```rust
+# async {
+use matrix_sdk::widget::{Capabilities, CapabilitiesProvider, WidgetSettings, WidgetDriver};
+use tokio::spawn;
+use url::Url;
+
 #[derive(Clone)]
 struct CapProv {}
+
+async fn prompt_user_for_capabilities(capabilities: Capabilities) -> Capabilities {
+    // Show a prompt to the user requesting capabilities.
+    todo!()
+}
 
 impl CapabilitiesProvider for CapProv {
     async fn acquire_capabilities(&self, requested_capabilities: Capabilities) -> Capabilities {
@@ -213,27 +223,37 @@ impl CapabilitiesProvider for CapProv {
     }
 }
 
-let widget_settings = WidgetSettings {
-    widget_id: "String",
-    init_on_content_load: true,
-    raw_url: "https://Url",
-};
+let widget_settings = WidgetSettings::new(
+    "String".to_owned(),
+    true,
+    "https://example.org",
+).unwrap();
 
 // Create the required structs:
 let (driver, handle) = WidgetDriver::new(widget_settings);
 let cap_provider = CapProv {};
 
-// Set up message routing
-let h = handle.clone();
-spawn(async move {
-    loop {
-        let message = my_platform::postmessage_receiver.recv::<String>().await;
-        h.send(message).await;
+mod my_platform {
+    pub fn eval(script: &str) {}
+    pub async fn receive_post_message() -> String { todo!() }
+}
+
+spawn({
+    // Set up message routing
+    let h = handle.clone();
+
+    async move {
+        loop {
+            let message = my_platform::receive_post_message().await;
+            h.send(message).await;
+        }
     }
 });
 
 spawn(async move {
-    while let Some(msg) = handle.recv().await {
+    let url = "http://example.org";
+
+    while let Some(message) = handle.recv().await {
         let script = format!(
             "document.getElementById('widget').contentWindow.postMessage({}, '{}');",
             message, url,
@@ -242,9 +262,12 @@ spawn(async move {
     }
 });
 
+# let room = todo!();
+
 spawn(async move {
     let _ = driver.run(room, cap_provider).await;
 });
+};
 ```
 
 ## Feature flags

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -24,8 +24,6 @@ use url::Url;
 
 use super::{WidgetSettings, url_params};
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
 /// Serialization struct for URL parameters for the Element Call widget.
 /// These are documented at https://github.com/element-hq/element-call/blob/livekit/docs/url-params.md
 ///
@@ -35,15 +33,15 @@ use super::{WidgetSettings, url_params};
 ///
 /// # Example:
 ///
-/// ```
-/// ElementCallParams {
+/// ```no_compile
+/// # use matrix_sdk::widget::settings::element_call::ElementCallUrlParams;
+/// ElementCallUrlParams {
 ///     // Required parameters:
 ///     user_id: "@1234",
 ///     room_id: "$1234",
-///     ...
 ///     // Optional configuration:
 ///     hide_screensharing: Some(true),
-///     ..ElementCallParams::default()
+///     ..Default::default()
 /// }
 /// ```
 /// will become: `my.url? ...requires_parameters... &hide_screensharing=true`
@@ -51,6 +49,8 @@ use super::{WidgetSettings, url_params};
 /// URLs parameters is that the `intent` implies defaults for all configuration
 /// values in the widget itself. Setting the URL parameter specifically will
 /// overwrite those defaults.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ElementCallUrlParams {
     user_id: String,
     room_id: String,

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -124,16 +124,12 @@ impl Display for CoverageOutputFormat {
 
 #[derive(Subcommand, PartialEq, Eq, PartialOrd, Ord)]
 enum FeatureSet {
+    All,
     NoEncryption,
     NoSqlite,
     NoEncryptionAndSqlite,
     SqliteCryptostore,
     ExperimentalEncryptedStateEvents,
-    Markdown,
-    Socks,
-    SsoLogin,
-    Search,
-    ElementRecentEmojis,
 }
 
 #[derive(Subcommand, PartialEq, Eq, PartialOrd, Ord)]
@@ -282,6 +278,7 @@ fn check_docs() -> Result<()> {
 
 fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
     let args = BTreeMap::from([
+        (FeatureSet::All, "--all-features"),
         (FeatureSet::NoEncryption, "--no-default-features --features sqlite,testing"),
         (FeatureSet::NoSqlite, "--no-default-features --features e2e-encryption,testing"),
         (FeatureSet::NoEncryptionAndSqlite, "--no-default-features --features testing"),
@@ -293,11 +290,6 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
             FeatureSet::ExperimentalEncryptedStateEvents,
             "--no-default-features --features experimental-encrypted-state-events,e2e-encryption,sqlite,testing",
         ),
-        (FeatureSet::Markdown, "--features markdown,testing"),
-        (FeatureSet::Socks, "--features socks,testing"),
-        (FeatureSet::SsoLogin, "--features sso-login,testing"),
-        (FeatureSet::Search, "--features experimental-search"),
-        (FeatureSet::ElementRecentEmojis, "--features experimental-element-recent-emojis"),
     ]);
 
     let sh = sh();


### PR DESCRIPTION
Now that our features have become additive, let's use the `--all-features` compile flag in our CI to avoid having separate targets for small additive features like `sso`, `socks`, or `markdown`.

This also makes it easier for each MSC to have its own feature flag.
