### PR TITLE
fix(base,sdk): When forgetting a room, clean the Event Cache correctly!

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -176,7 +176,7 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
                 .unwrap()
                 .as_clean()
                 .unwrap()
-                .clear_all_events()
+                .clear_all_events(None)
                 .await
                 .unwrap();
 

--- a/crates/matrix-sdk-base/changelog.d/6749.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/6749.changed.md
@@ -1,0 +1,20 @@
+The `EventCacheStore::remove_room` method has been removed: it is replaced
+by `EventCacheStore::clear_all_events` which gains a new argument:
+`Option<&RoomId>`.
+
+Before:
+
+```rust
+event_cache_store.remove_room(room_id).await?;
+```
+
+After:
+
+```rust
+event_cache_store.clear_all_events(Some(room_id)).await?;
+```
+
+Note that `clear_all_events(None)` will remove events for all the rooms. By
+room, one must understand all events for a particular room, which includes all
+possible caches, like `RoomEventCache`, `ThreadEventCache` and
+`PinnedEventsCache`.

--- a/crates/matrix-sdk-base/changelog.d/6749.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6749.fixed.md
@@ -1,0 +1,8 @@
+The `Client::forget_room` contained two bugs:
+
+1. It was removing events for the `RoomEventCache` associated to the given
+   `room_id` only, missing the `ThreadEventCache`s and the `PinnedEventsCache`.
+2. It was removing in-store data only, missing the in-memory data!
+
+The patch adds an `EventCache::forget_room` methods, called by
+`Client::forget_room`, to properly clears all events.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -58,7 +58,7 @@ use crate::{
     RoomStateFilter, SessionMeta, StateStore,
     deserialized_responses::DisplayName,
     error::{Error, Result},
-    event_cache::store::{EventCacheStoreLock, EventCacheStoreLockState},
+    event_cache::store::EventCacheStoreLock,
     media::store::MediaStoreLock,
     response_processors::{self as processors, Context},
     room::{
@@ -1057,17 +1057,6 @@ impl BaseClient {
     pub async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
         // Forget the room in the state store.
         self.state_store.forget_room(room_id).await?;
-
-        // Remove the room in the event cache store too.
-        match self.event_cache_store().lock().await? {
-            // If the lock is clear, we can do the operation as expected.
-            // If the lock is dirty, we can ignore to refresh the state, we just need to remove a
-            // room. Also, we must not mark the lock as non-dirty because other operations may be
-            // critical and may need to refresh the `EventCache`' state.
-            EventCacheStoreLockState::Clean(guard) | EventCacheStoreLockState::Dirty(guard) => {
-                guard.remove_room(room_id).await?
-            }
-        }
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1310,7 +1310,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         );
 
         // Clear the chunks.
-        self.clear_all_events().await.unwrap();
+        self.clear_all_events(None).await.unwrap();
 
         // Both rooms now have no linked chunk.
         assert!(
@@ -1368,7 +1368,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .unwrap();
 
         // Try to remove content from r0.
-        self.remove_room(r0).await.unwrap();
+        self.clear_all_events(Some(r0)).await.unwrap();
 
         // Check that r0 doesn't have a linked chunk anymore.
         let r0_linked_chunk = self.load_all_chunks(linked_chunk_id0).await.unwrap();
@@ -1527,7 +1527,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         );
 
         // Clearing the rooms also clears the event's storage.
-        self.clear_all_events().await.expect("failed to clear all rooms chunks");
+        self.clear_all_events(None).await.expect("failed to clear all rooms chunks");
         assert!(
             self.find_event(room_id, event_comte.event_id().unwrap())
                 .await

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -191,11 +191,11 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test that loading a linked chunk's metadata works as intended.
     async fn test_load_all_chunks_metadata(&self);
 
-    /// Test that clear all the rooms' linked chunks works.
+    /// Test that clearing all the rooms' events and linked chunks work.
     async fn test_clear_all_events(&self);
 
-    /// Test that removing a room from storage empties all associated data.
-    async fn test_remove_room(&self);
+    /// Test that clearing a specific room events and linked chunks works.
+    async fn test_clear_all_events_for_specific_room(&self);
 
     /// Test that filtering duplicated events works as expected.
     async fn test_filter_duplicated_events(&self);
@@ -1247,136 +1247,177 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     }
 
     async fn test_clear_all_events(&self) {
-        let r0 = room_id!("!r0:matrix.org");
-        let linked_chunk_id0 = LinkedChunkId::Room(r0);
-        let r1 = room_id!("!r1:matrix.org");
-        let linked_chunk_id1 = LinkedChunkId::Room(r1);
+        let linked_chunk_ids = [
+            LinkedChunkId::Room(room_id!("!r0")),
+            LinkedChunkId::Thread(room_id!("!r1"), event_id!("$r1_thread_root0")),
+            LinkedChunkId::PinnedEvents(room_id!("!r2")),
+            // `LinkedChunkId::EventFocused` are not persisted in the database, no need to test it.
+        ];
 
-        // Add updates for the first room.
-        self.handle_linked_chunk_updates(
-            linked_chunk_id0,
-            vec![
-                // new chunk
-                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
-                // new items on 0
-                Update::PushItems {
-                    at: Position::new(CId::new(0), 0),
-                    items: vec![make_test_event(r0, "hello"), make_test_event(r0, "world")],
-                },
-            ],
-        )
-        .await
-        .unwrap();
+        // Create data for each `LinkedChunkId`.
+        for linked_chunk_id in linked_chunk_ids {
+            let room_id = linked_chunk_id.room_id();
 
-        // Add updates for the second room.
-        self.handle_linked_chunk_updates(
-            linked_chunk_id1,
-            vec![
-                // Empty items chunk.
-                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
-                // a gap chunk
-                Update::NewGapChunk {
-                    previous: Some(CId::new(0)),
-                    new: CId::new(1),
-                    next: None,
-                    gap: Gap { token: "bleu d'auvergne".to_owned() },
-                },
-                // another items chunk
-                Update::NewItemsChunk { previous: Some(CId::new(1)), new: CId::new(2), next: None },
-                // new items on 0
-                Update::PushItems {
-                    at: Position::new(CId::new(2), 0),
-                    items: vec![make_test_event(r1, "yummy")],
-                },
-            ],
-        )
-        .await
-        .unwrap();
+            // Assume the thread has been “remembered” correctly (this is done in
+            // `ThreadEventCacheState::new`).
+            if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
+                self.remember_thread(room_id, thread_id).await.unwrap();
+            }
 
-        // Sanity check: both linked chunks can be reloaded.
-        assert!(
-            lazy_loader::from_all_chunks::<3, _, _>(
-                self.load_all_chunks(linked_chunk_id0).await.unwrap()
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![
+                    // New chunk
+                    Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                    // New items on 0.
+                    Update::PushItems {
+                        at: Position::new(CId::new(0), 0),
+                        items: vec![
+                            make_test_event(room_id, "foo"),
+                            make_test_event(room_id, "bar"),
+                            make_test_event(room_id, "baz"),
+                        ],
+                    },
+                ],
             )
-            .unwrap()
-            .is_some()
-        );
-        assert!(
-            lazy_loader::from_all_chunks::<3, _, _>(
-                self.load_all_chunks(linked_chunk_id1).await.unwrap()
-            )
-            .unwrap()
-            .is_some()
-        );
+            .await
+            .unwrap();
 
-        // Clear the chunks.
+            // Linked chunks all exist!
+            assert!(
+                lazy_loader::from_all_chunks::<3, _, _>(
+                    self.load_all_chunks(linked_chunk_id).await.unwrap()
+                )
+                .unwrap()
+                .is_some()
+            );
+
+            // Events exist!
+            assert_eq!(self.get_room_events(room_id, None, None).await.unwrap().len(), 3);
+        }
+
+        // Clear all events!
         self.clear_all_events(None).await.unwrap();
 
-        // Both rooms now have no linked chunk.
-        assert!(
-            lazy_loader::from_all_chunks::<3, _, _>(
-                self.load_all_chunks(linked_chunk_id0).await.unwrap()
-            )
-            .unwrap()
-            .is_none()
-        );
-        assert!(
-            lazy_loader::from_all_chunks::<3, _, _>(
-                self.load_all_chunks(linked_chunk_id1).await.unwrap()
-            )
-            .unwrap()
-            .is_none()
-        );
+        // Check all data have been removed, forever.
+        for linked_chunk_id in linked_chunk_ids {
+            let room_id = linked_chunk_id.room_id();
+
+            // No more linked chunks!
+            assert!(
+                lazy_loader::from_all_chunks::<3, _, _>(
+                    self.load_all_chunks(linked_chunk_id).await.unwrap()
+                )
+                .unwrap()
+                .is_none()
+            );
+
+            // No more events!
+            assert!(self.get_room_events(room_id, None, None).await.unwrap().is_empty());
+        }
     }
 
-    async fn test_remove_room(&self) {
-        let r0 = room_id!("!r0:matrix.org");
-        let linked_chunk_id0 = LinkedChunkId::Room(r0);
-        let r1 = room_id!("!r1:matrix.org");
-        let linked_chunk_id1 = LinkedChunkId::Room(r1);
+    async fn test_clear_all_events_for_specific_room(&self) {
+        let linked_chunk_ids_for_room_0 = [
+            LinkedChunkId::Room(room_id!("!r0")),
+            LinkedChunkId::Thread(room_id!("!r0"), event_id!("$r0_thread_root")),
+            LinkedChunkId::PinnedEvents(room_id!("!r0")),
+        ];
+        let linked_chunk_ids_for_room_1 = [
+            LinkedChunkId::Room(room_id!("!r1")),
+            LinkedChunkId::Thread(room_id!("!r1"), event_id!("$r1_thread_root")),
+            LinkedChunkId::PinnedEvents(room_id!("!r1")),
+        ];
+        let linked_chunk_ids_for_room_2 = [
+            LinkedChunkId::Room(room_id!("!r2")),
+            LinkedChunkId::Thread(room_id!("!r2"), event_id!("$r2_thread_root")),
+            LinkedChunkId::PinnedEvents(room_id!("!r2")),
+        ];
 
-        // Add updates to the first room.
-        self.handle_linked_chunk_updates(
-            linked_chunk_id0,
-            vec![
-                // new chunk
-                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
-                // new items on 0
-                Update::PushItems {
-                    at: Position::new(CId::new(0), 0),
-                    items: vec![make_test_event(r0, "hello"), make_test_event(r0, "world")],
-                },
-            ],
-        )
-        .await
-        .unwrap();
+        // Create data for each `LinkedChunkId`.
+        for linked_chunk_id in linked_chunk_ids_for_room_0
+            .iter()
+            .chain(&linked_chunk_ids_for_room_1)
+            .chain(&linked_chunk_ids_for_room_2)
+        {
+            let room_id = linked_chunk_id.room_id();
 
-        // Add updates to the second room.
-        self.handle_linked_chunk_updates(
-            linked_chunk_id1,
-            vec![
-                // new chunk
-                Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
-                // new items on 0
-                Update::PushItems {
-                    at: Position::new(CId::new(0), 0),
-                    items: vec![make_test_event(r0, "yummy")],
-                },
-            ],
-        )
-        .await
-        .unwrap();
+            // Assume the thread has been “remembered” correctly (this is done in
+            // `ThreadEventCacheState::new`).
+            if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
+                self.remember_thread(room_id, thread_id).await.unwrap();
+            }
 
-        // Try to remove content from r0.
-        self.clear_all_events(Some(r0)).await.unwrap();
+            self.handle_linked_chunk_updates(
+                *linked_chunk_id,
+                vec![
+                    // New chunk
+                    Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                    // New items on 0.
+                    Update::PushItems {
+                        at: Position::new(CId::new(0), 0),
+                        items: vec![
+                            make_test_event(room_id, "foo"),
+                            make_test_event(room_id, "bar"),
+                            make_test_event(room_id, "baz"),
+                        ],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
 
-        // Check that r0 doesn't have a linked chunk anymore.
-        let r0_linked_chunk = self.load_all_chunks(linked_chunk_id0).await.unwrap();
-        assert!(r0_linked_chunk.is_empty());
+            // Linked chunks all exist!
+            assert!(
+                lazy_loader::from_all_chunks::<3, _, _>(
+                    self.load_all_chunks(*linked_chunk_id).await.unwrap()
+                )
+                .unwrap()
+                .is_some()
+            );
 
-        // Check that r1 is unaffected.
-        let r1_linked_chunk = self.load_all_chunks(linked_chunk_id1).await.unwrap();
-        assert!(!r1_linked_chunk.is_empty());
+            // Events exist!
+            assert_eq!(self.get_room_events(room_id, None, None).await.unwrap().len(), 3);
+        }
+
+        // Clear all events for room 1 **ONLY**!
+        self.clear_all_events(Some(linked_chunk_ids_for_room_1[0].room_id())).await.unwrap();
+
+        // Check all data have been removed for room 1 **ONLY**, forever.
+        for linked_chunk_id in linked_chunk_ids_for_room_1 {
+            let room_id = linked_chunk_id.room_id();
+
+            // No more linked chunks!
+            assert!(
+                lazy_loader::from_all_chunks::<3, _, _>(
+                    self.load_all_chunks(linked_chunk_id).await.unwrap()
+                )
+                .unwrap()
+                .is_none()
+            );
+
+            // No more events!
+            assert!(self.get_room_events(room_id, None, None).await.unwrap().is_empty());
+        }
+
+        // Check all the other data are untouched.
+        for linked_chunk_id in
+            linked_chunk_ids_for_room_0.iter().chain(&linked_chunk_ids_for_room_2)
+        {
+            let room_id = linked_chunk_id.room_id();
+
+            // Linked chunks all exist!
+            assert!(
+                lazy_loader::from_all_chunks::<3, _, _>(
+                    self.load_all_chunks(*linked_chunk_id).await.unwrap()
+                )
+                .unwrap()
+                .is_some()
+            );
+
+            // Events exist!
+            assert_eq!(self.get_room_events(room_id, None, None).await.unwrap().len(), 3);
+        }
     }
 
     async fn test_filter_duplicated_events(&self) {
@@ -2424,10 +2465,10 @@ macro_rules! event_cache_store_integration_tests {
             }
 
             #[async_test]
-            async fn test_remove_room() {
+            async fn test_clear_all_events_for_specific_room() {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
-                event_cache_store.test_remove_room().await;
+                event_cache_store.test_clear_all_events_for_specific_room().await;
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1286,7 +1286,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
                 // new items on 0
                 Update::PushItems {
                     at: Position::new(CId::new(2), 0),
-                    items: vec![make_test_event(r0, "yummy")],
+                    items: vec![make_test_event(r1, "yummy")],
                 },
             ],
         )

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -191,6 +191,9 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test that loading a linked chunk's metadata works as intended.
     async fn test_load_all_chunks_metadata(&self);
 
+    /// Test that remembering a thread acts as expected.
+    async fn test_remember_thread(&self);
+
     /// Test that clearing all the rooms' events and linked chunks work.
     async fn test_clear_all_events(&self);
 
@@ -1244,6 +1247,16 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             assert_eq!(events.len(), 1);
             check_test_event(&events[0], "beaufort is the best");
         });
+    }
+
+    async fn test_remember_thread(&self) {
+        let room_id = room_id!("!r0");
+        let thread_id = event_id!("$t0");
+
+        assert!(self.remember_thread(room_id, thread_id).await.is_ok());
+
+        // Remember the same thread does return successfully.
+        assert!(self.remember_thread(room_id, thread_id).await.is_ok());
     }
 
     async fn test_clear_all_events(&self) {
@@ -2455,6 +2468,13 @@ macro_rules! event_cache_store_integration_tests {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_load_all_chunks_metadata().await;
+            }
+
+            #[async_test]
+            async fn test_remember_thread() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_remember_thread().await;
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -179,8 +179,15 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
-    async fn clear_all_events(&self) -> Result<(), Self::Error> {
-        self.inner.write().unwrap().events.clear();
+    async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {
+        match room_id {
+            Some(room_id) => {
+                self.inner.write().unwrap().events.clear_room(room_id);
+            }
+            None => {
+                self.inner.write().unwrap().events.clear();
+            }
+        }
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -28,7 +28,7 @@ use matrix_sdk_common::{
         RawChunk, Update, relational::RelationalLinkedChunk,
     },
 };
-use ruma::{EventId, OwnedEventId, RoomId, events::relation::RelationType};
+use ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId, events::relation::RelationType};
 use tracing::error;
 
 use super::{EventCacheStore, EventCacheStoreError, Result, extract_event_relation};
@@ -50,8 +50,14 @@ pub struct MemoryStore {
 
 #[derive(Debug)]
 struct MemoryStoreInner {
+    /// Leases for the cross-process lock.
     leases: HashMap<String, Lease>,
+
+    /// All events organised in a `LinkedChunk`.
     events: RelationalLinkedChunk<OwnedEventId, Event, Gap>,
+
+    /// List of all threads.
+    threads: Vec<(OwnedRoomId, OwnedEventId)>,
 }
 
 impl Default for MemoryStore {
@@ -60,6 +66,7 @@ impl Default for MemoryStore {
             inner: Arc::new(StdRwLock::new(MemoryStoreInner {
                 leases: Default::default(),
                 events: RelationalLinkedChunk::new(),
+                threads: Vec::new(),
             })),
         }
     }
@@ -155,8 +162,26 @@ impl EventCacheStore for MemoryStore {
             .map_err(|err| EventCacheStoreError::InvalidData { details: err })
     }
 
+    async fn remember_thread(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        let mut inner = self.inner.write().unwrap();
+        let threads = &mut inner.threads;
+
+        let pair = (room_id.to_owned(), thread_id.to_owned());
+
+        if !threads.contains(&pair) {
+            threads.push(pair);
+        }
+
+        Ok(())
+    }
+
     async fn clear_all_events(&self) -> Result<(), Self::Error> {
         self.inner.write().unwrap().events.clear();
+
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -58,13 +58,6 @@ pub trait EventCacheStore: AsyncTraitDeps {
         updates: Vec<Update<Event, Gap>>,
     ) -> Result<(), Self::Error>;
 
-    /// Remove all data tied to a given room from the cache.
-    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
-        // Right now, this means removing all the linked chunk. If implementations
-        // override this behavior, they should *also* include this code.
-        self.handle_linked_chunk_updates(LinkedChunkId::Room(room_id), vec![Update::Clear]).await
-    }
-
     /// Return all the raw components of a linked chunk, so the caller may
     /// reconstruct the linked chunk later.
     #[doc(hidden)]
@@ -115,7 +108,8 @@ pub trait EventCacheStore: AsyncTraitDeps {
         thread_id: &EventId,
     ) -> Result<(), Self::Error>;
 
-    /// Clear persisted events for all the rooms.
+    /// Clear persisted events for all the rooms if `room_id` is `None`, or a
+    /// single room otherwise.
     ///
     /// This will empty and remove all the linked chunks stored previously,
     /// using the above [`Self::handle_linked_chunk_updates`] methods. It
@@ -124,7 +118,7 @@ pub trait EventCacheStore: AsyncTraitDeps {
     /// ⚠ This is meant only for super specific use cases, where there shouldn't
     /// be any live in-memory linked chunks. In general, prefer using
     /// `EventCache::clear_all_rooms()` from the common SDK crate.
-    async fn clear_all_events(&self) -> Result<(), Self::Error>;
+    async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error>;
 
     /// Given a set of event IDs, return the duplicated events along with their
     /// position if there are any.
@@ -283,8 +277,8 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
         self.0.remember_thread(room_id, thread_id).await.map_err(Into::into)
     }
 
-    async fn clear_all_events(&self) -> Result<(), Self::Error> {
-        self.0.clear_all_events().await.map_err(Into::into)
+    async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {
+        self.0.clear_all_events(room_id).await.map_err(Into::into)
     }
 
     async fn filter_duplicated_events(

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -102,6 +102,19 @@ pub trait EventCacheStore: AsyncTraitDeps {
         before_chunk_identifier: ChunkIdentifier,
     ) -> Result<Option<RawChunk<Event, Gap>>, Self::Error>;
 
+    /// Register a new thread.
+    ///
+    /// It does nothing regarding events or linked chunks: it simply remembers
+    /// that a thread has been created. This is important if one wants to list
+    /// all threads, or remove specific events or linked chunks.
+    ///
+    /// If the thread already exists, it returns successfully.
+    async fn remember_thread(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error>;
+
     /// Clear persisted events for all the rooms.
     ///
     /// This will empty and remove all the linked chunks stored previously,
@@ -260,6 +273,14 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
             .load_previous_chunk(linked_chunk_id, before_chunk_identifier)
             .await
             .map_err(Into::into)
+    }
+
+    async fn remember_thread(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        self.0.remember_thread(room_id, thread_id).await.map_err(Into::into)
     }
 
     async fn clear_all_events(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-common/src/linked_chunk/identifiers.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/identifiers.rs
@@ -59,6 +59,15 @@ impl LinkedChunkId<'_> {
         }
     }
 
+    pub fn room_id(&self) -> &RoomId {
+        match self {
+            Self::Room(room_id)
+            | Self::Thread(room_id, ..)
+            | Self::PinnedEvents(room_id, ..)
+            | Self::EventFocused(room_id, ..) => room_id,
+        }
+    }
+
     pub fn to_owned(&self) -> OwnedLinkedChunkId {
         match self {
             LinkedChunkId::Room(room_id) => OwnedLinkedChunkId::Room((*room_id).to_owned()),

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -68,7 +68,7 @@ enum Either<Item, Gap> {
 /// This type is also designed to receive [`Update`]. Applying `Update`s
 /// directly on a [`LinkedChunk`] is not ideal and particularly not trivial as
 /// the `Update`s do _not_ match the internal data layout of the `LinkedChunk`,
-/// they have been designed for storages, like a relational database for
+/// they have been designed for databases, like a relational database for
 /// example.
 ///
 /// This type is not as performant as [`LinkedChunk`] (in terms of memory

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -129,6 +129,15 @@ where
         Self { chunks: Vec::new(), items_chunks: Vec::new(), items: HashMap::new() }
     }
 
+    /// Remove all the chunks and items for a particular room for this
+    /// relational linked chunk.
+    pub fn clear_room(&mut self, room_id: &RoomId) {
+        self.chunks.retain(|ChunkRow { linked_chunk_id, .. }| linked_chunk_id.room_id() != room_id);
+        self.items_chunks
+            .retain(|ItemRow { linked_chunk_id, .. }| linked_chunk_id.room_id() != room_id);
+        self.items.retain(|key, _| key.room_id() != room_id);
+    }
+
     /// Removes all the chunks and items from this relational linked chunk.
     pub fn clear(&mut self) {
         self.chunks.clear();

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -292,9 +292,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use gloo_utils::format::JsValueSerdeExt;
-    use indexed_db_futures::{
-        database::VersionChangeEvent, prelude::*, transaction::TransactionMode,
-    };
+    use indexed_db_futures::{database::VersionChangeEvent, transaction::TransactionMode};
     use matrix_sdk_common::{
         deserialized_responses::WithheldCode, js_tracing::make_tracing_subscriber,
     };

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v4};
+    use super::{Version, v5};
 
-    pub const VERSION: Version = Version::V4;
-    pub use v4::keys;
+    pub const VERSION: Version = Version::V5;
+    pub use v5::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -60,6 +60,8 @@ pub enum Version {
     V3 = 3,
     /// Version 4 of the database, for details see [`v4`].
     V4 = 4,
+    /// Version 5 of the database, for details see [`v5`].
+    V5 = 5,
 }
 
 impl Version {
@@ -70,7 +72,8 @@ impl Version {
             Self::V1 => v1::upgrade(transaction).map(Some),
             Self::V2 => v2::upgrade(transaction).map(Some),
             Self::V3 => v3::upgrade(transaction).map(Some),
-            Self::V4 => Ok(None),
+            Self::V4 => v4::upgrade(transaction).map(Some),
+            Self::V5 => Ok(None),
         }
     }
 }
@@ -89,6 +92,7 @@ impl TryFrom<u32> for Version {
             2 => Ok(Version::V2),
             3 => Ok(Version::V3),
             4 => Ok(Version::V4),
+            5 => Ok(Version::V5),
             v => Err(UnknownVersionError(v)),
         }
     }
@@ -329,6 +333,49 @@ mod v4 {
 
         let events = transaction.object_store(keys::EVENTS)?;
         events.clear()?;
+
+        Ok(())
+    }
+
+    /// Upgrade database from `v4` to `v5`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v5::empty_event_cache(transaction)?;
+        v5::create_threads_object_store(transaction.db())?;
+        Ok(Version::V5)
+    }
+}
+
+pub mod v5 {
+    use indexed_db_futures::Build;
+
+    pub mod keys {
+        // Re-use all the same keys from `v4`.
+        pub use super::super::v4::keys::*;
+
+        // Add new keys.
+        pub const THREADS: &str = "threads";
+        pub const THREADS_KEY_PATH: &str = "id";
+    }
+    use super::*;
+
+    pub fn empty_event_cache(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let linked_chunks = transaction.object_store(keys::LINKED_CHUNKS)?;
+        linked_chunks.clear()?;
+
+        let gaps = transaction.object_store(keys::GAPS)?;
+        gaps.clear()?;
+
+        let events = transaction.object_store(keys::EVENTS)?;
+        events.clear()?;
+
+        Ok(())
+    }
+
+    pub fn create_threads_object_store(db: &Database) -> Result<(), Error> {
+        let _ = db
+            .create_object_store(keys::THREADS)
+            .with_key_path(keys::THREADS_KEY_PATH.into())
+            .build()?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -433,17 +433,56 @@ impl EventCacheStore for IndexeddbEventCacheStore {
     }
 
     #[instrument(skip(self))]
-    async fn clear_all_events(&self) -> Result<(), IndexeddbEventCacheStoreError> {
+    async fn clear_all_events(
+        &self,
+        room_id: Option<&RoomId>,
+    ) -> Result<(), IndexeddbEventCacheStoreError> {
         let _timer = timer!("method");
 
         let transaction = self.transaction(
-            &[keys::LINKED_CHUNKS, keys::EVENTS, keys::GAPS],
+            &[keys::LINKED_CHUNKS, keys::EVENTS, keys::GAPS, keys::THREADS],
             IdbTransactionMode::Readwrite,
         )?;
-        transaction.clear::<types::Chunk>().await?;
-        transaction.clear::<types::Event>().await?;
-        transaction.clear::<types::Gap>().await?;
-        transaction.commit().await?;
+
+        match room_id {
+            // Clear all events.
+            None => {
+                transaction.clear::<types::Chunk>().await?;
+                transaction.clear::<types::Event>().await?;
+                transaction.clear::<types::Gap>().await?;
+                transaction.commit().await?;
+            }
+
+            // Clear events for specific room.
+            Some(room_id) => {
+                // Delete linked chunks for the room and pinned-events caches.
+                {
+                    for linked_chunk_id in
+                        [LinkedChunkId::Room(room_id), LinkedChunkId::PinnedEvents(room_id)]
+                    {
+                        // Remove all the items, gaps and events about the current `LinkedChunkId`.
+                        transaction.delete_chunks_by_linked_chunk_id(linked_chunk_id).await?;
+                        transaction.delete_gaps_by_linked_chunk_id(linked_chunk_id).await?;
+                        transaction.delete_events_by_linked_chunk_id(linked_chunk_id).await?;
+                    }
+                }
+
+                // Delete linked chunks for the thread caches.
+                {
+                    for thread in transaction.get_threads_by_room_id(room_id).await? {
+                        let linked_chunk_id = thread.linked_chunk();
+
+                        // Remove all the items, gaps and events about the current `LinkedChunkId`.
+                        transaction.delete_chunks_by_linked_chunk_id(linked_chunk_id).await?;
+                        transaction.delete_gaps_by_linked_chunk_id(linked_chunk_id).await?;
+                        transaction.delete_events_by_linked_chunk_id(linked_chunk_id).await?;
+                    }
+                }
+
+                // Is everything alright? Good. We can commit the transaction.
+                transaction.commit().await?;
+            }
+        }
         Ok(())
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     event_cache_store::{
         migrations::current::keys,
         transaction::IndexeddbEventCacheStoreTransaction,
-        types::{ChunkType, InBandEvent, Lease, OutOfBandEvent},
+        types::{ChunkType, InBandEvent, Lease, OutOfBandEvent, Thread},
     },
     serializer::indexed_type::{IndexedTypeSerializer, traits::Indexed},
     transaction::TransactionError,
@@ -413,6 +413,23 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         } else {
             Ok(None)
         }
+    }
+
+    #[instrument(skip(self))]
+    async fn remember_thread(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        let _timer = timer!("method");
+
+        let transaction = self.transaction(&[keys::THREADS], IdbTransactionMode::Readwrite)?;
+        let thread = Thread { room_id: room_id.to_owned(), thread_id: thread_id.to_owned() };
+
+        transaction.put_thread(&thread).await?;
+        transaction.commit().await?;
+
+        Ok(())
     }
 
     #[instrument(skip(self))]

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -723,3 +723,15 @@ impl IndexedKey<Thread> for IndexedThreadIdKey {
         Self(room_id, event_id)
     }
 }
+
+impl IndexedPrefixKeyBounds<Thread, &RoomId> for IndexedThreadIdKey {
+    fn lower_key_with_prefix(room_id: &RoomId, serializer: &SafeEncodeSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id.as_str());
+        Self(room_id, (*INDEXED_KEY_LOWER_STRING).clone())
+    }
+
+    fn upper_key_with_prefix(room_id: &RoomId, serializer: &SafeEncodeSerializer) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id.as_str());
+        Self(room_id, (*INDEXED_KEY_UPPER_STRING).clone())
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -41,7 +41,7 @@ use crate::{
             INDEXED_KEY_LOWER_EVENT_POSITION, INDEXED_KEY_UPPER_CHUNK_IDENTIFIER,
             INDEXED_KEY_UPPER_EVENT_INDEX, INDEXED_KEY_UPPER_EVENT_POSITION,
         },
-        types::{Chunk, Event, Gap, Lease, Position},
+        types::{Chunk, Event, Gap, Lease, Position, Thread},
     },
     serializer::{
         indexed_type::{
@@ -95,6 +95,9 @@ pub type IndexedEventContent = MaybeEncrypted;
 /// A (possibly) encrypted representation of a [`Gap`]
 pub type IndexedGapContent = MaybeEncrypted;
 
+/// A (possibly) encrypted representation of a [`Thread`]
+pub type IndexedThreadContent = MaybeEncrypted;
+
 /// Represents the [`LEASES`][1] object store.
 ///
 /// [1]: crate::event_cache_store::migrations::v1::create_lease_object_store
@@ -136,7 +139,7 @@ impl Indexed for Lease {
 /// [`Lease::key`]. This value may or may not be hashed depending on the
 /// provided [`IndexeddbSerializer`].
 ///
-/// [1]: crate::event_cache_store::migrations::v1::create_linked_chunks_object_store
+/// [1]: crate::event_cache_store::migrations::v1::create_lease_object_store
 pub type IndexedLeaseIdKey = String;
 
 impl IndexedKey<Lease> for IndexedLeaseIdKey {
@@ -657,5 +660,66 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Gap, LinkedChunkId<'a>> for Indexed
         <Self as IndexedPrefixKeyComponentBounds<Chunk, _>>::upper_key_components_with_prefix(
             linked_chunk_id,
         )
+    }
+}
+
+/// Represents the [`THREADS`][1] object store.
+///
+/// [1]: crate::event_cache_store::migrations::v5::create_threads_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedThread {
+    /// The primary key of the object store.
+    pub id: IndexedThreadIdKey,
+    /// The (possibly encrypted) content - i.e., a [`Thread`].
+    pub content: IndexedThreadContent,
+}
+
+impl Indexed for Thread {
+    type IndexedType = IndexedThread;
+
+    const OBJECT_STORE: &'static str = keys::THREADS;
+
+    type Error = CryptoStoreError;
+
+    fn to_indexed(
+        &self,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self::IndexedType, Self::Error> {
+        Ok(IndexedThread {
+            id: <IndexedThreadIdKey as IndexedKey<Thread>>::encode(
+                (&self.room_id, &self.thread_id),
+                serializer,
+            ),
+            content: serializer.maybe_encrypt_value(self)?,
+        })
+    }
+
+    fn from_indexed(
+        indexed: Self::IndexedType,
+        serializer: &SafeEncodeSerializer,
+    ) -> Result<Self, Self::Error> {
+        serializer.maybe_decrypt_value(indexed.content)
+    }
+}
+
+/// The value associated with the [primary key](IndexedThread::id) of the
+/// [`THREADS`][1] object store, which is constructed from the value in
+/// [`Thread::key`]. This value may or may not be hashed depending on the
+/// provided [`IndexeddbSerializer`].
+///
+/// [1]: crate::event_cache_store::migrations::v5::create_threads_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedThreadIdKey(IndexedRoomId, IndexedEventId);
+
+impl IndexedKey<Thread> for IndexedThreadIdKey {
+    type KeyComponents<'a> = (&'a RoomId, &'a EventId);
+
+    fn encode(
+        (room_id, event_id): Self::KeyComponents<'_>,
+        serializer: &SafeEncodeSerializer,
+    ) -> Self {
+        let room_id = serializer.encode_key_as_string(keys::ROOMS, room_id.as_str());
+        let event_id = serializer.encode_key_as_string(keys::EVENTS, event_id);
+        Self(room_id, event_id)
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -28,9 +28,9 @@ use crate::{
         serializer::indexed_types::{
             IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
             IndexedEventPositionKey, IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey,
-            IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey,
+            IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
         },
-        types::{Chunk, ChunkType, Event, Gap, Lease, Position},
+        types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
     serializer::indexed_type::{
         IndexedTypeSerializer,
@@ -528,5 +528,10 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         linked_chunk_id: LinkedChunkId<'_>,
     ) -> Result<(), TransactionError> {
         self.delete_items_by_linked_chunk_id::<Gap, IndexedGapIdKey>(linked_chunk_id).await
+    }
+
+    /// Remember a thread.
+    pub async fn put_thread(&self, thread: &Thread) -> Result<IndexedThread, TransactionError> {
+        self.put_item(thread).await
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -29,6 +29,7 @@ use crate::{
             IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
             IndexedEventPositionKey, IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey,
             IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
+            IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -533,5 +534,18 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// Remember a thread.
     pub async fn put_thread(&self, thread: &Thread) -> Result<IndexedThread, TransactionError> {
         self.put_item(thread).await
+    }
+
+    /// List all threads (remembered with [`Self::put_thread`]) for a particular
+    /// room ID.
+    pub async fn get_threads_by_room_id(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<Thread>, TransactionError> {
+        self.get_items_by_key::<Thread, IndexedThreadIdKey>(IndexedKeyRange::all_with_prefix(
+            room_id,
+            self.serializer().inner(),
+        ))
+        .await
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -20,7 +20,7 @@ use matrix_sdk_base::{
     event_cache::store::extract_event_relation,
     linked_chunk::{ChunkIdentifier, LinkedChunkId, OwnedLinkedChunkId},
 };
-use ruma::{EventId, OwnedEventId, RoomId};
+use ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
 
 /// Representation of a time-based lock on the entire
@@ -231,4 +231,14 @@ pub struct Gap {
     /// "end" field of a `/messages` response.
     #[serde(alias = "prev_token")]
     pub token: String,
+}
+
+/// A representation of a _thread_ for the thread list which can be stored in
+/// IndexedDB.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Thread {
+    /// The room of the thread.
+    pub room_id: OwnedRoomId,
+    /// The root of the thread.
+    pub thread_id: OwnedEventId,
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -242,3 +242,10 @@ pub struct Thread {
     /// The root of the thread.
     pub thread_id: OwnedEventId,
 }
+
+impl Thread {
+    /// Get the [`LinkedChunkId`] associated to this [`Thread`].
+    pub fn linked_chunk(&self) -> LinkedChunkId<'_> {
+        LinkedChunkId::Thread(&self.room_id, &self.thread_id)
+    }
+}

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/016_threads.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/016_threads.sql
@@ -1,0 +1,37 @@
+-- We need a place where all threads are listed so that we can query it to
+-- remove linked chunks or events, or to list all threads basically.
+
+CREATE TABLE "threads" (
+    -- This table offers a mapping between encoded `LinkedChunkId::Thread` and
+    -- encoded `RoomId`.
+    --
+    -- Given a `RoomId`, it can be encoded, and then, thanks to this table,
+    -- the encoded `LinkedChunkId` can be retrieved, which allows to query the
+    -- other tables, like `linked_chunks`. In addition, the `EventId` can be
+    -- retrieved, decoded, and used to built back the `LinkedChunkId`.
+
+    -- The encoded `LinkedChunkId` (which is necessarily a `Thread` variant).
+    --
+    -- This value cannot be decoded.
+    linked_chunk_id BLOB NOT NULL,
+
+    -- The encoded `RoomId` from `LinkedChunkId::room_id()`.
+    --
+    -- This value cannot be decoded.
+    room_id BLOB NOT NULL,
+
+    -- The encoded `EventId` from `LinkedChunkId::Thread(_, event_id)`, so it is
+    -- the thread root.
+    --
+    -- This value can be decoded.
+    event_id BLOB NOT NULL,
+
+    -- The unique values are `linked_chunk_id` and `event_id` (`room_id`
+    -- cannot be unique — imagine two threads for the same room, the room ID is
+    -- repeated twice). Having `event_id` in the primary key is not necessary.
+    -- However, having `room_id` in the primary key is important to provide fast
+    -- query from `room_id` to `linked_chunk_id`, which the primary purpose of
+    -- this table (because a `PRIMARY KEY` will create an index automatically)!
+    PRIMARY KEY (linked_chunk_id, room_id)
+)
+WITHOUT ROWID;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -674,7 +674,6 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         let hashed_linked_chunk_id =
             self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
-        let linked_chunk_id = linked_chunk_id.to_owned();
         let hashed_room_id =
             self.encryption.encode_room_id(keys::EVENTS, linked_chunk_id.room_id());
         let encryption = self.encryption.clone();

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -689,10 +689,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let new = new.index();
                         let next = next.as_ref().map(ChunkIdentifier::index);
 
-                        trace!(
-                            %linked_chunk_id,
-                            "new events chunk (prev={previous:?}, i={new}, next={next:?})",
-                        );
+                        trace!("new events chunk (prev={previous:?}, i={new}, next={next:?})");
 
                         insert_chunk(
                             txn,
@@ -711,10 +708,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let new = new.index();
                         let next = next.as_ref().map(ChunkIdentifier::index);
 
-                        trace!(
-                            %linked_chunk_id,
-                            "new gap chunk (prev={previous:?}, i={new}, next={next:?})",
-                        );
+                        trace!("new gap chunk (prev={previous:?}, i={new}, next={next:?})");
 
                         // Insert the chunk as a gap.
                         insert_chunk(
@@ -739,7 +733,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     Update::RemoveChunk(chunk_identifier) => {
                         let chunk_id = chunk_identifier.index();
 
-                        trace!(%linked_chunk_id, "removing chunk @ {chunk_id}");
+                        trace!("removing chunk @ {chunk_id}");
 
                         // Find chunk to delete.
                         let (previous, next): (Option<usize>, Option<usize>) = txn.query_row(
@@ -771,7 +765,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         let chunk_id = at.chunk_identifier().index();
 
-                        trace!(%linked_chunk_id, "pushing {} items @ {chunk_id}", items.len());
+                        trace!("pushing {} items @ {chunk_id}", items.len());
 
                         let mut chunk_statement = txn.prepare(
                             "INSERT INTO event_chunks(chunk_id, linked_chunk_id, event_id, position) VALUES (?, ?, ?, ?)"
@@ -787,7 +781,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
                         let invalid_event = |event: TimelineEvent| {
                             let Some(event_id) = event.event_id() else {
-                                error!(%linked_chunk_id, "Trying to push an event with no ID");
+                                error!("Trying to push an event with no ID");
                                 return None;
                             };
 
@@ -839,11 +833,11 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let chunk_id = at.chunk_identifier().index();
                         let index = at.index();
 
-                        trace!(%linked_chunk_id, "replacing item @ {chunk_id}:{index}");
+                        trace!("replacing item @ {chunk_id}:{index}");
 
                         // The event ID should be the same, but just in case it changed…
                         let Some(event_id) = event.event_id().map(|event_id| event_id.to_owned()) else {
-                            error!(%linked_chunk_id, "Trying to replace an event with a new one that has no ID");
+                            error!("Trying to replace an event with a new one that has no ID");
                             continue;
                         };
 
@@ -893,7 +887,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let chunk_id = at.chunk_identifier().index();
                         let index = at.index();
 
-                        trace!(%linked_chunk_id, "removing item @ {chunk_id}:{index}");
+                        trace!("removing item @ {chunk_id}:{index}");
 
                         // Remove the entry in the chunk table.
                         txn.execute("DELETE FROM event_chunks WHERE linked_chunk_id = ? AND chunk_id = ? AND position = ?", (&hashed_linked_chunk_id, chunk_id, index))?;
@@ -1021,7 +1015,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         let chunk_id = at.chunk_identifier().index();
                         let index = at.index();
 
-                        trace!(%linked_chunk_id, "truncating items >= {chunk_id}:{index}");
+                        trace!("truncating items >= {chunk_id}:{index}");
 
                         // Remove these entries.
                         txn.execute("DELETE FROM event_chunks WHERE linked_chunk_id = ? AND chunk_id = ? AND position >= ?", (&hashed_linked_chunk_id, chunk_id, index))?;
@@ -1031,7 +1025,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     }
 
                     Update::Clear => {
-                        trace!(%linked_chunk_id, "clearing items");
+                        trace!("clearing items");
 
                         // Remove chunks, and let cascading do its job.
                         txn.execute(

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1387,21 +1387,70 @@ impl EventCacheStore for SqliteEventCacheStore {
     }
 
     #[instrument(skip(self))]
-    async fn clear_all_events(&self) -> Result<(), Self::Error> {
+    async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {
         let _timer = timer!("method");
 
-        self.write()
-            .await?
-            .with_transaction(move |txn| {
-                // Remove all the chunks, and let cascading do its job.
-                txn.execute("DELETE FROM linked_chunks", ())?;
+        match room_id {
+            // Clear all events.
+            None => {
+                self.write()
+                    .await?
+                    .with_transaction(move |txn| {
+                        // Remove all the chunks, and let cascading do its job.
+                        txn.execute("DELETE FROM linked_chunks", ())?;
 
-                // Also clear all the events' contents, and let cascading do its job.
-                txn.execute("DELETE FROM events", ())?;
+                        // Also clear all the events' contents, and let cascading do its job.
+                        txn.execute("DELETE FROM events", ())?;
 
-                Ok(())
-            })
-            .await
+                        Ok(())
+                    })
+                    .await
+            }
+
+            // Clear events for specific room.
+            Some(room_id) => {
+                let encryption = self.encryption.clone();
+                let room_id = room_id.to_owned();
+
+                self.write()
+                    .await?
+                    .with_transaction(move |txn| {
+                        // Delete linked chunks for the room and pinned-events caches.
+                        {
+                            let mut delete =
+                                txn.prepare("DELETE FROM linked_chunks WHERE linked_chunk_id = ?")?;
+
+                            for linked_chunk_id in
+                                [LinkedChunkId::Room(&room_id), LinkedChunkId::PinnedEvents(&room_id)]
+                            {
+                                let linked_chunk_id = encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
+
+                                // Remove all the chunks about the current `LinkedChunkId`, and let cascading
+                                // do its job.
+                                delete.execute((&linked_chunk_id,))?;
+                            }
+                        }
+
+                        let encoded_room_id = encryption.encode_room_id(keys::EVENTS, &room_id);
+
+                        // Delete linked chunks for the thread caches.
+                        {
+                            txn.execute(
+                                "DELETE FROM linked_chunks WHERE linked_chunk_id IN (SELECT linked_chunk_id FROM threads WHERE room_id = ?)",
+                                (&encoded_room_id,),
+                            )?;
+                        }
+
+                        // Also clear all the events' contents.
+                        txn.execute(
+                            "DELETE FROM events WHERE room_id = ?",
+                            (encoded_room_id,),
+                        )?;
+
+                        Ok(())
+                    })
+                    .await
+            }
         }
     }
 

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -124,6 +124,20 @@ impl Encryption {
     fn encode_linked_chunk(&self, table_name: &str, linked_chunk_id: &LinkedChunkId<'_>) -> Key {
         self.encode_key(table_name, linked_chunk_id.storage_key())
     }
+
+    /// Encode a thread ID (which is an [`EventId`]).
+    fn encode_thread_id(&self, thread_id: &EventId) -> Result<Vec<u8>> {
+        self.encode_value(String::from(thread_id.as_str()))
+    }
+
+    /// Decode a thread ID (which is an [`EventId`]).
+    #[cfg(test)]
+    fn decode_thread_id(&self, encoded_thread_id: &[u8]) -> Result<OwnedEventId> {
+        let as_slice = self.decode_value(encoded_thread_id)?;
+        let as_str = str::from_utf8(as_slice.as_ref())?;
+
+        Ok(EventId::parse(as_str)?)
+    }
 }
 
 impl EncryptableStore for Encryption {
@@ -613,6 +627,15 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
                 "../migrations/event_cache_store/015_event_ids_are_encoded.sql"
             ))?;
             txn.set_db_version(15)
+        })
+        .await?;
+    }
+
+    if version < 16 {
+        debug!("Upgrading database to version 16");
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!("../migrations/event_cache_store/016_threads.sql"))?;
+            txn.set_db_version(16)
         })
         .await?;
     }
@@ -1339,6 +1362,30 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
+    async fn remember_thread(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<(), Self::Error> {
+        let hashed_linked_chunk_id = self
+            .encryption
+            .encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Thread(room_id, thread_id));
+        let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
+        let hashed_thread_id = self.encryption.encode_thread_id(thread_id)?;
+
+        self.write()
+            .await?
+            .with_transaction(move |txn| {
+                txn.execute(
+                    "INSERT OR IGNORE INTO threads VALUES (?, ?, ?)",
+                    (hashed_linked_chunk_id, hashed_room_id, hashed_thread_id),
+                )?;
+
+                Ok(())
+            })
+            .await
+    }
+
     #[instrument(skip(self))]
     async fn clear_all_events(&self) -> Result<(), Self::Error> {
         let _timer = timer!("method");
@@ -1350,11 +1397,12 @@ impl EventCacheStore for SqliteEventCacheStore {
                 txn.execute("DELETE FROM linked_chunks", ())?;
 
                 // Also clear all the events' contents, and let cascading do its job.
-                txn.execute("DELETE FROM events", ())
-            })
-            .await?;
+                txn.execute("DELETE FROM events", ())?;
 
-        Ok(())
+                Ok(())
+            })
+            .await
+        }
     }
 
     #[instrument(skip(self, event_ids))]
@@ -1851,6 +1899,7 @@ mod tests {
         linked_chunk::{ChunkIdentifier, LinkedChunkId, Update},
     };
     use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test};
+    use ruma::{OwnedEventId, event_id};
     use tempfile::{TempDir, tempdir};
 
     use super::{SqliteEventCacheStore, keys};
@@ -1874,6 +1923,18 @@ mod tests {
 
     event_cache_store_integration_tests!();
     event_cache_store_integration_tests_time!();
+
+    #[async_test]
+    async fn test_encryption_encode_decode_thread_id_roundtrip() {
+        let store = get_event_cache_store().await.expect("creating cache store failed");
+        let thread_id: OwnedEventId = event_id!("$event").to_owned();
+
+        let encoded_thread_id = store.encryption.encode_thread_id(&thread_id).unwrap();
+        let decoded_thread_id: OwnedEventId =
+            store.encryption.decode_thread_id(&encoded_thread_id).unwrap();
+
+        assert_eq!(thread_id, decoded_thread_id);
+    }
 
     #[async_test]
     async fn test_pool_size() {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -119,6 +119,11 @@ impl Encryption {
     fn encode_room_id(&self, table_name: &str, room_id: &RoomId) -> Key {
         self.encode_key(table_name, room_id)
     }
+
+    /// Encode a [`LinkedChunkId`].
+    fn encode_linked_chunk(&self, table_name: &str, linked_chunk_id: &LinkedChunkId<'_>) -> Key {
+        self.encode_key(table_name, linked_chunk_id.storage_key())
+    }
 }
 
 impl EncryptableStore for Encryption {
@@ -673,7 +678,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let hashed_room_id =
             self.encryption.encode_room_id(keys::EVENTS, linked_chunk_id.room_id());
         let encryption = self.encryption.clone();
@@ -1057,8 +1062,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
-
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let encryption = self.encryption.clone();
 
         let result = self
@@ -1101,7 +1105,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
 
         self.read()
             .await?
@@ -1196,8 +1200,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
-
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let encryption = self.encryption.clone();
 
         self
@@ -1292,8 +1295,7 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
-
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let encryption = self.encryption.clone();
 
         self
@@ -1372,7 +1374,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         // Select all events that exist in the store, i.e. the duplicates.
         let hashed_linked_chunk_id =
-            self.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key());
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let event_ids_and_hashed_event_ids = event_ids
             .into_iter()
             .map(|event_id| {
@@ -1509,9 +1511,8 @@ impl EventCacheStore for SqliteEventCacheStore {
         let _timer = timer!("method");
 
         let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
-        let hashed_linked_chunk_id = self
-            .encryption
-            .encode_key(keys::LINKED_CHUNKS, LinkedChunkId::Room(room_id).storage_key());
+        let hashed_linked_chunk_id =
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Room(room_id));
         let hashed_event_id = self.encryption.encode_event_id(keys::EVENTS, event_id);
 
         let filters = filters.map(ToOwned::to_owned);
@@ -1852,12 +1853,8 @@ mod tests {
     use matrix_sdk_test::{DEFAULT_TEST_ROOM_ID, async_test};
     use tempfile::{TempDir, tempdir};
 
-    use super::SqliteEventCacheStore;
-    use crate::{
-        SqliteStoreConfig,
-        event_cache_store::keys,
-        utils::{EncryptableStore as _, SqliteAsyncConnExt},
-    };
+    use super::{SqliteEventCacheStore, keys};
+    use crate::{SqliteStoreConfig, utils::SqliteAsyncConnExt};
 
     static TMP_DIR: LazyLock<TempDir> = LazyLock::new(|| tempdir().unwrap());
     static NUM: AtomicU32 = AtomicU32::new(0);
@@ -1926,7 +1923,9 @@ mod tests {
         store.clone().into_event_cache_store().test_linked_chunk_remove_item().await;
 
         let room_id = *DEFAULT_TEST_ROOM_ID;
-        let linked_chunk_id = LinkedChunkId::Room(room_id);
+        let hashed_linked_chunk_id = store
+            .encryption
+            .encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Room(room_id));
 
         // Make sure the position have been updated for the remaining events.
         let num_rows: u64 = store
@@ -1936,7 +1935,7 @@ mod tests {
             .with_transaction(move |txn| {
                 txn.query_row(
                     "SELECT COUNT(*) FROM event_chunks WHERE chunk_id = 42 AND linked_chunk_id = ? AND position IN (2, 3, 4)",
-                    (store.encryption.encode_key(keys::LINKED_CHUNKS, linked_chunk_id.storage_key()),),
+                    (hashed_linked_chunk_id,),
                     |row| row.get(0),
                 )
             })

--- a/crates/matrix-sdk/changelog.d/6749.added.md
+++ b/crates/matrix-sdk/changelog.d/6749.added.md
@@ -1,0 +1,7 @@
+The new `EventCache::forget_room` method properly forget a specific room. It is
+different from `EventCache::clear_all_events` where (i) it's for a particular
+room instead of all rooms, (ii) it forgets the room, i.e. it's deleted from the
+Event Cache entirely instead of being cleared only.
+
+If you want to forget the room client-wise, look at `Client::forget_room` (which
+calls `EventCache::forget_room` at the time of writing).

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -114,6 +114,11 @@ impl ThreadEventCacheState {
     ) -> Result<Self> {
         let linked_chunk_id = LinkedChunkId::Thread(&room_id, &thread_id);
 
+        // Register the thread in the list of threads. It does nothing regarding events
+        // or linked chunks: it only remembers the thread exists for the thread list
+        // feature.
+        store_guard.remember_thread(&room_id, &thread_id).await?;
+
         // Load the full linked chunk's metadata, so as to feed the order tracker.
         //
         // If loading the full linked chunk failed, we'll clear the event cache, as it

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -93,6 +93,84 @@ pub struct ThreadEventCacheState {
 }
 
 impl ThreadEventCacheState {
+    /// Create a new state, or reload it from storage if it's been enabled.
+    ///
+    /// Not all events are going to be loaded. Only a portion of them. The
+    /// [`EventLinkedChunk`] relies on a [`LinkedChunk`] to store all
+    /// events. Only the last chunk will be loaded. It means the
+    /// events are loaded from the most recent to the oldest. To
+    /// load more events, see [`ThreadPagination`].
+    ///
+    /// [`LinkedChunk`]: matrix_sdk_common::linked_chunk::LinkedChunk
+    /// [`ThreadPagination`]: super::pagination::ThreadPagination
+    pub async fn new(
+        room_id: OwnedRoomId,
+        thread_id: OwnedEventId,
+        own_user_id: OwnedUserId,
+        room_version_rules: RoomVersionRules,
+        store_guard: EventCacheStoreLockGuard,
+        update_sender: ThreadEventCacheUpdateSender,
+        linked_chunk_update_sender: Sender<RoomEventCacheLinkedChunkUpdate>,
+    ) -> Result<Self> {
+        let linked_chunk_id = LinkedChunkId::Thread(&room_id, &thread_id);
+
+        // Load the full linked chunk's metadata, so as to feed the order tracker.
+        //
+        // If loading the full linked chunk failed, we'll clear the event cache, as it
+        // indicates that at some point, there's some malformed data.
+        let full_linked_chunk_metadata =
+            match load_linked_chunk_metadata(&store_guard, linked_chunk_id).await {
+                Ok(metas) => metas,
+                Err(err) => {
+                    error!("error when loading a linked chunk's metadata from the store: {err}");
+
+                    // Try to clear storage for this thread.
+                    store_guard
+                        .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
+                        .await?;
+
+                    // Restart with an empty linked chunk.
+                    None
+                }
+            };
+
+        let linked_chunk = match store_guard
+            .load_last_chunk(linked_chunk_id)
+            .await
+            .map_err(EventCacheError::from)
+            .and_then(|(last_chunk, chunk_identifier_generator)| {
+                lazy_loader::from_last_chunk(last_chunk, chunk_identifier_generator)
+                    .map_err(EventCacheError::from)
+            }) {
+            Ok(linked_chunk) => linked_chunk,
+            Err(err) => {
+                error!("error when loading a linked chunk's latest chunk from the store: {err}");
+
+                // Try to clear storage for this thread.
+                store_guard
+                    .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
+                    .await?;
+
+                None
+            }
+        };
+
+        Ok(ThreadEventCacheState {
+            room_id,
+            thread_id,
+            own_user_id,
+            room_version_rules,
+            thread_linked_chunk: EventLinkedChunk::with_initial_linked_chunk(
+                linked_chunk,
+                full_linked_chunk_metadata,
+            ),
+            update_sender,
+            linked_chunk_update_sender,
+            waited_for_initial_prev_token: false,
+            subscribers_handle: SubscribersHandle::default(),
+        })
+    }
+
     /// If storage is enabled, unload all the chunks, then reloads only the
     /// last one.
     ///
@@ -180,86 +258,6 @@ impl ThreadEventCacheState {
 
         send_updates_to_store(store, linked_chunk_id, &self.linked_chunk_update_sender, updates)
             .await
-    }
-}
-
-impl ThreadEventCacheState {
-    /// Create a new state, or reload it from storage if it's been enabled.
-    ///
-    /// Not all events are going to be loaded. Only a portion of them. The
-    /// [`EventLinkedChunk`] relies on a [`LinkedChunk`] to store all
-    /// events. Only the last chunk will be loaded. It means the
-    /// events are loaded from the most recent to the oldest. To
-    /// load more events, see [`ThreadPagination`].
-    ///
-    /// [`LinkedChunk`]: matrix_sdk_common::linked_chunk::LinkedChunk
-    /// [`ThreadPagination`]: super::pagination::ThreadPagination
-    pub async fn new(
-        room_id: OwnedRoomId,
-        thread_id: OwnedEventId,
-        own_user_id: OwnedUserId,
-        room_version_rules: RoomVersionRules,
-        store_guard: EventCacheStoreLockGuard,
-        update_sender: ThreadEventCacheUpdateSender,
-        linked_chunk_update_sender: Sender<RoomEventCacheLinkedChunkUpdate>,
-    ) -> Result<Self> {
-        let linked_chunk_id = LinkedChunkId::Thread(&room_id, &thread_id);
-
-        // Load the full linked chunk's metadata, so as to feed the order tracker.
-        //
-        // If loading the full linked chunk failed, we'll clear the event cache, as it
-        // indicates that at some point, there's some malformed data.
-        let full_linked_chunk_metadata =
-            match load_linked_chunk_metadata(&store_guard, linked_chunk_id).await {
-                Ok(metas) => metas,
-                Err(err) => {
-                    error!("error when loading a linked chunk's metadata from the store: {err}");
-
-                    // Try to clear storage for this thread.
-                    store_guard
-                        .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
-                        .await?;
-
-                    // Restart with an empty linked chunk.
-                    None
-                }
-            };
-
-        let linked_chunk = match store_guard
-            .load_last_chunk(linked_chunk_id)
-            .await
-            .map_err(EventCacheError::from)
-            .and_then(|(last_chunk, chunk_identifier_generator)| {
-                lazy_loader::from_last_chunk(last_chunk, chunk_identifier_generator)
-                    .map_err(EventCacheError::from)
-            }) {
-            Ok(linked_chunk) => linked_chunk,
-            Err(err) => {
-                error!("error when loading a linked chunk's latest chunk from the store: {err}");
-
-                // Try to clear storage for this thread.
-                store_guard
-                    .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
-                    .await?;
-
-                None
-            }
-        };
-
-        Ok(ThreadEventCacheState {
-            room_id,
-            thread_id,
-            own_user_id,
-            room_version_rules,
-            thread_linked_chunk: EventLinkedChunk::with_initial_linked_chunk(
-                linked_chunk,
-                full_linked_chunk_metadata,
-            ),
-            update_sender,
-            linked_chunk_update_sender,
-            waited_for_initial_prev_token: false,
-            subscribers_handle: SubscribersHandle::default(),
-        })
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -461,6 +461,13 @@ impl EventCache {
         ))
     }
 
+    /// Forget all caches related to a single room.
+    ///
+    /// This will notify any live observers that the room has been cleared.
+    pub async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
+        self.inner.forget_room(room_id).await
+    }
+
     /// Cleanly clear all the rooms' event caches.
     ///
     /// This will notify any live observers that the room has been cleared.
@@ -621,7 +628,21 @@ impl EventCacheInner {
         self.client.get().ok_or(EventCacheError::ClientDropped)
     }
 
-    /// Clears all the room's data.
+    /// Clear a single room's data.
+    async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
+        // The constraints are very similar to what we do in `clear_all_rooms`. See this
+        // information to understand them.
+
+        let mut caches_for_all_rooms = self.by_room.write().await;
+        self.state.clear_and_reload(&caches_for_all_rooms, Some(room_id)).await?;
+
+        // Finally, we forget all the caches if any exists in memory.
+        caches_for_all_rooms.remove(room_id);
+
+        Ok(())
+    }
+
+    /// Clears all the rooms' data.
     async fn clear_all_rooms(&self) -> Result<()> {
         // Okay, here's where things get delicate.
         //
@@ -649,7 +670,11 @@ impl EventCacheInner {
         // same time, we'll have to take the lock for *all* the live caches and
         // for the states, so as to properly clear the underlying storage.
 
-        self.state.clear_and_reload(self.by_room.write().await).await?;
+        // We acquire an exclusive access to `by_room`.
+        let caches_for_all_rooms = self.by_room.write().await;
+
+        // Then, we can clear and reload the states for all the rooms.
+        self.state.clear_and_reload(&caches_for_all_rooms, None).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1280,8 +1280,16 @@ mod tests {
             self.memory_store.load_previous_chunk(linked_chunk_id, before_chunk_identifier).await
         }
 
-        async fn clear_all_events(&self) -> Result<(), Self::Error> {
-            self.memory_store.clear_all_events().await
+        async fn remember_thread(
+            &self,
+            room_id: &RoomId,
+            thread_id: &EventId,
+        ) -> Result<(), Self::Error> {
+            self.memory_store.remember_thread(room_id, thread_id).await
+        }
+
+        async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {
+            self.memory_store.clear_all_events(room_id).await
         }
 
         async fn filter_duplicated_events(

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -24,7 +24,7 @@ use std::{
 use matrix_sdk_base::event_cache::store::{
     EventCacheStoreLock, EventCacheStoreLockGuard, EventCacheStoreLockState,
 };
-use ruma::{OwnedEventId, OwnedRoomId};
+use ruma::{OwnedEventId, OwnedRoomId, RoomId};
 use tokio::sync::{Mutex, RwLock, RwLockMappedWriteGuard, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{
@@ -207,14 +207,16 @@ impl StateLock {
         })
     }
 
-    /// Clear and reload all states: in-memory and in-store.
+    /// Clear and reload all states —in-memory and in-store— for all rooms if
+    /// `room` is `None`, otherwise for a single room.
     ///
     /// The `caches_for_all_rooms_exclusive_lock_guard` argument ensures an
     /// exclusive lock over all the caches has been acquired. This is required
     /// to ensure safety for this method.
     pub(super) async fn clear_and_reload(
         &self,
-        caches_for_all_rooms_exclusive_lock_guard: RwLockWriteGuard<'_, CachesByRoom>,
+        _caches_for_all_rooms_exclusive_lock_guard: &RwLockWriteGuard<'_, CachesByRoom>,
+        room_id: Option<&RoomId>,
     ) -> Result<()> {
         let state_guard = self.inner.locked_state.write().await;
 
@@ -226,7 +228,7 @@ impl StateLock {
         };
 
         // Clear all the events.
-        guard.store.clear_all_events().await?;
+        guard.store.clear_all_events(room_id).await?;
 
         // At this point, all the in-memory `LinkedChunk`s are desynchronised
         // from the storage. Resynchronise them manually by reloading them.
@@ -237,8 +239,6 @@ impl StateLock {
             // cross-process lock as non-dirty.
             EventCacheStoreLockGuard::clear_dirty(&guard.store);
         }
-
-        drop(caches_for_all_rooms_exclusive_lock_guard);
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3726,7 +3726,9 @@ impl Room {
             RoomState::Left | RoomState::Banned => {}
         }
 
-        let request = forget_room::v3::Request::new(self.inner.room_id().to_owned());
+        let room_id = self.room_id();
+
+        let request = forget_room::v3::Request::new(room_id.to_owned());
         let _response = self.client.send(request).await?;
 
         // If it was a DM, remove the room from the `m.direct` global account data.
@@ -3735,10 +3737,11 @@ impl Room {
         {
             // It is not important whether we managed to remove the room, it will not have
             // any consequences, so just log the error.
-            warn!(room_id = ?self.room_id(), "failed to remove room from m.direct account data: {e}");
+            warn!(?room_id, "failed to remove room from m.direct account data: {e}");
         }
 
-        self.client.base_client().forget_room(self.inner.room_id()).await?;
+        self.client.base_client().forget_room(room_id).await?;
+        self.client.event_cache().forget_room(room_id).await?;
 
         Ok(())
     }

--- a/testing/matrix-sdk-test/src/test_json/sync.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync.rs
@@ -69,7 +69,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -85,7 +85,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -99,7 +99,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "history_visibility": "shared"
                                 },
                                 "event_id": "$15139375515VaJEY:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.history_visibility",
@@ -112,7 +112,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "creator": "@example:localhost"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -127,7 +127,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     ]
                                 },
                                 "event_id": "$15139375516NUgtD:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "localhost",
                                 "type": "m.room.aliases",
@@ -140,7 +140,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "topic": "room topic"
                                 },
                                 "event_id": "$151957878228ssqrJ:localhost",
-                                "origin_server_ts": 151957878000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.topic",
@@ -174,7 +174,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -187,7 +187,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "alias": "#tutorial:localhost"
                                 },
                                 "event_id": "$15139375513VdeRF:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.canonical_alias",
@@ -203,7 +203,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$152034824468gOeNB:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 152034824000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example2:localhost",
                                 "state_key": "@example2:localhost",
                                 "type": "m.room.member",
@@ -228,7 +228,7 @@ pub static SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -331,7 +331,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -347,7 +347,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -361,7 +361,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "history_visibility": "shared"
                                 },
                                 "event_id": "$15139375515VaJEY:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.history_visibility",
@@ -374,7 +374,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "creator": "@example:localhost"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -387,7 +387,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "topic": "room topic"
                                 },
                                 "event_id": "$151957878228ssqrJ:localhost",
-                                "origin_server_ts": 151957878000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.topic",
@@ -421,7 +421,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -437,7 +437,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$152034824468gOeNB:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 152034824000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example2:localhost",
                                 "state_key": "@example2:localhost",
                                 "type": "m.room.member",
@@ -458,7 +458,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                   "displayname": "example"
                                 },
                                 "event_id": "$1585345508297748AIUBh:matrix.org",
-                                "origin_server_ts": 158534550000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -486,7 +486,7 @@ pub static DEFAULT_SYNC_SUMMARY: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -634,7 +634,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -650,7 +650,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -664,7 +664,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "history_visibility": "shared"
                                 },
                                 "event_id": "$15139375515VaJEY:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.history_visibility",
@@ -677,7 +677,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "creator": "@example:localhost"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -692,7 +692,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     ]
                                 },
                                 "event_id": "$15139375516NUgtD:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "localhost",
                                 "type": "m.room.aliases",
@@ -705,7 +705,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "topic": "room topic"
                                 },
                                 "event_id": "$151957878228ssqrJ:localhost",
-                                "origin_server_ts": 151957878000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.topic",
@@ -739,7 +739,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -752,7 +752,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "alias": "#tutorial:localhost"
                                 },
                                 "event_id": "$15139375513VdeRF:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.canonical_alias",
@@ -768,7 +768,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$152034824468gOeNB:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 152034824000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example2:localhost",
                                 "state_key": "@example2:localhost",
                                 "type": "m.room.member",
@@ -789,7 +789,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                   "displayname": "example"
                                 },
                                 "event_id": "$1585345508297748AIUBh:matrix.org",
-                                "origin_server_ts": 158534550000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -817,7 +817,7 @@ pub static LEAVE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -882,7 +882,7 @@ pub static LEAVE_SYNC_EVENT: LazyLock<JsonValue> = LazyLock::new(|| {
                                 "content": {
                                     "membership": "leave"
                                 },
-                                "origin_server_ts": 158957809000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -985,7 +985,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -1001,7 +1001,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -1015,7 +1015,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "history_visibility": "shared"
                                 },
                                 "event_id": "$15139375515VaJEY:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.history_visibility",
@@ -1029,7 +1029,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "type": "m.space"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -1044,7 +1044,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     ]
                                 },
                                 "event_id": "$15139375516NUgtD:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "localhost",
                                 "type": "m.room.aliases",
@@ -1057,7 +1057,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "topic": "room topic"
                                 },
                                 "event_id": "$151957878228ssqrJ:localhost",
-                                "origin_server_ts": 151957878000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.topic",
@@ -1091,7 +1091,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -1104,7 +1104,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "alias": "#tutorial:localhost"
                                 },
                                 "event_id": "$15139375513VdeRF:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.canonical_alias",
@@ -1120,7 +1120,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$152034824468gOeNB:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 152034824000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example2:localhost",
                                 "state_key": "@example2:localhost",
                                 "type": "m.room.member",
@@ -1145,7 +1145,7 @@ pub static JOIN_SPACE_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -1253,7 +1253,7 @@ pub static MIXED_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "alias": "#tutorial:localhost"
                                 },
                                 "event_id": "$15139375513VdeRF:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "",
                                 "type": "m.room.canonical_alias",
@@ -1273,7 +1273,7 @@ pub static MIXED_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -1346,7 +1346,7 @@ pub static MIXED_SYNC: LazyLock<JsonValue> = LazyLock::new(|| {
                                 "content": {
                                     "membership": "leave"
                                 },
-                                "origin_server_ts": 158957809000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@example:localhost",
                                 "state_key": "@example:localhost",
                                 "type": "m.room.member",
@@ -1421,7 +1421,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -1437,7 +1437,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "@admin:localhost",
                                 "type": "m.room.member",
@@ -1454,7 +1454,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140518rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 1518001450000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@mod:localhost",
                                 "state_key": "@mod:localhost",
                                 "type": "m.room.member",
@@ -1467,7 +1467,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "history_visibility": "shared"
                                 },
                                 "event_id": "$15139375515VaJEY:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.history_visibility",
@@ -1480,7 +1480,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "creator": "@example:localhost"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -1493,7 +1493,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "topic": "room topic"
                                 },
                                 "event_id": "$151957878228ssqrJ:localhost",
-                                "origin_server_ts": 151957878000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.topic",
@@ -1528,7 +1528,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -1548,7 +1548,7 @@ pub static SYNC_ADMIN_AND_MOD: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {
@@ -1610,7 +1610,7 @@ pub static CUSTOM_ROOM_POWER_LEVELS: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "join_rule": "public"
                                 },
                                 "event_id": "$15139375514WsgmR:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.join_rules",
@@ -1626,7 +1626,7 @@ pub static CUSTOM_ROOM_POWER_LEVELS: LazyLock<JsonValue> = LazyLock::new(|| {
                                 },
                                 "event_id": "$151800140517rfvjc:localhost",
                                 "membership": "join",
-                                "origin_server_ts": 151800140000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "@admin:localhost",
                                 "type": "m.room.member",
@@ -1640,7 +1640,7 @@ pub static CUSTOM_ROOM_POWER_LEVELS: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "creator": "@example:localhost"
                                 },
                                 "event_id": "$15139375510KUZHi:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.create",
@@ -1669,7 +1669,7 @@ pub static CUSTOM_ROOM_POWER_LEVELS: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "users_default": 0
                                 },
                                 "event_id": "$15139375512JaHAW:localhost",
-                                "origin_server_ts": 151393755000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "state_key": "",
                                 "type": "m.room.power_levels",
@@ -1689,7 +1689,7 @@ pub static CUSTOM_ROOM_POWER_LEVELS: LazyLock<JsonValue> = LazyLock::new(|| {
                                     "msgtype": "m.text"
                                 },
                                 "event_id": "$152037280074GZeOm:localhost",
-                                "origin_server_ts": 152037280000000_u64,
+                                "origin_server_ts": 1784626598,
                                 "sender": "@admin:localhost",
                                 "type": "m.room.message",
                                 "unsigned": {

--- a/xtask/src/log/timer.rs
+++ b/xtask/src/log/timer.rs
@@ -81,8 +81,8 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
                 let duration = duration_as_str;
 
                 // According to
-                // https://github.com/rust-lang/rust/blob/0028f344ce9f64766259577c998a1959ca1f6a0b/library/core/src/time.rs#L1488-L15
-                // 10, there is 4 possible suffixes. Let's get through them.
+                // https://github.com/rust-lang/rust/blob/0028f344ce9f64766259577c998a1959ca1f6a0b/library/core/src/time.rs#L1488-L1510,
+                // there is 4 possible suffixes. Let's get through them.
 
                 let pivot = duration.floor_char_boundary(duration.len().saturating_sub(2));
 


### PR DESCRIPTION
tl;dr: When `BaseClient::forget_room` was called, it was calling `EventCacheStore::remove_room` without clearing the in-memory data of the Event Cache. This is the bug this patch is trying to fix.

Best to review one patch at a time.

---

- Based on https://github.com/matrix-org/matrix-rust-sdk/pull/6739.
- Blocked by https://github.com/matrix-org/matrix-rust-sdk/pull/6752

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
