### PR TITLE
Swift: Allow setting the macOS deployment target

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -190,7 +190,13 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=dev --ios-deployment-target=18.0
+        run: |
+          target/debug/xtask swift build-framework \
+            --target=aarch64-apple-ios \
+            --target=aarch64-apple-darwin \
+            --profile=dev \
+            --ios-deployment-target=18.0 \
+            --macos-deployment-target=12.0
 
   complement-crypto:
     name: "Run Complement Crypto tests"

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -190,13 +190,7 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: |
-          target/debug/xtask swift build-framework \
-            --target=aarch64-apple-ios \
-            --target=aarch64-apple-darwin \
-            --profile=dev \
-            --ios-deployment-target=18.0 \
-            --macos-deployment-target=12.0
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios --profile=dev --ios-deployment-target=18.0
 
   complement-crypto:
     name: "Run Complement Crypto tests"

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -49,6 +49,13 @@ enum SwiftCommand {
         #[clap(long)]
         components_path: Option<Utf8PathBuf>,
 
+        /// The macOS deployment target to use when building the framework.
+        ///
+        /// Defaults to not being set, which implies that the build will use the
+        /// default values provided by the Rust and Xcode toolchains.
+        #[clap(long)]
+        macos_deployment_target: Option<String>,
+
         /// The iOS deployment target to use when building the framework.
         ///
         /// Defaults to not being set, which implies that the build will use the
@@ -84,6 +91,7 @@ impl SwiftArgs {
                 target: targets,
                 tier3_targets,
                 components_path,
+                macos_deployment_target,
                 ios_deployment_target,
                 watchos_deployment_target,
                 sequentially,
@@ -98,6 +106,7 @@ impl SwiftArgs {
                     tier3_targets,
                     components_path,
                     sequentially,
+                    macos_deployment_target.as_deref(),
                     ios_deployment_target.as_deref(),
                     watchos_deployment_target.as_deref(),
                 )
@@ -266,6 +275,7 @@ fn build_xcframework(
     tier3_targets: bool,
     components_path: Option<Utf8PathBuf>,
     sequentially: bool,
+    macos_deployment_target: Option<&str>,
     ios_deployment_target: Option<&str>,
     watchos_deployment_target: Option<&str>,
 ) -> Result<()> {
@@ -301,6 +311,7 @@ fn build_xcframework(
         targets,
         profile,
         sequentially,
+        macos_deployment_target,
         ios_deployment_target,
         watchos_deployment_target,
     )?;
@@ -372,6 +383,7 @@ fn build_targets(
     targets: Vec<&Target>,
     profile: &str,
     sequentially: bool,
+    macos_deployment_target: Option<&str>,
     ios_deployment_target: Option<&str>,
     watchos_deployment_target: Option<&str>,
 ) -> Result<HashMap<Platform, Vec<Utf8PathBuf>>> {
@@ -383,8 +395,10 @@ fn build_targets(
         sh.push_env("CARGO_TARGET_AARCH64_APPLE_IOS_RUSTFLAGS", "-Clinker=/usr/bin/clang");
     let _env_guard2 = sh.push_env("AARCH64_APPLE_IOS_CC", "/usr/bin/clang");
     let _env_guard3 =
-        ios_deployment_target.map(|target| sh.push_env("IPHONEOS_DEPLOYMENT_TARGET", target));
+        macos_deployment_target.map(|target| sh.push_env("MACOSX_DEPLOYMENT_TARGET", target));
     let _env_guard4 =
+        ios_deployment_target.map(|target| sh.push_env("IPHONEOS_DEPLOYMENT_TARGET", target));
+    let _env_guard5 =
         watchos_deployment_target.map(|target| sh.push_env("WATCHOS_DEPLOYMENT_TARGET", target));
 
     if sequentially {


### PR DESCRIPTION
## Summary

Add a `--macos-deployment-target` option to `xtask swift build-framework` and propagate it as `MACOSX_DEPLOYMENT_TARGET` while Cargo builds the Apple XCFramework.

The existing command already supports equivalent iOS and watchOS deployment-target options. Without a macOS option, published archive members inherit the release builder's current macOS version even though the Swift package declares macOS 12+ support.

Fixes #6750.

## Verification

- RED source contract: CLI option, forwarding, and environment propagation were absent.
- `cargo fmt --all -- --check`
- `cargo check -p xtask`
- `cargo run -p xtask -- swift build-framework --help` exposes `--macos-deployment-target <MACOS_DEPLOYMENT_TARGET>`.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo run -p xtask -- swift build-framework --target=aarch64-apple-darwin --release --macos-deployment-target=12.0` compiled the optimized `libmatrix_sdk_ffi.a` and assembled `MatrixSDKFFI.xcframework` successfully.
- The release XCFramework is approximately 262 MB for its arm64 macOS slice. `vtool -show-build` reports `platform=MACOS minos=12.0` for representative Rust and vendored C/assembly members, including `matrix_sdk_ffi`, `entropy_common`, `blake3_neon`, and `sha3_keccak4` objects.
- A macOS 13 SwiftPM consumer linked the generated release XCFramework with zero `built for newer 'macOS' version` warnings and zero oversized `__eh_frame` warnings; its focused SDK test and clean release app packaging passed.
- For release-manifest parity, the local development package's explicitly dynamic library was consumed as the static/default product used by `matrix-rust-components-swift`. The resulting 132 MB arm64 app reports `minos 13.0`, has no Matrix dylib load command, passes deep strict ad-hoc code-sign verification, launches successfully, and was terminated after the smoke test.
- The Apple bindings CI framework step now builds both iOS and arm64 macOS, passing each platform's explicit deployment target to prevent regression.

## Follow-up

The `matrix-rust-components-swift` release caller must pass `--macos-deployment-target=12.0` when building release XCFrameworks. That packaging repository is tracked separately in matrix-org/matrix-rust-components-swift#30.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries