### PR TITLE
sliding_sync: eagerly send verification responses after a sync response

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -612,6 +612,20 @@ impl OlmMachine {
         Ok(requests)
     }
 
+    /// Get *only* the outgoing requests produced by the verification machine
+    /// (e.g. SAS `.key`/`.mac` responses, in-room or to-device).
+    ///
+    /// Unlike [`OlmMachine::outgoing_requests()`], this is a cheap,
+    /// synchronous, in-memory read of just the verification requests, so
+    /// they can be sent eagerly the moment they're produced rather than
+    /// waiting for the next sync iteration to flush them. The responses
+    /// still need to be passed back via [`mark_request_as_sent`].
+    ///
+    /// [`mark_request_as_sent`]: #method.mark_request_as_sent
+    pub fn outgoing_verification_requests(&self) -> Vec<OutgoingRequest> {
+        self.inner.verification_machine.outgoing_messages()
+    }
+
     /// Generate an "out-of-band" key query request for the given set of users.
     ///
     /// This can be useful if we need the results from [`get_identity`] or

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -870,6 +870,51 @@ impl Client {
 
         Ok(())
     }
+
+    /// Eagerly send *only* the outgoing verification requests the crypto
+    /// machine has queued (e.g. SAS `.key`/`.mac` responses), without
+    /// waiting for the next sync iteration to flush them via
+    /// [`Self::send_outgoing_requests`].
+    ///
+    /// Verification responses are produced as a side effect of handling a sync
+    /// response, but — unlike a normal message send, which shares its room key
+    /// inline via `send_to_device` — they are otherwise only drained by the
+    /// sliding-sync loop's periodic `send_outgoing_requests`. On the idle,
+    /// no-rooms encryption connection that loop sits in a full poll timeout
+    /// (~30s), so an in-room SAS between two rust-SDK peers stalls ~30s per
+    /// leg. Sending them here, right after the response that produced them,
+    /// brings verification in line with the eager-send path used for room
+    /// keys, while leaving unrelated crypto requests (key uploads/queries)
+    /// on the sync cadence.
+    ///
+    /// This is a latency optimization layered on top of the existing reliable
+    /// delivery, NOT a replacement for it:
+    /// `OlmMachine::outgoing_verification_requests()` *clones* the queued
+    /// requests (it does not drain them), and a request is only removed
+    /// from the queue by `mark_request_as_sent`, which
+    /// [`Self::send_outgoing_request`] calls *only on a successful send*. So if
+    /// an eager send here fails, the request stays queued and is retried by the
+    /// sliding-sync loop's regular `send_outgoing_requests` on the next
+    /// iteration — the same retry path every crypto request uses. Hence the
+    /// per-request failures are merely logged here, not propagated: the worst
+    /// case is simply falling back to the pre-existing (slower) delivery.
+    pub(crate) async fn send_outgoing_verification_requests(&self) -> Result<()> {
+        // Collect the requests and drop the `OlmMachine` guard before awaiting the
+        // sends.
+        let requests = {
+            let guard = self.olm_machine().await;
+            let Some(machine) = guard.as_ref() else { return Ok(()) };
+            machine.outgoing_verification_requests()
+        };
+
+        for request in requests {
+            if let Err(error) = self.send_outgoing_request(request).await {
+                warn!(?error, "Error while eagerly sending an outgoing verification request");
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(any(feature = "testing", test))]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -642,6 +642,22 @@ impl SlidingSync {
             // It means that other responses can be generated and then handled later.
             drop(position_guard);
 
+            // Eagerly flush any verification responses the crypto machine produced while
+            // handling this response (e.g. an incoming in-room SAS `.key`
+            // auto-produces our `.key`/`.mac`), instead of leaving them for the
+            // next sync iteration's `send_outgoing_requests`. On the
+            // idle, no-rooms encryption connection that next iteration can be a full poll
+            // timeout (~30s) away, which otherwise adds ~30s of latency per SAS
+            // leg between two rust-SDK peers. Mirrors the eager-send path used
+            // for room keys. Best-effort.
+            #[cfg(feature = "e2e-encryption")]
+            if let Err(error) = this.inner.client.send_outgoing_verification_requests().await {
+                warn!(
+                    ?error,
+                    "Error while eagerly sending outgoing verification requests after a sync response"
+                );
+            }
+
             debug!("Done handling response");
 
             Ok(updates)


### PR DESCRIPTION
User verification has always been painfully slow on matrix-rust-sdk - worst case you have to wait 60s for it to complete. It turns out this is because we only send the SAS handshake when /sync times out, which could be 30s.  If you're on a chatty account then this speeds up, but many times i've seen it take forever; this fixes it.

While I spotted this on cross-user verification, I presume it could also impact same-user verification and would finally explain and fix https://github.com/element-hq/element-x-ios/issues/2428.

> In-room (MSC2241) verification messages (SAS .key/.mac) are produced by the OlmMachine as a side effect of handling a sync response, but - unlike a normal message send, which shares its room key inline via send_to_device - they are only drained by the sliding-sync loop's periodic send_outgoing_requests. That runs once per iteration; on Element X's idle, no-rooms "encryption" sliding-sync connection an iteration is a full poll timeout (~30s). So an in-room SAS between two rust-SDK peers stalls ~30s per .key leg (~60s total before emojis render), while it's fast against a js-sdk peer (eager send + classic /sync).
>
> Fix: after handling a sync response, eagerly flush ONLY the verification machine's outgoing requests (new OlmMachine::outgoing_verification_requests() + Client::send_outgoing_verification_requests(), reusing the existing send_outgoing_request routing that sends ToDevice via send_to_device and RoomMessage via the room send helper, and marks them sent). This mirrors the eager-send path used for room keys and leaves unrelated crypto requests (key uploads/queries) on the sync cadence. Best-effort; failures are logged.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
