### PR TITLE
feat(ui): add a room list filter for rooms with unread mentions

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6754.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6754.added.md
@@ -1,0 +1,1 @@
+Add `RoomListEntriesDynamicFilterKind::Mentions`, to filter the room list for rooms with unread mentions.

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -32,8 +32,7 @@ use matrix_sdk_ui::{
         new_filter_deduplicate_versions, new_filter_favourite, new_filter_fuzzy_match_room_name,
         new_filter_identifiers, new_filter_invite, new_filter_joined, new_filter_low_priority,
         new_filter_mentions, new_filter_non_left, new_filter_none,
-        new_filter_normalized_match_room_name, new_filter_not, new_filter_space,
-        new_filter_unread,
+        new_filter_normalized_match_room_name, new_filter_not, new_filter_space, new_filter_unread,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -31,8 +31,9 @@ use matrix_sdk_ui::{
         BoxedFilterFn, RoomCategory, new_filter_all, new_filter_any, new_filter_category,
         new_filter_deduplicate_versions, new_filter_favourite, new_filter_fuzzy_match_room_name,
         new_filter_identifiers, new_filter_invite, new_filter_joined, new_filter_low_priority,
-        new_filter_non_left, new_filter_none, new_filter_normalized_match_room_name,
-        new_filter_not, new_filter_space, new_filter_unread,
+        new_filter_mentions, new_filter_non_left, new_filter_none,
+        new_filter_normalized_match_room_name, new_filter_not, new_filter_space,
+        new_filter_unread,
     },
     unable_to_decrypt_hook::UtdHookManager,
 };
@@ -482,6 +483,7 @@ pub enum RoomListEntriesDynamicFilterKind {
     // support in uniffi https://github.com/mozilla/uniffi-rs/issues/396
     Joined,
     Unread,
+    Mentions,
     Favourite,
     LowPriority,
     NonLowPriority,
@@ -528,6 +530,7 @@ impl From<RoomListEntriesDynamicFilterKind> for BoxedFilterFn {
             Kind::NonLeft => Box::new(new_filter_non_left()),
             Kind::Joined => Box::new(new_filter_joined()),
             Kind::Unread => Box::new(new_filter_unread()),
+            Kind::Mentions => Box::new(new_filter_mentions()),
             Kind::Favourite => Box::new(new_filter_favourite()),
             Kind::LowPriority => Box::new(new_filter_low_priority()),
             Kind::NonLowPriority => Box::new(new_filter_not(Box::new(new_filter_low_priority()))),

--- a/crates/matrix-sdk-ui/changelog.d/6754.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6754.added.md
@@ -1,0 +1,1 @@
+Add `new_filter_mentions` to the room list service filters, to filter for rooms with unread mentions.

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mentions.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mentions.rs
@@ -1,0 +1,88 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_base::read_receipts::RoomReadReceipts;
+
+use super::{super::RoomListItem, Filter};
+
+fn matches<F>(read_receipts: F, room: &RoomListItem) -> bool
+where
+    F: Fn(&RoomListItem) -> RoomReadReceipts,
+{
+    read_receipts(room).num_mentions > 0
+}
+
+/// Create a new filter that will filter out rooms that have no unread mentions
+/// (as computed client-side and exposed via
+/// [`matrix_sdk_base::Room::num_unread_mentions`]).
+pub fn new_filter() -> impl Filter {
+    let read_receipts = |room: &RoomListItem| room.read_receipts();
+
+    move |room_list_entry| -> bool { matches(read_receipts, room_list_entry) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
+    use matrix_sdk_base::read_receipts::RoomReadReceipts;
+    use matrix_sdk_test::async_test;
+    use ruma::room_id;
+
+    use super::{super::new_rooms, *};
+
+    #[async_test]
+    async fn test_has_unread_mentions() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
+
+        let read_receipts = |_: &RoomListItem| RoomReadReceipts {
+            num_unread: 42,
+            num_notifications: 42,
+            num_mentions: 42,
+            ..Default::default()
+        };
+
+        assert!(matches(read_receipts, &room));
+    }
+
+    #[async_test]
+    async fn test_has_unread_notifications_but_no_unread_mentions() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
+
+        let read_receipts = |_: &RoomListItem| RoomReadReceipts {
+            num_unread: 42,
+            num_notifications: 42,
+            num_mentions: 0,
+            ..Default::default()
+        };
+
+        assert!(matches(read_receipts, &room).not());
+    }
+
+    #[async_test]
+    async fn test_has_no_unread_mentions() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
+
+        let read_receipts = |_: &RoomListItem| RoomReadReceipts::default();
+
+        assert!(matches(read_receipts, &room).not());
+    }
+}

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -71,6 +71,7 @@ mod identifiers;
 mod invite;
 mod joined;
 mod low_priority;
+mod mentions;
 mod non_left;
 mod none;
 mod normalized_match_room_name;
@@ -89,6 +90,7 @@ pub use self::{
     invite::new_filter as new_filter_invite,
     joined::new_filter as new_filter_joined,
     low_priority::new_filter as new_filter_low_priority,
+    mentions::new_filter as new_filter_mentions,
     non_left::new_filter as new_filter_non_left,
     none::new_filter as new_filter_none,
     normalized_match_room_name::new_filter as new_filter_normalized_match_room_name,


### PR DESCRIPTION
Add `new_filter_mentions` to the room list service filters, matching rooms whose read receipts report one or more unread mentions, and expose it over FFI as `RoomListEntriesDynamicFilterKind::Mentions`.

This lets clients offer a room list filter surfacing rooms where the user has been mentioned, independently of the unread filter (see element-hq/element-x-ios#3952).

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
