### PR TITLE
Rename `dist` profile to `small-release-stripped`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,21 +212,20 @@ debug = 2
 inherits = "dbg"
 opt-level = 3
 
-[profile.dist]
-# Use release profile as a base
-inherits = "release"
-# Strip the minimal debug info, while still allowing us to have proper backtraces, but it will affect debuggers
-strip = "debuginfo"
-# Use link time optimizations
-lto = true
-# Use binary size optimization, since this is intended for distributed copies of the SDK
-opt-level = "s"
-
 # Profile for the distributed Apple framework. `opt-level = "s"` measured ~33%
 # smaller linked code than `release`.
 [profile.small-release]
 inherits = "release"
 opt-level = "s"
+
+# This is the same as `small-release`, but it also strips debug symbols.
+[profile.small-release-stripped]
+# Use release profile as a base
+inherits = "small-release"
+# Strip the minimal debug info, while still allowing us to have proper backtraces, but it will affect debuggers
+strip = "debuginfo"
+# Use link time optimizations
+lto = true
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
Following the addition of the  `small-release` profile in https://github.com/matrix-org/matrix-rust-sdk/pull/6714, it makes sense to rename `dist` to `small-release-stripped` for consistency since it has the same base options + stripping the debug symbols

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
