### PR TITLE
fix(ui) : handle beacon start with prev_content in latest event

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -181,6 +181,23 @@ impl TimelineItemContent {
         .await;
         match actions.as_slice() {
             [TimelineAction::AddItem { content }] => Some(content.clone()),
+            [
+                TimelineAction::AddItem { content },
+                TimelineAction::HandleAggregation {
+                    kind: HandleAggregationKind::BeaconStop { .. },
+                    ..
+                },
+            ] => {
+                if content.is_live_location_state() {
+                    Some(content.clone())
+                } else {
+                    warn!(
+                        "Unexpected [AddItem, BeaconStop] actions with a non-live-location \
+                         AddItem; ignoring event"
+                    );
+                    None
+                }
+            }
             // Aggregated event: only edits and beacon stop are supported at the moment.
             [
                 TimelineAction::HandleAggregation {
@@ -219,8 +236,6 @@ impl TimelineItemContent {
                 None
             }
             [_, _, ..] => {
-                // Multiple actions can happen e.g. when a beacon_info with prev_content
-                // is processed: it produces both an AddItem and a HandleAggregation.
                 // There is no meaningful single content to extract in that case.
                 warn!("Ignoring event that produced multiple timeline actions");
                 None
@@ -241,6 +256,12 @@ impl TimelineItemContent {
             kind: MsgLikeKind::LiveLocation(state),
             ..
         }) => state)
+    }
+
+    /// Check whether this item's content is a
+    /// [`LiveLocation`][MsgLikeKind::LiveLocation].
+    pub fn is_live_location_state(&self) -> bool {
+        matches!(self, Self::MsgLike(MsgLikeContent { kind: MsgLikeKind::LiveLocation(_), .. }))
     }
 
     /// If `self` is of the [`MsgLike`][Self::MsgLike] variant, return the

--- a/crates/matrix-sdk-ui/src/timeline/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/timeline/latest_event.rs
@@ -184,7 +184,10 @@ mod tests {
     use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
     use ruma::{
         MilliSecondsSinceUnixEpoch, event_id,
-        events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent},
+        events::{
+            AnyMessageLikeEventContent, beacon_info::BeaconInfoEventContent,
+            room::message::RoomMessageEventContent,
+        },
         owned_event_id, room_id, uint, user_id,
     };
 
@@ -412,6 +415,53 @@ mod tests {
                 TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::LiveLocation(state), .. }) => {
                     assert!(!state.is_live(), "stop beacon should not be live");
                     assert_eq!(state.description(), Some("Alice's walk"));
+                }
+            );
+        })
+    }
+
+    #[async_test]
+    async fn test_remote_beacon_start_with_prev_content() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room = server.sync_room(&client, JoinedRoomBuilder::new(room_id!("!r0"))).await;
+        let sender = user_id!("@mnt_io:matrix.org");
+        let event_factory = EventFactory::new();
+
+        let prev_content = BeaconInfoEventContent::new(
+            Some("Alice's previous walk".to_owned()),
+            Duration::from_secs(30),
+            false,
+            None,
+        );
+        let base_value = BaseLatestEventValue::Remote(RemoteLatestEventValue::from_plaintext(
+            event_factory
+                .server_ts(42)
+                .sender(sender)
+                .beacon_info(
+                    Some("Alice's new walk".to_owned()),
+                    Duration::from_secs(60),
+                    true,
+                    None,
+                )
+                .state_key(sender)
+                .event_id(event_id!("$beacon-start-2"))
+                .prev_content(prev_content)
+                .into_raw_sync(),
+        ));
+        let value =
+            LatestEventValue::from_base_latest_event_value(base_value, &room, &client).await;
+
+        assert_matches!(value, LatestEventValue::Remote { timestamp, sender: received_sender, is_own, profile, content } => {
+            assert_eq!(u64::from(timestamp.get()), 42u64);
+            assert_eq!(received_sender, sender);
+            assert!(is_own.not());
+            assert_matches!(profile, TimelineDetails::Unavailable);
+            assert_matches!(
+                content,
+                TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::LiveLocation(state), .. }) => {
+                    assert!(state.is_live(), "restart beacon should be live");
+                    assert_eq!(state.description(), Some("Alice's new walk"));
                 }
             );
         })


### PR DESCRIPTION
<!-- description of the changes in this PR -->
What the title says
- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
