### PR TITLE
fix(sdk): Keep `OrderTracker` in sync when the last chunk is reloaded

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6757.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6757.fixed.md
@@ -1,0 +1,5 @@
+The `OrderTracker` inside the Event Cache no longer gets out of sync, removing a
+panic. It was getting out of sync when the `RoomEventCache` or the
+`ThreadEventCache` was reloaded because the Event Cache cross-process lock was
+dirty. The caches were reloaded but not the `OrderTracker` which needs the
+`LinkedChunk` metadata to be re-initialised.

--- a/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
@@ -565,22 +565,30 @@ impl EventLinkedChunk {
         r
     }
 
-    /// Replace the events with the given last chunk of events and generator.
+    /// Replace all chunks by the last (loaded) one.
     ///
-    /// Happens only during lazy loading.
-    ///
-    /// This clears all the chunks in memory before resetting to the new chunk,
-    /// if provided.
+    /// Since the last chunk has been loaded, it is assumed the metadata of the
+    /// `LinkedChunk` might have changed. That's why
+    /// `full_linked_chunk_metadata` is required if this type has been built
+    /// with [`EventLinkedChunk::with_initial_linked_chunk`].
     #[instrument(err, skip_all, fields(sentry = true))]
-    pub(in super::super) fn replace_with(
+    pub(in super::super) fn shrink_to_last_reloaded_chunk(
         &mut self,
         last_chunk: Option<RawChunk<Event, Gap>>,
         chunk_identifier_generator: ChunkIdentifierGenerator,
+        full_linked_chunk_metadata: Option<Vec<ChunkMetadata>>,
     ) -> Result<(), LazyLoaderError> {
         // Since `replace_with` is used only to unload some chunks, we don't want it to
         // affect the chunk ordering.
         self.inhibit_updates_to_ordering_tracker(move |this| {
-            lazy_loader::replace_with(&mut this.chunks, last_chunk, chunk_identifier_generator)
+            lazy_loader::replace_with(&mut this.chunks, last_chunk, chunk_identifier_generator)?;
+
+            this.order_tracker = this
+                .chunks
+                .order_tracker(full_linked_chunk_metadata)
+                .expect("`LinkedChunk` must have been built with `new_with_update_history`");
+
+            Ok(())
         })
     }
 

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -336,7 +336,12 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
 
         {
             let mut current_chunk_identifier = last_chunk.identifier;
-            self.state.chunk.replace_with(Some(last_chunk), chunk_id_gen)?;
+            self.state.chunk.shrink_to_last_reloaded_chunk(
+                Some(last_chunk),
+                chunk_id_gen,
+                // This cache doesn't use the `OrderTracker`.
+                None,
+            )?;
 
             // Reload the entire chunk.
             while let Some(previous_chunk) =

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -325,9 +325,26 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     /// pending diff updates with the result of this function.
     ///
     /// Otherwise, returns `None`.
+    #[instrument(skip(self))]
     async fn shrink_to_last_chunk(&mut self) -> Result<(), EventCacheError> {
         // Attempt to load the last chunk.
         let linked_chunk_id = LinkedChunkId::Room(&self.state.room_id);
+
+        let full_linked_chunk_metadata =
+            match load_linked_chunk_metadata(&self.store, linked_chunk_id).await {
+                Ok(metas) => metas,
+                Err(err) => {
+                    error!("error when reloading a linked chunk's metadata from the store: {err}");
+
+                    // Try to clear storage for this room.
+                    self.store
+                        .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
+                        .await?;
+
+                    // Restart with an empty linked chunk.
+                    None
+                }
+            };
 
         let (last_chunk, chunk_identifier_generator) =
             match self.store.load_last_chunk(linked_chunk_id).await {
@@ -351,9 +368,11 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
 
         // Remove all the chunks from the linked chunks, except for the last one, and
         // updates the chunk identifier generator.
-        if let Err(err) =
-            self.state.room_linked_chunk.replace_with(last_chunk, chunk_identifier_generator)
-        {
+        if let Err(err) = self.state.room_linked_chunk.shrink_to_last_reloaded_chunk(
+            last_chunk,
+            chunk_identifier_generator,
+            full_linked_chunk_metadata,
+        ) {
             error!("error when replacing the linked chunk: {err}");
 
             self.state.room_linked_chunk.reset();

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -312,7 +312,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             ReloadPreprocessing::None => {}
         }
 
-        self.shrink_to_last_chunk().await?;
+        self.shrink_to_last_reloaded_chunk().await?;
 
         Ok(self.room_linked_chunk_mut().updates_as_vector_diffs())
     }
@@ -326,7 +326,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     ///
     /// Otherwise, returns `None`.
     #[instrument(skip(self))]
-    async fn shrink_to_last_chunk(&mut self) -> Result<(), EventCacheError> {
+    async fn shrink_to_last_reloaded_chunk(&mut self) -> Result<(), EventCacheError> {
         // Attempt to load the last chunk.
         let linked_chunk_id = LinkedChunkId::Room(&self.state.room_id);
 
@@ -422,7 +422,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             // subscriber could be created, creating a race, except that this method takes a
             // `&mut`, ensuring an exclusive access to the state, ensuring no other
             // subscribers can be created.
-            self.shrink_to_last_chunk().await?;
+            self.shrink_to_last_reloaded_chunk().await?;
 
             Ok(Some(self.state.room_linked_chunk.updates_as_vector_diffs()))
         } else {
@@ -598,7 +598,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             //
             // We must do this *after* persisting these events to storage (in
             // `post_process_new_events`).
-            self.shrink_to_last_chunk().await?;
+            self.shrink_to_last_reloaded_chunk().await?;
         }
 
         let timeline_event_diffs = self.room_linked_chunk.updates_as_vector_diffs();

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -101,9 +101,24 @@ impl ThreadEventCacheState {
     /// pending diff updates with the result of this function.
     ///
     /// Otherwise, returns `None`.
+    #[instrument(skip(self, store))]
     async fn shrink_to_last_chunk(&mut self, store: &EventCacheStoreLockGuard) -> Result<()> {
         // Attempt to load the last chunk.
         let linked_chunk_id = LinkedChunkId::Thread(&self.room_id, &self.thread_id);
+
+        let full_linked_chunk_metadata =
+            match load_linked_chunk_metadata(store, linked_chunk_id).await {
+                Ok(metas) => metas,
+                Err(err) => {
+                    error!("error when reloading a linked chunk's metadata from the store: {err}");
+
+                    // Try to clear storage for this thread.
+                    store.handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear]).await?;
+
+                    // Restart with an empty linked chunk.
+                    None
+                }
+            };
 
         let (last_chunk, chunk_identifier_generator) =
             match store.load_last_chunk(linked_chunk_id).await {
@@ -113,7 +128,7 @@ impl ThreadEventCacheState {
                     // If loading the last chunk failed, clear the entire linked chunk.
                     error!("error when reloading a linked chunk from memory: {err}");
 
-                    // Clear storage for this room.
+                    // Clear storage for this thread.
                     store.handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear]).await?;
 
                     // Restart with an empty linked chunk.
@@ -125,9 +140,11 @@ impl ThreadEventCacheState {
 
         // Remove all the chunks from the linked chunks, except for the last one, and
         // updates the chunk identifier generator.
-        if let Err(err) =
-            self.thread_linked_chunk.replace_with(last_chunk, chunk_identifier_generator)
-        {
+        if let Err(err) = self.thread_linked_chunk.shrink_to_last_reloaded_chunk(
+            last_chunk,
+            chunk_identifier_generator,
+            full_linked_chunk_metadata,
+        ) {
             error!("error when replacing the linked chunk: {err}");
 
             self.thread_linked_chunk.reset();
@@ -199,7 +216,7 @@ impl ThreadEventCacheState {
                 Err(err) => {
                     error!("error when loading a linked chunk's metadata from the store: {err}");
 
-                    // Try to clear storage for this room.
+                    // Try to clear storage for this thread.
                     store_guard
                         .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
                         .await?;
@@ -221,7 +238,7 @@ impl ThreadEventCacheState {
             Err(err) => {
                 error!("error when loading a linked chunk's latest chunk from the store: {err}");
 
-                // Try to clear storage for this room.
+                // Try to clear storage for this thread.
                 store_guard
                     .handle_linked_chunk_updates(linked_chunk_id, vec![Update::Clear])
                     .await?;

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -102,7 +102,10 @@ impl ThreadEventCacheState {
     ///
     /// Otherwise, returns `None`.
     #[instrument(skip(self, store))]
-    async fn shrink_to_last_chunk(&mut self, store: &EventCacheStoreLockGuard) -> Result<()> {
+    async fn shrink_to_last_reloaded_chunk(
+        &mut self,
+        store: &EventCacheStoreLockGuard,
+    ) -> Result<()> {
         // Attempt to load the last chunk.
         let linked_chunk_id = LinkedChunkId::Thread(&self.room_id, &self.thread_id);
 
@@ -414,6 +417,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         match preprocessing {
             ReloadPreprocessing::ForgetAll => {
                 // Clear the `LinkedChunk` and broadcast the updates to the store.
+
                 self.thread_linked_chunk_mut().reset();
                 self.state.propagate_changes(&self.store).await?;
 
@@ -426,7 +430,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             ReloadPreprocessing::None => {}
         }
 
-        self.state.shrink_to_last_chunk(&self.store).await?;
+        self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
 
         Ok(self.thread_linked_chunk_mut().updates_as_vector_diffs())
     }
@@ -485,7 +489,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             // valid gap in between, and observers may not render it (yet).
             //
             // We must do this *after* persisting these events to storage.
-            self.state.shrink_to_last_chunk(&self.store).await?;
+            self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
         }
 
         // Do stuff for each event.
@@ -664,7 +668,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             // subscriber could be created, creating a race, except that this method takes a
             // `&mut`, ensuring an exclusive access to the state, ensuring no other
             // subscribers can be created.
-            self.state.shrink_to_last_chunk(&self.store).await?;
+            self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
 
             Ok(Some(self.state.thread_linked_chunk.updates_as_vector_diffs()))
         } else {

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -32,7 +32,7 @@ use super::{
 };
 
 /// Load a linked chunk's full metadata, making sure the chunks are
-/// according to their their links.
+/// correct according to their links.
 ///
 /// Returns `None` if there's no such linked chunk in the store, or an
 /// error if the linked chunk is malformed.

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -35,7 +35,7 @@ use ruma::{
     room_version_rules::RedactionRules,
     user_id,
 };
-use tokio::{spawn, sync::broadcast, time::sleep};
+use tokio::{spawn, sync::broadcast, task::yield_now, time::sleep};
 
 mod read_receipts;
 mod threads;
@@ -3027,4 +3027,103 @@ async fn test_backpaginate_on_a_single_event_inserted_via_send_queue_from_an_emp
     // The event cache can't know whether this is the start or not, and it shouldn't
     // assume so.
     assert!(reached_start.not());
+}
+
+/// Related issues:
+///
+/// - https://github.com/matrix-org/matrix-rust-sdk/issues/5896
+/// - https://github.com/matrix-org/matrix-rust-sdk/issues/5416
+#[async_test]
+async fn test_order_tracker_is_reset_when_cross_process_is_dirty() {
+    let server = MatrixMockServer::new().await;
+
+    let room_id = room_id!("!r0");
+    let event_factory = EventFactory::new().room(room_id).sender(*ALICE);
+
+    let event_id_4 = event_id!("$ev4");
+    let event_0 = event_factory.text_msg("foo").event_id(event_id!("$ev0")).into_raw_sync();
+    let event_1 = event_factory.text_msg("bar").event_id(event_id!("$ev1")).into_raw_sync();
+    let event_2 = event_factory.text_msg("baz").event_id(event_id!("$ev2")).into_raw_sync();
+    let event_3 = event_factory.text_msg("qux").event_id(event_id!("$ev3")).into_raw_sync();
+    let event_4 = event_factory.text_msg("wat").event_id(event_id_4).into_raw_sync();
+
+    let event_cache_store = Arc::new(MemoryStore::new());
+
+    // Setup two clients from two simulated “processes”.
+    let client_a = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new(CrossProcessLockConfig::multi_process("process_a"))
+                    .event_cache_store(event_cache_store.clone()),
+            )
+        })
+        .build()
+        .await;
+    let client_b = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.store_config(
+                StoreConfig::new(CrossProcessLockConfig::multi_process("process_b"))
+                    .event_cache_store(event_cache_store.clone()),
+            )
+        })
+        .build()
+        .await;
+
+    client_a.event_cache().subscribe().unwrap();
+    client_b.event_cache().subscribe().unwrap();
+
+    // Little dance to force `process_a` to be dirty:
+    // - process A syncs 2 events,
+    // - process B syncs a gap + 1 event (to ensure process A won't be able to
+    //   retrieve an event if something went wrong): it is dirty, it will reload, no
+    //   problem,
+    // - process B syncs a gap + 1 event again: it is not dirty, no problem.
+    // - process A is syncs 3 events: it is dirty, it will reload, but if the
+    //   `OrderTracker` is not reset correctly, it will panic.
+    let room_a = server
+        .sync_room(
+            &client_a,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![event_0, event_1]),
+        )
+        .await;
+
+    let (room_event_cache_a, _drop_handles_a) = room_a.event_cache().await.unwrap();
+
+    server
+        .sync_room(
+            &client_b,
+            JoinedRoomBuilder::new(room_id)
+                .set_timeline_limited()
+                .set_timeline_prev_batch("prev-batch-token")
+                .add_timeline_bulk(vec![event_2.clone()]),
+        )
+        .await;
+
+    server
+        .sync_room(
+            &client_b,
+            JoinedRoomBuilder::new(room_id)
+                .set_timeline_limited()
+                .set_timeline_prev_batch("prev-batch-token-2")
+                .add_timeline_bulk(vec![event_3.clone()]),
+        )
+        .await;
+
+    server
+        .sync_room(
+            &client_a,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk(vec![event_2, event_3, event_4]),
+        )
+        .await;
+
+    // Give time to the `RoomEventCache` to do its business.
+    yield_now().await;
+
+    // If the `OrderTracker` didn't panic, process A must be able to fetch
+    // `event_4`.
+    let events = room_event_cache_a.events().await.unwrap();
+
+    assert!(events.iter().any(|ev| ev.event_id() == Some(event_id_4)));
 }


### PR DESCRIPTION
First off, this patch renames `EventLinkedChunk::replace_with` to `shrink_to_last_reloaded_chunk` to make it obvious it's about the `shrink_to_last_chunk` operation.

Second, when the last chunk has been reloaded from the store, it's very likely that the `LinkedChunk`'s metadata must also be reloaded to recreate an `OrderTracker`, otherwise it becomes out of sync, and can panic.

This is what this patch does. This method now takes an `Option<Vec<ChunkMetadata>>`. It must be `Some` if the `EventLinkedChunk` has been built with `with_initial_linked_chunk`.

---

- Close https://github.com/matrix-org/matrix-rust-sdk/issues/5416
- Close https://github.com/matrix-org/matrix-rust-sdk/issues/5896

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
