### PR TITLE
chore(sdk): The `PinnedEventsCache` does not use the `OrderTracker`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -208,10 +208,8 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
     ///
     /// This method should be used only for updates that happen *outside*
     /// the in-memory linked chunk. Such updates must be applied
-    /// onto the ordering tracker as well as to the persistent
-    /// storage.
+    /// onto the persistent storage.
     async fn apply_store_only_updates(&mut self, updates: Vec<Update<Event, Gap>>) -> Result<()> {
-        self.state.chunk.order_tracker.map_updates(&updates);
         self.send_updates_to_store(updates).await
     }
 


### PR DESCRIPTION
The `EventLinkedChunk::event_order` method is never used by the `PinnedEventsCache`, so no need to maintain the `OrderTracker`.

---

- Confirm why https://github.com/matrix-org/matrix-rust-sdk/pull/6466 should indeed be closed.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
