### PR TITLE
Profiles: Add a method to subscribe to the user's own profile.

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6760.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6760.added.md
@@ -1,0 +1,1 @@
+Add `Client::subscribe_to_own_profile`, which reports the current user's profile to a `ProfileListener` and notifies it of any subsequent changes. **Note:** Without the Profiles sliding sync extension enabled only an empty profile will be emitted and no updates will be published.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -285,6 +285,13 @@ pub trait BeaconInfoListener: SyncOutsideWasm + SendOutsideWasm {
     fn on_update(&self, update: BeaconInfoUpdate);
 }
 
+/// A listener for the current user's global profile.
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait ProfileListener: SyncOutsideWasm + SendOutsideWasm {
+    /// Called whenever the current user's global profile changes.
+    fn on_update(&self, profile: UserProfile);
+}
+
 /// Information about the old and new key that caused a duplicate key upload
 /// error in /keys/upload.
 #[derive(uniffi::Record)]
@@ -1368,6 +1375,32 @@ impl Client {
     /// Retrieves an avatar cached from a previous call to [`Self::avatar_url`].
     pub async fn cached_avatar_url(&self) -> Result<Option<String>, ClientError> {
         Ok(self.inner.account().get_cached_avatar_url().await?.map(Into::into))
+    }
+
+    /// Subscribe to the current user's profile.
+    ///
+    /// Emits the current value immediately, if present, then again whenever the
+    /// user's profile changes during sync.
+    ///
+    /// **Note:** Without the Profiles sliding sync extension enabled only an
+    /// empty profile will be emitted and no updates will be published.
+    pub fn subscribe_to_own_profile(
+        &self,
+        listener: Box<dyn ProfileListener>,
+    ) -> Result<Arc<TaskHandle>, ClientError> {
+        let user_id = self.inner.user_id().context("No user ID found")?.to_owned();
+        let stream = self.inner.subscribe_to_own_profile()?;
+
+        Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
+            pin_mut!(stream);
+
+            while let Some(profile) = stream.next().await {
+                match UserProfile::from_profile(&user_id, &profile) {
+                    Ok(profile) => listener.on_update(profile),
+                    Err(error) => error!("Failed to convert global profile update: {error}"),
+                }
+            }
+        }))))
     }
 
     pub fn device_id(&self) -> Result<String, ClientError> {
@@ -2516,13 +2549,21 @@ impl UserProfile {
     /// API.
     pub(crate) async fn fetch(account: &Account, user_id: &UserId) -> Result<Self, ClientError> {
         let response = account.fetch_user_profile_of(user_id).await?;
-        let display_name = response.get_static::<DisplayName>()?;
-        let avatar_url = response.get_static::<AvatarUrl>()?.map(|url| url.to_string());
+        Self::from_profile(user_id, &response.data)
+    }
+
+    /// Build a [`UserProfile`] from a [`ruma::profile::UserProfile`].
+    fn from_profile(
+        user_id: &UserId,
+        profile: &ruma::profile::UserProfile,
+    ) -> Result<Self, ClientError> {
+        let display_name = profile.get_static::<DisplayName>()?;
+        let avatar_url = profile.get_static::<AvatarUrl>()?.map(|url| url.to_string());
 
         #[cfg(feature = "unstable-msc4426")]
-        let status = response.get_static::<Status>()?.map(UserStatus::from);
+        let status = profile.get_static::<Status>()?.map(UserStatus::from);
         #[cfg(feature = "unstable-msc4426")]
-        let call = response.get_static::<Call>()?.map(UserCall::from);
+        let call = profile.get_static::<Call>()?.map(UserCall::from);
 
         Ok(UserProfile {
             user_id: user_id.to_string(),

--- a/crates/matrix-sdk/changelog.d/6760.added.md
+++ b/crates/matrix-sdk/changelog.d/6760.added.md
@@ -1,0 +1,1 @@
+Add `Client::subscribe_to_own_profile`, returning a stream of the current user's global profile. It emits the currently stored value and re-emits whenever the profile changes during sync, or an empty profile when none is stored. **Note:** Without the Profiles sliding sync extension enabled only an empty profile will be emitted and no updates will be published.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -720,6 +720,43 @@ impl Client {
         self.base_client().subscribe_to_global_profile_updates()
     }
 
+    /// Observe updates to the current user's global profile.
+    ///
+    /// Emits the current value immediately, then again whenever the user's
+    /// global profile changes during sync. When no profile is stored (nothing
+    /// received yet) an empty [`UserProfile`] is emitted.
+    ///
+    /// **Note:** Without the Profiles sliding sync extension enabled only an
+    /// empty profile will be emitted and no updates will be published.
+    ///
+    /// [`UserProfile`]: ruma::profile::UserProfile
+    pub fn subscribe_to_own_profile(
+        &self,
+    ) -> Result<impl Stream<Item = ruma::profile::UserProfile> + use<>> {
+        let own_user_id = self.user_id().ok_or(Error::AuthenticationRequired)?.to_owned();
+        let mut updates = self.subscribe_to_global_profile_updates();
+        let client = self.clone();
+
+        Ok(async_stream::stream! {
+            // Emit the initial value.
+            match client.state_store().get_global_profile(&own_user_id).await {
+                Ok(profile) => yield profile.unwrap_or_default(),
+                Err(error) => error!(?error, "Failed to load the stored global profile"),
+            }
+
+            while let Ok(updated_user_ids) = updates.recv().await {
+                if !updated_user_ids.contains(&own_user_id) {
+                    continue;
+                }
+
+                match client.state_store().get_global_profile(&own_user_id).await {
+                    Ok(profile) => yield profile.unwrap_or_default(),
+                    Err(error) => error!(?error, "Failed to load the updated global profile"),
+                }
+            }
+        })
+    }
+
     /// Performs a search for users.
     /// The search is performed case-insensitively on user IDs and display names
     ///

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1020,12 +1020,14 @@ mod tests {
         events::{direct::DirectEvent, room::member::MembershipState},
         owned_room_id,
         presence::PresenceState,
+        profile::{AvatarUrl, DisplayName, UserProfileUpdate},
         room_id,
         serde::Raw,
         uint,
     };
     use serde::Deserialize;
     use serde_json::json;
+    use stream_assert::assert_pending;
     use wiremock::{
         Match, Mock, MockServer, Request, ResponseTemplate, http::Method, matchers::method,
     };
@@ -1064,6 +1066,65 @@ mod tests {
         let sliding_sync = sliding_sync_builder.build().await?;
 
         Ok((server, sliding_sync))
+    }
+
+    #[async_test]
+    async fn test_subscribe_to_own_profile() {
+        let client = logged_in_client(None).await;
+        let own_user_id = client.user_id().expect("client should be logged in").to_owned();
+
+        // Given a stored global profile for the current user, received through a
+        // previous sync.
+        let mut response = http::Response::new("0".to_owned());
+        response.extensions.profiles.insert(
+            own_user_id.clone(),
+            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Example"))]),
+        );
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .expect("Failed to process sync");
+
+        // Subscribing emits the currently stored value immediately.
+        let stream = client.subscribe_to_own_profile().expect("client should be logged in");
+        pin_mut!(stream);
+
+        let profile = stream.next().await.expect("should emit the initial profile");
+        assert_eq!(profile.get_static::<DisplayName>().unwrap().as_deref(), Some("Example"));
+
+        // An update for another user only is ignored: nothing is emitted.
+        let mut response = http::Response::new("1".to_owned());
+        response.extensions.profiles.insert(
+            ALICE.to_owned(),
+            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice"))]),
+        );
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .expect("Failed to process sync");
+
+        assert_pending!(stream);
+
+        // An update for the current user is emitted with the merged value.
+        let mut response = http::Response::new("2".to_owned());
+        response.extensions.profiles.insert(
+            own_user_id.clone(),
+            UserProfileUpdate::from_iter([(
+                "avatar_url".to_owned(),
+                json!("mxc://example.org/avatar"),
+            )]),
+        );
+        client
+            .process_sliding_sync_test_helper(&response, &RequestedRequiredStates::default())
+            .await
+            .expect("Failed to process sync");
+
+        let profile = stream.next().await.expect("should emit the updated profile");
+        assert_eq!(profile.get_static::<DisplayName>().unwrap().as_deref(), Some("Example"));
+        assert_eq!(
+            profile.get_static::<AvatarUrl>().unwrap().map(|url| url.to_string()).as_deref(),
+            Some("mxc://example.org/avatar")
+        );
     }
 
     #[async_test]


### PR DESCRIPTION
This should allow clients (that have enabled the profiles sss extension) to automatically update with profile changes made by the user on a different device 🎉

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries