### PR TITLE
Outline some parts of HttpClient::send

### DIFF
--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -89,71 +89,89 @@ where
     boxed_into_future!();
 
     fn into_future(self) -> Self::IntoFuture {
+        enum RetryRequest {
+            Yes,
+            No,
+        }
+
+        // split out so this only get compiled once,
+        // not monomorphized per request type
+        async fn handle_unknown_token_error(
+            e: &HttpError,
+            client: &Client,
+        ) -> HttpResult<RetryRequest> {
+            // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token refresh.
+            let Some(ErrorKind::UnknownToken(unknown_token_data)) = e.client_api_error_kind()
+            else {
+                return Ok(RetryRequest::No);
+            };
+
+            trace!("Token refresh: Unknown token error received.");
+
+            // If automatic token refresh isn't supported, there is nothing more to do.
+            if !client.inner.auth_ctx.handle_refresh_tokens {
+                trace!("Token refresh: Automatic refresh disabled.");
+                client.broadcast_unknown_token(unknown_token_data);
+                return Ok(RetryRequest::No);
+            }
+
+            // Try to refresh the token and retry the request.
+            if let Err(refresh_error) = client.refresh_access_token().await {
+                match &refresh_error {
+                    RefreshTokenError::RefreshTokenRequired => {
+                        trace!("Token refresh: The session doesn't have a refresh token.");
+                        // Refreshing access tokens is not supported by this `Session`, ignore.
+                        client.broadcast_unknown_token(unknown_token_data);
+                        Ok(RetryRequest::No)
+                    }
+
+                    RefreshTokenError::OAuth(oauth_error) => {
+                        match &**oauth_error {
+                            OAuthError::RefreshToken(RequestTokenError::ServerResponse(
+                                error_response,
+                            )) if *error_response.error()
+                                == BasicErrorResponseType::InvalidGrant =>
+                            {
+                                error!(
+                                    "Token refresh: OAuth 2.0 refresh_token rejected \
+                                         with invalid grant"
+                                );
+                                // The refresh was denied, signal to sign out the user.
+                                client.broadcast_unknown_token(unknown_token_data);
+                            }
+                            _ => {
+                                trace!("Token refresh: OAuth 2.0 refresh encountered a problem.");
+                                // The refresh failed for other reasons, no
+                                // need to sign out.
+                            }
+                        }
+                        Err(HttpError::RefreshToken(refresh_error))
+                    }
+
+                    _ => {
+                        trace!("Token refresh: Token refresh failed.");
+                        // This isn't necessarily correct, but matches the behaviour when
+                        // implementing OAuth 2.0.
+                        client.broadcast_unknown_token(unknown_token_data);
+                        Err(HttpError::RefreshToken(refresh_error))
+                    }
+                }
+            } else {
+                trace!("Token refresh: Refresh succeeded, retrying request.");
+                Ok(RetryRequest::Yes)
+            }
+        }
+
         let Self { client, request, config, send_progress } = self;
 
         Box::pin(async move {
             let res =
                 Box::pin(client.send_inner(request.clone(), config, send_progress.clone())).await;
 
-            // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token refresh.
-            if let Err(Some(ErrorKind::UnknownToken(unknown_token_data))) =
-                res.as_ref().map_err(HttpError::client_api_error_kind)
+            if let Err(e) = &res
+                && let RetryRequest::Yes = handle_unknown_token_error(e, &client).await?
             {
-                trace!("Token refresh: Unknown token error received.");
-
-                // If automatic token refresh isn't supported, there is nothing more to do.
-                if !client.inner.auth_ctx.handle_refresh_tokens {
-                    trace!("Token refresh: Automatic refresh disabled.");
-                    client.broadcast_unknown_token(unknown_token_data);
-                    return res;
-                }
-
-                // Try to refresh the token and retry the request.
-                if let Err(refresh_error) = client.refresh_access_token().await {
-                    match &refresh_error {
-                        RefreshTokenError::RefreshTokenRequired => {
-                            trace!("Token refresh: The session doesn't have a refresh token.");
-                            // Refreshing access tokens is not supported by this `Session`, ignore.
-                            client.broadcast_unknown_token(unknown_token_data);
-                        }
-
-                        RefreshTokenError::OAuth(oauth_error) => {
-                            match &**oauth_error {
-                                OAuthError::RefreshToken(RequestTokenError::ServerResponse(
-                                    error_response,
-                                )) if *error_response.error()
-                                    == BasicErrorResponseType::InvalidGrant =>
-                                {
-                                    error!(
-                                        "Token refresh: OAuth 2.0 refresh_token rejected \
-                                         with invalid grant"
-                                    );
-                                    // The refresh was denied, signal to sign out the user.
-                                    client.broadcast_unknown_token(unknown_token_data);
-                                }
-                                _ => {
-                                    trace!(
-                                        "Token refresh: OAuth 2.0 refresh encountered a problem."
-                                    );
-                                    // The refresh failed for other reasons, no
-                                    // need to sign out.
-                                }
-                            }
-                            return Err(HttpError::RefreshToken(refresh_error));
-                        }
-
-                        _ => {
-                            trace!("Token refresh: Token refresh failed.");
-                            // This isn't necessarily correct, but matches the behaviour when
-                            // implementing OAuth 2.0.
-                            client.broadcast_unknown_token(unknown_token_data);
-                            return Err(HttpError::RefreshToken(refresh_error));
-                        }
-                    }
-                } else {
-                    trace!("Token refresh: Refresh succeeded, retrying request.");
-                    return Box::pin(client.send_inner(request, config, send_progress)).await;
-                }
+                return Box::pin(client.send_inner(request, config, send_progress)).await;
             }
 
             res

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -36,7 +36,7 @@ use ruma::api::{
     path_builder,
 };
 use tokio::sync::{Semaphore, SemaphorePermit};
-use tracing::{debug, error, field::debug, instrument, trace};
+use tracing::{Instrument, debug, error, field::debug, trace};
 
 use crate::{HttpResult, config::RequestConfig, error::HttpError};
 
@@ -134,21 +134,7 @@ impl HttpClient {
         Ok(request)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(
-        skip(self, request, config, homeserver, access_token, path_builder_input, send_progress),
-        fields(
-            uri,
-            method,
-            request_id,
-            request_size,
-            request_duration,
-            status,
-            response_size,
-            sentry_event_id
-        )
-    )]
-    pub async fn send<R>(
+    pub fn send<R>(
         &self,
         request: R,
         config: Option<RequestConfig>,
@@ -156,7 +142,7 @@ impl HttpClient {
         access_token: Option<&str>,
         path_builder_input: <R::PathBuilder as path_builder::PathBuilder>::Input<'_>,
         send_progress: SharedObservable<TransmissionProgress>,
-    ) -> Result<R::IncomingResponse, HttpError>
+    ) -> impl Future<Output = Result<R::IncomingResponse, HttpError>>
     where
         R: OutgoingRequest + Debug,
         R::Authentication: SupportedAuthScheme,
@@ -164,12 +150,21 @@ impl HttpClient {
     {
         // some functions split out so they only get compiled once,
         // not monomorphized per request type
-        fn span_record_fields_1(client: &HttpClient, config: &RequestConfig) {
-            tracing::Span::current()
-                .record("config", debug(config))
-                .record("request_id", client.get_request_id());
+        fn make_span(client: &HttpClient, config: &RequestConfig) -> tracing::Span {
+            tracing::info_span!(
+                "send",
+                uri = tracing::field::Empty,
+                ?config,
+                method = tracing::field::Empty,
+                request_id = client.get_request_id(),
+                request_size = tracing::field::Empty,
+                request_duration = tracing::field::Empty,
+                status = tracing::field::Empty,
+                response_size = tracing::field::Empty,
+                sentry_event_id = tracing::field::Empty
+            )
         }
-        fn span_record_fields_2(request: &http::Request<Bytes>) {
+        fn record_request_uri_and_size(request: &http::Request<Bytes>) {
             let method = request.method();
 
             let mut uri_parts = request.uri().clone().into_parts();
@@ -210,27 +205,29 @@ impl HttpClient {
             None => self.request_config,
         };
 
-        span_record_fields_1(self, &config);
-        let request = self
-            .serialize_request(request, config, homeserver, access_token, path_builder_input)
-            .map_err(HttpError::IntoHttp)?;
-        span_record_fields_2(&request);
+        async move {
+            let request = self
+                .serialize_request(request, config, homeserver, access_token, path_builder_input)
+                .map_err(HttpError::IntoHttp)?;
+            record_request_uri_and_size(&request);
 
-        // will be automatically dropped at the end of this function
-        let _handle = self.concurrent_request_semaphore.acquire().await;
+            // will be automatically dropped at the end of this function
+            let _handle = self.concurrent_request_semaphore.acquire().await;
 
-        // There's a bunch of state in send_request, factor out a pinned inner
-        // future to reduce the size of futures that await this function.
-        match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
-            Ok(response) => {
-                log_got_response();
-                Ok(response)
-            }
-            Err(e) => {
-                log_error(&e);
-                Err(e)
+            // There's a bunch of state in send_request, factor out a pinned inner
+            // future to reduce the size of futures that await this function.
+            match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
+                Ok(response) => {
+                    log_got_response();
+                    Ok(response)
+                }
+                Err(e) => {
+                    log_error(&e);
+                    Err(e)
+                }
             }
         }
+        .instrument(make_span(self, &config))
     }
 }
 

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -162,25 +162,14 @@ impl HttpClient {
         R::Authentication: SupportedAuthScheme,
         HttpError: From<FromHttpResponseError<R::EndpointError>>,
     {
-        let config = match config {
-            Some(config) => config,
-            None => self.request_config,
-        };
-
-        // Keep some local variables in a separate scope so the compiler doesn't include
-        // them in the future type. https://github.com/rust-lang/rust/issues/57478
-        let request = {
-            let request_id = self.get_request_id();
-            let span = tracing::Span::current();
-
-            // At this point in the code, the config isn't behind an Option anymore, that's
-            // why we record it here, instead of in the #[instrument] macro.
-            span.record("config", debug(config)).record("request_id", request_id);
-
-            let request = self
-                .serialize_request(request, config, homeserver, access_token, path_builder_input)
-                .map_err(HttpError::IntoHttp)?;
-
+        // some functions split out so they only get compiled once,
+        // not monomorphized per request type
+        fn span_record_fields_1(client: &HttpClient, config: &RequestConfig) {
+            tracing::Span::current()
+                .record("config", debug(config))
+                .record("request_id", client.get_request_id());
+        }
+        fn span_record_fields_2(request: &http::Request<Bytes>) {
             let method = request.method();
 
             let mut uri_parts = request.uri().clone().into_parts();
@@ -194,6 +183,7 @@ impl HttpClient {
 
             let uri = http::Uri::from_parts(uri_parts).expect("created from valid URI");
 
+            let span = tracing::Span::current();
             span.record("method", debug(method)).record("uri", uri.to_string());
 
             // POST, PUT, PATCH are the only methods that are reasonably used
@@ -205,22 +195,39 @@ impl HttpClient {
                     ByteSize(request_size).display().si_short().to_string(),
                 );
             }
+        }
+        // these macros expand to a lot of code, also want to skip monomorphization
+        // for them even though they might look super simple
+        fn log_got_response() {
+            debug!("Got response");
+        }
+        fn log_error(e: &HttpError) {
+            error!("Error while sending request: {e:?}");
+        }
 
-            request
+        let config = match config {
+            Some(config) => config,
+            None => self.request_config,
         };
+
+        span_record_fields_1(self, &config);
+        let request = self
+            .serialize_request(request, config, homeserver, access_token, path_builder_input)
+            .map_err(HttpError::IntoHttp)?;
+        span_record_fields_2(&request);
 
         // will be automatically dropped at the end of this function
         let _handle = self.concurrent_request_semaphore.acquire().await;
 
         // There's a bunch of state in send_request, factor out a pinned inner
-        // future to reduce this size of futures that await this function.
+        // future to reduce the size of futures that await this function.
         match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
             Ok(response) => {
-                debug!("Got response");
+                log_got_response();
                 Ok(response)
             }
             Err(e) => {
-                error!("Error while sending request: {e:?}");
+                log_error(&e);
                 Err(e)
             }
         }

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -32,6 +32,7 @@ use tracing::{debug, info, warn};
 
 use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{
+    HttpResult,
     config::RequestConfig,
     error::{HttpError, RetryKind},
 };
@@ -42,69 +43,115 @@ impl HttpClient {
         request: http::Request<Bytes>,
         config: RequestConfig,
         send_progress: SharedObservable<TransmissionProgress>,
-    ) -> Result<R::IncomingResponse, HttpError>
+    ) -> HttpResult<R::IncomingResponse>
     where
         R: OutgoingRequest + Debug,
         HttpError: From<FromHttpResponseError<R::EndpointError>>,
     {
-        // These values were picked because we used to use the `backoff` crate, those
-        // were defined here: https://docs.rs/backoff/0.4.0/backoff/default/index.html
-        let backoff = ExponentialBuilder::new()
-            .with_min_delay(Duration::from_millis(500))
-            .with_max_delay(Duration::from_secs(60))
-            .with_total_delay(Some(Duration::from_secs(15 * 60)))
-            .without_max_times();
+        // some functions split out so they only get compiled once,
+        // not monomorphized per request type
+        fn make_backoff(config: &RequestConfig) -> ExponentialBuilder {
+            // These values were picked because we used to use the `backoff` crate, those
+            // were defined here: https://docs.rs/backoff/0.4.0/backoff/default/index.html
+            let mut backoff = ExponentialBuilder::new()
+                .with_min_delay(Duration::from_millis(500))
+                .with_max_delay(Duration::from_secs(60))
+                .with_total_delay(Some(Duration::from_secs(15 * 60)))
+                .without_max_times();
 
-        // Let's now apply any override the user or the SDK might have set.
-        let backoff = if let Some(max_delay) = config.max_retry_time {
-            backoff.with_max_delay(max_delay)
-        } else {
-            backoff
-        };
+            // Let's now apply any override the user or the SDK might have set.
+            if let Some(max_delay) = config.max_retry_time {
+                backoff = backoff.with_max_delay(max_delay)
+            }
 
-        let backoff = if let Some(max_times) = config.retry_limit {
-            // Backon behaves a bit differently to our own handcrafted max retry logic.
-            // We were counting from one while `backon` counts from zero.
-            backoff.with_max_times(max_times.saturating_sub(1))
-        } else {
+            if let Some(max_times) = config.retry_limit {
+                // Backon behaves a bit differently to our own handcrafted max retry logic.
+                // We were counting from one while `backon` counts from zero.
+                backoff = backoff.with_max_times(max_times.saturating_sub(1))
+            }
+
             backoff
-        };
+        }
+        async fn send_request_inner(
+            http_client: &reqwest::Client,
+            request: &http::Request<Bytes>,
+            timeout: Option<Duration>,
+            retry_count: &AtomicU64,
+            send_progress: SharedObservable<TransmissionProgress>,
+        ) -> HttpResult<http::Response<Bytes>> {
+            let num_attempt = retry_count.fetch_add(1, Ordering::SeqCst);
+            debug!(num_attempt, "Sending request");
+            let before = ruma::time::Instant::now();
+
+            let response = execute_request(http_client, request, timeout, send_progress).await?;
+
+            let request_duration = ruma::time::Instant::now().saturating_duration_since(before);
+
+            let status_code = response.status();
+            let response_size = ByteSize(response.body().len().try_into().unwrap_or(u64::MAX));
+            tracing::Span::current()
+                .record("status", status_code.as_u16())
+                .record("response_size", response_size.display().si_short().to_string())
+                .record("request_duration", tracing::field::debug(request_duration));
+
+            // Record interesting headers. If you add more headers, ensure they're not
+            // confidential.
+            for (header_name, header_value) in response.headers() {
+                let header_name = header_name.as_str().to_lowercase();
+
+                // Header added in case of OAuth 2.0 authentication failure, so we can correlate
+                // failures with a Sentry event emitted by the OAuth 2.0 authentication server.
+                if header_name == "x-sentry-event-id" {
+                    tracing::Span::current()
+                        .record("sentry_event_id", header_value.to_str().unwrap_or("<???>"));
+                }
+            }
+
+            Ok(response)
+        }
+        fn adjust_backoff(
+            err: &HttpError,
+            backon_suggested_timeout: Option<Duration>,
+            has_retry_limit: bool,
+        ) -> Option<Duration> {
+            match err.retry_kind() {
+                RetryKind::Transient { retry_after } => {
+                    // This bit is somewhat tricky but it's necessary so we respect the
+                    // `max_times` limit from `backon`.
+                    //
+                    // The exponential backoff in `backon` is implemented as an iterator that
+                    // returns `None` when we hit the `max_times` limit; if it returned `None`,
+                    // that means we ran out of attempts. So it's necessary to only override
+                    // the `backon_suggested_timeout` if it's `Some`.
+                    if backon_suggested_timeout.is_some() {
+                        retry_after.or(backon_suggested_timeout)
+                    } else {
+                        None
+                    }
+                }
+                RetryKind::Permanent => None,
+                RetryKind::NetworkFailure => {
+                    // If we ran into a network failure, only retry if there's some retry limit
+                    // associated to this request's configuration; otherwise, we would end up
+                    // running an infinite loop of network requests in offline mode.
+                    if has_retry_limit { backon_suggested_timeout } else { None }
+                }
+            }
+        }
 
         let retry_count = AtomicU64::new(1);
 
         let send_request = || {
             let send_progress = send_progress.clone();
-
             async {
-                let num_attempt = retry_count.fetch_add(1, Ordering::SeqCst);
-                debug!(num_attempt, "Sending request");
-                let before = ruma::time::Instant::now();
-
-                let response =
-                    send_request(&self.inner, &request, config.timeout, send_progress).await?;
-
-                let request_duration = ruma::time::Instant::now().saturating_duration_since(before);
-
-                let status_code = response.status();
-                let response_size = ByteSize(response.body().len().try_into().unwrap_or(u64::MAX));
-                tracing::Span::current()
-                    .record("status", status_code.as_u16())
-                    .record("response_size", response_size.display().si_short().to_string())
-                    .record("request_duration", tracing::field::debug(request_duration));
-
-                // Record interesting headers. If you add more headers, ensure they're not
-                // confidential.
-                for (header_name, header_value) in response.headers() {
-                    let header_name = header_name.as_str().to_lowercase();
-
-                    // Header added in case of OAuth 2.0 authentication failure, so we can correlate
-                    // failures with a Sentry event emitted by the OAuth 2.0 authentication server.
-                    if header_name == "x-sentry-event-id" {
-                        tracing::Span::current()
-                            .record("sentry_event_id", header_value.to_str().unwrap_or("<???>"));
-                    }
-                }
-
+                let response = send_request_inner(
+                    &self.inner,
+                    &request,
+                    config.timeout,
+                    &retry_count,
+                    send_progress,
+                )
+                .await?;
                 R::IncomingResponse::try_from_http_response(response).map_err(HttpError::from)
             }
         };
@@ -112,31 +159,9 @@ impl HttpClient {
         let has_retry_limit = config.retry_limit.is_some();
 
         send_request
-            .retry(backoff)
+            .retry(make_backoff(&config))
             .adjust(|err, backon_suggested_timeout| {
-                match err.retry_kind() {
-                    RetryKind::Transient { retry_after } => {
-                        // This bit is somewhat tricky but it's necessary so we respect the
-                        // `max_times` limit from `backon`.
-                        //
-                        // The exponential backoff in `backon` is implemented as an iterator that
-                        // returns `None` when we hit the `max_times` limit; if it returned `None`,
-                        // that means we ran out of attempts. So it's necessary to only override
-                        // the `backon_suggested_timeout` if it's `Some`.
-                        if backon_suggested_timeout.is_some() {
-                            retry_after.or(backon_suggested_timeout)
-                        } else {
-                            None
-                        }
-                    }
-                    RetryKind::Permanent => None,
-                    RetryKind::NetworkFailure => {
-                        // If we ran into a network failure, only retry if there's some retry limit
-                        // associated to this request's configuration; otherwise, we would end up
-                        // running an infinite loop of network requests in offline mode.
-                        if has_retry_limit { backon_suggested_timeout } else { None }
-                    }
-                }
+                adjust_backoff(err, backon_suggested_timeout, has_retry_limit)
             })
             .await
     }
@@ -209,7 +234,7 @@ impl HttpSettings {
     }
 }
 
-pub(super) async fn send_request(
+pub(super) async fn execute_request(
     client: &reqwest::Client,
     request: &http::Request<Bytes>,
     timeout: Option<Duration>,


### PR DESCRIPTION
I ran `cargo rustc -p matrix-sdk -- -Zdump-mono-stats` following reports of slow compile times of the `matrix-sdk` crate (slower than Ruma! 😜). Found that three of the top five most "costly" monomorphizations ([full output](https://gist.github.com/jplatte/084042f782d7d01768895dedfa8c79ac/7616a7e14e8fe6c30da74ea7d2c9746af501e0da)) were generic async functions where a lot of the code inside of them didn't actually need to be monomorphized.

With this change, all of those three items drop much lower in the list, the highest being `http_client::native::<impl http_client::HttpClient>::send_request::{closure#0}::{closure#0}::{closure#0}` (position 5 in the [updated output](https://gist.github.com/jplatte/084042f782d7d01768895dedfa8c79ac/5760b1efc5cfa74b0597d220f9cf94bc894304fc))). I'm happy to also optimize that one, if you don't find these changes too awful to maintain.

I haven't yet checked whether this improves compile time (will CI report about that?). I'll check if there's a noticeable impact locally w/ hyperfine I guess :)

- [ ] No changes to public API
- [ ] No use of "AI"

Signed-off-by: Jonas Platte
