### PR TITLE
chore(ci): Bump Rust nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly-2026-02-26
+          toolchain: nightly-2026-07-18
           components: clippy, rustfmt
 
       - name: Load cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly-2026-02-26
+          toolchain: nightly-2026-07-18
 
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ mut_mut = "warn"
 needless_borrow = "warn"
 nonstandard_macro_braces = "warn"
 redundant_clone = "warn"
+single_range_in_vec_init = "allow" # Triggers false positives (https://github.com/rust-lang/rust-clippy/issues/11086)
 str_to_string = "warn"
 todo = "warn"
 unnecessary_semicolon = "warn"

--- a/bindings/matrix-sdk-ffi/changelog.d/6763.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6763.changed.md
@@ -1,0 +1,2 @@
+[**breaking**] `ClientBuildError::WellKnownLookupFailed` inner type is now
+`Box`ed to reduce the error enum's size.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3234,15 +3234,7 @@ impl TryFrom<JoinRule> for RumaJoinRule {
 }
 
 fn ruma_allow_rules_from_ffi(value: Vec<AllowRule>) -> Result<Vec<RumaAllowRule>, ClientError> {
-    let mut ret = Vec::with_capacity(value.len());
-    for rule in value {
-        let rule: Result<RumaAllowRule, ClientError> = rule.try_into();
-        match rule {
-            Ok(rule) => ret.push(rule),
-            Err(error) => return Err(error),
-        }
-    }
-    Ok(ret)
+    value.into_iter().map(TryInto::try_into).collect()
 }
 
 impl TryFrom<AllowRule> for RumaAllowRule {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -434,7 +434,7 @@ impl Client {
         match store_mode {
             CrossProcessLockConfig::MultiProcess { holder_name } => {
                 if session_delegate.is_none() {
-                    return Err(anyhow::anyhow!(
+                    Err(anyhow::anyhow!(
                         "missing session delegates with multi-process lock configuration"
                     ))?;
                 }

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -71,7 +71,7 @@ pub enum ClientBuildError {
     #[error(transparent)]
     ServerUnreachable(HttpError),
     #[error(transparent)]
-    WellKnownLookupFailed(RumaApiError),
+    WellKnownLookupFailed(Box<RumaApiError>),
     #[error(transparent)]
     WellKnownDeserializationError(DeserializationError),
     #[error(transparent)]
@@ -94,12 +94,15 @@ impl From<MatrixClientBuildError> for ClientBuildError {
         match e {
             MatrixClientBuildError::InvalidServerName => ClientBuildError::InvalidServerName,
             MatrixClientBuildError::Http(e) => ClientBuildError::ServerUnreachable(e),
-            MatrixClientBuildError::AutoDiscovery(FromHttpResponseError::Server(e)) => {
-                ClientBuildError::WellKnownLookupFailed(e)
-            }
-            MatrixClientBuildError::AutoDiscovery(FromHttpResponseError::Deserialization(e)) => {
-                ClientBuildError::WellKnownDeserializationError(e)
-            }
+            MatrixClientBuildError::AutoDiscovery(e) => match *e {
+                FromHttpResponseError::Server(e) => {
+                    ClientBuildError::WellKnownLookupFailed(Box::new(e))
+                }
+                FromHttpResponseError::Deserialization(e) => {
+                    ClientBuildError::WellKnownDeserializationError(e)
+                }
+                _ => ClientBuildError::Sdk(MatrixClientBuildError::AutoDiscovery(e)),
+            },
             MatrixClientBuildError::SlidingSyncVersion(e) => {
                 ClientBuildError::SlidingSyncVersion(e)
             }

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(unused_qualifications, clippy::new_without_default)]
 // Needed because uniffi macros contain empty lines after docs.
 #![allow(clippy::empty_line_after_doc_comments)]
+// Needed because uniffi generates a big const array.
+#![allow(clippy::large_const_arrays)]
 
 mod authentication;
 mod chunk_iterator;

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -2067,7 +2067,7 @@ mod tests {
         };
 
         with_settings!({ prepend_module_to_snapshot => false }, {
-            assert_json_snapshot!(info)
+            assert_json_snapshot!(info);
         });
     }
 
@@ -2114,7 +2114,7 @@ mod tests {
         };
 
         with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
-            assert_json_snapshot!(info)
+            assert_json_snapshot!(info);
         })
     }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -2325,7 +2325,7 @@ mod tests {
                 .build_response();
             allow_duplicates! {
                 with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
-                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()));
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -2381,7 +2381,7 @@ mod tests {
                 .build_response();
             allow_duplicates! {
                 with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
-                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()));
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -2449,7 +2449,7 @@ mod tests {
                 .build_response();
             allow_duplicates! {
                 with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
-                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()));
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
@@ -2580,7 +2580,7 @@ mod tests {
                 .build_response();
             allow_duplicates! {
                 with_settings!({ sort_maps => true, prepend_module_to_snapshot => false }, {
-                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()))
+                    assert_json_snapshot!(ruma_response_to_json(keys_query.clone()));
                 });
             }
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/types/backup.rs
+++ b/crates/matrix-sdk-crypto/src/types/backup.rs
@@ -174,7 +174,7 @@ mod tests {
         });
 
         with_settings!({sort_maps =>true}, {
-            assert_json_snapshot!(info)
+            assert_json_snapshot!(info);
         });
 
         let info = RoomKeyBackupInfo::Other {

--- a/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/mod.rs
@@ -201,7 +201,7 @@ mod test {
         ]));
 
         with_settings!({sort_maps => true, prepend_module_to_snapshot => false}, {
-            assert_json_snapshot!(signatures)
+            assert_json_snapshot!(signatures);
         });
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -1742,9 +1742,9 @@ mod tests {
         let (alice, bob) = get_sas_pair(None);
 
         let mut content = bob.as_content();
-        let mut method = content.method_mut();
+        let method = content.method_mut();
 
-        match &mut method {
+        match method {
             AcceptMethod::SasV1(c) => {
                 c.commitment = Base64::empty();
             }
@@ -1781,9 +1781,9 @@ mod tests {
         let (alice, bob) = get_sas_pair(None);
 
         let mut content = bob.as_content();
-        let mut method = content.method_mut();
+        let method = content.method_mut();
 
-        match &mut method {
+        match method {
             AcceptMethod::SasV1(c) => {
                 c.short_authentication_string = vec![];
             }

--- a/crates/matrix-sdk/changelog.d/6763.changed.md
+++ b/crates/matrix-sdk/changelog.d/6763.changed.md
@@ -1,0 +1,3 @@
+[**breaking**] `QRCodeGrantLoginError::UnexpectedMessage`'s `received` field
+type and `ClientBuildError::AutoDiscovery`'s inner type are now `Box`ed to
+reduce the error enums' sizes.

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -76,7 +76,7 @@ async fn finish_login_grant<Q>(
         message => {
             return Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.protocol",
-                received: message,
+                received: Box::new(message),
             });
         }
     };
@@ -140,7 +140,7 @@ async fn finish_login_grant<Q>(
         message => {
             return Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.success",
-                received: message,
+                received: Box::new(message),
             });
         }
     }
@@ -1287,13 +1287,17 @@ mod test {
         });
 
         // Wait for all tasks to finish / fail.
-        assert_matches!(
-            grant.await,
+        assert_let!(
             Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.protocol",
-                received: QrAuthMessage::LoginSuccess
-            }),
-            "Alice should abort the login with expected error"
+                received,
+            }) = grant.await,
+            "Alice should abort the login with expected error variant"
+        );
+        assert_matches!(
+            *received,
+            QrAuthMessage::LoginSuccess,
+            "Alice should abort the login with expected error message"
         );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
@@ -1398,13 +1402,17 @@ mod test {
         });
 
         // Wait for all tasks to finish / fail.
-        assert_matches!(
-            grant.await,
+        assert_let!(
             Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.protocol",
-                received: QrAuthMessage::LoginSuccess
-            }),
-            "Alice should abort the login with expected error"
+                received,
+            }) = grant.await,
+            "Alice should abort the login with expected error variant"
+        );
+        assert_matches!(
+            *received,
+            QrAuthMessage::LoginSuccess,
+            "Alice should abort the login with expected error message"
         );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
@@ -2711,13 +2719,17 @@ mod test {
         });
 
         // Wait for all tasks to finish / fail.
-        assert_matches!(
-            grant.await,
+        assert_let!(
             Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.success",
-                received: QrAuthMessage::LoginProtocolAccepted
-            }),
-            "Alice should abort the login with expected error"
+                received,
+            }) = grant.await,
+            "Alice should abort the login with expected error variant"
+        );
+        assert_matches!(
+            *received,
+            QrAuthMessage::LoginProtocolAccepted,
+            "Alice should abort the login with expected error message"
         );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");
@@ -2840,13 +2852,17 @@ mod test {
         });
 
         // Wait for all tasks to finish / fail.
-        assert_matches!(
-            grant.await,
+        assert_let!(
             Err(QRCodeGrantLoginError::UnexpectedMessage {
                 expected: "m.login.success",
-                received: QrAuthMessage::LoginProtocolAccepted
-            }),
-            "Alice should abort the login with expected error"
+                received,
+            }) = grant.await,
+            "Alice should abort the login with expected error variant"
+        );
+        assert_matches!(
+            *received,
+            QrAuthMessage::LoginProtocolAccepted,
+            "Alice should abort the login with expected error message"
         );
         updates_task.await.expect("Alice should run through all progress states");
         bob_task.await.expect("Bob's task should finish");

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -97,7 +97,7 @@ async fn finish_login<Q>(
 
             return Err(QRCodeLoginError::UnexpectedMessage {
                 expected: "m.login.protocol_accepted",
-                received: message,
+                received: Box::new(message),
             });
         }
     }
@@ -176,7 +176,7 @@ async fn finish_login<Q>(
 
             return Err(QRCodeLoginError::UnexpectedMessage {
                 expected: "m.login.secrets",
-                received: message,
+                received: Box::new(message),
             });
         }
     };
@@ -410,7 +410,7 @@ impl<'a> IntoFuture for LoginWithGeneratedQrCode<'a> {
 
                     return Err(QRCodeLoginError::UnexpectedMessage {
                         expected: "m.login.protocols",
-                        received: message,
+                        received: Box::new(message),
                     });
                 }
             };

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -81,7 +81,7 @@ pub enum QRCodeLoginError {
         /// The message we expected.
         expected: &'static str,
         /// The message we received instead.
-        received: QrAuthMessage,
+        received: Box<QrAuthMessage>,
     },
 
     /// An error happened while exchanging messages with the other device.
@@ -178,7 +178,7 @@ pub enum QRCodeGrantLoginError {
         /// The message we expected.
         expected: &'static str,
         /// The message we received instead.
-        received: QrAuthMessage,
+        received: Box<QrAuthMessage>,
     },
 
     /// The other device has signaled to us that the login has failed.

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -187,7 +187,7 @@ async fn discover_homeserver(
         )
         .await
         .map_err(|e| match e {
-            HttpError::Api(err) => ClientBuildError::AutoDiscovery(*err),
+            HttpError::Api(err) => ClientBuildError::AutoDiscovery(err),
             err => ClientBuildError::Http(err),
         })?;
 

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -856,7 +856,7 @@ pub enum ClientBuildError {
 
     /// Error looking up the .well-known endpoint on auto-discovery
     #[error("Error looking up the .well-known endpoint on auto-discovery")]
-    AutoDiscovery(FromHttpResponseError<RumaApiError>),
+    AutoDiscovery(Box<FromHttpResponseError<RumaApiError>>),
 
     /// Error when building the sliding sync version.
     #[error(transparent)]
@@ -961,7 +961,8 @@ pub(crate) mod tests {
         let error = builder.build().await.unwrap_err();
 
         // Then the operation should fail with a server discovery error.
-        assert_matches!(error, ClientBuildError::AutoDiscovery(FromHttpResponseError::Server(_)));
+        assert_let!(ClientBuildError::AutoDiscovery(e) = error);
+        assert_matches!(*e, FromHttpResponseError::Server(_));
     }
 
     #[async_test]
@@ -998,10 +999,8 @@ pub(crate) mod tests {
         let error = builder.build().await.unwrap_err();
 
         // Then the operation should fail due to the well-known file's contents.
-        assert_matches!(
-            error,
-            ClientBuildError::AutoDiscovery(FromHttpResponseError::Deserialization(_))
-        );
+        assert_let!(ClientBuildError::AutoDiscovery(e) = error);
+        assert_matches!(*e, FromHttpResponseError::Deserialization(_));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -606,7 +606,7 @@ mod tests {
         let new = attach_room_id(&raw, room_id);
 
         insta::with_settings!({prepend_module_to_snapshot => false}, {
-            insta::assert_json_snapshot!(new.deserialize_as::<Value>().unwrap())
+            insta::assert_json_snapshot!(new.deserialize_as::<Value>().unwrap());
         });
 
         let attached: AnyTimelineEvent = new.deserialize().unwrap();
@@ -634,7 +634,7 @@ mod tests {
         let new = attach_room_id(&raw, room_id);
 
         insta::with_settings!({prepend_module_to_snapshot => false}, {
-            insta::assert_json_snapshot!(new.deserialize_as::<Value>().unwrap())
+            insta::assert_json_snapshot!(new.deserialize_as::<Value>().unwrap());
         });
 
         let attached: AnyTimelineEvent = new.deserialize().unwrap();

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -130,6 +130,7 @@ impl WidgetDriver {
     ///
     /// The function returns once the widget is disconnected or any terminal
     /// error occurs.
+    #[expect(clippy::result_unit_err)]
     pub async fn run(
         mut self,
         room: Room,

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -56,8 +56,8 @@ async fn print_devices(user_id: &UserId, client: &Client) {
 async fn sas_verification_handler(client: Client, sas: SasVerification) {
     println!(
         "Starting verification with {} {}",
-        &sas.other_device().user_id(),
-        &sas.other_device().device_id()
+        sas.other_device().user_id(),
+        sas.other_device().device_id()
     );
     print_devices(sas.other_device().user_id(), &client).await;
     sas.accept().await.unwrap();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,7 @@ use release::ReleaseArgs;
 use swift::SwiftArgs;
 use xshell::{Shell, cmd};
 
-const NIGHTLY: &str = "nightly-2026-02-26";
+const NIGHTLY: &str = "nightly-2026-07-18";
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 


### PR DESCRIPTION
This fixes the new compilation warnings and clippy lints due to the toolchain bump. Each commit fixes a separate error.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

