### PR TITLE
Use a custom UniFFI version with a patch to disable checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8461,4 +8461,4 @@ dependencies = [
 [[patch.unused]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=e025321febd9f409813af680f16d8e6b3e078266#e025321febd9f409813af680f16d8e6b3e078266"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8457,3 +8457,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[patch.unused]]
+name = "ruma"
+version = "0.16.0"
+source = "git+https://github.com/matrix-org/ruma?rev=e025321febd9f409813af680f16d8e6b3e078266#e025321febd9f409813af680f16d8e6b3e078266"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,9 @@ lto = false
 [patch.crates-io]
 async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27c8b290f1f1dcfc0c4ec22c464e38528aa591" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
+# Needed to disable checksums since they're incorrect in 32bit devices.
+# Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "e025321febd9f409813af680f16d8e6b3e078266" }
 # Needed to fix rotation log issue on Android (https://github.com/tokio-rs/tracing/issues/2937)
 tracing = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
 # Needed to disable checksums since they're incorrect in 32bit devices.
 # Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "e025321febd9f409813af680f16d8e6b3e078266" }
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "2a1d714314f6f711d5bca755c73cf2ce3053c3d1" }
 # Needed to fix rotation log issue on Android (https://github.com/tokio-rs/tracing/issues/2937)
 tracing = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }

--- a/bindings/matrix-sdk-crypto-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-crypto-ffi/uniffi.toml
@@ -1,6 +1,9 @@
 [bindings.kotlin]
 package_name = "org.matrix.rustcomponents.sdk.crypto"
 cdylib_name = "matrix_sdk_crypto_ffi"
+# Checksums are incorrectly failing for users with 32bit (and sometimes 64bit?) devices at the moment
+# Remove once https://github.com/mozilla/uniffi-rs/issues/2740 is fixed or JNI is used instead of JNA
+omit_checksums = true
 
 [bindings.swift]
 module_name = "MatrixSDKCrypto"

--- a/bindings/matrix-sdk-ffi/changelog.d/6764.internal.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6764.internal.md
@@ -1,0 +1,1 @@
+Use a forked Ruma version with a workaround to avoid verifying the JNA checksums on the generated Kotlin bindings: these checksums consistently fail on 32bit devices and leave any implementing client unable to use any bindings.


### PR DESCRIPTION
These checksums consistently fail on Android in ARM 32bit devices and 64bit devices with 32bit OS (see https://github.com/element-hq/element-x-android/issues/6028).

This PR should be reverted to use the Ruma repo once the mentioned UniFFI issue is fixed and the fix is tracked in Ruma.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
