### PR TITLE
Profiles: Update ruma to include the latest changes for MSC4262.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "assign",
  "js_int",
@@ -5163,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "as_variant",
  "assign",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "as_variant",
  "base64",
@@ -5218,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5242,7 +5242,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "headers",
  "http",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5274,7 +5274,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "js_int",
  "thiserror 2.0.18",
@@ -5283,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5299,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/ruma/ruma?rev=a494c58c541c63042b26380a9238a24bdda4d85c#a494c58c541c63042b26380a9238a24bdda4d85c"
+source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rand = { version = "0.10.1", default-features = false, features = ["std", "std_r
 regex = { version = "1.12.2", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "a494c58c541c63042b26380a9238a24bdda4d85c", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "db24422e03aea7c7974230098fe9aeb5481cddc6", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -87,8 +87,6 @@ ruma = { workspace = true, features = [
     "unstable-msc3245",
     # Emote event type
     "unstable-msc3954",
-    # Image pack event type
-    "unstable-msc2545",
     # Room language event type
     "unstable-msc4334",
     # User status profile fields (m.status, m.call).

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1281,7 +1281,9 @@ mod tests {
         event_factory::EventFactory, ruma_response_from_json,
     };
     #[cfg(feature = "unstable-msc4426")]
-    use ruma::profile::{ProfileFieldValue, StatusProfileField, UserProfileUpdate};
+    use ruma::profile::{
+        ProfileFieldValue, StatusProfileField, UserProfileChanges, UserProfileUpdate,
+    };
     use ruma::{
         api::client::{self as api, sync::sync_events::v5},
         event_id,
@@ -1816,13 +1818,13 @@ mod tests {
 
         // Save a global profile carrying an `m.status` for the member.
         let mut changes = StateChanges::default();
-        changes.global_profiles.insert(
-            user_id.to_owned(),
-            UserProfileUpdate::from_iter([ProfileFieldValue::Status(StatusProfileField::new(
-                "Working".to_owned(),
-                "💻".to_owned(),
-            ))]),
-        );
+        changes.global_profiles.insert(user_id.to_owned(), {
+            let mut profile_changes = UserProfileChanges::new();
+            profile_changes.insert_updated_value(ProfileFieldValue::Status(
+                StatusProfileField::new("Working".to_owned(), "💻".to_owned()),
+            ));
+            UserProfileUpdate::Updated(profile_changes)
+        });
         client.state_store().save_changes(&changes).await.unwrap();
 
         // `get_member` surfaces the status from the global profile.

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -772,7 +772,10 @@ mod tests {
     async fn test_room_heroes_carry_global_profile() {
         use ruma::{
             SecondsSinceUnixEpoch,
-            profile::{CallProfileField, ProfileFieldValue, StatusProfileField, UserProfileUpdate},
+            profile::{
+                CallProfileField, ProfileFieldValue, StatusProfileField, UserProfileChanges,
+                UserProfileUpdate,
+            },
         };
 
         use crate::store::StateChanges;
@@ -804,16 +807,14 @@ mod tests {
         let mut call = CallProfileField::new();
         call.call_joined_ts = Some(SecondsSinceUnixEpoch(1_700_000_000u32.into()));
         let mut changes = StateChanges::default();
-        changes.global_profiles.insert(
-            alice_id.to_owned(),
-            UserProfileUpdate::from_iter([
-                ProfileFieldValue::Status(StatusProfileField::new(
-                    "Working".to_owned(),
-                    "💻".to_owned(),
-                )),
-                ProfileFieldValue::Call(call),
-            ]),
-        );
+        changes.global_profiles.insert(alice_id.to_owned(), {
+            let mut profile_changes = UserProfileChanges::new();
+            profile_changes.insert_updated_value(ProfileFieldValue::Status(
+                StatusProfileField::new("Working".to_owned(), "💻".to_owned()),
+            ));
+            profile_changes.insert_updated_value(ProfileFieldValue::Call(call));
+            UserProfileUpdate::Updated(profile_changes)
+        });
         client.state_store().save_changes(&changes).await.unwrap();
 
         // The hero now surfaces the status and call from the global profile.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -207,7 +207,7 @@ impl BaseClient {
         context.state_changes.ambiguity_maps = ambiguity_cache.cache;
 
         // Persist any global profile updates received through the profiles extension.
-        context.state_changes.global_profiles = extensions.profiles.clone();
+        context.state_changes.global_profiles = extensions.profiles.users.clone();
 
         // Save the changes and apply them.
         processors::changes::save_and_apply(
@@ -224,7 +224,7 @@ impl BaseClient {
         if !extensions.profiles.is_empty() {
             let _ = self
                 .global_profile_updates_sender
-                .send(extensions.profiles.keys().cloned().collect());
+                .send(extensions.profiles.users.keys().cloned().collect());
 
             // Nudge `RoomInfo` so hero status/call fields are re-read.
             #[cfg(feature = "unstable-msc4426")]
@@ -232,7 +232,7 @@ impl BaseClient {
                 if room
                     .hero_user_ids()
                     .iter()
-                    .any(|user_id| extensions.profiles.contains_key(user_id))
+                    .any(|user_id| extensions.profiles.users.contains_key(user_id))
                 {
                     let _ = self.state_store.room_info_notable_update_sender.send(
                         crate::RoomInfoNotableUpdate {
@@ -327,7 +327,7 @@ mod tests {
             },
         },
         mxc_uri, owned_event_id, owned_mxc_uri, owned_user_id,
-        profile::UserProfileUpdate,
+        profile::{ProfileFieldName, UserProfileChanges, UserProfileUpdate},
         room_alias_id, room_id,
         serde::Raw,
         uint, user_id,
@@ -473,13 +473,13 @@ mod tests {
         // Given a sliding sync response carrying the profiles extension (MSC4262)
         // for two users, and no rooms.
         let mut response = http::Response::new("0".to_owned());
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             alice.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Alice")),
         );
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             bob.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Bob"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Bob")),
         );
 
         // When the response is processed.
@@ -513,9 +513,9 @@ mod tests {
 
         // When a subsequent response only carries an update for Alice.
         let mut response = http::Response::new("1".to_owned());
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             alice.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice Updated"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Alice Updated")),
         );
 
         client
@@ -557,13 +557,13 @@ mod tests {
 
         // When a sliding sync response carries the profiles extension for two users.
         let mut response = http::Response::new("0".to_owned());
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             alice.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Alice")),
         );
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             bob.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Bob"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Bob")),
         );
         client
             .process_sliding_sync(
@@ -583,9 +583,9 @@ mod tests {
 
         // When a subsequent response only carries an update for Alice.
         let mut response = http::Response::new("1".to_owned());
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             alice.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice Updated"))]),
+            make_profile_update(ProfileFieldName::DisplayName, json!("Alice Updated")),
         );
         client
             .process_sliding_sync(
@@ -1663,8 +1663,6 @@ mod tests {
     #[cfg(feature = "unstable-msc4426")]
     #[async_test]
     async fn test_hero_global_profile_update_triggers_notable_update() {
-        use ruma::profile::UserProfileUpdate;
-
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let alice = owned_user_id!("@alice:e.uk");
@@ -1688,12 +1686,9 @@ mod tests {
 
         // When a subsequent sync carries only a profiles-extension update for Alice.
         let mut response = http::Response::new("1".to_owned());
-        response.extensions.profiles.insert(
+        response.extensions.profiles.users.insert(
             alice.clone(),
-            UserProfileUpdate::from_iter([(
-                "org.matrix.msc4426.status".to_owned(),
-                json!({ "text": "Away", "emoji": "🌴" }),
-            )]),
+            make_profile_update(ProfileFieldName::Status, json!({ "text": "Away", "emoji": "🌴" })),
         );
         client
             .process_sliding_sync(
@@ -2921,5 +2916,11 @@ mod tests {
         }))
         .expect("Failed to create state event")
         .cast_unchecked()
+    }
+
+    fn make_profile_update(field: ProfileFieldName, value: serde_json::Value) -> UserProfileUpdate {
+        let mut changes = UserProfileChanges::new();
+        changes.updated.insert(field, value);
+        UserProfileUpdate::Updated(changes)
     }
 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -37,7 +37,7 @@ use ruma::{
     },
     mxc_uri, owned_event_id, owned_mxc_uri,
     presence::PresenceState,
-    profile::UserProfileUpdate,
+    profile::{ProfileFieldName, UserProfileChanges, UserProfileUpdate},
     push::Ruleset,
     room_id,
     room_version_rules::AuthorizationRules,
@@ -2156,10 +2156,10 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         assert_matches!(self.get_global_profile(user_id).await, Ok(None));
 
-        let mut fields = BTreeMap::new();
-        fields.insert("displayname".to_owned(), json!("Alice"));
-        fields.insert("avatar_url".to_owned(), json!(null));
-        let update = UserProfileUpdate::from_iter(fields);
+        let mut changes = UserProfileChanges::new();
+        changes.updated.insert(ProfileFieldName::DisplayName, json!("Alice"));
+        changes.removed.push(ProfileFieldName::AvatarUrl);
+        let update = UserProfileUpdate::Updated(changes);
 
         let mut changes = StateChanges::default();
         changes.global_profiles.insert(user_id.to_owned(), update);
@@ -2170,10 +2170,10 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(loaded_map.get("displayname"), Some(&json!("Alice")));
         assert!(!loaded_map.contains_key("avatar_url"));
 
-        let mut fields = BTreeMap::new();
-        fields.insert("displayname".to_owned(), json!(null));
-        fields.insert("avatar_url".to_owned(), json!("mxc://example.com/avatar"));
-        let update2 = UserProfileUpdate::from_iter(fields);
+        let mut changes = UserProfileChanges::new();
+        changes.removed.push(ProfileFieldName::DisplayName);
+        changes.updated.insert(ProfileFieldName::AvatarUrl, json!("mxc://example.com/avatar"));
+        let update2 = UserProfileUpdate::Updated(changes);
 
         let mut changes = StateChanges::default();
         changes.global_profiles.insert(user_id.to_owned(), update2);
@@ -2193,14 +2193,16 @@ impl StateStoreIntegrationTests for DynStateStore {
         let unknown = user_id!("@unknown:localhost");
 
         let mut changes = StateChanges::default();
-        changes.global_profiles.insert(
-            alice.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Alice"))]),
-        );
-        changes.global_profiles.insert(
-            bob.to_owned(),
-            UserProfileUpdate::from_iter([("displayname".to_owned(), json!("Bob"))]),
-        );
+        changes.global_profiles.insert(alice.to_owned(), {
+            let mut profile_changes = UserProfileChanges::new();
+            profile_changes.updated.insert(ProfileFieldName::DisplayName, json!("Alice"));
+            UserProfileUpdate::Updated(profile_changes)
+        });
+        changes.global_profiles.insert(bob.to_owned(), {
+            let mut profile_changes = UserProfileChanges::new();
+            profile_changes.updated.insert(ProfileFieldName::DisplayName, json!("Bob"));
+            UserProfileUpdate::Updated(profile_changes)
+        });
         self.save_changes(&changes).await?;
 
         // The bulk getter returns the stored profiles and omits unknown users.

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -33,7 +33,7 @@ use ruma::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
     },
-    profile::UserProfile,
+    profile::{UserProfile, UserProfileUpdate},
     serde::Raw,
     time::Instant,
 };
@@ -540,9 +540,21 @@ impl StateStore for MemoryStore {
         }
 
         for (user_id, profile_update) in &changes.global_profiles {
-            let mut profile = inner.global_profiles.get(user_id).cloned().unwrap_or_default();
-            profile.merge(profile_update.clone());
-            inner.global_profiles.insert(user_id.clone(), profile);
+            match profile_update {
+                UserProfileUpdate::Updated(profile_changes) => {
+                    inner
+                        .global_profiles
+                        .entry(user_id.clone())
+                        .or_default()
+                        .apply(profile_changes.clone());
+                }
+                UserProfileUpdate::Dropped => {
+                    inner.global_profiles.remove(user_id);
+                }
+                _ => {
+                    warn!(%user_id, "Unhandled UserProfileUpdate variant; ignoring");
+                }
+            }
         }
 
         debug!("Saved changes in {:?}", now.elapsed());

--- a/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
@@ -16,13 +16,11 @@ use matrix_sdk::RumaApiError;
 use matrix_sdk_crypto::olm::Curve25519PublicKey;
 use ruma::{
     api::{
-        Metadata, OutgoingRequest,
-        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
-        error::IntoHttpError,
-        path_builder::PathBuilder,
+        BytesBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        error::IntoHttpError, path_builder::PathBuilder,
     },
     events::room::EncryptedFile,
-    exports::{bytes::BufMut, http::Request},
+    exports::http::Request,
     metadata,
 };
 
@@ -58,28 +56,20 @@ impl DownloadAndScanEncryptedMediaRequest {
 }
 
 impl OutgoingRequest for DownloadAndScanEncryptedMediaRequest {
+    type Body = BytesBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = DownloadAndScanMediaResponse;
 
-    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+    fn try_into_http_request_inner(
         self,
         _base_url: &str,
-        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
-    ) -> Result<Request<T>, IntoHttpError> {
+    ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
 
         let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
-        let body = ruma::serde::json_to_buf(&body)?;
+        let body = BytesBody(ruma::serde::json_to_buf(&body)?);
 
-        let mut request = Request::builder().method(Self::METHOD).uri(url).body(body)?;
-        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
-            Self::Authentication::add_authentication(
-                &mut request,
-                SendAccessToken::IfRequired(access_token),
-            )?
-        }
-
-        Ok(request)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(body)?)
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/download/unencrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/unencrypted.rs
@@ -15,12 +15,10 @@
 use matrix_sdk::RumaApiError;
 use ruma::{
     api::{
-        Metadata, OutgoingRequest,
-        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
-        error::IntoHttpError,
-        path_builder::PathBuilder,
+        EmptyBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        error::IntoHttpError, path_builder::PathBuilder,
     },
-    exports::{bytes::BufMut, http::Request},
+    exports::http::Request,
     metadata,
 };
 
@@ -60,15 +58,15 @@ impl DownloadAndScanMediaRequest {
 }
 
 impl OutgoingRequest for DownloadAndScanMediaRequest {
+    type Body = EmptyBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = DownloadAndScanMediaResponse;
 
-    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+    fn try_into_http_request_inner(
         self,
         _base_url: &str,
-        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
-    ) -> Result<Request<T>, IntoHttpError> {
+    ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(
             path_builder_input,
             &self.scanner_url,
@@ -76,14 +74,6 @@ impl OutgoingRequest for DownloadAndScanMediaRequest {
             "",
         )?;
 
-        let mut request = Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
-        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
-            Self::Authentication::add_authentication(
-                &mut request,
-                SendAccessToken::IfRequired(access_token),
-            )?
-        }
-
-        Ok(request)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?)
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
@@ -15,13 +15,12 @@
 use matrix_sdk::RumaApiError;
 use ruma::{
     api::{
-        IncomingResponse, Metadata, OutgoingRequest,
-        auth_scheme::{AuthScheme, NoAuthentication},
+        EmptyBody, IncomingResponse, Metadata, OutgoingRequest,
+        auth_scheme::NoAuthentication,
         error::{FromHttpResponseError, IntoHttpError},
         path_builder::PathBuilder,
     },
     exports::{
-        bytes::BufMut,
         http::{Request, Response},
         serde_json,
     },
@@ -53,17 +52,17 @@ impl PublicServerKeyRequest {
 }
 
 impl OutgoingRequest for PublicServerKeyRequest {
+    type Body = EmptyBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = PublicServerKeyResponse;
 
-    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+    fn try_into_http_request_inner(
         self,
         _base_url: &str,
-        _authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
-    ) -> Result<Request<T>, IntoHttpError> {
+    ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
-        Ok(Request::builder().method(Self::METHOD).uri(url).body(T::default())?)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?)
     }
 }
 

--- a/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::{RumaApiError, bytes::BufMut, encryption::vodozemac::Curve25519PublicKey};
+use matrix_sdk::{RumaApiError, encryption::vodozemac::Curve25519PublicKey};
 use ruma::{
     api::{
-        Metadata, OutgoingRequest,
-        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
-        error::IntoHttpError,
-        path_builder::PathBuilder,
+        BytesBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        error::IntoHttpError, path_builder::PathBuilder,
     },
     events::room::EncryptedFile,
     exports::http::Request,
@@ -57,29 +55,20 @@ impl EncryptedMediaScanRequest {
 }
 
 impl OutgoingRequest for EncryptedMediaScanRequest {
+    type Body = BytesBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = MediaScanResponse;
 
-    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+    fn try_into_http_request_inner(
         self,
         _base_url: &str,
-        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
-    ) -> Result<Request<T>, IntoHttpError> {
+    ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
 
         let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
-        let body = ruma::serde::json_to_buf(&body)?;
+        let body = BytesBody(ruma::serde::json_to_buf(&body)?);
 
-        let mut request = Request::builder().method(Self::METHOD).uri(url).body(body)?;
-
-        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
-            Self::Authentication::add_authentication(
-                &mut request,
-                SendAccessToken::IfRequired(access_token),
-            )?
-        }
-
-        Ok(request)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(body)?)
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/scan/unencrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/unencrypted.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::{RumaApiError, bytes::BufMut};
+use matrix_sdk::RumaApiError;
 use ruma::{
     api::{
-        Metadata, OutgoingRequest,
-        auth_scheme::{AccessTokenOptional, AuthScheme, SendAccessToken},
-        error::IntoHttpError,
-        path_builder::PathBuilder,
+        EmptyBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        error::IntoHttpError, path_builder::PathBuilder,
     },
     exports::http::Request,
     metadata,
@@ -52,15 +50,15 @@ impl MediaScanRequest {
 }
 
 impl OutgoingRequest for MediaScanRequest {
+    type Body = EmptyBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = MediaScanResponse;
 
-    fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
+    fn try_into_http_request_inner(
         self,
         _base_url: &str,
-        authentication_input: <Self::Authentication as AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
-    ) -> Result<Request<T>, IntoHttpError> {
+    ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(
             path_builder_input,
             &self.scanner_url,
@@ -68,15 +66,6 @@ impl OutgoingRequest for MediaScanRequest {
             "",
         )?;
 
-        let mut request = Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
-
-        if let Some(access_token) = authentication_input.get_required_for_endpoint() {
-            Self::Authentication::add_authentication(
-                &mut request,
-                SendAccessToken::IfRequired(access_token),
-            )?
-        }
-
-        Ok(request)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?)
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -54,7 +54,7 @@ use ruma::{
             MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent, SyncRoomMemberEvent,
         },
     },
-    profile::UserProfile,
+    profile::{UserProfile, UserProfileUpdate},
     serde::Raw,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned, ser::Error};
@@ -1106,13 +1106,26 @@ impl_state_store!({
             let store = tx.object_store(keys::GLOBAL_PROFILES)?;
             for (user_id, profile_update) in &changes.global_profiles {
                 let key = self.encode_key(keys::GLOBAL_PROFILES, user_id);
-                let existing: Option<UserProfile> =
-                    store.get(&key).await?.map(|f| self.deserialize_value(&f)).transpose()?;
+                match profile_update {
+                    UserProfileUpdate::Updated(profile_changes) => {
+                        let existing: Option<UserProfile> = store
+                            .get(&key)
+                            .await?
+                            .map(|f| self.deserialize_value(&f))
+                            .transpose()?;
 
-                let mut profile = existing.unwrap_or_default();
-                profile.merge(profile_update.clone());
+                        let mut profile = existing.unwrap_or_default();
+                        profile.apply(profile_changes.clone());
 
-                store.put(&self.serialize_value(&profile)?).with_key(key).build()?;
+                        store.put(&self.serialize_value(&profile)?).with_key(key).build()?;
+                    }
+                    UserProfileUpdate::Dropped => {
+                        store.delete(&key).build()?;
+                    }
+                    _ => {
+                        warn!(%user_id, "Unhandled UserProfileUpdate variant; ignoring");
+                    }
+                }
             }
         }
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -34,7 +34,7 @@ use ruma::{
             member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
         },
     },
-    profile::UserProfile,
+    profile::{UserProfile, UserProfileUpdate},
     serde::Raw,
 };
 use rusqlite::{OptionalExtension, Transaction};
@@ -1609,20 +1609,34 @@ impl StateStore for SqliteStateStore {
                     let mut insert_stmt = txn.prepare_cached(
                         "INSERT OR REPLACE INTO global_profiles (user_id, profile_data) VALUES (?, ?)",
                     )?;
+                    let mut delete_stmt =
+                        txn.prepare_cached("DELETE FROM global_profiles WHERE user_id = ?")?;
 
-                    for (user_id, profile_update) in global_profiles {
-                        let user_id = this.encode_key(keys::GLOBAL_PROFILES, &user_id);
-                        let existing_data: Option<Vec<u8>> =
-                            select_stmt.query_row([&user_id], |row| row.get(0)).optional()?;
+                    for (raw_user_id, profile_update) in global_profiles {
+                        let user_id = this.encode_key(keys::GLOBAL_PROFILES, &raw_user_id);
+                        match profile_update {
+                            UserProfileUpdate::Updated(profile_changes) => {
+                                let existing_data: Option<Vec<u8>> = select_stmt
+                                    .query_row([&user_id], |row| row.get(0))
+                                    .optional()?;
 
-                        let mut profile: UserProfile = existing_data
-                            .map(|data| this.deserialize_json(&data))
-                            .transpose()?
-                            .unwrap_or_default();
-                        profile.merge(profile_update);
+                                let mut profile: UserProfile = existing_data
+                                    .map(|data| this.deserialize_json(&data))
+                                    .transpose()?
+                                    .unwrap_or_default();
+                                profile.apply(profile_changes);
 
-                        let serialized = this.serialize_json(&profile)?;
-                        insert_stmt.execute((&user_id, serialized))?;
+                                let serialized = this.serialize_json(&profile)?;
+                                insert_stmt.execute((&user_id, serialized))?;
+                            }
+                            // The user left all shared rooms, so drop their stored profile.
+                            UserProfileUpdate::Dropped => {
+                                delete_stmt.execute([&user_id])?;
+                            }
+                            _ => {
+                                warn!(%raw_user_id, "Unhandled UserProfileUpdate variant; ignoring");
+                            }
+                        }
                     }
                 }
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1602,40 +1602,36 @@ impl StateStore for SqliteStateStore {
                     }
                 }
 
-                if !global_profiles.is_empty() {
-                    let mut select_stmt = txn.prepare_cached(
-                        "SELECT profile_data FROM global_profiles WHERE user_id = ?",
-                    )?;
-                    let mut insert_stmt = txn.prepare_cached(
-                        "INSERT OR REPLACE INTO global_profiles (user_id, profile_data) VALUES (?, ?)",
-                    )?;
-                    let mut delete_stmt =
-                        txn.prepare_cached("DELETE FROM global_profiles WHERE user_id = ?")?;
+                for (raw_user_id, profile_update) in global_profiles {
+                    let user_id = this.encode_key(keys::GLOBAL_PROFILES, &raw_user_id);
+                    match profile_update {
+                        UserProfileUpdate::Updated(profile_changes) => {
+                            let existing_data: Option<Vec<u8>> = txn
+                                .prepare_cached(
+                                    "SELECT profile_data FROM global_profiles WHERE user_id = ?",
+                                )?
+                                .query_row([&user_id], |row| row.get(0))
+                                .optional()?;
 
-                    for (raw_user_id, profile_update) in global_profiles {
-                        let user_id = this.encode_key(keys::GLOBAL_PROFILES, &raw_user_id);
-                        match profile_update {
-                            UserProfileUpdate::Updated(profile_changes) => {
-                                let existing_data: Option<Vec<u8>> = select_stmt
-                                    .query_row([&user_id], |row| row.get(0))
-                                    .optional()?;
+                            let mut profile: UserProfile = existing_data
+                                .map(|data| this.deserialize_json(&data))
+                                .transpose()?
+                                .unwrap_or_default();
+                            profile.apply(profile_changes);
 
-                                let mut profile: UserProfile = existing_data
-                                    .map(|data| this.deserialize_json(&data))
-                                    .transpose()?
-                                    .unwrap_or_default();
-                                profile.apply(profile_changes);
-
-                                let serialized = this.serialize_json(&profile)?;
-                                insert_stmt.execute((&user_id, serialized))?;
-                            }
-                            // The user left all shared rooms, so drop their stored profile.
-                            UserProfileUpdate::Dropped => {
-                                delete_stmt.execute([&user_id])?;
-                            }
-                            _ => {
-                                warn!(%raw_user_id, "Unhandled UserProfileUpdate variant; ignoring");
-                            }
+                            let serialized = this.serialize_json(&profile)?;
+                            txn.prepare_cached(
+                                "INSERT OR REPLACE INTO global_profiles (user_id, profile_data) VALUES (?, ?)",
+                            )?
+                            .execute((&user_id, serialized))?;
+                        }
+                        // The user left all shared rooms, so drop their stored profile.
+                        UserProfileUpdate::Dropped => {
+                            txn.prepare_cached("DELETE FROM global_profiles WHERE user_id = ?")?
+                                .execute([&user_id])?;
+                        }
+                        _ => {
+                            warn!(%raw_user_id, "Unhandled UserProfileUpdate variant; ignoring");
                         }
                     }
                 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -727,9 +727,13 @@ async fn test_timeline_refreshes_sender_profile_on_global_profile_update() -> Re
             "lists": {},
             "rooms": {},
             "extensions": {
-                "users": {
-                    "@alice:bar.org": {
-                        "org.matrix.msc4426.status": { "text": "Away", "emoji": "🌴" }
+                "org.matrix.msc4262.profiles": {
+                    "users": {
+                        "@alice:bar.org": {
+                            "updated": {
+                                "org.matrix.msc4426.status": { "text": "Away", "emoji": "🌴" }
+                            }
+                        }
                     }
                 }
             }

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -23,7 +23,7 @@ use std::{borrow::Cow, fmt};
 use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
 use ruma::{
     api::{
-        OutgoingRequest,
+        OutgoingRequestExt,
         auth_scheme::SendAccessToken,
         client::{
             account::register,

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -30,7 +30,7 @@ use eyeball::SharedObservable;
 use http::Method;
 use matrix_sdk_base::SendOutsideWasm;
 use ruma::api::{
-    OutgoingRequest, SupportedVersions,
+    OutgoingRequest, OutgoingRequestExt, SupportedVersions,
     auth_scheme::{self, AuthScheme, SendAccessToken},
     error::{FromHttpResponseError, IntoHttpError},
     path_builder,


### PR DESCRIPTION
This PR updates Ruma to include https://github.com/ruma/ruma/pull/2531 and handles API breaks for:
- The updated `UserProfileUpdate`/`UserProfileChanges` types.
- The stabilisation of `unstable-msc2545`.

Required for #6764. Not sure if this requires anything specific in a changelog?

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries