### PR TITLE
Support compiling matrix-sdk-crypto to WASM by switching to ring crypto for X.509 stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,9 +3634,11 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rcgen",
+ "ring",
  "rmp-serde",
  "ruma",
  "rustls",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "serde_json",
@@ -3807,6 +3809,7 @@ dependencies = [
  "rand 0.10.1",
  "rcgen",
  "reqwest",
+ "rustls",
  "serde_json",
  "sha2",
  "similar-asserts",
@@ -5568,8 +5571,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5590,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ proc-macro2 = { version = "1.0.106", default-features = false }
 proptest = { version = "1.9.0", default-features = false, features = ["std"] }
 quote = { version = "1.0.37", default-features = false }
 rand = { version = "0.10.1", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-rcgen = { version = "0.14.8", features = ["aws_lc_rs", "x509-parser"] }
+rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.12.2", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.0", default-features = false }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -14,10 +14,14 @@ version = "0.18.0"
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
-# `cargo-machete` doesn't consider lib renames unless `--with-metadata`
-# is passed, but this errors CI further.
+# rustls-wbpki: `cargo-machete` doesn't consider lib renames unless
+# `--with-metadata` is passed, but this errors CI further.
+
+# rustls-pki-types: this is an indirect dependency, but we need to add this to
+# control its feature flags.
+# See https://github.com/bnjbvr/cargo-machete/issues/170
 [package.metadata.cargo-machete]
-ignored = ["rustls-webpki"]
+ignored = ["rustls-webpki", "rustls-pki-types"]
 
 [features]
 default = []
@@ -53,7 +57,7 @@ experimental-push-secrets = []
 experimental-x509-identity-verification = ["dep:cms", "dep:pkcs1", "sha2/oid"]
 
 # Enable a pure-rust implementation of the X.509 signer and verifier, via `rustls`.
-rust-x509-verifier-impl = ["experimental-x509-identity-verification", "dep:rustls", "dep:rustls-webpki"]
+rust-x509-verifier-impl = ["experimental-x509-identity-verification", "dep:rustls", "dep:rustls-pki-types", "dep:rustls-webpki", "dep:ring"]
 
 [dependencies]
 aes = { version = "0.8.4", default-features = false }
@@ -78,9 +82,11 @@ matrix-sdk-test = { workspace = true, optional = true }  # feature = testing onl
 pbkdf2.workspace = true
 pkcs1 = { version = "0.7.5", default-features = false, optional = true }
 rand.workspace = true
+ring = { version = "0.17.14", optional = true, features = ["wasm32_unknown_unknown_js"] }
 rmp-serde.workspace = true
 ruma = { workspace = true, features = ["rand", "unstable-msc3814"] }
-rustls = { version = "0.23.40", default-features = false, optional = true }
+rustls = { version = "0.23.40", optional = true, default-features = false, features = ["std", "ring"] }
+rustls-pki-types = { version = "1.15.0", optional = true, default-features = false, features = ["alloc", "web"] }
 rustls-webpki = { version = "0.103.13", default-features = false, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
@@ -114,15 +120,17 @@ matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
 proptest.workspace = true
 rmp-serde.workspace = true
-rcgen.workspace = true
+rcgen = { workspace = true, features = ["ring", "x509-parser"] }
 similar-asserts.workspace = true
 # required for async_test macro
 stream_assert.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 # The x509 tests use rust-x509-verifier-impl, so we need its dependencies
-rustls = { version = "0.23.40" }
+ring = { version = "0.17.14", features = ["wasm32_unknown_unknown_js"] }
+rustls = { version = "0.23.40", default-features = false, features = ["std", "ring"] }
 rustls-webpki = { version = "0.103.13", default-features = false }
+rustls-pki-types = { version = "1.15.0", default-features = false, features = ["alloc", "web"] }
 
 [lints]
 workspace = true

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -167,6 +167,8 @@ pub(crate) mod tests {
     pub(crate) fn cert_and_key_with_email_in_subject_distinguished_name(
         email: &str,
     ) -> (Certificate, KeyPair) {
+        set_up_default_crypto_provider();
+
         let signing_key = generate_rsa_key();
 
         let mut cert_params = CertificateParams::default();
@@ -184,6 +186,8 @@ pub(crate) mod tests {
     pub(crate) fn cert_and_key_with_email_in_subject_alternate_name(
         email: &str,
     ) -> (Certificate, KeyPair) {
+        set_up_default_crypto_provider();
+
         let signing_key = generate_rsa_key();
 
         let mut cert_params = CertificateParams::default();
@@ -203,6 +207,8 @@ pub(crate) mod tests {
     pub(crate) fn cert_and_key_with_user_id_in_subject_alternate_name(
         user_id: &str,
     ) -> (Certificate, KeyPair) {
+        set_up_default_crypto_provider();
+
         let signing_key = generate_rsa_key();
 
         let user_id_uri =
@@ -222,6 +228,8 @@ pub(crate) mod tests {
 
     /// Create a certificate that does not contain a user ID or email address
     pub(crate) fn cert_and_key_with_no_user_id() -> (Certificate, KeyPair) {
+        set_up_default_crypto_provider();
+
         let signing_key = generate_rsa_key();
 
         let mut cert_params = CertificateParams::default();
@@ -268,6 +276,8 @@ pub(crate) mod tests {
     /// Generate a little certificate authority i.e. a key pair and a
     /// self-signed certificate.
     pub(crate) fn ca_cert() -> (Certificate, KeyPair) {
+        set_up_default_crypto_provider();
+
         let cert_params = cert_params("You Can Trust Us Certificate Authority");
 
         let signing_key = generate_rsa_key();
@@ -320,5 +330,10 @@ pub(crate) mod tests {
             X509Verifier::new(Arc::new(rust_raw_x509_verifier))
         };
         (x509_signer, x509_verifier)
+    }
+
+    fn set_up_default_crypto_provider() {
+        // Ignore errors: they just mean that this method was called before.
+        let _ = rustls::crypto::ring::default_provider().install_default();
     }
 }

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use rustls::{
     SignatureScheme,
-    crypto::aws_lc_rs,
+    crypto::ring,
     pki_types::{PrivateKeyDer, pem::PemObject},
     sign::SigningKey,
 };
@@ -71,7 +71,7 @@ impl RustRawX509Signer {
         certificate_chain_pem: &str,
         private_key_pem: &str,
     ) -> Result<Self, RustX509SignError> {
-        let provider = aws_lc_rs::default_provider();
+        let provider = ring::default_provider();
 
         let private_key = PrivateKeyDer::from_pem_slice(private_key_pem.as_bytes())
             .map_err(RustX509SignError::PrivateKeyParse)?;

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -40,8 +40,9 @@ matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
 matrix-sdk-ui = { workspace = true, default-features = true }
 rand.workspace = true
-rcgen.workspace = true
+rcgen = { workspace = true, features = ["aws_lc_rs", "pem", "x509-parser"] }
 reqwest.workspace = true
+rustls = { version = "0.23.42", default-features = false, features = ["aws_lc_rs"] }
 serde_json.workspace = true
 sha2.workspace = true
 similar-asserts.workspace = true

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
@@ -158,6 +158,8 @@ async fn create_encryption_enabled_client(
     x509_signer: Option<Arc<dyn RawX509Signer>>,
     x509_verifier: Option<Arc<dyn RawX509Verifier>>,
 ) -> anyhow::Result<SyncTokenAwareClient> {
+    set_up_default_crypto_provider();
+
     let encryption_settings =
         EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
 
@@ -178,6 +180,8 @@ async fn create_encryption_enabled_client(
 /// Generate a little certificate authority i.e. a key pair and a
 /// self-signed certificate.
 fn ca_cert() -> (Certificate, KeyPair) {
+    set_up_default_crypto_provider();
+
     let cert_params = cert_params("Delboy Inc Trust Us Certificate Authority");
 
     let signing_key =
@@ -268,4 +272,9 @@ pub(crate) fn subject_key_identifier_extension(
     let ski_der = [&[0x04, ski_bytes.len() as u8], ski_bytes].concat();
 
     CustomExtension::from_oid_content(OID_SUBJECT_KEY_IDENTIFIER, ski_der)
+}
+
+fn set_up_default_crypto_provider() {
+    // Ignore errors: they just mean that this method was called before.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
@@ -48,7 +48,7 @@ async fn test_user_is_verified_if_their_msk_is_signed() -> anyhow::Result<()> {
     let alice_span = tracing::info_span!("alice");
     let bob_span = tracing::info_span!("bob");
 
-    let (alice_username, alice_email) = username_and_email("alice");
+    let (alice_username, alice_email) = username_and_email("alice").await;
 
     // This is the happy path.
     //
@@ -73,7 +73,7 @@ async fn test_user_is_verified_if_their_msk_is_signed() -> anyhow::Result<()> {
             .await?;
 
     // Bob can verify signatures that are properly linked to the CA
-    let (bob_username, _bob_email) = username_and_email("bob");
+    let (bob_username, _bob_email) = username_and_email("bob").await;
     let bob_x509_verifier: Arc<dyn RawX509Verifier> =
         Arc::new(RustRawX509Verifier::new_from_pem_data(&ca_cert.pem()).unwrap());
 
@@ -97,7 +97,7 @@ async fn test_user_is_not_verified_if_we_dont_trust_their_cert() -> anyhow::Resu
     let alice_span = tracing::info_span!("alice");
     let bob_span = tracing::info_span!("bob");
 
-    let (alice_username, alice_email) = username_and_email("alice");
+    let (alice_username, alice_email) = username_and_email("alice").await;
 
     // This is a failure case: Alice and Bob know about X.509, but they use a
     // different CA, so Bob doesn't trust Alice's signature.
@@ -124,7 +124,7 @@ async fn test_user_is_not_verified_if_we_dont_trust_their_cert() -> anyhow::Resu
             .await?;
 
     // Bob can verify signatures that are properly linked to their CA
-    let (bob_username, _bob_email) = username_and_email("bob");
+    let (bob_username, _bob_email) = username_and_email("bob").await;
     let bob_x509_verifier: Arc<dyn RawX509Verifier> =
         Arc::new(RustRawX509Verifier::new_from_pem_data(&bob_ca_cert.pem()).unwrap());
 
@@ -232,13 +232,18 @@ fn cert_params(common_name: &str) -> CertificateParams {
     cert_params
 }
 
-fn username_and_email(prefix: &str) -> (String, String) {
+async fn username_and_email(prefix: &str) -> (String, String) {
     let suffix: u128 = rand::rng().random();
-
     let username = format!("{prefix}{suffix}");
-    // N.B: CI uses `synapse` as server name, which we must match. This
-    // will error the local integration test setup in `ci-start.sh`.
-    let email = format!("{username}@synapse");
+
+    // Discover the server name by creating a temporary client. We need to
+    // discover it because the server name used in CI differs from that used
+    // when running locally. We need to know the server name before we create
+    // our real users because we want to embed the email address in the
+    // certificate that will sign their identity.
+    let tmp_client = TestClientBuilder::new("tmpuser").build().await.unwrap();
+    let server_name = tmp_client.user_id().unwrap().server_name();
+    let email = format!("{username}@{server_name}");
 
     (username, email)
 }


### PR DESCRIPTION
I moved the rcgen dependency out of the workspace because it's only used for tests, and the two places where we use it for tests actually want different features. This feels cleaner to me, but I am persuadable.

- [x] I've documented the public API changes in the appropriate changelog files.
- No AI was used.