### PR TITLE
FFI: Add a `Client::is_user_status_supported` check for apps to gate the feature against.

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = [
 ]
 
 [features]
-default = ["bundled-sqlite", "unstable-msc4274", "unstable-msc4426", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
+default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
 experimental-search = ["matrix-sdk/experimental-search", "matrix-sdk-ui/experimental-search"]
 # Use SQLite for the session storage.
 sqlite = ["matrix-sdk/sqlite"]
@@ -33,7 +33,6 @@ bundled-sqlite = ["sqlite", "matrix-sdk/bundled-sqlite"]
 # Use IndexedDB for the session storage.
 indexeddb = ["matrix-sdk/indexeddb"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
-unstable-msc4426 = ["matrix-sdk-ui/unstable-msc4426"]
 # Required when targeting a Javascript environment, like Wasm in a browser.
 js = ["matrix-sdk-ui/js"]
 # Enable sentry error monitoring, not compatible with Wasm platforms.
@@ -67,7 +66,7 @@ matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true
 matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-contentscanner = { workspace = true, features = ["uniffi", "e2e-encryption"] }
-matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
+matrix-sdk-ui = { workspace = true, features = ["uniffi", "unstable-msc4426"] }
 mime = { version = "0.3.17", default-features = false }
 ruma = { workspace = true, features = [
     "html",
@@ -90,8 +89,6 @@ ruma = { workspace = true, features = [
     "unstable-msc3954",
     # Room language event type
     "unstable-msc4334",
-    # User status profile fields (m.status, m.call).
-    "unstable-msc4426",
     "unstable-uniffi",
 ] }
 serde.workspace = true

--- a/bindings/matrix-sdk-ffi/changelog.d/6778.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6778.added.md
@@ -1,0 +1,1 @@
+Add `Client::is_user_status_supported()`, which returns whether the homeserver supports user status. This is the case when the server supports MSC4262 (Profiles Sliding Sync Extension) and allows setting the `m.status` extended profile field.

--- a/bindings/matrix-sdk-ffi/changelog.d/6778.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6778.changed.md
@@ -1,0 +1,1 @@
+The dedicated `unstable-msc4426` Cargo feature has been removed. This feature was previously enabled by default and there is no change in functionality.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -77,8 +77,6 @@ use matrix_sdk_ui::{
 };
 use mime::Mime;
 use oauth2::Scope;
-#[cfg(feature = "unstable-msc4426")]
-use ruma::api::client::profile::{Call, Status};
 use ruma::{
     OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
     api::{
@@ -88,7 +86,7 @@ use ruma::{
             discovery::get_authorization_server_metadata::v1::{
                 AccountManagementActionData, DeviceDeleteData, DeviceViewData,
             },
-            profile::{AvatarUrl, DisplayName, ProfileFieldName},
+            profile::{AvatarUrl, Call, DisplayName, ProfileFieldName, Status},
             room::create_room::{RoomPowerLevelsContentOverride, v3::CreationContent},
             uiaa::{EmailUserIdentifier, UserIdentifier},
         },
@@ -130,8 +128,6 @@ use super::{
     room::{Room, room_info::RoomInfo},
     session_verification::SessionVerificationController,
 };
-#[cfg(feature = "unstable-msc4426")]
-use crate::ruma::{UserCall, UserStatus};
 use crate::{
     ClientError,
     authentication::{
@@ -152,7 +148,7 @@ use crate::{
     room_preview::RoomPreview,
     ruma::{
         AccountDataEvent, AccountDataEventType, AuthData, InviteAvatars, MediaPreviewConfig,
-        MediaPreviews, MediaSource, PresenceState, RoomAccountDataEvent,
+        MediaPreviews, MediaSource, PresenceState, RoomAccountDataEvent, UserCall, UserStatus,
     },
     runtime::get_runtime_handle,
     spaces::SpaceService,
@@ -2578,14 +2574,12 @@ pub struct UserProfile {
     pub avatar_url: Option<String>,
 
     /// The user's status (MSC4426 `m.status` profile field), if set.
-    #[cfg(feature = "unstable-msc4426")]
     pub status: Option<UserStatus>,
 
     /// Set when the user is in a call (MSC4426 `m.call` profile field).
     ///
     /// `None` means the user is not in a call. `Some(UserCall { call_joined_ts:
     /// None })` means the user is in a call but the join time wasn't recorded.
-    #[cfg(feature = "unstable-msc4426")]
     pub call: Option<UserCall>,
 }
 
@@ -2604,21 +2598,10 @@ impl UserProfile {
     ) -> Result<Self, ClientError> {
         let display_name = profile.get_static::<DisplayName>()?;
         let avatar_url = profile.get_static::<AvatarUrl>()?.map(|url| url.to_string());
-
-        #[cfg(feature = "unstable-msc4426")]
         let status = profile.get_static::<Status>()?.map(UserStatus::from);
-        #[cfg(feature = "unstable-msc4426")]
         let call = profile.get_static::<Call>()?.map(UserCall::from);
 
-        Ok(UserProfile {
-            user_id: user_id.to_string(),
-            display_name,
-            avatar_url,
-            #[cfg(feature = "unstable-msc4426")]
-            status,
-            #[cfg(feature = "unstable-msc4426")]
-            call,
-        })
+        Ok(UserProfile { user_id: user_id.to_string(), display_name, avatar_url, status, call })
     }
 }
 
@@ -2628,15 +2611,12 @@ impl From<&search_users::v3::User> for UserProfile {
             user_id: value.user_id.to_string(),
             display_name: value.display_name.clone(),
             avatar_url: value.avatar_url.as_ref().map(|url| url.to_string()),
-            #[cfg(feature = "unstable-msc4426")]
             status: None,
-            #[cfg(feature = "unstable-msc4426")]
             call: None,
         }
     }
 }
 
-#[cfg(feature = "unstable-msc4426")]
 #[matrix_sdk_ffi_macros::export]
 impl Client {
     /// Set the current user's status (MSC4426 `m.status` profile field).

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -82,12 +82,13 @@ use ruma::api::client::profile::{Call, Status};
 use ruma::{
     OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
     api::{
+        FeatureFlag,
         client::{
             alias::get_alias,
             discovery::get_authorization_server_metadata::v1::{
                 AccountManagementActionData, DeviceDeleteData, DeviceViewData,
             },
-            profile::{AvatarUrl, DisplayName},
+            profile::{AvatarUrl, DisplayName, ProfileFieldName},
             room::create_room::{RoomPowerLevelsContentOverride, v3::CreationContent},
             uiaa::{EmailUserIdentifier, UserIdentifier},
         },
@@ -2150,6 +2151,24 @@ impl Client {
             .await?
             .iter()
             .any(|focus| matches!(focus, RtcTransport::LiveKit(_))))
+    }
+
+    /// Checks if the server supports user status.
+    pub async fn is_user_status_supported(&self) -> Result<bool, ClientError> {
+        let supports_profiles_sync_extension = self
+            .inner
+            .unstable_features()
+            .await?
+            .contains(&FeatureFlag::from("org.matrix.msc4262"));
+
+        let can_set_status_field = self
+            .inner
+            .homeserver_capabilities()
+            .extended_profile_fields()
+            .await?
+            .can_set_field(&ProfileFieldName::Status);
+
+        Ok(supports_profiles_sync_extension && can_set_status_field)
     }
 
     /// Get information about the homeserver's advertised map tile server, if

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -49,8 +49,6 @@ use ruma::{
 use tracing::error;
 
 use self::{power_levels::RoomPowerLevels, room_info::RoomInfo};
-#[cfg(feature = "unstable-msc4426")]
-use crate::ruma::{UserCall, UserStatus};
 use crate::{
     TaskHandle,
     chunk_iterator::ChunkIterator,
@@ -64,7 +62,9 @@ use crate::{
     live_locations_observer::LiveLocationsObserver,
     room_member::{RoomMember, RoomMemberWithSenderInfo},
     room_preview::RoomPreview,
-    ruma::{AudioInfo, FileInfo, ImageInfo, MediaSource, ThumbnailInfo, VideoInfo},
+    ruma::{
+        AudioInfo, FileInfo, ImageInfo, MediaSource, ThumbnailInfo, UserCall, UserStatus, VideoInfo,
+    },
     runtime::get_runtime_handle,
     timeline::{
         AbstractProgress, LatestEventValue, ReceiptType, SendHandle, Timeline, UploadSource,
@@ -1407,10 +1407,8 @@ pub struct RoomHero {
     /// The avatar URL of the hero.
     avatar_url: Option<String>,
     /// The hero's user-set status, taken from their global profile.
-    #[cfg(feature = "unstable-msc4426")]
     status: Option<UserStatus>,
     /// The hero's call indicator, taken from their global profile.
-    #[cfg(feature = "unstable-msc4426")]
     call: Option<UserCall>,
 }
 
@@ -1420,9 +1418,7 @@ impl From<SdkRoomHeroWithProfile> for RoomHero {
             user_id: value.user_id.to_string(),
             display_name: value.display_name.clone(),
             avatar_url: value.avatar_url.as_ref().map(ToString::to_string),
-            #[cfg(feature = "unstable-msc4426")]
             status: value.status.map(UserStatus::from),
-            #[cfg(feature = "unstable-msc4426")]
             call: value.call.map(UserCall::from),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -1,9 +1,10 @@
 use matrix_sdk::room::{RoomMember as SdkRoomMember, RoomMemberRole};
 use ruma::{UserId, events::room::power_levels::UserPowerLevel};
 
-use crate::error::{ClientError, NotYetImplemented};
-#[cfg(feature = "unstable-msc4426")]
-use crate::ruma::{UserCall, UserStatus};
+use crate::{
+    error::{ClientError, NotYetImplemented},
+    ruma::{UserCall, UserStatus},
+};
 
 #[derive(Clone, uniffi::Enum)]
 pub enum MembershipState {
@@ -92,9 +93,7 @@ pub struct RoomMember {
     pub user_id: String,
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
-    #[cfg(feature = "unstable-msc4426")]
     pub status: Option<UserStatus>,
-    #[cfg(feature = "unstable-msc4426")]
     pub call: Option<UserCall>,
     pub membership: MembershipState,
     pub is_name_ambiguous: bool,
@@ -113,9 +112,7 @@ impl TryFrom<SdkRoomMember> for RoomMember {
             user_id: m.user_id().to_string(),
             display_name: m.display_name().map(|s| s.to_owned()),
             avatar_url: m.avatar_url().map(|a| a.to_string()),
-            #[cfg(feature = "unstable-msc4426")]
             status: m.status().cloned().map(UserStatus::from),
-            #[cfg(feature = "unstable-msc4426")]
             call: m.call().cloned().map(UserCall::from),
             membership: m.membership().clone().try_into()?,
             is_name_ambiguous: m.name_ambiguous(),

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -22,7 +22,7 @@ use extension_trait::extension_trait;
 use matrix_sdk::attachment::{BaseAudioInfo, BaseFileInfo, BaseImageInfo, BaseVideoInfo};
 use ruma::{
     KeyDerivationAlgorithm as RumaKeyDerivationAlgorithm, MatrixToUri, MatrixUri as RumaMatrixUri,
-    OwnedRoomId, OwnedUserId, UInt, UserId, assign,
+    OwnedRoomId, OwnedUserId, SecondsSinceUnixEpoch, UInt, UserId, assign,
     events::{
         GlobalAccountDataEvent as RumaGlobalAccountDataEvent,
         GlobalAccountDataEventType as RumaGlobalAccountDataEventType,
@@ -79,16 +79,12 @@ use ruma::{
     },
     matrix_uri::MatrixId as RumaMatrixId,
     presence::PresenceState as RumaPresenceState,
+    profile::{CallProfileField, StatusProfileField},
     push::{
         ConditionalPushRule as RumaConditionalPushRule, PatternedPushRule as RumaPatternedPushRule,
         Ruleset as RumaRuleset, SimplePushRule as RumaSimplePushRule,
     },
     serde::JsonObject,
-};
-#[cfg(feature = "unstable-msc4426")]
-use ruma::{
-    SecondsSinceUnixEpoch,
-    profile::{CallProfileField, StatusProfileField},
 };
 use tracing::info;
 
@@ -226,21 +222,18 @@ impl From<RumaPresenceState> for PresenceState {
 }
 
 /// A user-set status (MSC4426 `m.status` profile field value).
-#[cfg(feature = "unstable-msc4426")]
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct UserStatus {
     pub emoji: String,
     pub text: String,
 }
 
-#[cfg(feature = "unstable-msc4426")]
 impl From<UserStatus> for StatusProfileField {
     fn from(value: UserStatus) -> Self {
         Self::new(value.text, value.emoji)
     }
 }
 
-#[cfg(feature = "unstable-msc4426")]
 impl From<StatusProfileField> for UserStatus {
     fn from(value: StatusProfileField) -> Self {
         Self { emoji: value.emoji, text: value.text }
@@ -251,20 +244,17 @@ impl From<StatusProfileField> for UserStatus {
 ///
 /// Presence of a `UserCall` value means the user is in a call. The optional
 /// `call_joined_ts` is the Unix-epoch seconds when they joined, if known.
-#[cfg(feature = "unstable-msc4426")]
 #[derive(Debug, Clone, uniffi::Record)]
 pub struct UserCall {
     pub call_joined_ts: Option<u64>,
 }
 
-#[cfg(feature = "unstable-msc4426")]
 impl From<CallProfileField> for UserCall {
     fn from(value: CallProfileField) -> Self {
         Self { call_joined_ts: value.call_joined_ts.map(|ts| u64::from(ts.get())) }
     }
 }
 
-#[cfg(feature = "unstable-msc4426")]
 impl From<UserCall> for CallProfileField {
     fn from(value: UserCall) -> Self {
         let mut field = CallProfileField::new();

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -61,14 +61,12 @@ use tracing::{error, warn};
 use uuid::Uuid;
 
 pub use self::{content::TimelineItemContent, msg_like::MessageContent};
-#[cfg(feature = "unstable-msc4426")]
-use crate::ruma::{UserCall, UserStatus};
 use crate::{
     error::{ClientError, RoomError},
     event::EventOrTransactionId,
     ruma::{
         AssetType, AudioInfo, FileInfo, FormattedBody, ImageInfo, Mentions, PollKind,
-        ThumbnailInfo, VideoInfo,
+        ThumbnailInfo, UserCall, UserStatus, VideoInfo,
     },
     runtime::get_runtime_handle,
     task_handle::TaskHandle,
@@ -1081,9 +1079,7 @@ pub enum ProfileDetails {
         display_name: Option<String>,
         display_name_ambiguous: bool,
         avatar_url: Option<String>,
-        #[cfg(feature = "unstable-msc4426")]
         status: Option<UserStatus>,
-        #[cfg(feature = "unstable-msc4426")]
         call: Option<UserCall>,
     },
     Error {
@@ -1100,9 +1096,7 @@ impl From<TimelineDetails<Profile>> for ProfileDetails {
                 display_name: profile.display_name,
                 display_name_ambiguous: profile.display_name_ambiguous,
                 avatar_url: profile.avatar_url.as_ref().map(ToString::to_string),
-                #[cfg(feature = "unstable-msc4426")]
                 status: profile.status.map(UserStatus::from),
-                #[cfg(feature = "unstable-msc4426")]
                 call: profile.call.map(UserCall::from),
             },
             TimelineDetails::Error(e) => Self::Error { message: e.to_string() },
@@ -1119,9 +1113,7 @@ impl From<&TimelineDetails<Profile>> for ProfileDetails {
                 display_name: profile.display_name.clone(),
                 display_name_ambiguous: profile.display_name_ambiguous,
                 avatar_url: profile.avatar_url.as_ref().map(ToString::to_string),
-                #[cfg(feature = "unstable-msc4426")]
                 status: profile.status.clone().map(UserStatus::from),
-                #[cfg(feature = "unstable-msc4426")]
                 call: profile.call.clone().map(UserCall::from),
             },
             TimelineDetails::Error(e) => Self::Error { message: e.to_string() },


### PR DESCRIPTION
This PR makes 2 changes in the FFI:
- Adds a method to check whether the server supports everything necessary to use the User Status feature.
- Removes the `unstable-msc4426` feature as it was enabled by default in the FFI and there seems little benefit to disabling it at this level.

I haven't added a changelog for the latter, can do if it makes sense but wasn't sure if it was necessary.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries