### PR TITLE
fix(content-scanner): decrypt the encrypted media sources in `ContentScannerMediaFetcher`

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -66,7 +66,7 @@ matrix-sdk = { workspace = true, features = [
 matrix-sdk-base.workspace = true
 matrix-sdk-common.workspace = true
 matrix-sdk-ffi-macros.workspace = true
-matrix-sdk-contentscanner = { workspace = true, features = ["uniffi"] }
+matrix-sdk-contentscanner = { workspace = true, features = ["uniffi", "e2e-encryption"] }
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 mime = { version = "0.3.17", default-features = false }
 ruma = { workspace = true, features = [

--- a/crates/matrix-sdk-contentscanner/Cargo.toml
+++ b/crates/matrix-sdk-contentscanner/Cargo.toml
@@ -9,13 +9,14 @@ rust-version.workspace = true
 
 [features]
 default = ["rustls-aws-lc-rs"]
+e2e-encryption = []
 uniffi = ["dep:uniffi", "matrix-sdk/uniffi"]
 
 rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs"]
 
 [dependencies]
 assert_matches2.workspace = true
-matrix-sdk = { workspace = true, features = ["testing", "e2e-encryption"] }
+matrix-sdk = { workspace = true, features = ["e2e-encryption", "testing"] }
 matrix-sdk-crypto.workspace = true
 ruma = { workspace = true, features = ["client-api"] }
 serde.workspace = true

--- a/crates/matrix-sdk-contentscanner/changelog.d/6779.fixed.md
+++ b/crates/matrix-sdk-contentscanner/changelog.d/6779.fixed.md
@@ -1,0 +1,1 @@
+Add media content decryption to the `ContentScannerMediaFetcher` when the media source provided is `MediaSource::Encrypted`. 

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "e2e-encryption")]
+use std::io::Read;
 use std::{
     fmt::{Debug, Formatter},
     sync::Arc,
@@ -30,6 +32,8 @@ use matrix_sdk::{
     media::{MediaFetcher, MediaRequestParameters},
     ruma::events::room::MediaSource,
 };
+#[cfg(feature = "e2e-encryption")]
+use matrix_sdk_crypto::AttachmentDecryptor;
 use matrix_sdk_crypto::olm::Curve25519PublicKey;
 use ruma::{
     events::room::EncryptedFile,
@@ -213,7 +217,28 @@ impl MediaFetcher for ContentScannerMediaFetcher {
         request: &'a MediaRequestParameters,
     ) -> BoxFuture<'a, matrix_sdk::Result<Vec<u8>, Error>> {
         Box::pin(async move {
-            Ok(self.content_scanner.get_media(client, &request.source).await?.content)
+            let content = self.content_scanner.get_media(client, &request.source).await?.content;
+            #[cfg(feature = "e2e-encryption")]
+            let content = {
+                match &request.source {
+                    MediaSource::Encrypted(file) => {
+                        let content_len = content.len();
+                        let mut cursor = std::io::Cursor::new(content);
+                        let mut reader =
+                            AttachmentDecryptor::new(&mut cursor, file.as_ref().clone().into())?;
+
+                        // Encrypted size should be the same as the decrypted size,
+                        // rounded up to a cipher block.
+                        let mut decrypted = Vec::with_capacity(content_len);
+
+                        reader.read_to_end(&mut decrypted)?;
+
+                        decrypted
+                    }
+                    MediaSource::Plain(_) => content,
+                }
+            };
+            Ok(content)
         })
     }
 }


### PR DESCRIPTION
This wasn't already there by mistake: I thought this step was handled in `matrix_sdk::Media`, it turns out it was done in the media fetcher.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
