### PR TITLE
Handle a subtle difference in the reporting of uploaded one-time key counts between the supported sync APIs

### DIFF
--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(unused_qualifications, clippy::new_without_default)]
 // Needed because uniffi macros contain empty lines after docs.
 #![allow(clippy::empty_line_after_doc_comments)]

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -46,6 +46,7 @@ pub async fn from_msc4186(
         e2ee.device_unused_fallback_key_types.as_deref(),
         to_device.as_ref().map(|to_device| to_device.next_batch.clone()),
         decryption_settings,
+        true,
     )
     .await
 }
@@ -68,6 +69,7 @@ pub async fn from_sync_v2(
         response.device_unused_fallback_key_types.as_deref(),
         Some(response.next_batch.clone()),
         decryption_settings,
+        false,
     )
     .await
 }
@@ -76,6 +78,7 @@ pub async fn from_sync_v2(
 ///
 /// This returns a list of all the to-device events that were passed in but
 /// encrypted ones were replaced with their decrypted version.
+#[allow(clippy::too_many_arguments)]
 async fn process(
     olm_machine: Option<&OlmMachine>,
     to_device_events: Vec<Raw<AnyToDeviceEvent>>,
@@ -84,6 +87,7 @@ async fn process(
     unused_fallback_keys: Option<&[OneTimeKeyAlgorithm]>,
     next_batch_token: Option<String>,
     decryption_settings: &DecryptionSettings,
+    msc_4188: bool,
 ) -> Result<Output> {
     let encryption_sync_changes = EncryptionSyncChanges {
         to_device_events,
@@ -98,8 +102,13 @@ async fn process(
         // decrypts to-device events, but leaves room events alone.
         // This makes sure that we have the decryption keys for the room
         // events at hand.
-        let (events, _room_key_updates) =
-            olm_machine.receive_sync_changes(encryption_sync_changes, decryption_settings).await?;
+        let (events, _room_key_updates) = if msc_4188 {
+            olm_machine
+                .receive_sync_changes_msc4186(encryption_sync_changes, decryption_settings)
+                .await?
+        } else {
+            olm_machine.receive_sync_changes(encryption_sync_changes, decryption_settings).await?
+        };
 
         Output { processed_to_device_events: events }
     } else {

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -87,7 +87,7 @@ async fn process(
     unused_fallback_keys: Option<&[OneTimeKeyAlgorithm]>,
     next_batch_token: Option<String>,
     decryption_settings: &DecryptionSettings,
-    msc_4188: bool,
+    msc_4186: bool,
 ) -> Result<Output> {
     let encryption_sync_changes = EncryptionSyncChanges {
         to_device_events,
@@ -102,7 +102,7 @@ async fn process(
         // decrypts to-device events, but leaves room events alone.
         // This makes sure that we have the decryption keys for the room
         // events at hand.
-        let (events, _room_key_updates) = if msc_4188 {
+        let (events, _room_key_updates) = if msc_4186 {
             olm_machine
                 .receive_sync_changes_msc4186(encryption_sync_changes, decryption_settings)
                 .await?

--- a/crates/matrix-sdk-crypto/changelog.d/6780.fixed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6780.fixed.md
@@ -1,0 +1,6 @@
+[**breaking**] The `OlmMachine::receive_sync_changes()` method now correctly
+treats a missing one-time key count to mean that zero one-time keys exist on the
+homeserver.
+
+A new method `OlmMachine::receive_sync_changes_msc4186()` was added if the
+MSC4816 semantics for one-time key counts should be used.

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1854,6 +1854,14 @@ impl OlmMachine {
     ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
         let mut store_transaction = self.inner.store.transaction().await;
 
+        {
+            let account = store_transaction.account().await?;
+            account.update_key_counts(
+                sync_changes.one_time_keys_counts,
+                sync_changes.unused_fallback_keys,
+            )
+        }
+
         let (events, changes) = self
             .preprocess_sync_changes(&mut store_transaction, sync_changes, decryption_settings)
             .await?;
@@ -1906,14 +1914,6 @@ impl OlmMachine {
         // The account is automatically saved by the store transaction created by the
         // caller.
         let mut changes = Default::default();
-
-        {
-            let account = transaction.account().await?;
-            account.update_key_counts(
-                sync_changes.one_time_keys_counts,
-                sync_changes.unused_fallback_keys,
-            )
-        }
 
         if let Err(e) = self
             .inner

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1852,13 +1852,49 @@ impl OlmMachine {
         sync_changes: EncryptionSyncChanges<'_>,
         decryption_settings: &DecryptionSettings,
     ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
-        self.receive_sync_changes_impl(sync_changes, decryption_settings).await
+        self.receive_sync_changes_impl(sync_changes, decryption_settings, true).await
     }
 
-    pub async fn receive_sync_changes_impl(
+    /// Handle changes in the end-to-end-encryption state we received from a
+    /// MSC4186 /sync request.
+    ///
+    /// This will decrypt and handle to-device messages returning the decrypted
+    /// versions of them.
+    ///
+    /// To decrypt an event from the room timeline, call
+    /// [`OlmMachine::decrypt_room_event`].
+    ///
+    /// # Arguments
+    ///
+    /// * `sync_changes` - an [`EncryptionSyncChanges`] value, constructed from
+    ///   a sync response.
+    ///
+    /// # Returns
+    ///
+    /// A tuple of (decrypted to-device events, updated room keys).
+    #[instrument(skip_all)]
+    pub async fn receive_sync_changes_msc4186(
         &self,
         sync_changes: EncryptionSyncChanges<'_>,
         decryption_settings: &DecryptionSettings,
+    ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
+        self.receive_sync_changes_impl(sync_changes, decryption_settings, false).await
+    }
+
+    /// Body for [`OlmMachine::receive_sync_changes`] and
+    /// [`OlmMachine::receive_sync_changes_msc4186`].
+    ///
+    /// There exist some semantic differences between the two sync APIs we
+    /// support, this is publicly exposed as different functions, but
+    /// internally we just use a simple boolean switch.
+    ///
+    /// Please take a look at the docs for [`OlmMachine::receive_sync_changes`]
+    /// and [`Account::update_key_counts`] for more info.
+    async fn receive_sync_changes_impl(
+        &self,
+        sync_changes: EncryptionSyncChanges<'_>,
+        decryption_settings: &DecryptionSettings,
+        is_missing_count_zero: bool,
     ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
         let mut store_transaction = self.inner.store.transaction().await;
 
@@ -1867,6 +1903,7 @@ impl OlmMachine {
             account.update_key_counts(
                 sync_changes.one_time_keys_counts,
                 sync_changes.unused_fallback_keys,
+                is_missing_count_zero,
             )
         }
 

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1852,6 +1852,14 @@ impl OlmMachine {
         sync_changes: EncryptionSyncChanges<'_>,
         decryption_settings: &DecryptionSettings,
     ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
+        self.receive_sync_changes_impl(sync_changes, decryption_settings).await
+    }
+
+    pub async fn receive_sync_changes_impl(
+        &self,
+        sync_changes: EncryptionSyncChanges<'_>,
+        decryption_settings: &DecryptionSettings,
+    ) -> OlmResult<(Vec<ProcessedToDeviceEvent>, Vec<RoomKeyInfo>)> {
         let mut store_transaction = self.inner.store.transaction().await;
 
         {

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1842,6 +1842,8 @@ impl OlmMachine {
     ///
     /// * `sync_changes` - an [`EncryptionSyncChanges`] value, constructed from
     ///   a sync response.
+    /// * `decryption_settings` - Settings controlling how the to-device
+    ///   messages passed in the [`EncryptionSyncChanges`] should be decrypted.
     ///
     /// # Returns
     ///
@@ -1868,6 +1870,8 @@ impl OlmMachine {
     ///
     /// * `sync_changes` - an [`EncryptionSyncChanges`] value, constructed from
     ///   a sync response.
+    /// * `decryption_settings` - Settings controlling how the to-device
+    ///   messages passed in the [`EncryptionSyncChanges`] should be decrypted.
     ///
     /// # Returns
     ///

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -1829,19 +1829,19 @@ impl OlmMachine {
             .is_some_and(|d| d.is_dehydrated()))
     }
 
-    /// Handle a to-device and one-time key counts from a sync response.
+    /// Handle changes in the end-to-end-encryption state we received from a
+    /// /sync request.
     ///
-    /// This will decrypt and handle to-device events returning the decrypted
+    /// This will decrypt and handle to-device messages returning the decrypted
     /// versions of them.
     ///
-    /// To decrypt an event from the room timeline, call [`decrypt_room_event`].
+    /// To decrypt an event from the room timeline, call
+    /// [`OlmMachine::decrypt_room_event`].
     ///
     /// # Arguments
     ///
     /// * `sync_changes` - an [`EncryptionSyncChanges`] value, constructed from
     ///   a sync response.
-    ///
-    /// [`decrypt_room_event`]: #method.decrypt_room_event
     ///
     /// # Returns
     ///

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -36,6 +36,7 @@ use ruma::{
     canonical_json::to_canonical_value,
     events::{AnyToDeviceEvent, room::history_visibility::HistoryVisibility},
     serde::Raw,
+    uint,
 };
 use serde::{Deserialize, Serialize, de::Error};
 use serde_json::value::{RawValue as RawJsonValue, to_raw_value};
@@ -527,13 +528,40 @@ impl Account {
         self.inner.max_number_of_one_time_keys()
     }
 
+    /// Update the number of one-time keys we consider to have available on the
+    /// server.
+    ///
+    /// # Arguments
+    ///
+    /// * `one_time_key_counts` - The number of one-time keys the homeserver
+    ///   told us we have available.
+    /// * `unused_fallback_keys` - The list of unused fallback keys we have on
+    ///   the homeserver. `None` means that the homeserver doesn't support
+    ///   fallback keys.
+    /// * `is_missing_count_zero` - A boolean telling us how to interpret the
+    ///   `one_time_key_counts` argument. Namely the semantics for the one-time
+    ///   key counts differs between sync v2 and sliding sync as defined in
+    ///   [MSC4186]. For classic sync a missing count should be interpreted as
+    ///   zero one-time keys on the homeserver, while for sliding sync it just
+    ///   means no change since the last sync.
     pub(crate) fn update_key_counts(
         &mut self,
         one_time_key_counts: &BTreeMap<OneTimeKeyAlgorithm, UInt>,
         unused_fallback_keys: Option<&[OneTimeKeyAlgorithm]>,
+        is_missing_count_zero: bool,
     ) {
-        if let Some(count) = one_time_key_counts.get(&OneTimeKeyAlgorithm::SignedCurve25519) {
-            let count: u64 = (*count).into();
+        let count = if is_missing_count_zero {
+            Some(
+                one_time_key_counts
+                    .get(&OneTimeKeyAlgorithm::SignedCurve25519)
+                    .copied()
+                    .unwrap_or(uint!(0)),
+            )
+        } else {
+            one_time_key_counts.get(&OneTimeKeyAlgorithm::SignedCurve25519).copied()
+        };
+
+        if let Some(count) = count.map(Into::into) {
             let old_count = self.uploaded_key_count();
 
             // Some servers might always return the key counts in the sync
@@ -1283,7 +1311,7 @@ impl Account {
         // First mark the current keys as published, as updating the key counts might
         // generate some new keys if we're still below the limit.
         self.mark_keys_as_published();
-        self.update_key_counts(&response.one_time_key_counts, None);
+        self.update_key_counts(&response.one_time_key_counts, None, false);
 
         Ok(())
     }
@@ -1999,7 +2027,7 @@ mod tests {
 
         // A `None` here means that the server doesn't support fallback keys, no
         // fallback key gets uploaded.
-        account.update_key_counts(&one_time_keys, None);
+        account.update_key_counts(&one_time_keys, None, false);
         let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(
             fallback_keys.is_empty(),
@@ -2011,7 +2039,7 @@ mod tests {
         // there isn't a unused fallback key on the server. This time we upload
         // a fallback key.
         let unused_fallback_keys = &[];
-        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()));
+        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()), false);
         let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(
             !fallback_keys.is_empty(),
@@ -2022,7 +2050,7 @@ mod tests {
         // There's no unused fallback key on the server, but our initial fallback key
         // did not yet expire.
         let unused_fallback_keys = &[];
-        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()));
+        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()), false);
         let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(
             fallback_keys.is_empty(),
@@ -2036,7 +2064,7 @@ mod tests {
         account.fallback_creation_timestamp =
             Some(MilliSecondsSinceUnixEpoch::from_system_time(fallback_key_timestamp).unwrap());
 
-        account.update_key_counts(&one_time_keys, None);
+        account.update_key_counts(&one_time_keys, None, false);
         let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(
             !fallback_keys.is_empty(),

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -188,6 +188,7 @@ insta.workspace = true
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
+rand.workspace = true
 reqwest = { workspace = true, features = ["rustls"] }
 serde_urlencoded = "0.7.1"
 similar-asserts.workspace = true

--- a/crates/matrix-sdk/changelog.d/6780.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6780.fixed.md
@@ -1,0 +1,3 @@
+The correct semantics for one-time key counts are now used when sync v2 is being
+used. This bug could have previously led to no one-time keys being uploaded to
+the homeserver.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3785,7 +3785,7 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
-        Error, TransmissionProgress,
+        Error, Result, TransmissionProgress,
         client::{WeakClient, caches::CachedValue, futures::SendMediaUploadRequest},
         config::{RequestConfig, SyncSettings},
         futures::SendRequest,
@@ -5164,5 +5164,87 @@ pub(crate) mod tests {
             .await;
 
         assert_matches!(client.fetch_client_well_known().await, Some(_));
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[async_test]
+    async fn test_syncing_one_time_key_counts_updates() -> Result<()> {
+        use wiremock::ResponseTemplate;
+
+        macro_rules! assert_key_count {
+            ($client: ident, $count:literal) => {{
+                let machine = $client.olm_machine().await;
+                let uploaded_key_counts =
+                    machine.as_ref().unwrap().uploaded_key_count().await.unwrap();
+                assert_eq!(uploaded_key_counts, $count)
+            }};
+        }
+
+        macro_rules! sync_with_key_count {
+            ($client: ident, $server:ident, $count:literal) => {
+                let count = Some($count);
+                sync_with_key_count!($client, $server, count);
+            };
+            ($client: ident, $server:ident, $count:ident) => {{
+                use rand::RngExt as _;
+
+                let next_batch: String = rand::rng()
+                    .sample_iter(&rand::distr::Alphanumeric)
+                    .take(16)
+                    .map(char::from)
+                    .collect();
+
+                let count: Option<u32> = $count;
+
+                let template = if let Some(count) = count {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "next_batch": next_batch,
+                        "rooms": {"leave": {}, "join": {}, "invite": {}},
+                        "device_lists": {
+                          "changed": [],
+                          "left": [],
+                        },
+                        "device_one_time_keys_count": {
+                          "signed_curve25519": count
+                        },
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                        "next_batch": next_batch,
+                        "rooms": {"leave": {}, "join": {}, "invite": {}},
+                        "device_lists": {
+                          "changed": [],
+                          "left": [],
+                        },
+                        "device_one_time_keys_count": {},
+                    }))
+                };
+
+                let _sync_mock_guard = $server.mock_sync().respond_with(template).mount_as_scoped().await;
+                $client.sync_once(Default::default()).await?;
+            }}
+        }
+
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server.mock_upload_keys().ok_with_signed_curve_key_count(50).mock_once().mount().await;
+
+        // In the beginning there were no uploaded keys.
+        assert_key_count!(client, 0);
+
+        // The first sync will upload 50 one-time keys.
+        sync_with_key_count!(client, server, 50);
+        assert_key_count!(client, 50);
+
+        // Syncing with a key count, will update the key count.
+        sync_with_key_count!(client, server, 10);
+        assert_key_count!(client, 10);
+
+        // Syncing with no key count will set the key count to zero.
+        sync_with_key_count!(client, server, None);
+        assert_key_count!(client, 0);
+
+        Ok(())
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -2875,4 +2875,89 @@ mod tests {
 
         Ok(())
     }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[async_test]
+    async fn test_syncing_one_time_key_counts_updates() -> Result<()> {
+        macro_rules! assert_key_count {
+            ($client: ident, $count:literal) => {{
+                let machine = $client.olm_machine().await;
+                let uploaded_key_counts =
+                    machine.as_ref().unwrap().uploaded_key_count().await.unwrap();
+                assert_eq!(uploaded_key_counts, $count)
+            }};
+        }
+
+        macro_rules! sync_with_key_count {
+            ($client: ident, $server:ident, $count:literal) => {
+                let count = Some($count);
+                sync_with_key_count!($client, $server, count);
+            };
+            ($client: ident, $server:ident, $count:ident) => {{
+                let count: Option<u32> = $count;
+
+                let template = if let Some(count) = count {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                                        "pos": "0",
+                                        "lists": {},
+                                        "extensions": {
+                                            "e2ee": {
+                                                "device_one_time_keys_count": {
+                                                    "signed_curve25519": count,
+                                                }
+                                            }
+                                        },
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({
+                                        "pos": "0",
+                                        "lists": {},
+                                        "extensions": {
+                                            "e2ee": {}
+                                        },
+                    }))
+                };
+
+                let _sync_mock_guard = Mock::given(SlidingSyncMatcher)
+                    .respond_with(template)
+                    .mount_as_scoped($server.server())
+                    .await;
+
+                let sliding_sync = $client
+                    .sliding_sync("test")?
+                    .with_e2ee_extension(
+                        assign!(http::request::E2EE::default(), { enabled: Some(true)}),
+                    )
+                    .build()
+                    .await?;
+
+                tokio::time::timeout(Duration::from_secs(5), sliding_sync.sync_once())
+                    .await
+                    .expect("Sync did not complete in time")
+                    .expect("Sync failed");
+            }}
+        }
+
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server.mock_upload_keys().ok_with_signed_curve_key_count(50).mock_once().mount().await;
+
+        // In the beginning there were no uploaded keys.
+        assert_key_count!(client, 0);
+
+        // The first sync will upload 50 one-time keys.
+        sync_with_key_count!(client, server, None);
+        assert_key_count!(client, 50);
+
+        // Syncing with no key count will not modify the local key count.
+        sync_with_key_count!(client, server, None);
+        assert_key_count!(client, 50);
+
+        // Syncing with a key count, will update the key count.
+        sync_with_key_count!(client, server, 10);
+        assert_key_count!(client, 10);
+
+        Ok(())
+    }
 }

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3688,6 +3688,16 @@ impl<'a> MockEndpoint<'a, UploadKeysEndpoint> {
             },
         })))
     }
+
+    /// Returns a successful response with the given number of signed curve25519
+    /// one-time keys.
+    pub fn ok_with_signed_curve_key_count(self, n: u32) -> MatrixMock<'a> {
+        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": {
+                "signed_curve25519": n,
+            },
+        })))
+    }
 }
 
 /// A prebuilt mock for `POST /keys/query` request.


### PR DESCRIPTION
Classic sync and sliding sync report one-time key counts slightly differently.

The following interpretation is used when one-time key counts are absent:

* Classic sync - No count -> count is `0`
* Sliding sync - No count -> no change in the count.

This PR adds a separate method for the MSC4186-specific sync responses.  

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.
