### PR TITLE
Ensure that event indices are updated after processing `Update::RemoveItem` in `IndexeddbEventCacheStore`

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6782.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6782.fixed.md
@@ -1,0 +1,3 @@
+`DynEventCacheStore::test_linked_chunk_remove_item` has been updated so
+that it ensures that removing an item from a chunk shifts the indices of
+subsequent items in that chunk.

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1006,6 +1006,19 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
                     ],
                 },
                 Update::RemoveItem { at: Position::new(CId::new(42), 2) /* "three" */ },
+                // After removing an item, we need to ensure that the indices of all subsequent
+                // items in the chunk have shifted down by one. We can ensure this by pushing
+                // an item at the smallest index we expect to be unoccupied, and checking to see
+                // whether the last item in the chunk was overwritten.
+                //
+                // For example, after removing the item at index 2, we should have 5 elements and
+                // the smallest unoccupied index should be index 5. If we push an item to index 5,
+                // it should not overwrite any existing elements - i.e., "six" - but should be
+                // appended to the end of the chunk.
+                Update::PushItems {
+                    at: Position::new(CId::new(42), 5),
+                    items: vec![make_test_event(room_id, "seven")],
+                },
             ],
         )
         .await
@@ -1020,13 +1033,19 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(c.previous, None);
         assert_eq!(c.next, None);
         assert_matches!(c.content, ChunkContent::Items(events) => {
-            assert_eq!(events.len(), 5);
+            assert_eq!(events.len(), 6);
             check_test_event(&events[0], "one");
             check_test_event(&events[1], "two");
             check_test_event(&events[2], "four");
             check_test_event(&events[3], "five");
             check_test_event(&events[4], "six");
+            check_test_event(&events[5], "seven");
         });
+
+        // The chunk metadata must agree on the number of items.
+        let metas = self.load_all_chunks_metadata(linked_chunk_id).await.unwrap();
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].num_items, 6);
     }
 
     async fn test_linked_chunk_detach_last_items(&self) {

--- a/crates/matrix-sdk-indexeddb/changelog.d/6782.fixed.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6782.fixed.md
@@ -1,0 +1,5 @@
+Ensure that `IndexeddbEventCacheStore` properly pushes and removes events from a chunk.
+Prior to these changes, pushing an event could erroneously replace an existing event, but
+now it only replaces an existing event if it is being promoted from out-of-band to in-band.
+Additionally, removing an event now properly shifts the indices of subsequent events in
+the chunk.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v5};
+    use super::{Version, v6};
 
-    pub const VERSION: Version = Version::V5;
-    pub use v5::keys;
+    pub const VERSION: Version = Version::V6;
+    pub use v6::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -62,6 +62,8 @@ pub enum Version {
     V4 = 4,
     /// Version 5 of the database, for details see [`v5`].
     V5 = 5,
+    /// Version 6 of the database, for details see [`v6`].
+    V6 = 6,
 }
 
 impl Version {
@@ -73,7 +75,8 @@ impl Version {
             Self::V2 => v2::upgrade(transaction).map(Some),
             Self::V3 => v3::upgrade(transaction).map(Some),
             Self::V4 => v4::upgrade(transaction).map(Some),
-            Self::V5 => Ok(None),
+            Self::V5 => v5::upgrade(transaction).map(Some),
+            Self::V6 => Ok(None),
         }
     }
 }
@@ -376,6 +379,44 @@ pub mod v5 {
             .create_object_store(keys::THREADS)
             .with_key_path(keys::THREADS_KEY_PATH.into())
             .build()?;
+
+        Ok(())
+    }
+
+    /// Upgrade database from `v4` to `v5`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v6::empty_event_cache(transaction)?;
+        Ok(Version::V6)
+    }
+}
+
+mod v6 {
+    // Re-use all the same keys from `v5`.
+    pub use super::v5::keys;
+    use super::*;
+
+    /// Prior iterations of this implementation of the event cache store did not
+    /// properly handle deleting events - namely, subsequent events in the same
+    /// chunk did not have their indices decremented after an event was deleted.
+    /// This caused bugs when callers tried to address events by position, as
+    /// the assumption is that deletions do not leave gaps between indices,
+    /// but rather shift higher indices down.
+    ///
+    /// The implementation has now been fixed, but it is also necessary to clear
+    /// existing data where the indices may have gaps due to deletions that
+    /// happened before this fix.
+    pub fn empty_event_cache(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let linked_chunks = transaction.object_store(keys::LINKED_CHUNKS)?;
+        linked_chunks.clear()?;
+
+        let gaps = transaction.object_store(keys::GAPS)?;
+        gaps.clear()?;
+
+        let events = transaction.object_store(keys::EVENTS)?;
+        events.clear()?;
+
+        let threads = transaction.object_store(keys::THREADS)?;
+        threads.clear()?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -215,7 +215,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
 
                     for (i, item) in items.into_iter().enumerate() {
                         transaction
-                            .put_event(&types::Event::InBand(InBandEvent {
+                            .add_event(&types::Event::InBand(InBandEvent {
                                 linked_chunk_id: linked_chunk_id.to_owned(),
                                 content: item,
                                 position: types::Position {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -429,18 +429,6 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// function returns the intermediary type [`IndexedEvent`] in case
     /// inspection is needed.
     pub async fn put_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
-        if let Some(position) = event.position() {
-            // For some reason, we can't simply replace an event with `put_item`
-            // because we can get an error stating that the data violates a uniqueness
-            // constraint on the `events_position` index. This is NOT expected, but
-            // it is not clear if this improperly implemented in the browser or the
-            // library we are using.
-            //
-            // As a workaround, if the event has a position, we delete it first and
-            // then call `put_item`. This should be fine as it all happens within the
-            // context of a single transaction.
-            self.delete_event_by_position(event.linked_chunk_id(), position).await?;
-        }
         self.put_item(event).await
     }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -424,6 +424,29 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.get_items_by_key::<Event, IndexedEventRelationKey>(range).await
     }
 
+    /// Adds an event to IndexedDB.
+    ///
+    /// If an event with the same key already exists, actions are
+    /// taken based on the following conditions. If the provided
+    /// event is an [`Event::InBand`] and the existing event is an
+    /// [`Event::OutOfBand`], the provided event will replace the
+    /// existing event. Otherwise, the provided event will be rejected.
+    /// This functionality allows events to be promoted from
+    /// out-of-band events to in-band events, but not vice versa.
+    ///
+    /// When the event is successfully added, the function returns
+    /// the intermediary type [`IndexedEvent`] in case inspection
+    /// is needed.
+    pub async fn add_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
+        let existing =
+            self.get_event_by_id(event.linked_chunk_id(), event.event_id().unwrap()).await?;
+        if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
+            self.put_event(event).await
+        } else {
+            self.add_item(event).await
+        }
+    }
+
     /// Puts an event in IndexedDB. If an event with the same key already
     /// exists, it will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`IndexedEvent`] in case

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -463,26 +463,36 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         .await
     }
 
-    /// Delete events in the given position range matching the given linked
-    /// chunk id
-    pub async fn delete_events_by_position(
-        &self,
-        linked_chunk_id: LinkedChunkId<'_>,
-        range: impl Into<IndexedKeyRange<Position>>,
-    ) -> Result<(), TransactionError> {
-        self.delete_items_by_key_components::<Event, IndexedEventPositionKey>(
-            range.into().map(|position| (linked_chunk_id, position)),
-        )
-        .await
-    }
-
-    /// Delete event in the given position matching the given linked chunk id
+    /// Delete event in the given position matching the given linked chunk id.
+    ///
+    /// Note that after removing the event, the index of each subsequent event
+    /// in the same chunk will be decremented by one. This is a potentially
+    /// expensive operation, as updating the indices requires reading the event,
+    /// then modifying it, then writing it back to IndexedDB.
     pub async fn delete_event_by_position(
         &self,
         linked_chunk_id: LinkedChunkId<'_>,
         position: Position,
     ) -> Result<(), TransactionError> {
-        self.delete_item_by_key::<Event, IndexedEventPositionKey>((linked_chunk_id, position)).await
+        self.delete_item_by_key::<Event, IndexedEventPositionKey>((linked_chunk_id, position))
+            .await?;
+
+        // After deleting an event, every subsequent event in the chunk
+        // must shift it's recorded index down one position.
+        let lower = (linked_chunk_id, position);
+        let upper = IndexedEventPositionKey::upper_key_components_with_prefix((
+            linked_chunk_id,
+            ChunkIdentifier::new(position.chunk_identifier),
+        ));
+        let range = IndexedKeyRange::Bound(lower, upper).map(|(_, position)| position);
+
+        self.update_events_by_position(linked_chunk_id, range, |mut event| {
+            if let Event::InBand(i) = &mut event {
+                i.position.index -= 1;
+            }
+            event
+        })
+        .await
     }
 
     /// Delete events in the given chunk matching the given linked chunk id
@@ -511,7 +521,11 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
             ChunkIdentifier::new(position.chunk_identifier),
         ));
         let range = IndexedKeyRange::Bound(lower, upper).map(|(_, position)| position);
-        self.delete_events_by_position(linked_chunk_id, range).await
+
+        self.delete_items_by_key_components::<Event, IndexedEventPositionKey>(
+            range.map(|position| (linked_chunk_id, position)),
+        )
+        .await
     }
 
     /// Delete all events matching the given linked chunk id

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -444,6 +444,25 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.put_item(event).await
     }
 
+    /// Update events in the given position range matching the given linked
+    /// chunk id by reading them, applying the function `F`, and then writing
+    /// them back to IndexedDB.
+    ///
+    /// Note that this is a potentially expensive operation, as IndexedDB
+    /// does not provide modification utilities.
+    pub async fn update_events_by_position<F: Fn(Event) -> Event>(
+        &self,
+        linked_chunk_id: LinkedChunkId<'_>,
+        range: impl Into<IndexedKeyRange<Position>>,
+        f: F,
+    ) -> Result<(), TransactionError> {
+        self.update_items_by_key_components::<Event, IndexedEventPositionKey, F>(
+            range.into().map(|position| (linked_chunk_id, position)),
+            f,
+        )
+        .await
+    }
+
     /// Delete events in the given position range matching the given linked
     /// chunk id
     pub async fn delete_events_by_position(

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -427,6 +427,29 @@ impl<'a> Transaction<'a> {
         }
     }
 
+    /// Update items in the given key component range by reading them,
+    /// applying the function `F`, and then writing them back to IndexedDB.
+    ///
+    /// Note that this is a potentially expensive operation, as IndexedDB
+    /// does not provide modification utilities.
+    pub async fn update_items_by_key_components<'b, T, K, F>(
+        &self,
+        range: impl Into<IndexedKeyRange<K::KeyComponents<'b>>>,
+        f: F,
+    ) -> Result<(), TransactionError>
+    where
+        T: Indexed + Serialize + 'b,
+        T::IndexedType: Serialize + DeserializeOwned,
+        T::Error: AsyncErrorDeps,
+        K: IndexedKey<T> + Serialize + 'b,
+        F: Fn(T) -> T,
+    {
+        for item in self.get_items_by_key_components::<T, K>(range).await? {
+            self.put_item(&f(item)).await?;
+        }
+        Ok(())
+    }
+
     /// Delete items in given key range from IndexedDB
     pub async fn delete_items_by_key<T, K>(
         &self,


### PR DESCRIPTION
`EventCacheStore::handle_linked_chunk_updates` is expected to update the indices of events in a chunk after removing an event. Namely, when an event is removed, all subsequent events in the chunk should have their indices reduced by one (see [`SqliteEventCacheStore`](https://github.com/matrix-org/matrix-rust-sdk/blob/279402e0e2f961fa6b2ecd80937503625fb38407/crates/matrix-sdk-sqlite/src/event_cache_store.rs#L913-L1039) and [`MemoryStore`](https://github.com/matrix-org/matrix-rust-sdk/blob/279402e0e2f961fa6b2ecd80937503625fb38407/crates/matrix-sdk-common/src/linked_chunk/relational.rs#L252-L258)).

`IndexeddbEventCacheStore` failed to do this, so it has been updated to properly shift event indices after a removal. Additionally, this revealed that pushing an event onto a chunk was erroneously replacing existing events. This was also fixed so that replacement only happens when an event is being promoted from out-of-band to in-band.

### Changes

- Update `DynEventCacheStore::test_linked_chunk_remove_item` so that it tests that indices have been shifted after a removal.
- Update processing logic for `Update::RemoveItem` so that it shifts indices of subsequent events in the chunk
- Update processing logic for `Update::PushItems` so that it only replaces events if they are being promoted from out-of-band to in-band.
- Add a migration to clear all existing data in the store, which likely has corrupted event indices.

### Considerations

Shifting event indices after a removal is an expensive operation in IndexedDB. This is because IndexedDB does not allow modifying a record in place. A record must, therefore, be read, modified, and then written back to the object store. In the worst case, the first event in a chunk is removed and the chunk is full, which means reading, modifying, and writing [`CHUNK_CAPACITY - 1`](https://github.com/matrix-org/matrix-rust-sdk/blob/279402e0e2f961fa6b2ecd80937503625fb38407/crates/matrix-sdk-common/src/linked_chunk/mod.rs#L350) records, where the default value of [`CHUNK_CAPACITY` is 128](https://github.com/matrix-org/matrix-rust-sdk/blob/279402e0e2f961fa6b2ecd80937503625fb38407/crates/matrix-sdk-base/src/event_cache/store/traits.rs#L34).

While it's possible that this could be improved by re-organizing the schema, this would very likely introduce inefficiencies in other queries as I believe it would require de-normalizing the object stores.

In any case, the limitation on the number of events in a chunk makes index shifting more palatable, though profiling would offer a more clear sense of the performance penalty. 

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
