### PR TITLE
FFI: Expose password change with typed UIAA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen-gitcl",
+ "wiremock",
  "zeroize",
  "zxcvbn",
 ]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -144,6 +144,7 @@ matrix-sdk = { workspace = true, features = ["testing", "rustls-aws-lc-rs"] }
 similar-asserts.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+wiremock.workspace = true
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/bindings/matrix-sdk-ffi/changelog.d/6783.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6783.added.md
@@ -1,0 +1,1 @@
+Expose password changes with typed UIAA challenge continuation and an explicit choice of whether to log out other devices.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3754,9 +3754,8 @@ mod tests {
                 Some("orphaned-session".to_owned()),
             )
             .await;
-        let error = match result {
-            Err(error) => error,
-            Ok(_) => panic!("expected a local validation error"),
+        let Err(error) = result else {
+            panic!("expected a local validation error");
         };
         assert_eq!(error.to_string(), "client error: A UIAA session requires authentication data");
     }
@@ -3808,9 +3807,8 @@ mod tests {
                 Some("uiaa-session".to_owned()),
             )
             .await;
-        let error = match result {
-            Err(error) => error,
-            Ok(_) => panic!("expected a weak-password error"),
+        let Err(error) = result else {
+            panic!("expected a weak-password error");
         };
         let rendered = format!("{error:?} {error}");
         assert!(!rendered.contains(new_password));

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2021,6 +2021,21 @@ impl Client {
         Ok(())
     }
 
+    /// Change the current account's password.
+    ///
+    /// This request may require user-interactive authentication. Call it with
+    /// no authentication data first, then retry with [`AuthData`] for a
+    /// supported homeserver authentication flow.
+    pub async fn change_password(
+        &self,
+        new_password: String,
+        auth_data: Option<AuthData>,
+    ) -> Result<(), ClientError> {
+        self.inner.account().change_password(&new_password, auth_data.map(Into::into)).await?;
+
+        Ok(())
+    }
+
     /// Checks if a room alias is not in use yet.
     ///
     /// Returns:
@@ -3462,12 +3477,18 @@ pub struct ExtendedProfileFields {
 mod tests {
     use std::time::Duration;
 
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use ruma::{
         ServerName,
         api::client::room::{Visibility, create_room},
         authentication::TokenType,
         events::StateEventType,
         room::RoomType,
+    };
+    use serde_json::json;
+    use wiremock::{
+        Mock, ResponseTemplate,
+        matchers::{body_json, method, path},
     };
 
     use crate::{
@@ -3539,6 +3560,31 @@ mod tests {
         assert_eq!(token.token_type, "Bearer");
         assert_eq!(token.matrix_server_name, "example.com");
         assert_eq!(token.expires_in_seconds, 3_600);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn change_password_forwards_to_the_account_api() {
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .on_builder(|builder| {
+                builder.cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+            })
+            .build()
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({ "new_password": "not-a-real-new-password" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        let client = super::Client::new(sdk_client, None, None).await.unwrap();
+        client.change_password("not-a-real-new-password".to_owned(), None).await.unwrap();
     }
 
     /// Dropping an FFI [`Client`] on a non-tokio thread must not panic.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -89,7 +89,10 @@ use ruma::{
             },
             profile::{AvatarUrl, DisplayName},
             room::create_room::{RoomPowerLevelsContentOverride, v3::CreationContent},
-            uiaa::{EmailUserIdentifier, UserIdentifier},
+            uiaa::{
+                AuthData as RumaAuthData, EmailUserIdentifier, Password as RumaPasswordAuthData,
+                UiaaInfo as RumaUiaaInfo, UserIdentifier,
+            },
         },
         error::ErrorKind,
     },
@@ -161,6 +164,50 @@ use crate::{
     utd::{UnableToDecryptDelegate, UtdHook},
     utils::AsyncRuntimeDropped,
 };
+
+/// An ordered sequence of authentication stages accepted by a homeserver.
+#[derive(Clone, uniffi::Record)]
+pub struct UiaaFlow {
+    pub stages: Vec<String>,
+}
+
+/// Structured user-interactive authentication information.
+#[derive(Clone, uniffi::Record)]
+pub struct UiaaChallenge {
+    pub flows: Vec<UiaaFlow>,
+    pub completed: Vec<String>,
+    /// Authentication parameters encoded as a JSON object.
+    pub params_json: Option<String>,
+    pub session: Option<String>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl From<&RumaUiaaInfo> for UiaaChallenge {
+    fn from(value: &RumaUiaaInfo) -> Self {
+        Self {
+            flows: value
+                .flows
+                .iter()
+                .map(|flow| UiaaFlow {
+                    stages: flow.stages.iter().map(ToString::to_string).collect(),
+                })
+                .collect(),
+            completed: value.completed.iter().map(ToString::to_string).collect(),
+            params_json: value.params.as_ref().map(|params| params.get().to_owned()),
+            session: value.session.clone(),
+            error_code: value.auth_error.as_ref().map(|error| error.kind.errcode().to_string()),
+            error_message: value.auth_error.as_ref().map(|error| error.message.clone()),
+        }
+    }
+}
+
+/// The result of a password-change request.
+#[derive(Clone, uniffi::Enum)]
+pub enum PasswordChangeOutcome {
+    Success,
+    AuthenticationRequired { challenge: UiaaChallenge },
+}
 
 #[derive(Clone, uniffi::Record)]
 pub struct PusherIdentifiers {
@@ -2023,17 +2070,56 @@ impl Client {
 
     /// Change the current account's password.
     ///
-    /// This request may require user-interactive authentication. Call it with
-    /// no authentication data first, then retry with [`AuthData`] for a
-    /// supported homeserver authentication flow.
+    /// This request may require user-interactive authentication. Call it
+    /// without a current password first. If the result contains a challenge,
+    /// retry with the current password and the challenge's session.
+    ///
+    /// `logout_devices` controls whether the account's other access tokens and
+    /// associated devices are revoked when the request succeeds.
     pub async fn change_password(
         &self,
         new_password: String,
-        auth_data: Option<AuthData>,
-    ) -> Result<(), ClientError> {
-        self.inner.account().change_password(&new_password, auth_data.map(Into::into)).await?;
+        logout_devices: bool,
+        current_password: Option<String>,
+        session: Option<String>,
+    ) -> Result<PasswordChangeOutcome, ClientError> {
+        let auth_data = match current_password {
+            Some(current_password) => {
+                let user_id = self.inner.user_id().ok_or_else(|| ClientError::Generic {
+                    msg: "Changing a password requires an authenticated session".to_owned(),
+                    details: None,
+                })?;
+                let mut password =
+                    RumaPasswordAuthData::new(user_id.to_owned().into(), current_password);
+                password.session = session;
+                Some(RumaAuthData::Password(password))
+            }
+            None if session.is_some() => {
+                return Err(ClientError::Generic {
+                    msg: "A UIAA session requires authentication data".to_owned(),
+                    details: None,
+                });
+            }
+            None => None,
+        };
 
-        Ok(())
+        match self
+            .inner
+            .account()
+            .change_password_with_logout_devices(&new_password, logout_devices, auth_data)
+            .await
+        {
+            Ok(_) => Ok(PasswordChangeOutcome::Success),
+            Err(error) => {
+                if let Some(challenge) = error.as_uiaa_response() {
+                    Ok(PasswordChangeOutcome::AuthenticationRequired {
+                        challenge: challenge.into(),
+                    })
+                } else {
+                    Err(error.into())
+                }
+            }
+        }
     }
 
     /// Checks if a room alias is not in use yet.
@@ -3564,27 +3650,171 @@ mod tests {
 
     #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
-    async fn change_password_forwards_to_the_account_api() {
+    async fn change_password_exposes_and_completes_uiaa() {
         use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 
         let server = MatrixMockServer::new().await;
         let sdk_client = server
             .client_builder()
             .on_builder(|builder| {
-                builder.cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                builder
+                    .cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                    .request_config(matrix_sdk::config::RequestConfig::new().disable_retry())
             })
             .build()
             .await;
+        let user_id = sdk_client.user_id().unwrap().to_string();
         Mock::given(method("POST"))
             .and(path("/_matrix/client/v3/account/password"))
-            .and(body_json(json!({ "new_password": "not-a-real-new-password" })))
+            .and(body_json(json!({
+                "new_password": "not-a-real-new-password",
+                "logout_devices": false,
+            })))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "flows": [{ "stages": ["m.login.password"] }],
+                "completed": [],
+                "params": { "m.login.password": {} },
+                "session": "uiaa-session",
+            })))
+            .expect(1)
+            .mount(server.server())
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": "not-a-real-new-password",
+                "logout_devices": false,
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id.clone() },
+                    "password": "not-a-real-current-password",
+                    "session": "uiaa-session",
+                },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": "another-not-real-new-password",
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id },
+                    "password": "not-a-real-current-password",
+                    "session": null,
+                },
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
             .expect(1)
             .mount(server.server())
             .await;
 
         let client = super::Client::new(sdk_client, None, None).await.unwrap();
-        client.change_password("not-a-real-new-password".to_owned(), None).await.unwrap();
+        let challenge = client
+            .change_password("not-a-real-new-password".to_owned(), false, None, None)
+            .await
+            .unwrap();
+        let super::PasswordChangeOutcome::AuthenticationRequired { challenge } = challenge else {
+            panic!("expected UIAA challenge")
+        };
+        assert_eq!(challenge.flows[0].stages, ["m.login.password"]);
+        assert_eq!(challenge.session.as_deref(), Some("uiaa-session"));
+        assert_eq!(challenge.params_json.as_deref(), Some(r#"{"m.login.password":{}}"#));
+
+        let outcome = client
+            .change_password(
+                "not-a-real-new-password".to_owned(),
+                false,
+                Some("not-a-real-current-password".to_owned()),
+                Some("uiaa-session".to_owned()),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(outcome, super::PasswordChangeOutcome::Success));
+
+        let outcome = client
+            .change_password(
+                "another-not-real-new-password".to_owned(),
+                true,
+                Some("not-a-real-current-password".to_owned()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(outcome, super::PasswordChangeOutcome::Success));
+
+        let result = client
+            .change_password(
+                "not-a-real-new-password".to_owned(),
+                false,
+                None,
+                Some("orphaned-session".to_owned()),
+            )
+            .await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("expected a local validation error"),
+        };
+        assert_eq!(error.to_string(), "client error: A UIAA session requires authentication data");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn password_change_errors_do_not_include_passwords() {
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .on_builder(|builder| {
+                builder
+                    .cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                    .request_config(matrix_sdk::config::RequestConfig::new().disable_retry())
+            })
+            .build()
+            .await;
+        let user_id = sdk_client.user_id().unwrap().to_string();
+        let new_password = "NEW_PASSWORD_SENTINEL_6771";
+        let current_password = "CURRENT_PASSWORD_SENTINEL_6771";
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": new_password,
+                "logout_devices": false,
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id },
+                    "password": current_password,
+                    "session": "uiaa-session",
+                },
+            })))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "errcode": "M_WEAK_PASSWORD",
+                "error": "Password is too weak",
+            })))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        let client = super::Client::new(sdk_client, None, None).await.unwrap();
+        let result = client
+            .change_password(
+                new_password.to_owned(),
+                false,
+                Some(current_password.to_owned()),
+                Some("uiaa-session".to_owned()),
+            )
+            .await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("expected a weak-password error"),
+        };
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains(new_password));
+        assert!(!rendered.contains(current_password));
     }
 
     /// Dropping an FFI [`Client`] on a non-tokio thread must not panic.

--- a/crates/matrix-sdk/changelog.d/6783.added.md
+++ b/crates/matrix-sdk/changelog.d/6783.added.md
@@ -1,0 +1,1 @@
+Add an options-aware account password-change API while preserving the existing behavior that logs out other devices by default.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -580,7 +580,21 @@ impl Account {
         new_password: &str,
         auth_data: Option<AuthData>,
     ) -> Result<change_password::v3::Response> {
+        self.change_password_with_logout_devices(new_password, true, auth_data).await
+    }
+
+    /// Change the password of the current account and choose whether the
+    /// account's other devices should be logged out.
+    ///
+    /// This has the same UIAA behavior as [`Self::change_password`].
+    pub async fn change_password_with_logout_devices(
+        &self,
+        new_password: &str,
+        logout_devices: bool,
+        auth_data: Option<AuthData>,
+    ) -> Result<change_password::v3::Response> {
         let request = assign!(change_password::v3::Request::new(new_password.to_owned()), {
+            logout_devices,
             auth: auth_data,
         });
         Ok(self.client.send(request).await?)


### PR DESCRIPTION
## Summary

Expose password changes through `matrix-sdk-ffi` with a complete typed UIAA continuation contract.

- Adds typed UIAA challenge data including flows, completed stages, parameters, session, and authentication errors.
- Binds password continuation to the authenticated client's user ID.
- Exposes the consequential `logout_devices` choice explicitly.
- Keeps the existing core API's default behavior while adding an options-aware core method.
- Keeps plaintext passwords out of generated records, debug rendering, and errors.

Fixes #6771.

## Verification

- Focused password-change tests: 6 passed.
- `cargo test -p matrix-sdk-ffi --lib`: 31 passed.
- `cargo check -p matrix-sdk-ffi`: passed.
- Relevant formatting and `git diff --check`: passed.
- Independent exact-head review: approved at `d1a71757f789fd5799eb2059d70d795564e7a60c` before the PR-numbered changelog-only follow-up.

## Baseline caveat

Strict Clippy reaches the pre-existing unrelated `unfulfilled-lint-expectations` error at `crates/matrix-sdk/src/widget/mod.rs:133`. This PR does not include an unrelated baseline repair.

## Security and scope

- Passwords remain method arguments and are not retained in UniFFI records.
- Malformed caller-provided user IDs are not parsed with `unwrap`; the authenticated session supplies the user ID.
- Both `logout_devices` values have serialization coverage.
- No side transport, credential retention, or authenticated URL is introduced.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Atkinson <g.atkinson112@gmail.com>
