### PR TITLE
FFI: Add atomic custom room state reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,6 +3707,7 @@ dependencies = [
  "matrix-sdk-common",
  "matrix-sdk-contentscanner",
  "matrix-sdk-ffi-macros",
+ "matrix-sdk-test",
  "matrix-sdk-ui",
  "mime",
  "oauth2",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -141,6 +141,7 @@ jvm-getter = "0.1.0"
 
 [dev-dependencies]
 matrix-sdk = { workspace = true, features = ["testing", "rustls-aws-lc-rs"] }
+matrix-sdk-test.workspace = true
 similar-asserts.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }

--- a/bindings/matrix-sdk-ffi/changelog.d/6784.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6784.added.md
@@ -1,0 +1,1 @@
+Expose atomic custom create-room initial state and exact raw state lookup by event type and state key.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::Debug,
     path::PathBuf,
     sync::{Arc, OnceLock},
@@ -2843,6 +2843,20 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
         };
 
         let mut initial_state: Vec<Raw<AnyInitialStateEvent>> = vec![];
+        let mut synthesized_state = HashSet::new();
+        if value.is_encrypted {
+            synthesized_state.insert(("m.room.encryption", ""));
+        }
+        if value.avatar.is_some() {
+            synthesized_state.insert(("m.room.avatar", ""));
+        }
+        if value.join_rule_override.is_some() {
+            synthesized_state.insert(("m.room.join_rules", ""));
+        }
+        if value.history_visibility_override.is_some() {
+            synthesized_state.insert(("m.room.history_visibility", ""));
+        }
+        let mut custom_state = HashSet::new();
 
         if let Some(custom_events) = value.initial_state {
             for event in custom_events {
@@ -2851,6 +2865,29 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
                         msg: format!("Failed to parse custom initial state event content: {e}"),
                         details: None,
                     })?;
+                if !content.is_object() {
+                    return Err(ClientError::Generic {
+                        msg: "Custom initial state event content must be a JSON object".to_owned(),
+                        details: None,
+                    });
+                }
+
+                let state_tuple = (event.event_type.clone(), event.state_key.clone());
+                if !custom_state.insert(state_tuple) {
+                    return Err(ClientError::Generic {
+                        msg: "Duplicate custom initial state event type and state key".to_owned(),
+                        details: None,
+                    });
+                }
+                if synthesized_state
+                    .contains(&(event.event_type.as_str(), event.state_key.as_str()))
+                {
+                    return Err(ClientError::Generic {
+                        msg: "Custom initial state event conflicts with synthesized room state"
+                            .to_owned(),
+                        details: None,
+                    });
+                }
                 let raw_event = Raw::new(&serde_json::json!({
                     "type": event.event_type,
                     "state_key": event.state_key,
@@ -3499,9 +3536,47 @@ mod tests {
     };
 
     use crate::{
-        client::{CreateRoomParameters, JoinRule, OpenIdToken, RoomPreset, RoomVisibility},
+        client::{
+            CreateRoomParameters, CustomInitialStateEvent, JoinRule, OpenIdToken, RoomPreset,
+            RoomVisibility,
+        },
         room::RoomHistoryVisibility,
     };
+
+    fn create_room_parameters(initial_state: Vec<CustomInitialStateEvent>) -> CreateRoomParameters {
+        CreateRoomParameters {
+            name: None,
+            topic: None,
+            is_encrypted: false,
+            is_direct: false,
+            visibility: RoomVisibility::Private,
+            preset: RoomPreset::PrivateChat,
+            invite: None,
+            avatar: None,
+            power_level_content_override: None,
+            join_rule_override: None,
+            history_visibility_override: None,
+            canonical_alias: None,
+            is_space: false,
+            initial_state: Some(initial_state),
+        }
+    }
+
+    fn custom_initial_state_event(
+        event_type: &str,
+        state_key: &str,
+        content: &str,
+    ) -> CustomInitialStateEvent {
+        CustomInitialStateEvent {
+            event_type: event_type.to_owned(),
+            state_key: state_key.to_owned(),
+            content: content.to_owned(),
+        }
+    }
+
+    fn custom_initial_state_error(params: CreateRoomParameters) -> String {
+        create_room::v3::Request::try_from(params).unwrap_err().to_string()
+    }
 
     #[test]
     fn test_create_room_parameters_mapping() {
@@ -3599,6 +3674,89 @@ mod tests {
 
         let error = create_room::v3::Request::try_from(params).unwrap_err().to_string();
         assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn custom_initial_state_content_must_be_a_json_object() {
+        let invalid_content = [
+            ("array", r#"["ARRAY_SECRET"]"#),
+            ("string", r#""STRING_SECRET""#),
+            ("number", "6777"),
+            ("boolean", "true"),
+            ("null", "null"),
+        ];
+
+        for (value_class, content) in invalid_content {
+            let params = create_room_parameters(vec![custom_initial_state_event(
+                "org.example.marker",
+                "operation-123",
+                content,
+            )]);
+            let error = custom_initial_state_error(params);
+
+            assert!(error.contains("JSON object"), "unexpected error for {value_class}: {error}");
+            assert!(!error.contains(content), "error leaked {value_class} content: {error}");
+        }
+    }
+
+    #[test]
+    fn duplicate_custom_initial_state_tuples_are_rejected() {
+        let params = create_room_parameters(vec![
+            custom_initial_state_event("org.example.marker", "operation-123", r#"{"first":1}"#),
+            custom_initial_state_event("org.example.marker", "operation-123", r#"{"second":2}"#),
+        ]);
+
+        assert!(custom_initial_state_error(params).contains("Duplicate custom initial state"));
+    }
+
+    #[test]
+    fn same_custom_event_type_with_distinct_state_keys_is_accepted() {
+        let params = create_room_parameters(vec![
+            custom_initial_state_event("org.example.marker", "operation-123", "{}"),
+            custom_initial_state_event("org.example.marker", "operation-456", "{}"),
+        ]);
+
+        let request = create_room::v3::Request::try_from(params).unwrap();
+        assert_eq!(request.initial_state.len(), 2);
+    }
+
+    #[test]
+    fn custom_initial_state_cannot_replace_synthesized_encryption() {
+        let mut params =
+            create_room_parameters(vec![custom_initial_state_event("m.room.encryption", "", "{}")]);
+        params.is_encrypted = true;
+
+        assert!(custom_initial_state_error(params).contains("synthesized room state"));
+    }
+
+    #[test]
+    fn custom_initial_state_cannot_replace_synthesized_avatar() {
+        let mut params =
+            create_room_parameters(vec![custom_initial_state_event("m.room.avatar", "", "{}")]);
+        params.avatar = Some("mxc://example.org/avatar".to_owned());
+
+        assert!(custom_initial_state_error(params).contains("synthesized room state"));
+    }
+
+    #[test]
+    fn custom_initial_state_cannot_replace_synthesized_join_rules() {
+        let mut params =
+            create_room_parameters(vec![custom_initial_state_event("m.room.join_rules", "", "{}")]);
+        params.join_rule_override = Some(JoinRule::Knock);
+
+        assert!(custom_initial_state_error(params).contains("synthesized room state"));
+    }
+
+    #[test]
+    fn custom_initial_state_cannot_replace_synthesized_history_visibility() {
+        let mut params = create_room_parameters(vec![custom_initial_state_event(
+            "m.room.history_visibility",
+            "",
+            "{}",
+        )]);
+        params.history_visibility_override = Some(RoomHistoryVisibility::Shared);
+
+        assert!(custom_initial_state_error(params).contains("synthesized room state"));
     }
 
     #[test]

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2780,6 +2780,15 @@ impl From<PowerLevels> for RoomPowerLevelsContentOverride {
     }
 }
 
+/// A custom state event to include atomically when creating a room.
+#[derive(uniffi::Record)]
+pub struct CustomInitialStateEvent {
+    pub event_type: String,
+    pub state_key: String,
+    /// The event content encoded as a JSON object.
+    pub content: String,
+}
+
 #[derive(uniffi::Record)]
 pub struct CreateRoomParameters {
     pub name: Option<String>,
@@ -2804,6 +2813,8 @@ pub struct CreateRoomParameters {
     pub canonical_alias: Option<String>,
     #[uniffi(default = false)]
     pub is_space: bool,
+    #[uniffi(default = None)]
+    pub initial_state: Option<Vec<CustomInitialStateEvent>>,
 }
 
 impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
@@ -2832,6 +2843,23 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
         };
 
         let mut initial_state: Vec<Raw<AnyInitialStateEvent>> = vec![];
+
+        if let Some(custom_events) = value.initial_state {
+            for event in custom_events {
+                let content: serde_json::Value =
+                    serde_json::from_str(&event.content).map_err(|e| ClientError::Generic {
+                        msg: format!("Failed to parse custom initial state event content: {e}"),
+                        details: None,
+                    })?;
+                let raw_event = Raw::new(&serde_json::json!({
+                    "type": event.event_type,
+                    "state_key": event.state_key,
+                    "content": content,
+                }))?
+                .cast_unchecked();
+                initial_state.push(raw_event);
+            }
+        }
 
         if value.is_encrypted {
             let content =
@@ -3491,6 +3519,11 @@ mod tests {
             history_visibility_override: Some(RoomHistoryVisibility::Shared),
             canonical_alias: Some("#a-room:example.com".to_owned()),
             is_space: true,
+            initial_state: Some(vec![super::CustomInitialStateEvent {
+                event_type: "org.example.idempotency_marker".to_owned(),
+                state_key: "operation-123".to_owned(),
+                content: r#"{"operation_id":"operation-123"}"#.to_owned(),
+            }]),
         };
 
         let request: create_room::v3::Request =
@@ -3513,6 +3546,22 @@ mod tests {
         assert!(
             initial_state.iter().any(|e| e.event_type() == StateEventType::RoomHistoryVisibility)
         );
+        let marker = request
+            .initial_state
+            .iter()
+            .find(|raw| {
+                raw.get_field::<String>("type").unwrap().as_deref()
+                    == Some("org.example.idempotency_marker")
+            })
+            .expect("custom initial state event is missing");
+        assert_eq!(
+            marker.get_field::<String>("state_key").unwrap().as_deref(),
+            Some("operation-123")
+        );
+        assert_eq!(
+            marker.get_field::<serde_json::Value>("content").unwrap(),
+            Some(serde_json::json!({ "operation_id": "operation-123" }))
+        );
         assert_eq!(request.room_alias_name, Some("#a-room:example.com".to_owned()));
 
         let room_type = request
@@ -3522,6 +3571,34 @@ mod tests {
             .expect("Creation content can't be deserialized")
             .room_type;
         assert_eq!(room_type, Some(RoomType::Space));
+    }
+
+    #[test]
+    fn invalid_custom_initial_state_content_does_not_leak_content() {
+        let secret = "TOP_SECRET_MARKER_CONTENT";
+        let params = CreateRoomParameters {
+            name: None,
+            topic: None,
+            is_encrypted: false,
+            is_direct: false,
+            visibility: RoomVisibility::Private,
+            preset: RoomPreset::PrivateChat,
+            invite: None,
+            avatar: None,
+            power_level_content_override: None,
+            join_rule_override: None,
+            history_visibility_override: None,
+            canonical_alias: None,
+            is_space: false,
+            initial_state: Some(vec![super::CustomInitialStateEvent {
+                event_type: "org.example.idempotency_marker".to_owned(),
+                state_key: "operation-123".to_owned(),
+                content: format!(r#"{{"secret":"{secret}""#),
+            }]),
+        };
+
+        let error = create_room::v3::Request::try_from(params).unwrap_err().to_string();
+        assert!(!error.contains(secret));
     }
 
     #[test]

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -2005,10 +2005,101 @@ impl TryFrom<SdkRoomSendQueueUpdate> for RoomSendQueueUpdate {
 mod tests {
     use std::time::Duration;
 
-    use matrix_sdk::{ruma::room_id, test_utils::mocks::MatrixMockServer};
+    use matrix_sdk::{
+        ruma::{
+            events::{AnyStrippedStateEvent, AnySyncStateEvent},
+            room_id,
+            serde::Raw,
+        },
+        test_utils::mocks::MatrixMockServer,
+    };
+    use matrix_sdk_test::{InvitedRoomBuilder, JoinedRoomBuilder};
     use tempfile::tempdir;
 
     use super::*;
+
+    #[tokio::test]
+    async fn raw_state_lookup_uses_the_exact_state_key_and_reports_absence() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!custom-state:example.com");
+        let state_a: Raw<AnySyncStateEvent> = Raw::from_json_string(
+            r#"{
+                "content":{"operation_id":"operation-a"},
+                "event_id":"$state-a:example.com",
+                "origin_server_ts":1,
+                "sender":"@example:localhost",
+                "state_key":"operation-a",
+                "type":"org.example.marker"
+            }"#
+            .to_owned(),
+        )
+        .unwrap();
+        let state_b: Raw<AnySyncStateEvent> = Raw::from_json_string(
+            r#"{
+                "content":{"operation_id":"operation-b"},
+                "event_id":"$state-b:example.com",
+                "origin_server_ts":2,
+                "sender":"@example:localhost",
+                "state_key":"operation-b",
+                "type":"org.example.marker"
+            }"#
+            .to_owned(),
+        )
+        .unwrap();
+        let sdk_room = server
+            .sync_room(
+                &client,
+                JoinedRoomBuilder::new(room_id).add_state_event(state_a).add_state_event(state_b),
+            )
+            .await;
+        let room = Room::new(sdk_room, None);
+
+        let raw = room
+            .get_state_event_raw("org.example.marker".to_owned(), "operation-a".to_owned())
+            .await
+            .unwrap()
+            .unwrap();
+        let event: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(event["state_key"], "operation-a");
+        assert_eq!(event["content"]["operation_id"], "operation-a");
+
+        let absent = room
+            .get_state_event_raw("org.example.marker".to_owned(), "missing".to_owned())
+            .await
+            .unwrap();
+        assert!(absent.is_none());
+    }
+
+    #[tokio::test]
+    async fn raw_state_lookup_returns_stripped_invite_state() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!invited-custom-state:example.com");
+        let state: Raw<AnyStrippedStateEvent> = Raw::from_json_string(
+            r#"{
+                "content":{"operation_id":"operation-invite"},
+                "sender":"@inviter:example.com",
+                "state_key":"operation-invite",
+                "type":"org.example.marker"
+            }"#
+            .to_owned(),
+        )
+        .unwrap();
+        let sdk_room = server
+            .sync_room(&client, InvitedRoomBuilder::new(room_id).add_state_event(state))
+            .await;
+        let room = Room::new(sdk_room, None);
+
+        let raw = room
+            .get_state_event_raw("org.example.marker".to_owned(), "operation-invite".to_owned())
+            .await
+            .unwrap()
+            .unwrap();
+        let event: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(event["state_key"], "operation-invite");
+        assert_eq!(event["content"]["operation_id"], "operation-invite");
+    }
 
     /// Dropping an FFI [`Room`] on a non-tokio thread must not panic.
     ///

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -21,6 +21,7 @@ use matrix_sdk::{
     DraftAttachment as SdkDraftAttachment, DraftAttachmentContent, DraftThumbnail, EncryptionState,
     PredecessorRoom as SdkPredecessorRoom, RoomHeroWithProfile as SdkRoomHeroWithProfile,
     RoomMemberships, RoomState, SuccessorRoom as SdkSuccessorRoom,
+    deserialized_responses::RawAnySyncOrStrippedState,
     encryption::LocalTrust,
     room::{
         Room as SdkRoom, RoomMemberRole, edit::EditedContent, power_levels::RoomPowerLevelChanges,
@@ -469,6 +470,22 @@ impl Room {
             self.inner.send_state_event_raw(&event_type, &state_key, content_json).await?;
 
         Ok(response.event_id.to_string())
+    }
+
+    /// Get an exact state event from the local room state after sync.
+    ///
+    /// The event is selected by its event type and state key and returned as a
+    /// raw JSON string so custom event types remain available through FFI.
+    pub async fn get_state_event_raw(
+        &self,
+        event_type: String,
+        state_key: String,
+    ) -> Result<Option<String>, ClientError> {
+        let event = self.inner.get_state_event(event_type.into(), &state_key).await?;
+        Ok(event.map(|event| match event {
+            RawAnySyncOrStrippedState::Sync(raw) => raw.json().get().to_owned(),
+            RawAnySyncOrStrippedState::Stripped(raw) => raw.json().get().to_owned(),
+        }))
     }
 
     /// Redacts an event from the room.


### PR DESCRIPTION
## Summary

Expose atomic custom create-room initial state and exact raw state reconciliation through `matrix-sdk-ffi`.

- Adds optional custom state events with event type, state key, and JSON-object content to the existing create-room request.
- Rejects malformed/non-object content, duplicate custom tuples, and collisions with SDK-generated encryption, avatar, join-rule, and history-visibility state.
- Adds exact raw state lookup by `(event_type, state_key)` for joined and stripped invite state.
- Keeps encryption and application marker events in one atomic create-room request.

## Motivation

FFI clients that provision encrypted rooms need to attach a stable application operation marker without a second state-send race. If the create response is lost, exact state-store lookup by event type and state key lets the client find the marker after sync and determine whether retrying would create a duplicate room. Raw joined and stripped state supports application-defined event types before and after join.

Fixes #6777.

## Verification

- `cargo test -p matrix-sdk-ffi --lib`: 39 passed.
- `cargo check -p matrix-sdk-ffi`: passed.
- Package formatting and `git diff --check`: passed.
- Independent exact-head review: approved at `eb91c8bde237b476ff4660477f3bb40d7bc838f9` before the PR-numbered changelog-only follow-up.

## Baseline caveat

Strict Clippy reaches the pre-existing unrelated `unfulfilled-lint-expectations` error at `crates/matrix-sdk/src/widget/mod.rs:133`. This PR does not include an unrelated baseline repair.

## Security and scope

- Validation errors do not include supplied JSON content.
- Tuple uniqueness is enforced before the network request.
- Raw lookup uses exact state-store authority after sync; no timeline inference or local success synthesis is introduced.
- No retry policy is added to FFI.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Atkinson <g.atkinson112@gmail.com>
