### PR TITLE
FFI: Add non-destructive first-device cross-signing bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen-gitcl",
+ "wiremock",
  "zeroize",
  "zxcvbn",
 ]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -144,6 +144,7 @@ matrix-sdk = { workspace = true, features = ["testing", "rustls-aws-lc-rs"] }
 similar-asserts.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+wiremock.workspace = true
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/bindings/matrix-sdk-ffi/changelog.d/6783.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6783.added.md
@@ -1,0 +1,1 @@
+Expose password changes with typed UIAA challenge continuation and an explicit choice of whether to log out other devices.

--- a/bindings/matrix-sdk-ffi/changelog.d/6785.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6785.added.md
@@ -1,0 +1,1 @@
+Expose non-destructive first-device cross-signing bootstrap with typed UIAA continuation, serialized retries, and runtime-safe handle ownership.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3754,9 +3754,8 @@ mod tests {
                 Some("orphaned-session".to_owned()),
             )
             .await;
-        let error = match result {
-            Err(error) => error,
-            Ok(_) => panic!("expected a local validation error"),
+        let Err(error) = result else {
+            panic!("expected a local validation error");
         };
         assert_eq!(error.to_string(), "client error: A UIAA session requires authentication data");
     }
@@ -3808,9 +3807,8 @@ mod tests {
                 Some("uiaa-session".to_owned()),
             )
             .await;
-        let error = match result {
-            Err(error) => error,
-            Ok(_) => panic!("expected a weak-password error"),
+        let Err(error) = result else {
+            panic!("expected a weak-password error");
         };
         let rendered = format!("{error:?} {error}");
         assert!(!rendered.contains(new_password));

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2021,6 +2021,21 @@ impl Client {
         Ok(())
     }
 
+    /// Change the current account's password.
+    ///
+    /// This request may require user-interactive authentication. Call it with
+    /// no authentication data first, then retry with [`AuthData`] for a
+    /// supported homeserver authentication flow.
+    pub async fn change_password(
+        &self,
+        new_password: String,
+        auth_data: Option<AuthData>,
+    ) -> Result<(), ClientError> {
+        self.inner.account().change_password(&new_password, auth_data.map(Into::into)).await?;
+
+        Ok(())
+    }
+
     /// Checks if a room alias is not in use yet.
     ///
     /// Returns:
@@ -3462,12 +3477,18 @@ pub struct ExtendedProfileFields {
 mod tests {
     use std::time::Duration;
 
+    use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use ruma::{
         ServerName,
         api::client::room::{Visibility, create_room},
         authentication::TokenType,
         events::StateEventType,
         room::RoomType,
+    };
+    use serde_json::json;
+    use wiremock::{
+        Mock, ResponseTemplate,
+        matchers::{body_json, method, path},
     };
 
     use crate::{
@@ -3539,6 +3560,31 @@ mod tests {
         assert_eq!(token.token_type, "Bearer");
         assert_eq!(token.matrix_server_name, "example.com");
         assert_eq!(token.expires_in_seconds, 3_600);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn change_password_forwards_to_the_account_api() {
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .on_builder(|builder| {
+                builder.cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+            })
+            .build()
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({ "new_password": "not-a-real-new-password" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        let client = super::Client::new(sdk_client, None, None).await.unwrap();
+        client.change_password("not-a-real-new-password".to_owned(), None).await.unwrap();
     }
 
     /// Dropping an FFI [`Client`] on a non-tokio thread must not panic.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -89,7 +89,10 @@ use ruma::{
             },
             profile::{AvatarUrl, DisplayName},
             room::create_room::{RoomPowerLevelsContentOverride, v3::CreationContent},
-            uiaa::{EmailUserIdentifier, UserIdentifier},
+            uiaa::{
+                AuthData as RumaAuthData, EmailUserIdentifier, Password as RumaPasswordAuthData,
+                UiaaInfo as RumaUiaaInfo, UserIdentifier,
+            },
         },
         error::ErrorKind,
     },
@@ -161,6 +164,50 @@ use crate::{
     utd::{UnableToDecryptDelegate, UtdHook},
     utils::AsyncRuntimeDropped,
 };
+
+/// An ordered sequence of authentication stages accepted by a homeserver.
+#[derive(Clone, uniffi::Record)]
+pub struct UiaaFlow {
+    pub stages: Vec<String>,
+}
+
+/// Structured user-interactive authentication information.
+#[derive(Clone, uniffi::Record)]
+pub struct UiaaChallenge {
+    pub flows: Vec<UiaaFlow>,
+    pub completed: Vec<String>,
+    /// Authentication parameters encoded as a JSON object.
+    pub params_json: Option<String>,
+    pub session: Option<String>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl From<&RumaUiaaInfo> for UiaaChallenge {
+    fn from(value: &RumaUiaaInfo) -> Self {
+        Self {
+            flows: value
+                .flows
+                .iter()
+                .map(|flow| UiaaFlow {
+                    stages: flow.stages.iter().map(ToString::to_string).collect(),
+                })
+                .collect(),
+            completed: value.completed.iter().map(ToString::to_string).collect(),
+            params_json: value.params.as_ref().map(|params| params.get().to_owned()),
+            session: value.session.clone(),
+            error_code: value.auth_error.as_ref().map(|error| error.kind.errcode().to_string()),
+            error_message: value.auth_error.as_ref().map(|error| error.message.clone()),
+        }
+    }
+}
+
+/// The result of a password-change request.
+#[derive(Clone, uniffi::Enum)]
+pub enum PasswordChangeOutcome {
+    Success,
+    AuthenticationRequired { challenge: UiaaChallenge },
+}
 
 #[derive(Clone, uniffi::Record)]
 pub struct PusherIdentifiers {
@@ -2023,17 +2070,56 @@ impl Client {
 
     /// Change the current account's password.
     ///
-    /// This request may require user-interactive authentication. Call it with
-    /// no authentication data first, then retry with [`AuthData`] for a
-    /// supported homeserver authentication flow.
+    /// This request may require user-interactive authentication. Call it
+    /// without a current password first. If the result contains a challenge,
+    /// retry with the current password and the challenge's session.
+    ///
+    /// `logout_devices` controls whether the account's other access tokens and
+    /// associated devices are revoked when the request succeeds.
     pub async fn change_password(
         &self,
         new_password: String,
-        auth_data: Option<AuthData>,
-    ) -> Result<(), ClientError> {
-        self.inner.account().change_password(&new_password, auth_data.map(Into::into)).await?;
+        logout_devices: bool,
+        current_password: Option<String>,
+        session: Option<String>,
+    ) -> Result<PasswordChangeOutcome, ClientError> {
+        let auth_data = match current_password {
+            Some(current_password) => {
+                let user_id = self.inner.user_id().ok_or_else(|| ClientError::Generic {
+                    msg: "Changing a password requires an authenticated session".to_owned(),
+                    details: None,
+                })?;
+                let mut password =
+                    RumaPasswordAuthData::new(user_id.to_owned().into(), current_password);
+                password.session = session;
+                Some(RumaAuthData::Password(password))
+            }
+            None if session.is_some() => {
+                return Err(ClientError::Generic {
+                    msg: "A UIAA session requires authentication data".to_owned(),
+                    details: None,
+                });
+            }
+            None => None,
+        };
 
-        Ok(())
+        match self
+            .inner
+            .account()
+            .change_password_with_logout_devices(&new_password, logout_devices, auth_data)
+            .await
+        {
+            Ok(_) => Ok(PasswordChangeOutcome::Success),
+            Err(error) => {
+                if let Some(challenge) = error.as_uiaa_response() {
+                    Ok(PasswordChangeOutcome::AuthenticationRequired {
+                        challenge: challenge.into(),
+                    })
+                } else {
+                    Err(error.into())
+                }
+            }
+        }
     }
 
     /// Checks if a room alias is not in use yet.
@@ -3564,27 +3650,171 @@ mod tests {
 
     #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
-    async fn change_password_forwards_to_the_account_api() {
+    async fn change_password_exposes_and_completes_uiaa() {
         use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 
         let server = MatrixMockServer::new().await;
         let sdk_client = server
             .client_builder()
             .on_builder(|builder| {
-                builder.cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                builder
+                    .cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                    .request_config(matrix_sdk::config::RequestConfig::new().disable_retry())
             })
             .build()
             .await;
+        let user_id = sdk_client.user_id().unwrap().to_string();
         Mock::given(method("POST"))
             .and(path("/_matrix/client/v3/account/password"))
-            .and(body_json(json!({ "new_password": "not-a-real-new-password" })))
+            .and(body_json(json!({
+                "new_password": "not-a-real-new-password",
+                "logout_devices": false,
+            })))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "flows": [{ "stages": ["m.login.password"] }],
+                "completed": [],
+                "params": { "m.login.password": {} },
+                "session": "uiaa-session",
+            })))
+            .expect(1)
+            .mount(server.server())
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": "not-a-real-new-password",
+                "logout_devices": false,
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id.clone() },
+                    "password": "not-a-real-current-password",
+                    "session": "uiaa-session",
+                },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": "another-not-real-new-password",
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id },
+                    "password": "not-a-real-current-password",
+                    "session": null,
+                },
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
             .expect(1)
             .mount(server.server())
             .await;
 
         let client = super::Client::new(sdk_client, None, None).await.unwrap();
-        client.change_password("not-a-real-new-password".to_owned(), None).await.unwrap();
+        let challenge = client
+            .change_password("not-a-real-new-password".to_owned(), false, None, None)
+            .await
+            .unwrap();
+        let super::PasswordChangeOutcome::AuthenticationRequired { challenge } = challenge else {
+            panic!("expected UIAA challenge")
+        };
+        assert_eq!(challenge.flows[0].stages, ["m.login.password"]);
+        assert_eq!(challenge.session.as_deref(), Some("uiaa-session"));
+        assert_eq!(challenge.params_json.as_deref(), Some(r#"{"m.login.password":{}}"#));
+
+        let outcome = client
+            .change_password(
+                "not-a-real-new-password".to_owned(),
+                false,
+                Some("not-a-real-current-password".to_owned()),
+                Some("uiaa-session".to_owned()),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(outcome, super::PasswordChangeOutcome::Success));
+
+        let outcome = client
+            .change_password(
+                "another-not-real-new-password".to_owned(),
+                true,
+                Some("not-a-real-current-password".to_owned()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(outcome, super::PasswordChangeOutcome::Success));
+
+        let result = client
+            .change_password(
+                "not-a-real-new-password".to_owned(),
+                false,
+                None,
+                Some("orphaned-session".to_owned()),
+            )
+            .await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("expected a local validation error"),
+        };
+        assert_eq!(error.to_string(), "client error: A UIAA session requires authentication data");
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn password_change_errors_do_not_include_passwords() {
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .on_builder(|builder| {
+                builder
+                    .cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+                    .request_config(matrix_sdk::config::RequestConfig::new().disable_retry())
+            })
+            .build()
+            .await;
+        let user_id = sdk_client.user_id().unwrap().to_string();
+        let new_password = "NEW_PASSWORD_SENTINEL_6771";
+        let current_password = "CURRENT_PASSWORD_SENTINEL_6771";
+        Mock::given(method("POST"))
+            .and(path("/_matrix/client/v3/account/password"))
+            .and(body_json(json!({
+                "new_password": new_password,
+                "logout_devices": false,
+                "auth": {
+                    "type": "m.login.password",
+                    "identifier": { "type": "m.id.user", "user": user_id },
+                    "password": current_password,
+                    "session": "uiaa-session",
+                },
+            })))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "errcode": "M_WEAK_PASSWORD",
+                "error": "Password is too weak",
+            })))
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        let client = super::Client::new(sdk_client, None, None).await.unwrap();
+        let result = client
+            .change_password(
+                new_password.to_owned(),
+                false,
+                Some(current_password.to_owned()),
+                Some("uiaa-session".to_owned()),
+            )
+            .await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("expected a weak-password error"),
+        };
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains(new_password));
+        assert!(!rendered.contains(current_password));
     }
 
     /// Dropping an FFI [`Client`] on a non-tokio thread must not panic.

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -622,11 +622,15 @@ impl Encryption {
         Ok(result?)
     }
 
-    /// Start a non-destructive first-device cross-signing bootstrap when the
-    /// authoritative server state has no identity.
+    /// Start a non-destructive first-device cross-signing bootstrap from the
+    /// authoritative server state.
     ///
-    /// `None` means the server identity already existed or bootstrap completed
-    /// without UIAA. A returned handle retains the exact generated requests.
+    /// Existing server identities are never replaced. If an interrupted local
+    /// bootstrap uploaded the matching identity but not the current device
+    /// signature, this method reconciles that signature and returns `None`.
+    /// Otherwise `None` means the server identity already existed or bootstrap
+    /// completed without UIAA. A returned handle retains the exact generated
+    /// requests.
     pub async fn bootstrap_cross_signing_if_needed(
         &self,
     ) -> Result<Option<Arc<CrossSigningBootstrapHandle>>, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -639,7 +639,9 @@ impl Encryption {
             .start_cross_signing_bootstrap_if_needed()
             .await
             .map_err(ClientError::from_err)?
-            .map(|inner| Arc::new(CrossSigningBootstrapHandle { inner })))
+            .map(|inner| {
+                Arc::new(CrossSigningBootstrapHandle { inner, _client: self._client.clone() })
+            }))
     }
 
     /// Completely reset the current user's crypto identity: reset the cross
@@ -856,6 +858,9 @@ impl UserIdentity {
 #[derive(uniffi::Object)]
 pub struct CrossSigningBootstrapHandle {
     inner: matrix_sdk::encryption::CrossSigningBootstrapHandle,
+    // Keep the runtime-safe FFI client ownership chain alive while foreign
+    // callers retain this handle.
+    _client: Arc<Client>,
 }
 
 #[matrix_sdk_ffi_macros::export]

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -25,7 +25,10 @@ use tracing::{error, info};
 use zeroize::Zeroize;
 
 use crate::{
-    client::Client, error::ClientError, ruma::AuthData, runtime::get_runtime_handle,
+    client::{Client, UiaaChallenge},
+    error::ClientError,
+    ruma::AuthData,
+    runtime::get_runtime_handle,
     task_handle::TaskHandle,
 };
 
@@ -619,6 +622,22 @@ impl Encryption {
         Ok(result?)
     }
 
+    /// Start a non-destructive first-device cross-signing bootstrap when the
+    /// authoritative server state has no identity.
+    ///
+    /// `None` means the server identity already existed or bootstrap completed
+    /// without UIAA. A returned handle retains the exact generated requests.
+    pub async fn bootstrap_cross_signing_if_needed(
+        &self,
+    ) -> Result<Option<Arc<CrossSigningBootstrapHandle>>, ClientError> {
+        Ok(self
+            .inner
+            .start_cross_signing_bootstrap_if_needed()
+            .await
+            .map_err(ClientError::from_err)?
+            .map(|inner| Arc::new(CrossSigningBootstrapHandle { inner })))
+    }
+
     /// Completely reset the current user's crypto identity: reset the cross
     /// signing keys, delete the existing backup and recovery key.
     pub async fn reset_identity(&self) -> Result<Option<Arc<IdentityResetHandle>>, ClientError> {
@@ -827,6 +846,36 @@ impl UserIdentity {
     /// Was this identity previously verified, and is no longer?
     pub fn has_verification_violation(&self) -> bool {
         self.inner.has_verification_violation()
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct CrossSigningBootstrapHandle {
+    inner: matrix_sdk::encryption::CrossSigningBootstrapHandle,
+}
+
+#[matrix_sdk_ffi_macros::export]
+impl CrossSigningBootstrapHandle {
+    /// Return the most recent UIAA challenge.
+    pub async fn challenge(&self) -> UiaaChallenge {
+        let challenge = self.inner.challenge().await;
+        UiaaChallenge::from(&challenge)
+    }
+
+    /// Continue bootstrap using password authentication. The password is a
+    /// method argument so generated bindings do not retain or print it.
+    pub async fn auth_with_password(
+        &self,
+        mut password: String,
+    ) -> Result<Option<UiaaChallenge>, ClientError> {
+        let result = self
+            .inner
+            .auth_with_password(&password)
+            .await
+            .map_err(ClientError::from_err)
+            .map(|challenge| challenge.as_ref().map(UiaaChallenge::from));
+        password.zeroize();
+        result
     }
 }
 

--- a/crates/matrix-sdk/changelog.d/6783.added.md
+++ b/crates/matrix-sdk/changelog.d/6783.added.md
@@ -1,0 +1,1 @@
+Add an options-aware account password-change API while preserving the existing behavior that logs out other devices by default.

--- a/crates/matrix-sdk/changelog.d/6785.added.md
+++ b/crates/matrix-sdk/changelog.d/6785.added.md
@@ -1,0 +1,1 @@
+Add a non-destructive first-device cross-signing bootstrap that preserves UIAA continuation state and safely reconciles interrupted device-signature uploads.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -580,7 +580,21 @@ impl Account {
         new_password: &str,
         auth_data: Option<AuthData>,
     ) -> Result<change_password::v3::Response> {
+        self.change_password_with_logout_devices(new_password, true, auth_data).await
+    }
+
+    /// Change the password of the current account and choose whether the
+    /// account's other devices should be logged out.
+    ///
+    /// This has the same UIAA behavior as [`Self::change_password`].
+    pub async fn change_password_with_logout_devices(
+        &self,
+        new_password: &str,
+        logout_devices: bool,
+        auth_data: Option<AuthData>,
+    ) -> Result<change_password::v3::Response> {
         let request = assign!(change_password::v3::Request::new(new_password.to_owned()), {
+            logout_devices,
             auth: auth_data,
         });
         Ok(self.client.send(request).await?)

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1564,8 +1564,13 @@ impl Encryption {
         Ok(())
     }
 
-    /// Start a non-destructive first-device cross-signing bootstrap if the
-    /// authoritative server query shows that no identity exists.
+    /// Start a non-destructive first-device cross-signing bootstrap from the
+    /// authoritative server state.
+    ///
+    /// Existing server identities are never replaced. If the server identity
+    /// exactly matches a complete local private identity but the current device
+    /// is not yet signed by it, the missing signature is reconciled without
+    /// uploading signing keys again.
     ///
     /// Returns a reusable handle when UIAA is required. The handle retains the
     /// exact signing-key and signature requests generated for this bootstrap.
@@ -1579,6 +1584,83 @@ impl Encryption {
         let (request_id, request) = olm_machine.query_keys_for_users([user_id]);
         let response = self.client.keys_query(&request_id, request.device_keys).await?;
         if response.master_keys.contains_key(user_id) {
+            let status = olm_machine.cross_signing_status().await;
+            if !status.is_complete() {
+                return Ok(None);
+            }
+
+            let CrossSigningBootstrapRequests {
+                upload_signing_keys_req,
+                upload_signatures_req,
+                ..
+            } = olm_machine.bootstrap_cross_signing(false).await?;
+
+            let Some(local_master_key) = upload_signing_keys_req.master_key.as_ref() else {
+                return Ok(None);
+            };
+            let Some(local_self_signing_key) = upload_signing_keys_req.self_signing_key.as_ref()
+            else {
+                return Ok(None);
+            };
+            let Some(local_user_signing_key) = upload_signing_keys_req.user_signing_key.as_ref()
+            else {
+                return Ok(None);
+            };
+            let Some(server_master_key) = response.master_keys.get(user_id) else {
+                return Ok(None);
+            };
+            let Some(server_self_signing_key) = response.self_signing_keys.get(user_id) else {
+                return Ok(None);
+            };
+            let Some(server_user_signing_key) = response.user_signing_keys.get(user_id) else {
+                return Ok(None);
+            };
+
+            let local_master_key: ruma::encryption::CrossSigningKey =
+                local_master_key.to_raw().deserialize()?;
+            let local_self_signing_key: ruma::encryption::CrossSigningKey =
+                local_self_signing_key.to_raw().deserialize()?;
+            let local_user_signing_key: ruma::encryption::CrossSigningKey =
+                local_user_signing_key.to_raw().deserialize()?;
+            let server_master_key = server_master_key.deserialize()?;
+            let server_self_signing_key = server_self_signing_key.deserialize()?;
+            let server_user_signing_key = server_user_signing_key.deserialize()?;
+
+            let same_public_key =
+                |local: &ruma::encryption::CrossSigningKey,
+                 server: &ruma::encryption::CrossSigningKey| {
+                    local.user_id == server.user_id
+                        && local.usage == server.usage
+                        && local.keys == server.keys
+                };
+            if !same_public_key(&local_master_key, &server_master_key)
+                || !same_public_key(&local_self_signing_key, &server_self_signing_key)
+                || !same_public_key(&local_user_signing_key, &server_user_signing_key)
+            {
+                return Ok(None);
+            }
+
+            let Some(device_id) = self.client.device_id() else {
+                return Ok(None);
+            };
+            let Some(device_keys) =
+                response.device_keys.get(user_id).and_then(|devices| devices.get(device_id))
+            else {
+                return Ok(None);
+            };
+            let device_keys = device_keys.deserialize()?;
+            let is_signed = device_keys.signatures.get(user_id).is_some_and(|signatures| {
+                signatures.keys().any(|signature_id| {
+                    server_self_signing_key
+                        .keys
+                        .keys()
+                        .any(|self_signing_id| signature_id.as_str() == self_signing_id.as_str())
+                })
+            });
+            if !is_signed {
+                self.client.send(upload_signatures_req).await?;
+            }
+
             return Ok(None);
         }
 
@@ -2603,6 +2685,110 @@ mod tests {
         assert!(handle.auth_with_password("password").await.is_err());
         assert_eq!(handle.challenge().await.session.as_deref(), Some("bootstrap-session"));
         assert!(handle.auth_with_password("password").await.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_reconciles_signature_after_handle_loss() {
+        let (client, server) = logged_in_client_with_server().await;
+        let uploaded_device_keys = Arc::new(StdMutex::new(None::<serde_json::Value>));
+        let uploaded_signing_keys = Arc::new(StdMutex::new(None::<serde_json::Value>));
+
+        let query_device_keys = uploaded_device_keys.clone();
+        let query_signing_keys = uploaded_signing_keys.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/query$"))
+            .respond_with(move |_request: &Request| {
+                let device_keys = query_device_keys.lock().unwrap().clone();
+                let signing_keys = query_signing_keys.lock().unwrap().clone();
+                match (device_keys, signing_keys) {
+                    (Some(device_keys), Some(signing_keys)) => ResponseTemplate::new(200)
+                        .set_body_json(json!({
+                            "device_keys": {
+                                "@example:localhost": { "DEVICEID": device_keys },
+                            },
+                            "failures": {},
+                            "master_keys": {
+                                "@example:localhost": signing_keys["master_key"].clone(),
+                            },
+                            "self_signing_keys": {
+                                "@example:localhost": signing_keys["self_signing_key"].clone(),
+                            },
+                            "user_signing_keys": {
+                                "@example:localhost": signing_keys["user_signing_key"].clone(),
+                            },
+                        })),
+                    _ => ResponseTemplate::new(200).set_body_json(empty_key_query_response()),
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let captured_device_keys = uploaded_device_keys.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/upload$"))
+            .respond_with(move |request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                *captured_device_keys.lock().unwrap() = Some(body["device_keys"].clone());
+                ResponseTemplate::new(200).set_body_json(json!({ "one_time_key_counts": {} }))
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let captured_signing_keys = uploaded_signing_keys.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(move |request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                if body.get("auth").is_none() {
+                    ResponseTemplate::new(401).set_body_json(json!({
+                        "flows": [{ "stages": ["m.login.password"] }],
+                        "params": {},
+                        "session": "bootstrap-session",
+                    }))
+                } else {
+                    *captured_signing_keys.lock().unwrap() = Some(body);
+                    ResponseTemplate::new(200).set_body_json(json!({}))
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let signature_attempts = Arc::new(AtomicUsize::new(0));
+        let attempts = signature_attempts.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(move |_request: &Request| {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(503).set_body_json(json!({
+                        "errcode": "M_UNAVAILABLE",
+                        "error": "try again",
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({}))
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        // Simulate the normal post-login state where device keys were already
+        // uploaded before the first cross-signing bootstrap.
+        let olm_machine = client.olm_machine().await.as_ref().unwrap().clone();
+        let (_, device_key_request) = olm_machine.upload_device_keys().await.unwrap().unwrap();
+        client.send_outgoing_request(device_key_request.into()).await.unwrap();
+
+        let handle =
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap();
+        assert!(handle.auth_with_password("password").await.is_err());
+        drop(handle);
+
+        assert!(
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().is_none()
+        );
+        assert_eq!(signature_attempts.load(Ordering::SeqCst), 2);
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -316,7 +316,20 @@ pub struct CrossSigningBootstrapHandle {
     client: Client,
     upload_request: UploadSigningKeysRequest,
     signatures_request: UploadSignaturesRequest,
-    challenge: Mutex<UiaaInfo>,
+    state: Mutex<CrossSigningBootstrapState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CrossSigningBootstrapPhase {
+    SigningKeys,
+    Signatures,
+    Complete,
+}
+
+#[derive(Debug)]
+struct CrossSigningBootstrapState {
+    challenge: UiaaInfo,
+    phase: CrossSigningBootstrapPhase,
 }
 
 impl CrossSigningBootstrapHandle {
@@ -326,12 +339,20 @@ impl CrossSigningBootstrapHandle {
         signatures_request: UploadSignaturesRequest,
         challenge: UiaaInfo,
     ) -> Self {
-        Self { client, upload_request, signatures_request, challenge: Mutex::new(challenge) }
+        Self {
+            client,
+            upload_request,
+            signatures_request,
+            state: Mutex::new(CrossSigningBootstrapState {
+                challenge,
+                phase: CrossSigningBootstrapPhase::SigningKeys,
+            }),
+        }
     }
 
     /// Return the most recent UIAA challenge.
     pub async fn challenge(&self) -> UiaaInfo {
-        self.challenge.lock().await.clone()
+        self.state.lock().await.challenge.clone()
     }
 
     /// Continue bootstrap with password authentication.
@@ -339,8 +360,18 @@ impl CrossSigningBootstrapHandle {
     /// Returns an updated challenge when authentication is rejected, and
     /// `None` once both the signing keys and device signatures are uploaded.
     pub async fn auth_with_password(&self, password: &str) -> Result<Option<UiaaInfo>> {
+        let mut state = self.state.lock().await;
+        if state.phase == CrossSigningBootstrapPhase::Complete {
+            return Ok(None);
+        }
+        if state.phase == CrossSigningBootstrapPhase::Signatures {
+            self.client.send(self.signatures_request.clone()).await?;
+            state.phase = CrossSigningBootstrapPhase::Complete;
+            return Ok(None);
+        }
+
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?.to_owned();
-        let session = self.challenge.lock().await.session.clone();
+        let session = state.challenge.session.clone();
         let mut auth = UiaaPassword::new(user_id.into(), password.to_owned());
         auth.session = session;
 
@@ -349,13 +380,15 @@ impl CrossSigningBootstrapHandle {
 
         match self.client.send(upload_request).await {
             Ok(_) => {
+                state.phase = CrossSigningBootstrapPhase::Signatures;
                 self.client.send(self.signatures_request.clone()).await?;
+                state.phase = CrossSigningBootstrapPhase::Complete;
                 Ok(None)
             }
             Err(error) => {
                 if let Some(challenge) = error.as_uiaa_response() {
                     let challenge = challenge.clone();
-                    *self.challenge.lock().await = challenge.clone();
+                    state.challenge = challenge.clone();
                     Ok(Some(challenge))
                 } else {
                     Err(error.into())
@@ -2685,6 +2718,46 @@ mod tests {
         assert!(handle.auth_with_password("password").await.is_err());
         assert_eq!(handle.challenge().await.session.as_deref(), Some("bootstrap-session"));
         assert!(handle.auth_with_password("password").await.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_serializes_concurrent_continuations() {
+        let (client, server) = logged_in_client_with_server().await;
+        mount_empty_key_query(&server).await;
+        mount_device_key_upload(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(|request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                if body.get("auth").is_none() {
+                    ResponseTemplate::new(401).set_body_json(json!({
+                        "flows": [{ "stages": ["m.login.password"] }],
+                        "params": {},
+                        "session": "bootstrap-session",
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({}))
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let handle =
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap();
+        let (first, second) = tokio::join!(
+            handle.auth_with_password("password"),
+            handle.auth_with_password("password"),
+        );
+
+        assert!(first.unwrap().is_none());
+        assert!(second.unwrap().is_none());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -68,7 +68,7 @@ use ruma::{
             to_device::send_event_to_device::v3::{
                 Request as RumaToDeviceRequest, Response as ToDeviceResponse,
             },
-            uiaa::{AuthData, AuthType, OAuthParams, UiaaInfo},
+            uiaa::{AuthData, AuthType, OAuthParams, Password as UiaaPassword, UiaaInfo},
         },
         error::{ErrorBody, StandardErrorBody},
     },
@@ -308,6 +308,61 @@ pub enum VerificationState {
     Verified,
     /// The device is unverified.
     Unverified,
+}
+
+/// A reusable, non-destructive first-device cross-signing bootstrap.
+#[derive(Debug)]
+pub struct CrossSigningBootstrapHandle {
+    client: Client,
+    upload_request: UploadSigningKeysRequest,
+    signatures_request: UploadSignaturesRequest,
+    challenge: Mutex<UiaaInfo>,
+}
+
+impl CrossSigningBootstrapHandle {
+    fn new(
+        client: Client,
+        upload_request: UploadSigningKeysRequest,
+        signatures_request: UploadSignaturesRequest,
+        challenge: UiaaInfo,
+    ) -> Self {
+        Self { client, upload_request, signatures_request, challenge: Mutex::new(challenge) }
+    }
+
+    /// Return the most recent UIAA challenge.
+    pub async fn challenge(&self) -> UiaaInfo {
+        self.challenge.lock().await.clone()
+    }
+
+    /// Continue bootstrap with password authentication.
+    ///
+    /// Returns an updated challenge when authentication is rejected, and
+    /// `None` once both the signing keys and device signatures are uploaded.
+    pub async fn auth_with_password(&self, password: &str) -> Result<Option<UiaaInfo>> {
+        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?.to_owned();
+        let session = self.challenge.lock().await.session.clone();
+        let mut auth = UiaaPassword::new(user_id.into(), password.to_owned());
+        auth.session = session;
+
+        let mut upload_request = self.upload_request.clone();
+        upload_request.auth = Some(AuthData::Password(auth));
+
+        match self.client.send(upload_request).await {
+            Ok(_) => {
+                self.client.send(self.signatures_request.clone()).await?;
+                Ok(None)
+            }
+            Err(error) => {
+                if let Some(challenge) = error.as_uiaa_response() {
+                    let challenge = challenge.clone();
+                    *self.challenge.lock().await = challenge.clone();
+                    Ok(Some(challenge))
+                } else {
+                    Err(error.into())
+                }
+            }
+        }
+    }
 }
 
 /// A stateful struct remembering the cross-signing keys we need to upload.
@@ -1509,6 +1564,60 @@ impl Encryption {
         Ok(())
     }
 
+    /// Start a non-destructive first-device cross-signing bootstrap if the
+    /// authoritative server query shows that no identity exists.
+    ///
+    /// Returns a reusable handle when UIAA is required. The handle retains the
+    /// exact signing-key and signature requests generated for this bootstrap.
+    pub async fn start_cross_signing_bootstrap_if_needed(
+        &self,
+    ) -> Result<Option<CrossSigningBootstrapHandle>> {
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+        let user_id = olm_machine.user_id();
+
+        let (request_id, request) = olm_machine.query_keys_for_users([user_id]);
+        let response = self.client.keys_query(&request_id, request.device_keys).await?;
+        if response.master_keys.contains_key(user_id) {
+            return Ok(None);
+        }
+
+        let CrossSigningBootstrapRequests {
+            upload_keys_req,
+            upload_signing_keys_req,
+            upload_signatures_req,
+        } = olm_machine.bootstrap_cross_signing(false).await?;
+        let upload_signing_keys_req = assign!(UploadSigningKeysRequest::new(), {
+            auth: None,
+            master_key: upload_signing_keys_req.master_key.map(|key| key.to_raw()),
+            self_signing_key: upload_signing_keys_req.self_signing_key.map(|key| key.to_raw()),
+            user_signing_key: upload_signing_keys_req.user_signing_key.map(|key| key.to_raw()),
+        });
+
+        if let Some(request) = upload_keys_req {
+            self.client.send_outgoing_request(request).await?;
+        }
+
+        match self.client.send(upload_signing_keys_req.clone()).await {
+            Ok(_) => {
+                self.client.send(upload_signatures_req).await?;
+                Ok(None)
+            }
+            Err(error) => {
+                if let Some(challenge) = error.as_uiaa_response() {
+                    Ok(Some(CrossSigningBootstrapHandle::new(
+                        self.client.clone(),
+                        upload_signing_keys_req,
+                        upload_signatures_req,
+                        challenge.clone(),
+                    )))
+                } else {
+                    Err(error.into())
+                }
+            }
+        }
+    }
+
     /// Create and upload a new cross signing identity, if that has not been
     /// done yet.
     ///
@@ -2236,8 +2345,8 @@ mod tests {
         ops::Not,
         str::FromStr,
         sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         time::Duration,
     };
@@ -2264,9 +2373,281 @@ mod tests {
             DuplicateOneTimeKeyErrorMessage, OAuthCrossSigningResetInfo, VerificationState,
         },
         test_utils::{
-            client::mock_matrix_session, logged_in_client, no_retry_test_client, set_client_session,
+            client::mock_matrix_session, logged_in_client, logged_in_client_with_server,
+            no_retry_test_client, set_client_session,
         },
     };
+
+    fn empty_key_query_response() -> serde_json::Value {
+        json!({
+            "device_keys": {},
+            "failures": {},
+            "master_keys": {},
+            "self_signing_keys": {},
+            "user_signing_keys": {},
+        })
+    }
+
+    async fn mount_empty_key_query(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/query$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(empty_key_query_response()))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_device_key_upload(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/upload$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "one_time_key_counts": {},
+            })))
+            .mount(server)
+            .await;
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_noops_when_server_identity_exists() {
+        let (client, server) = logged_in_client_with_server().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/query$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(devices_to_verify_against_keys_query_response(vec![])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/(?:upload|device_signing/upload|signatures/upload)$"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let handle = client
+            .encryption()
+            .start_cross_signing_bootstrap_if_needed()
+            .await
+            .expect("the authoritative key query should succeed");
+
+        assert!(handle.is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_returns_uiaa_challenge_without_sending_signatures() {
+        let (client, server) = logged_in_client_with_server().await;
+        mount_empty_key_query(&server).await;
+        mount_device_key_upload(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "flows": [{ "stages": ["m.login.password"] }],
+                "params": { "m.login.password": {} },
+                "session": "bootstrap-session",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let handle = client
+            .encryption()
+            .start_cross_signing_bootstrap_if_needed()
+            .await
+            .unwrap()
+            .expect("UIAA should return a reusable handle");
+
+        assert_eq!(handle.challenge().await.session.as_deref(), Some("bootstrap-session"));
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_continues_with_logged_in_user_password_and_session() {
+        let (client, server) = logged_in_client_with_server().await;
+        mount_empty_key_query(&server).await;
+        mount_device_key_upload(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(|request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                match body.get("auth") {
+                    None | Some(serde_json::Value::Null) => ResponseTemplate::new(401)
+                        .set_body_json(json!({
+                            "flows": [{ "stages": ["m.login.password"] }],
+                            "params": {},
+                            "session": "bootstrap-session",
+                        })),
+                    Some(auth) => {
+                        assert_eq!(auth["identifier"]["user"], "@example:localhost");
+                        assert_eq!(auth["password"], "correct-password");
+                        assert_eq!(auth["session"], "bootstrap-session");
+                        ResponseTemplate::new(200).set_body_json(json!({}))
+                    }
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let handle =
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap();
+        let challenge = handle.auth_with_password("correct-password").await.unwrap();
+
+        assert!(challenge.is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_updates_uiaa_and_retries_on_same_handle() {
+        let (client, server) = logged_in_client_with_server().await;
+        mount_empty_key_query(&server).await;
+        mount_device_key_upload(&server).await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(|request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                match body.pointer("/auth/password").and_then(|v| v.as_str()) {
+                    None => ResponseTemplate::new(401).set_body_json(json!({
+                        "flows": [{ "stages": ["m.login.password"] }],
+                        "params": {},
+                        "session": "first-session",
+                    })),
+                    Some("wrong-password") => {
+                        assert_eq!(body["auth"]["session"], "first-session");
+                        ResponseTemplate::new(401).set_body_json(json!({
+                            "errcode": "M_FORBIDDEN",
+                            "error": "Invalid password",
+                            "flows": [{ "stages": ["m.login.password"] }],
+                            "params": {},
+                            "session": "updated-session",
+                        }))
+                    }
+                    Some("correct-password") => {
+                        assert_eq!(body["auth"]["session"], "updated-session");
+                        ResponseTemplate::new(200).set_body_json(json!({}))
+                    }
+                    Some(password) => panic!("unexpected password: {password}"),
+                }
+            })
+            .expect(3)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let handle =
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap();
+        let challenge = handle
+            .auth_with_password("wrong-password")
+            .await
+            .unwrap()
+            .expect("wrong password should return updated UIAA");
+        assert_eq!(challenge.session.as_deref(), Some("updated-session"));
+        assert_eq!(challenge.auth_error.as_ref().unwrap().message, "Invalid password");
+        assert!(handle.auth_with_password("correct-password").await.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_preserves_handle_after_transient_error() {
+        let (client, server) = logged_in_client_with_server().await;
+        mount_empty_key_query(&server).await;
+        mount_device_key_upload(&server).await;
+        let authenticated_attempts = Arc::new(AtomicUsize::new(0));
+        let attempts = authenticated_attempts.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(move |request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                if body.get("auth").is_none() {
+                    ResponseTemplate::new(401).set_body_json(json!({
+                        "flows": [{ "stages": ["m.login.password"] }],
+                        "params": {},
+                        "session": "bootstrap-session",
+                    }))
+                } else if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(503).set_body_json(json!({
+                        "errcode": "M_UNAVAILABLE",
+                        "error": "try again",
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(json!({}))
+                }
+            })
+            .expect(3)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/signatures/upload$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let handle =
+            client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap();
+        assert!(handle.auth_with_password("password").await.is_err());
+        assert_eq!(handle.challenge().await.session.as_deref(), Some("bootstrap-session"));
+        assert!(handle.auth_with_password("password").await.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn test_first_device_bootstrap_restart_reuses_unshared_local_identity() {
+        let (client, server) = logged_in_client_with_server().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3)/keys/query$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(empty_key_query_response()))
+            .expect(2)
+            .mount(&server)
+            .await;
+        mount_device_key_upload(&server).await;
+        let master_keys = Arc::new(StdMutex::new(Vec::new()));
+        let captured_master_keys = master_keys.clone();
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/(?:r0|v3|unstable)/keys/device_signing/upload$"))
+            .respond_with(move |request: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                captured_master_keys.lock().unwrap().push(body["master_key"].clone());
+                ResponseTemplate::new(401).set_body_json(json!({
+                    "flows": [{ "stages": ["m.login.password"] }],
+                    "params": {},
+                    "session": "bootstrap-session",
+                }))
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        drop(client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap());
+        drop(client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap());
+
+        let master_keys = master_keys.lock().unwrap();
+        assert_eq!(master_keys.len(), 2);
+        assert_eq!(master_keys[0], master_keys[1]);
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests.iter().all(|request| {
+            let path = request.url.path();
+            request.method.as_str() != "POST"
+                || path.ends_with("/keys/query")
+                || path.ends_with("/keys/upload")
+                || path.ends_with("/keys/device_signing/upload")
+        }));
+    }
 
     #[async_test]
     async fn test_reaction_sending() {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -2894,9 +2894,11 @@ mod tests {
         drop(client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap());
         drop(client.encryption().start_cross_signing_bootstrap_if_needed().await.unwrap().unwrap());
 
-        let master_keys = master_keys.lock().unwrap();
-        assert_eq!(master_keys.len(), 2);
-        assert_eq!(master_keys[0], master_keys[1]);
+        {
+            let master_keys = master_keys.lock().unwrap();
+            assert_eq!(master_keys.len(), 2);
+            assert_eq!(master_keys[0], master_keys[1]);
+        }
 
         let requests = server.received_requests().await.unwrap();
         assert!(requests.iter().all(|request| {


### PR DESCRIPTION
## Summary

Expose a non-destructive first-device cross-signing bootstrap through `matrix-sdk-ffi`.

This PR is stacked on #6771 and reuses its typed UIAA challenge contract.

- Queries own-user server keys authoritatively before bootstrap.
- Never resets or replaces an existing server identity.
- Retains exact signing-key and signature requests across UIAA continuation.
- Uploads device keys before signing keys and signatures only after signing-key success.
- Serializes continuation through `SigningKeys -> Signatures -> Complete` phases.
- Reconciles an interrupted pre-shared-device bootstrap only when complete local and server master/self/user public keys match exactly.
- Retains the FFI `Arc<Client>` ownership chain for runtime-safe destruction.

Fixes #6776.
Depends on #6771.

## Verification

- Focused bootstrap tests: 8 passed.
- `cargo test -p matrix-sdk --lib`: 598 passed.
- `cargo test -p matrix-sdk-ffi --lib`: 31 passed.
- `cargo check -p matrix-sdk-ffi`: passed.
- Formatting and `git diff --check`: passed.
- Independent exact-head review: approved at `38d5222797652f6806707ef7faa33fc8b242aff1` before PR-numbered changelog/stack-maintenance follow-ups.

## Baseline caveat

Strict Clippy reaches the pre-existing unrelated `unfulfilled-lint-expectations` error at `crates/matrix-sdk/src/widget/mod.rs:133`. This PR does not include an unrelated baseline repair.

## Security and scope

- Existing identities are never replaced; reset and Recovery APIs are not used.
- Password continuation derives the authenticated user's ID, retains no password-bearing record, and zeroizes the FFI-owned argument.
- Wrong-password challenges replace continuation state safely.
- Concurrent calls cannot duplicate uploads or overwrite terminal state.
- No backup deletion, secret-storage mutation, SAS, re-login, or alternate transport is introduced.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Atkinson <g.atkinson112@gmail.com>
