### PR TITLE
feat(ffi): expose Room::load_user_receipt

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6787.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6787.added.md
@@ -1,0 +1,5 @@
+`Room` gained a `load_user_receipt()` method, exposing the existing SDK API
+of the same name: it returns a user's receipt of the given type in the room,
+optionally scoped to a thread (`ReceiptThread`), read from the local store.
+This allows e.g. computing per-thread read state from threaded receipts
+without instantiating a thread-focused timeline per thread.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -38,7 +38,7 @@ use ruma::{
     ServerName, UserId, assign,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
-        receipt::ReceiptThread,
+        receipt::ReceiptThread as RumaReceiptThread,
         room::{
             MediaSource as RumaMediaSource, avatar::ImageInfo as RumaAvatarImageInfo,
             history_visibility::HistoryVisibility as RumaHistoryVisibility,
@@ -67,7 +67,8 @@ use crate::{
     },
     runtime::get_runtime_handle,
     timeline::{
-        AbstractProgress, LatestEventValue, ReceiptType, SendHandle, Timeline, UploadSource,
+        AbstractProgress, LatestEventValue, ReceiptThread, ReceiptType, SendHandle, Timeline,
+        UploadSource, UserReceipt,
         configuration::{TimelineConfiguration, TimelineFilter},
         threads::{ThreadListService, ThreadSubscription},
     },
@@ -713,6 +714,33 @@ impl Room {
         Ok(())
     }
 
+    /// Load the receipt of the given type for the given user in this room,
+    /// optionally scoped to a thread.
+    ///
+    /// The receipt is read from the local store, which is fed by sync, so it
+    /// also reflects receipts sent by the user's other devices. Returns
+    /// `None` if the user has no matching receipt in this room.
+    ///
+    /// Note: [`ReceiptType::FullyRead`] is a marker, not an event receipt,
+    /// and is rejected.
+    pub async fn load_user_receipt(
+        &self,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: String,
+    ) -> Result<Option<UserReceipt>, ClientError> {
+        let user_id = UserId::parse(&*user_id)?;
+
+        Ok(self
+            .inner
+            .load_user_receipt(receipt_type.try_into()?, thread.try_into()?, &user_id)
+            .await?
+            .map(|(event_id, receipt)| UserReceipt {
+                event_id: event_id.to_string(),
+                receipt: receipt.into(),
+            }))
+    }
+
     /// Mark a room as fully read, by attaching a read receipt to the provided
     /// `event_id`.
     ///
@@ -726,7 +754,11 @@ impl Room {
         let event_id = EventId::parse(event_id)?;
 
         self.inner
-            .send_single_receipt(ReceiptType::FullyRead.into(), ReceiptThread::Unthreaded, event_id)
+            .send_single_receipt(
+                ReceiptType::FullyRead.into(),
+                RumaReceiptThread::Unthreaded,
+                event_id,
+            )
             .await?;
 
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -1064,6 +1064,15 @@ impl From<ruma::events::receipt::Receipt> for Receipt {
     }
 }
 
+/// A receipt of a user in a room, as read from the local store.
+#[derive(uniffi::Record)]
+pub struct UserReceipt {
+    /// The ID of the event the receipt is attached to.
+    pub event_id: String,
+    /// The receipt itself.
+    pub receipt: Receipt,
+}
+
 #[derive(Clone, uniffi::Record)]
 pub struct EventTimelineItemDebugInfo {
     model: String,
@@ -1239,6 +1248,53 @@ impl From<ReceiptType> for ruma::api::client::receipt::create_receipt::v3::Recei
             ReceiptType::ReadPrivate => Self::ReadPrivate,
             ReceiptType::FullyRead => Self::FullyRead,
         }
+    }
+}
+
+impl TryFrom<ReceiptType> for ruma::events::receipt::ReceiptType {
+    type Error = ClientError;
+
+    fn try_from(value: ReceiptType) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ReceiptType::Read => Self::Read,
+            ReceiptType::ReadPrivate => Self::ReadPrivate,
+            // `m.fully_read` is a marker, not an event receipt: it has no
+            // counterpart in `ruma::events::receipt::ReceiptType`.
+            ReceiptType::FullyRead => {
+                return Err(ClientError::Generic {
+                    msg: "FullyRead is a marker, not an event receipt".to_owned(),
+                    details: None,
+                });
+            }
+        })
+    }
+}
+
+/// The thread scope of a read receipt.
+#[derive(Clone, uniffi::Enum)]
+pub enum ReceiptThread {
+    /// The receipt applies to the room, regardless of threads.
+    Unthreaded,
+    /// The receipt applies to the un-threaded main timeline only.
+    Main,
+    /// The receipt applies to the thread with the given root event.
+    Thread {
+        /// The ID of the thread's root event.
+        thread_root_event_id: String,
+    },
+}
+
+impl TryFrom<ReceiptThread> for ruma::events::receipt::ReceiptThread {
+    type Error = ruma::IdParseError;
+
+    fn try_from(value: ReceiptThread) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ReceiptThread::Unthreaded => Self::Unthreaded,
+            ReceiptThread::Main => Self::Main,
+            ReceiptThread::Thread { thread_root_event_id } => {
+                Self::Thread(EventId::parse(thread_root_event_id)?)
+            }
+        })
     }
 }
 
@@ -1650,5 +1706,37 @@ mod galleries {
 
             Ok(handle)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma::{event_id, events::receipt::ReceiptThread as RumaReceiptThread};
+
+    use super::ReceiptThread;
+
+    #[test]
+    fn test_receipt_thread_conversion() {
+        assert_eq!(
+            RumaReceiptThread::try_from(ReceiptThread::Unthreaded),
+            Ok(RumaReceiptThread::Unthreaded)
+        );
+        assert_eq!(RumaReceiptThread::try_from(ReceiptThread::Main), Ok(RumaReceiptThread::Main));
+
+        let thread_root = event_id!("$root:example.org");
+        assert_eq!(
+            RumaReceiptThread::try_from(ReceiptThread::Thread {
+                thread_root_event_id: thread_root.to_string(),
+            }),
+            Ok(RumaReceiptThread::Thread(thread_root.to_owned()))
+        );
+
+        // An invalid thread root event ID is rejected.
+        assert!(
+            RumaReceiptThread::try_from(ReceiptThread::Thread {
+                thread_root_event_id: "not an event id".to_owned(),
+            })
+            .is_err()
+        );
     }
 }


### PR DESCRIPTION
matrix_sdk::Room::load_user_receipt(receipt_type, thread, user_id) reads a user's receipt from the local store, including thread-scoped receipts, but it isn't reachable through the FFI.

The use case is computing per-thread read state on the client. Threaded receipts are sent and synced fine (a thread-focused Timeline sends them via mark_as_read and they land in the store), but reading one back currently requires building a receipt-tracking thread Timeline and scanning its items for the user's receipt. For a room list or thread list rendering unread indicators for many threads, that's a timeline instance per thread when the data is one store lookup away. 

Thread subscriptions (MSC4306) will eventually make the server compute this; this fills the gap for servers that don't have it yet.