### PR TITLE
Replace `Readwrite` with `Readonly` transactions when loading chunks in `IndexeddbEventCacheStore`

### DIFF
--- a/crates/matrix-sdk-indexeddb/changelog.d/6788.changed.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6788.changed.md
@@ -1,0 +1,3 @@
+Use `Readonly` rather than `Readwrite` transactions in
+`EventCacheStore::{load_all_chunks, load_all_chunks_metadata}`
+as these functions only read data from the database.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -282,7 +282,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
 
         let transaction = self.transaction(
             &[keys::LINKED_CHUNKS, keys::GAPS, keys::EVENTS],
-            IdbTransactionMode::Readwrite,
+            IdbTransactionMode::Readonly,
         )?;
 
         let mut raw_chunks = Vec::new();
@@ -317,7 +317,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
 
         let transaction = self.transaction(
             &[keys::LINKED_CHUNKS, keys::EVENTS, keys::GAPS],
-            IdbTransactionMode::Readwrite,
+            IdbTransactionMode::Readonly,
         )?;
 
         let mut raw_chunks = Vec::new();


### PR DESCRIPTION
In the IndexedDB implementation of `EventCacheStore`, `load_all_chunks` and `load_all_chunks_metadata` open `Readwrite` transactions, when they are only reading data. The transaction mode on these calls is replaced with `Readonly`, to avoid the contention created by using `Readwrite` mode.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
