### PR TITLE
feat(client): Support for RTC transports discovery

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2141,12 +2141,12 @@ impl Client {
 
     /// Checks if the server supports the LiveKit RTC focus for placing calls.
     pub async fn is_livekit_rtc_supported(&self) -> Result<bool, ClientError> {
-        Ok(self
-            .inner
-            .well_known_rtc_transports()
-            .await?
-            .iter()
-            .any(|focus| matches!(focus, RtcTransport::LiveKit(_))))
+        let transports = match self.inner.rtc_transports().await? {
+            Some(transports) => transports,
+            // discovery not supported, fallback to well-known
+            None => self.inner.well_known_rtc_transports().await?,
+        };
+        Ok(transports.iter().any(|focus| matches!(focus, RtcTransport::LiveKit(_))))
     }
 
     /// Checks if the server supports user status.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2143,7 +2143,7 @@ impl Client {
     pub async fn is_livekit_rtc_supported(&self) -> Result<bool, ClientError> {
         Ok(self
             .inner
-            .rtc_foci()
+            .well_known_rtc_transports()
             .await?
             .iter()
             .any(|focus| matches!(focus, RtcTransport::LiveKit(_))))

--- a/crates/matrix-sdk/changelog.d/6789.added.md
+++ b/crates/matrix-sdk/changelog.d/6789.added.md
@@ -1,0 +1,6 @@
+Add `Client::rtc_transports` that queries the RTC transport advertised by the homeserver using
+the new authenticated `GET /_matrix/client/v1/rtc/transports` API. The value is cached for 1 day,
+and it is possible to force refresh with `Client::refresh_rtc_transports`, or to by-pass cache with
+`Client::fetch_rtc_transports`.
+[**breaking**] `Client::rtc_foci` has been renamed to `Client::well_known_rtc_transports` and should
+only be used as a fallback for homeservers that do not support the new API. 

--- a/crates/matrix-sdk/changelog.d/6789.added.md
+++ b/crates/matrix-sdk/changelog.d/6789.added.md
@@ -2,5 +2,5 @@ Add `Client::rtc_transports` that queries the RTC transport advertised by the ho
 the new authenticated `GET /_matrix/client/v1/rtc/transports` API. The value is cached for 1 day,
 and it is possible to force refresh with `Client::refresh_rtc_transports`, or to by-pass cache with
 `Client::fetch_rtc_transports`.
-[**breaking**] `Client::rtc_foci` has been renamed to `Client::well_known_rtc_transports` and should
-only be used as a fallback for homeservers that do not support the new API. 
+[**breaking**] `Client::rtc_foci` has been deprecated and should only be used as a fallback
+for homeservers that do not support the new API (see `Client::well_known_rtc_transports`). 

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -18,9 +18,12 @@ use matrix_sdk_base::store::WellKnownResponse;
 use matrix_sdk_common::{locks::Mutex, ttl::TtlValue};
 use ruma::api::{
     SupportedVersions,
-    client::discovery::{
-        get_authorization_server_metadata::v1::AuthorizationServerMetadata,
-        get_capabilities::v3::Capabilities,
+    client::{
+        discovery::{
+            get_authorization_server_metadata::v1::AuthorizationServerMetadata,
+            get_capabilities::v3::Capabilities,
+        },
+        rtc::RtcTransport,
     },
 };
 use tokio::sync::Mutex as AsyncMutex;
@@ -43,6 +46,13 @@ pub(crate) struct ClientCaches {
     pub(crate) server_metadata: Cache<AuthorizationServerMetadata, ()>,
     /// Homeserver capabilities.
     pub(crate) homeserver_capabilities: Cache<Capabilities, Arc<HttpError>>,
+    /// RTC transports advertised by the homeserver
+    /// ([MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143)).
+    ///
+    /// `None` is cached to represent a homeserver that doesn't implement the
+    /// discovery endpoint, as distinct from one that advertises no transports
+    /// (`Some(vec![])`).
+    pub(crate) rtc_transports: Cache<Option<Vec<RtcTransport>>, Arc<HttpError>>,
 }
 
 /// A cached value that can either be set or not set, used to avoid confusion

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2644,9 +2644,10 @@ impl Client {
     /// Get information about the homeserver's advertised RTC foci by fetching
     /// the well-known file from the server or the cache.
     ///
-    /// This will be soon deprecated in favor of [`Client::rtc_transports`], which fetches the RTC
-    /// transports advertised by the homeserver through the authenticated
-    /// `GET /_matrix/client/v1/rtc/transports` endpoint.
+    /// This will be soon deprecated in favor of [`Client::rtc_transports`],
+    /// which fetches the RTC transports advertised by the homeserver
+    /// through the authenticated `GET /_matrix/client/v1/rtc/transports`
+    /// endpoint.
     ///
     /// # Examples
     /// ```no_run
@@ -2687,8 +2688,8 @@ impl Client {
     ///   list may be empty if the homeserver advertises no transports),
     /// - `Ok(None)` if the homeserver doesn't implement the endpoint (this is
     ///   also cached, so the endpoint isn't hit on every call). Callers may
-    ///   want to fall back to [`Client::well_known_rtc_transports`] (the well-known foci) in
-    ///   this case,
+    ///   want to fall back to [`Client::well_known_rtc_transports`] (the
+    ///   well-known foci) in this case,
     /// - `Err(_)` on a transient error (not cached).
     ///
     /// # Examples

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -62,7 +62,7 @@ use ruma::{
             membership::{join_room_by_id, join_room_by_id_or_alias},
             presence::set_presence as set_presence_status,
             room::create_room,
-            rtc::RtcTransport,
+            rtc::{RtcTransport, transports},
             session::login::v3::DiscoveryInfo,
             sync::sync_events,
             threads::get_thread_subscriptions_changes,
@@ -454,6 +454,7 @@ impl ClientInner {
             well_known: Cache::with_value(well_known),
             server_metadata: Cache::new(),
             homeserver_capabilities: Cache::new(),
+            rtc_transports: Cache::new(),
         };
 
         let client = Self {
@@ -2643,6 +2644,10 @@ impl Client {
     /// Get information about the homeserver's advertised RTC foci by fetching
     /// the well-known file from the server or the cache.
     ///
+    /// This will be soon deprecated in favor of [`Client::rtc_transports`], which fetches the RTC
+    /// transports advertised by the homeserver through the authenticated
+    /// `GET /_matrix/client/v1/rtc/transports` endpoint.
+    ///
     /// # Examples
     /// ```no_run
     /// # use matrix_sdk::{Client, config::SyncSettings, ruma::api::client::rtc::RtcTransport};
@@ -2664,6 +2669,155 @@ impl Client {
         let well_known = self.well_known().await;
 
         Ok(well_known.map(|well_known| well_known.rtc_foci).unwrap_or_default())
+    }
+
+    /// Get the RTC transports advertised by the homeserver by fetching them
+    /// from the server or the cache.
+    ///
+    /// The transports are discovered through the authenticated
+    /// `GET /_matrix/client/v1/rtc/transports` endpoint
+    /// ([MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143)).
+    ///
+    /// The result is cached in memory for a day. Use
+    /// [`Client::fetch_rtc_transports`] to bypass the cache, or
+    /// [`Client::reset_rtc_transports`] to clear it.
+    ///
+    /// Returns:
+    /// - `Ok(Some(transports))` if the homeserver supports the endpoint (the
+    ///   list may be empty if the homeserver advertises no transports),
+    /// - `Ok(None)` if the homeserver doesn't implement the endpoint (this is
+    ///   also cached, so the endpoint isn't hit on every call). Callers may
+    ///   want to fall back to [`Client::rtc_foci`] (the well-known foci) in
+    ///   this case,
+    /// - `Err(_)` on a transient error (not cached).
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use matrix_sdk::{Client, ruma::api::client::rtc::RtcTransport};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://localhost:8080")?;
+    /// let client = Client::new(homeserver).await?;
+    /// // The endpoint is authenticated, so the client must be logged in.
+    /// client.matrix_auth().login_username("example", "password").send().await?;
+    ///
+    /// let transports = match client.rtc_transports().await? {
+    ///     Some(transports) => transports,
+    ///     // The homeserver doesn't support the discovery endpoint; fall back
+    ///     // to the RTC foci advertised in the well-known.
+    ///     None => client.rtc_foci().await?,
+    /// };
+    /// for transport in transports {
+    ///     println!("transport type: {}", transport.transport_type());
+    /// }
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn rtc_transports(&self) -> HttpResult<Option<Vec<RtcTransport>>> {
+        match self.rtc_transports_cached() {
+            CachedValue::Cached(value) => Ok(value),
+            // The cache is empty, make a request.
+            CachedValue::NotSet => self.refresh_rtc_transports_cache().await,
+        }
+    }
+
+    /// Get the RTC transports advertised by the homeserver from the cache.
+    ///
+    /// Returns [`CachedValue::NotSet`] if nothing has been cached yet. If the
+    /// cached data has expired, this triggers a background task to refresh it
+    /// and returns the stale value.
+    fn rtc_transports_cached(&self) -> CachedValue<Option<Vec<RtcTransport>>> {
+        let cache = &self.inner.caches.rtc_transports;
+
+        let CachedValue::Cached(value) = cache.value() else {
+            return CachedValue::NotSet;
+        };
+
+        // Spawn a task to refresh the cache if it has expired and we have a valid
+        // access token.
+        if value.has_expired() && self.auth_ctx().has_valid_access_token() {
+            debug!("spawning task to refresh RTC transports cache");
+
+            let client = self.clone();
+            self.task_monitor().spawn_finite_task("refresh RTC transports cache", async move {
+                if let Err(error) = client.refresh_rtc_transports_cache().await {
+                    warn!("failed to refresh RTC transports cache: {error}");
+                }
+            });
+        }
+
+        CachedValue::Cached(value.into_data())
+    }
+
+    /// Refresh the RTC transports advertised by the homeserver in the cache.
+    async fn refresh_rtc_transports_cache(&self) -> HttpResult<Option<Vec<RtcTransport>>> {
+        let cache = &self.inner.caches.rtc_transports;
+
+        let mut refresh_guard = match cache.refresh_lock.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                // There is already a refresh in progress, wait for it to finish.
+                let guard = cache.refresh_lock.lock().await;
+
+                if let Err(error) = guard.as_ref() {
+                    // There was an error in the previous refresh, return it.
+                    return Err(HttpError::Cached(error.clone()));
+                }
+
+                // Reuse the data if it was cached and it hasn't expired.
+                if let CachedValue::Cached(value) = cache.value()
+                    && !value.has_expired()
+                {
+                    return Ok(value.into_data());
+                }
+
+                // The data wasn't cached or has expired, we need to make another request.
+                guard
+            }
+        };
+
+        match self.fetch_rtc_transports().await {
+            Ok(transports) => {
+                *refresh_guard = Ok(());
+                cache.set_value(TtlValue::new(Some(transports.clone())));
+                Ok(Some(transports))
+            }
+            Err(error) if error.is_endpoint_not_implemented() => {
+                // The homeserver doesn't implement the RTC transports endpoint. Cache
+                // `None` (with the normal TTL) so we don't hit the endpoint on every
+                // call; this self-heals after the TTL in case the homeserver is
+                // upgraded. `None` is kept distinct from `Some(vec![])` (a homeserver
+                // that advertises no transports) so callers can decide whether to fall
+                // back to the well-known foci (see `Client::rtc_foci`).
+                debug!("homeserver does not implement the RTC transports endpoint");
+                *refresh_guard = Ok(());
+                cache.set_value(TtlValue::new(None));
+                Ok(None)
+            }
+            Err(error) => {
+                let error = Arc::new(error);
+                *refresh_guard = Err(error.clone());
+                Err(HttpError::Cached(error))
+            }
+        }
+    }
+
+    /// Fetch the RTC transports advertised by the homeserver from the network,
+    /// bypassing the cache.
+    ///
+    /// Unlike [`Client::rtc_transports`], this does not special-case a
+    /// homeserver that doesn't implement the endpoint: it returns the raw error
+    /// in that case. The cache is not updated with the result.
+    pub async fn fetch_rtc_transports(&self) -> HttpResult<Vec<RtcTransport>> {
+        let response = self.send(transports::v1::Request::new()).await?;
+        Ok(response.rtc_transports)
+    }
+
+    /// Empty the RTC transports cache.
+    ///
+    /// Since the SDK caches the RTC transports, it's possible to have a stale
+    /// entry in the cache. This function makes it possible to force reset it.
+    pub fn reset_rtc_transports(&self) {
+        self.inner.caches.rtc_transports.reset();
     }
 
     /// Get information about the homeserver's advertised map tile server, if
@@ -4420,6 +4574,105 @@ pub(crate) mod tests {
         // user will fail, only the requests using the homeserver URL will succeed.
         sleep(Duration::from_secs(5)).await;
         assert_matches!(client.inner.caches.well_known.value(), CachedValue::Cached(value) if !value.has_expired());
+    }
+
+    #[async_test]
+    async fn test_rtc_transports_caching() {
+        use wiremock::{
+            Mock, ResponseTemplate,
+            matchers::{method, path_regex},
+        };
+
+        let server = MatrixMockServer::new().await;
+        let transports = vec![RtcTransport::livekit("https://livekit.example.com".to_owned())];
+
+        let transports_mock = Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "rtc_transports": [
+                    { "type": "livekit", "livekit_service_url": "https://livekit.example.com" }
+                ]
+            })))
+            .named("first transports mock")
+            .expect(1)
+            .mount_as_scoped(server.server())
+            .await;
+
+        let client = server.client_builder().build().await;
+
+        // First call hits the network.
+        assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
+        // Subsequent call hits the in-memory cache.
+        assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
+
+        drop(transports_mock);
+
+        // Reset the cache, and observe the endpoint being called again once.
+        client.reset_rtc_transports();
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "rtc_transports": [
+                    { "type": "livekit", "livekit_service_url": "https://livekit.example.com" }
+                ]
+            })))
+            .named("second transports mock")
+            .expect(2)
+            .mount(server.server())
+            .await;
+
+        // Hits network again.
+        assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
+        // Hits in-memory cache again.
+        assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
+
+        // Force an expiry of the data.
+        let mut ttl_value = TtlValue::new(Some(transports.clone()));
+        ttl_value.expire();
+        client.inner.caches.rtc_transports.set_value(ttl_value);
+
+        // Call the method again to trigger a cache refresh background task.
+        client.rtc_transports().await.unwrap();
+
+        // We wait for the task to finish, the endpoint should have been called again.
+        sleep(Duration::from_secs(1)).await;
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
+    }
+
+    #[async_test]
+    async fn test_rtc_transports_unsupported_caching() {
+        use wiremock::{
+            Mock, ResponseTemplate,
+            matchers::{method, path_regex},
+        };
+
+        let server = MatrixMockServer::new().await;
+
+        // The homeserver doesn't implement the endpoint: it responds with a 404 and an
+        // `M_UNRECOGNIZED` error (as a homeserver does for an unrecognized endpoint).
+        // We expect it to be hit only once, despite several calls, thanks to the
+        // negative caching.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "errcode": "M_UNRECOGNIZED",
+                "error": "Unrecognized request",
+            })))
+            .named("unrecognized transports mock")
+            .expect(1)
+            .mount(server.server())
+            .await;
+
+        let client = server.client_builder().build().await;
+
+        // First call hits the network and gets a 404, which is cached as `None`
+        // (unsupported), distinct from `Some(vec![])` (supported but empty).
+        assert_eq!(client.rtc_transports().await.unwrap(), None);
+        // Subsequent call hits the in-memory cache, without re-hitting the endpoint.
+        assert_eq!(client.rtc_transports().await.unwrap(), None);
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2804,12 +2804,11 @@ impl Client {
 
     /// Fetch the RTC transports advertised by the homeserver from the network,
     /// bypassing the cache.
-    ///
-    /// Unlike [`Client::rtc_transports`], this does not special-case a
-    /// homeserver that doesn't implement the endpoint: it returns the raw error
-    /// in that case. The cache is not updated with the result.
     pub async fn fetch_rtc_transports(&self) -> HttpResult<Vec<RtcTransport>> {
-        let response = self.send(transports::v1::Request::new()).await?;
+        let response = self
+            .send(transports::v1::Request::new())
+            .with_request_config(RequestConfig::short_retry())
+            .await?;
         Ok(response.rtc_transports)
     }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2655,7 +2655,7 @@ impl Client {
     /// # async {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let mut client = Client::new(homeserver).await?;
-    /// let rtc_foci = client.rtc_foci().await?;
+    /// let rtc_foci = client.well_known_rtc_transports().await?;
     /// let default_livekit_focus_info = rtc_foci.iter().find_map(|focus| match focus {
     ///     RtcTransport::LiveKit(info) => Some(info),
     ///     _ => None,
@@ -2665,7 +2665,7 @@ impl Client {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    pub async fn rtc_foci(&self) -> HttpResult<Vec<RtcTransport>> {
+    pub async fn well_known_rtc_transports(&self) -> HttpResult<Vec<RtcTransport>> {
         let well_known = self.well_known().await;
 
         Ok(well_known.map(|well_known| well_known.rtc_foci).unwrap_or_default())
@@ -2687,7 +2687,7 @@ impl Client {
     ///   list may be empty if the homeserver advertises no transports),
     /// - `Ok(None)` if the homeserver doesn't implement the endpoint (this is
     ///   also cached, so the endpoint isn't hit on every call). Callers may
-    ///   want to fall back to [`Client::rtc_foci`] (the well-known foci) in
+    ///   want to fall back to [`Client::well_known_rtc_transports`] (the well-known foci) in
     ///   this case,
     /// - `Err(_)` on a transient error (not cached).
     ///
@@ -2705,7 +2705,7 @@ impl Client {
     ///     Some(transports) => transports,
     ///     // The homeserver doesn't support the discovery endpoint; fall back
     ///     // to the RTC foci advertised in the well-known.
-    ///     None => client.rtc_foci().await?,
+    ///     None => client.well_known_rtc_transports().await?,
     /// };
     /// for transport in transports {
     ///     println!("transport type: {}", transport.transport_type());
@@ -4523,10 +4523,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         // This subsequent call hits the in-memory cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         drop(client);
 
@@ -4543,10 +4543,10 @@ pub(crate) mod tests {
             .await;
 
         // This call to the new client hits the on-disk cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         // Then this call hits the in-memory cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         drop(well_known_mock);
 
@@ -4556,9 +4556,9 @@ pub(crate) mod tests {
         server.mock_well_known().ok().named("second well known mock").expect(2).mount().await;
 
         // Hits network again.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
         // Hits in-memory cache again.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         // Force an expiry of the data.
         let well_known = client.well_known().await;
@@ -4700,10 +4700,10 @@ pub(crate) mod tests {
             .build()
             .await;
 
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         // This subsequent call hits the in-memory cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         drop(client);
 
@@ -4719,10 +4719,10 @@ pub(crate) mod tests {
             .await;
 
         // This call to the new client hits the on-disk cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         // Then this call hits the in-memory cache.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
 
         drop(well_known_mock);
 
@@ -4738,9 +4738,9 @@ pub(crate) mod tests {
             .await;
 
         // Hits network again.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
         // Hits in-memory cache again.
-        assert_eq!(client.rtc_foci().await.unwrap(), rtc_foci);
+        assert_eq!(client.well_known_rtc_transports().await.unwrap(), rtc_foci);
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2641,6 +2641,13 @@ impl Client {
         self.refresh_well_known_cache().await
     }
 
+    /// Get information about the homeserver's advertised RTC transports by
+    /// fetching the well-known file from the server or the cache.
+    #[deprecated = "Use `Client::rtc_transports` instead"]
+    pub async fn rtc_foci(&self) -> HttpResult<Vec<RtcTransport>> {
+        self.well_known_rtc_transports().await
+    }
+
     /// Get information about the homeserver's advertised RTC foci by fetching
     /// the well-known file from the server or the cache.
     ///


### PR DESCRIPTION
<!-- description of the changes in this PR -->

RTC transport discovery has now a new authenticated end-point on the homeserver `GET /_matrix/client/v1/rtc/transports`

This PR add supports for that via a new client API `Client::rtc_transports`, it uses the existing cache mecanism used by similar APIs (well-known, supported_version). I used a similar pattern.

The old `rtc_foci` endpoint has been renamed to `wellknown_rtc_transport` and should only be used as fallback if new endpoint is not supported


- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
