### PR TITLE
feat(widget): Support RTC transports discovery action

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6791.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6791.changed.md
@@ -1,0 +1,4 @@
+`Client::is_livekit_rtc_supported` that checks if the server supports livekit-based RTC calls is
+now **by default** only checking the new rtc discovery endpoint (MSC4143) and not falling back to the old
+well-known discovery method. If needed, for backwards compatibility, use the `fallback_to_well_known` parameter
+to also check the old method. 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2140,11 +2140,21 @@ impl Client {
     }
 
     /// Checks if the server supports the LiveKit RTC focus for placing calls.
-    pub async fn is_livekit_rtc_supported(&self) -> Result<bool, ClientError> {
+    ///
+    /// Transports are discovered through the authenticated
+    /// `GET /_matrix/client/v1/rtc/transports` endpoint (MSC4143). If the
+    /// homeserver doesn't implement it and `fallback_to_well_known` is `true`,
+    /// then the well-known will be queried.
+    #[uniffi::method(default(fallback_to_well_known = false))]
+    pub async fn is_livekit_rtc_supported(
+        &self,
+        fallback_to_well_known: bool,
+    ) -> Result<bool, ClientError> {
         let transports = match self.inner.rtc_transports().await? {
             Some(transports) => transports,
-            // discovery not supported, fallback to well-known
-            None => self.inner.well_known_rtc_transports().await?,
+            // discovery not supported, fallback to well-known if allowed
+            None if fallback_to_well_known => self.inner.well_known_rtc_transports().await?,
+            None => return Ok(false),
         };
         Ok(transports.iter().any(|focus| matches!(focus, RtcTransport::LiveKit(_))))
     }

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -267,6 +267,7 @@ pub fn get_element_call_required_permissions(
         update_delayed_event: true,
         send_delayed_event: true,
         download_files: true,
+        rtc_transports: true,
     }
 }
 
@@ -334,6 +335,9 @@ pub struct WidgetCapabilities {
     pub send_delayed_event: bool,
     /// This allows the widget to download files (avatars)
     pub download_files: bool,
+    /// This allows the widget to discover the RTC transports advertised by the
+    /// homeserver (MSC4515).
+    pub rtc_transports: bool,
 }
 
 impl From<WidgetCapabilities> for matrix_sdk::widget::Capabilities {
@@ -345,6 +349,7 @@ impl From<WidgetCapabilities> for matrix_sdk::widget::Capabilities {
             update_delayed_event: value.update_delayed_event,
             send_delayed_event: value.send_delayed_event,
             download_file: value.download_files,
+            rtc_transports: value.rtc_transports,
         }
     }
 }
@@ -358,6 +363,7 @@ impl From<matrix_sdk::widget::Capabilities> for WidgetCapabilities {
             update_delayed_event: value.update_delayed_event,
             send_delayed_event: value.send_delayed_event,
             download_files: value.download_file,
+            rtc_transports: value.rtc_transports,
         }
     }
 }

--- a/crates/matrix-sdk/changelog.d/6791.added.md
+++ b/crates/matrix-sdk/changelog.d/6791.added.md
@@ -1,0 +1,1 @@
+- Add support for [MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)for RTC transport discovery for widgets.

--- a/crates/matrix-sdk/changelog.d/6791.added.md
+++ b/crates/matrix-sdk/changelog.d/6791.added.md
@@ -1,1 +1,1 @@
-- Add support for [MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)for RTC transport discovery for widgets.
+- Add support for [MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515) and RTC transport discovery for widgets.

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -9,6 +9,7 @@ following MSC's:
 - [MSC2762: Allowing widgets to send/receive events](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/widgets-send-receive-events/proposals/2762-widget-event-receiving.md)
 - [MSC4157: Delayed Events (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4157)
 - [MSC3819: Allowing widgets to send/receive to-device messages](https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
+- [MSC4515: RTC transports discovery (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)
 
 It supports sending and reading events and provides some rudimentary client
 navigation features. There are some additional actions:
@@ -16,6 +17,7 @@ navigation features. There are some additional actions:
 - Get an OpenID token (not OAuth) to identify a user.
 - Ask for supported API versions.
 - Inform the client that the widget has loaded its content and is ready.
+- Discover the RTC transports advertised by the homeserver.
 
 ## The widget api
 

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -60,6 +60,10 @@ pub struct Capabilities {
 
     /// This allows the widget to download files as per MSC4039.
     pub download_file: bool,
+
+    /// This allows the widget to discover the RTC transports advertised by the
+    /// homeserver as per MSC4515.
+    pub rtc_transports: bool,
 }
 
 impl Capabilities {
@@ -118,6 +122,8 @@ pub(super) const SEND_DELAYED_EVENT: &str = "org.matrix.msc4157.send.delayed_eve
 pub(super) const UPDATE_DELAYED_EVENT: &str = "org.matrix.msc4157.update_delayed_event";
 
 pub(super) const DOWNLOAD_FILE: &str = "org.matrix.msc4039.download_file";
+
+pub(super) const RTC_TRANSPORTS: &str = "org.matrix.msc4515.rtc_transports";
 
 impl Serialize for Capabilities {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -182,6 +188,9 @@ impl Serialize for Capabilities {
         if self.download_file {
             seq.serialize_element(DOWNLOAD_FILE)?;
         }
+        if self.rtc_transports {
+            seq.serialize_element(RTC_TRANSPORTS)?;
+        }
         for filter in &self.read {
             let name = match filter {
                 Filter::MessageLike(_) => READ_EVENT,
@@ -213,6 +222,7 @@ impl<'de> Deserialize<'de> for Capabilities {
             UpdateDelayedEvent,
             SendDelayedEvent,
             DownloadFile,
+            RtcTransports,
             Read(Filter),
             Send(Filter),
             Unknown,
@@ -235,6 +245,9 @@ impl<'de> Deserialize<'de> for Capabilities {
                 }
                 if s == DOWNLOAD_FILE {
                     return Ok(Self::DownloadFile);
+                }
+                if s == RTC_TRANSPORTS {
+                    return Ok(Self::RtcTransports);
                 }
 
                 match s.split_once(':') {
@@ -297,6 +310,7 @@ impl<'de> Deserialize<'de> for Capabilities {
                 Permission::UpdateDelayedEvent => capabilities.update_delayed_event = true,
                 Permission::SendDelayedEvent => capabilities.send_delayed_event = true,
                 Permission::DownloadFile => capabilities.download_file = true,
+                Permission::RtcTransports => capabilities.rtc_transports = true,
             }
         }
 
@@ -335,7 +349,8 @@ mod tests {
             "org.matrix.msc3819.send.to_device:io.element.call.encryption_keys",
             "org.matrix.msc4157.send.delayed_event",
             "org.matrix.msc4157.update_delayed_event",
-            "org.matrix.msc4039.download_file"
+            "org.matrix.msc4039.download_file",
+            "org.matrix.msc4515.rtc_transports"
         ]"#;
 
         let parsed = serde_json::from_str::<Capabilities>(capabilities_str).unwrap();
@@ -366,6 +381,7 @@ mod tests {
             update_delayed_event: true,
             send_delayed_event: true,
             download_file: true,
+            rtc_transports: true,
         };
 
         assert_eq!(parsed, expected);
@@ -397,6 +413,7 @@ mod tests {
             update_delayed_event: false,
             send_delayed_event: false,
             download_file: false,
+            rtc_transports: true,
         };
 
         let capabilities_str = serde_json::to_string(&capabilities).unwrap();

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -31,7 +31,10 @@ use super::{
     Action, MatrixDriverRequestMeta, SendToDeviceEventResponse, WidgetMachine,
     from_widget::SendEventResponse, incoming::MatrixDriverResponse,
 };
-use crate::widget::{Capabilities, StateKeySelector, machine::from_widget::DownloadFileResponse};
+use crate::widget::{
+    Capabilities, StateKeySelector,
+    machine::from_widget::{DownloadFileResponse, RtcTransportsResponse},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) enum MatrixDriverRequestData {
@@ -62,6 +65,9 @@ pub(crate) enum MatrixDriverRequestData {
 
     /// Request a download of a file.
     DownloadFile(DownloadFileRequest),
+
+    /// Get the RTC transports advertised by the homeserver.
+    GetRtcTransports,
 }
 
 /// A handle to a pending `toWidget` request.
@@ -156,6 +162,20 @@ impl From<RequestOpenId> for MatrixDriverRequestData {
 
 impl MatrixDriverRequest for RequestOpenId {
     type Response = request_openid_token::v3::Response;
+}
+
+/// Request the RTC transports advertised by the homeserver.
+#[derive(Debug)]
+pub(crate) struct RequestRtcTransports;
+
+impl From<RequestRtcTransports> for MatrixDriverRequestData {
+    fn from(_: RequestRtcTransports) -> Self {
+        MatrixDriverRequestData::GetRtcTransports
+    }
+}
+
+impl MatrixDriverRequest for RequestRtcTransports {
+    type Response = RtcTransportsResponse;
 }
 
 impl FromMatrixDriverResponse for request_openid_token::v3::Response {

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -18,8 +18,9 @@ use as_variant::as_variant;
 use ruma::{
     OwnedEventId, OwnedRoomId,
     api::{
-        client::delayed_events::{
-            delayed_message_event, delayed_state_event, update_delayed_event,
+        client::{
+            delayed_events::{delayed_message_event, delayed_state_event, update_delayed_event},
+            rtc::RtcTransport,
         },
         error::{ErrorBody, StandardErrorBody},
     },
@@ -56,6 +57,8 @@ pub(super) enum FromWidgetRequest {
     DelayedEventUpdate(UpdateDelayedEventRequest),
     #[serde(rename = "org.matrix.msc4039.download_file")]
     DownloadFile(DownloadFileRequest),
+    #[serde(rename = "org.matrix.msc4515.get_rtc_transports")]
+    GetRtcTransports {},
 }
 
 /// The full response a client sends to a [`FromWidgetRequest`] in case of an
@@ -153,6 +156,7 @@ impl SupportedApiVersionsResponse {
                 ApiVersion::MSC2871,
                 ApiVersion::MSC3819,
                 ApiVersion::MSC4039,
+                ApiVersion::MSC4515,
             ],
         }
     }
@@ -203,6 +207,10 @@ pub(super) enum ApiVersion {
 
     #[serde(rename = "org.matrix.msc4039")]
     MSC4039,
+
+    /// Supports discovering the RTC transports advertised by the homeserver.
+    #[serde(rename = "org.matrix.msc4515")]
+    MSC4515,
 }
 
 #[derive(Deserialize, Debug)]
@@ -303,6 +311,28 @@ impl FromMatrixDriverResponse for DownloadFileResponse {
         match matrix_driver_response {
             MatrixDriverResponse::FileDownloaded(resp) => {
                 Some(Self { file_data_base64: resp.file_data_base64 })
+            }
+            _ => {
+                error!("bug in MatrixDriver, received wrong event response");
+                None
+            }
+        }
+    }
+}
+
+/// Response for a `get_rtc_transports` request.
+/// <https://github.com/matrix-org/matrix-spec-proposals/pull/4515>
+#[derive(Serialize, Debug)]
+pub(crate) struct RtcTransportsResponse {
+    /// The RTC transports advertised by the homeserver.
+    pub(crate) rtc_transports: Vec<RtcTransport>,
+}
+
+impl FromMatrixDriverResponse for RtcTransportsResponse {
+    fn from_response(matrix_driver_response: MatrixDriverResponse) -> Option<Self> {
+        match matrix_driver_response {
+            MatrixDriverResponse::RtcTransportsReceived(rtc_transports) => {
+                Some(Self { rtc_transports })
             }
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use ruma::{
-    api::client::{account::request_openid_token, delayed_events},
+    api::client::{account::request_openid_token, delayed_events, rtc::RtcTransport},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEvent},
     serde::Raw,
 };
@@ -89,6 +89,9 @@ pub(crate) enum MatrixDriverResponse {
     DelayedEventUpdated(delayed_events::update_delayed_event::unstable_v1::Response),
     /// The client successfully downloaded a file from a widget action.
     FileDownloaded(DownloadFileResponse),
+    /// Client fetched the RTC transports advertised by the homeserver.
+    /// A response to a [`MatrixDriverRequestData::GetRtcTransports`] command.
+    RtcTransportsReceived(Vec<RtcTransport>),
 }
 
 pub(super) struct IncomingWidgetMessage {
@@ -191,5 +194,26 @@ mod tests {
         assert_let!(FromWidgetRequest::DownloadFile(req) = incoming_request.deserialize().unwrap());
 
         assert!(!req.content_uri.is_valid());
+    }
+
+    #[test]
+    fn parse_get_rtc_transports_widget_action() {
+        let raw = r#"
+        {
+            "api": "fromWidget",
+            "widgetId": "aGNStSuL3hhIISSCXgpt15j2",
+            "requestId": "generated-id-1234",
+            "action": "org.matrix.msc4515.get_rtc_transports",
+            "data": {}
+        }
+        "#;
+
+        assert_let!(
+            IncomingWidgetMessageKind::Request(incoming_request) =
+                serde_json::from_str::<IncomingWidgetMessage>(raw).unwrap().kind
+        );
+        assert_let!(
+            FromWidgetRequest::GetRtcTransports {} = incoming_request.deserialize().unwrap()
+        );
     }
 }

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -33,6 +33,7 @@ use uuid::Uuid;
 use self::{
     driver_req::{
         AcquireCapabilities, MatrixDriverRequest, MatrixDriverRequestHandle, RequestOpenId,
+        RequestRtcTransports,
     },
     from_widget::{
         FromWidgetErrorResponse, FromWidgetRequest, ReadEventsResponse,
@@ -55,7 +56,11 @@ use super::{
 };
 use crate::{
     Error, Result,
-    widget::{Filter, capabilities::DOWNLOAD_FILE, machine::driver_req::DownloadFileRequest},
+    widget::{
+        Filter,
+        capabilities::{DOWNLOAD_FILE, RTC_TRANSPORTS},
+        machine::driver_req::DownloadFileRequest,
+    },
 };
 
 mod driver_req;
@@ -386,6 +391,10 @@ impl WidgetMachine {
             }
             FromWidgetRequest::DownloadFile(req) => self
                 .process_download_file_request(req, raw_request)
+                .map(|a| vec![a])
+                .unwrap_or_default(),
+            FromWidgetRequest::GetRtcTransports {} => self
+                .process_get_rtc_transports_request(raw_request)
                 .map(|a| vec![a])
                 .unwrap_or_default(),
         }
@@ -919,6 +928,35 @@ impl WidgetMachine {
         }
 
         let (request, action) = self.send_matrix_driver_request(req)?;
+
+        request.add_response_handler(|result, _| {
+            vec![Self::send_from_widget_response(
+                raw_request,
+                result.map_err(FromWidgetErrorResponse::from_error),
+            )]
+        });
+        Some(action)
+    }
+
+    fn process_get_rtc_transports_request(
+        &mut self,
+        raw_request: Raw<FromWidgetRequest>,
+    ) -> Option<Action> {
+        let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                "Received get RTC transports request before capabilities negotiation",
+            ));
+        };
+
+        if !capabilities.rtc_transports {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                format!("Not allowed: missing the {RTC_TRANSPORTS} capability."),
+            ));
+        }
+
+        let (request, action) = self.send_matrix_driver_request(RequestRtcTransports)?;
 
         request.add_response_handler(|result, _| {
             vec![Self::send_from_widget_response(

--- a/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
@@ -52,6 +52,7 @@ fn test_get_supported_api_versions() {
                     "org.matrix.msc2871",
                     "org.matrix.msc3819",
                     "org.matrix.msc4039",
+                    "org.matrix.msc4515",
                 ]
             },
         }),

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -78,6 +78,32 @@ impl MatrixDriver {
             .map_err(|error| Error::Http(Box::new(error)))
     }
 
+    /// Fetches the RTC transports advertised by the homeserver.
+    ///
+    /// This delegates to [`Client::rtc_transports`], so the result is served
+    /// from (and populates) the client's in-memory cache.
+    ///
+    /// Returns an error if the homeserver doesn't implement the discovery
+    /// endpoint, so that the widget receives an error response (as opposed to
+    /// an empty list, which would be indistinguishable from a homeserver that
+    /// advertises no transports).
+    ///
+    /// [`Client::rtc_transports`]: crate::Client::rtc_transports
+    pub(crate) async fn get_rtc_transports(
+        &self,
+    ) -> Result<Vec<ruma::api::client::rtc::RtcTransport>> {
+        self.room
+            .client
+            .rtc_transports()
+            .await
+            .map_err(|error| Error::Http(Box::new(error)))?
+            .ok_or_else(|| {
+                Error::UnknownError(
+                    "the homeserver does not support RTC transport discovery".into(),
+                )
+            })
+    }
+
     /// Reads the latest `limit` events of a given `event_type` from the room's
     /// timeline.
     pub(crate) async fn read_events(

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -261,6 +261,11 @@ impl WidgetDriver {
                                 file_data_base64,
                             })
                         }),
+
+                    MatrixDriverRequestData::GetRtcTransports => matrix_driver
+                        .get_rtc_transports()
+                        .await
+                        .map(MatrixDriverResponse::RtcTransportsReceived),
                 };
 
                 // Forward the Matrix driver response to the incoming message stream.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -2045,6 +2045,101 @@ async fn test_try_download_file() {
     assert_eq!(decoded.as_bytes(), bundle.as_slice());
 }
 
+#[async_test]
+async fn test_get_rtc_transports() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4515.rtc_transports"])).await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "rtc_transports": [
+                { "type": "livekit", "livekit_service_url": "https://livekit-jwt.example.com" }
+            ]
+        })))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "get-rtc-transports",
+        "org.matrix.msc4515.get_rtc_transports",
+        json!({}),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["api"], "fromWidget");
+    assert_eq!(response["action"], "org.matrix.msc4515.get_rtc_transports");
+    assert_eq!(response["requestId"], "get-rtc-transports");
+    assert_eq!(
+        response["response"],
+        json!({
+            "rtc_transports": [
+                { "type": "livekit", "livekit_service_url": "https://livekit-jwt.example.com" }
+            ]
+        })
+    );
+}
+
+#[async_test]
+async fn test_get_rtc_transports_endpoint_unsupported() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4515.rtc_transports"])).await;
+
+    // The homeserver doesn't implement the discovery endpoint.
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_UNRECOGNIZED",
+            "error": "Unrecognized request",
+        })))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "get-rtc-transports",
+        "org.matrix.msc4515.get_rtc_transports",
+        json!({}),
+    )
+    .await;
+
+    // The widget receives an error (as opposed to an empty list), so it can tell
+    // the endpoint apart from a homeserver that advertises no transports.
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["api"], "fromWidget");
+    assert_eq!(response["action"], "org.matrix.msc4515.get_rtc_transports");
+    assert!(response["response"]["error"]["message"].is_string());
+}
+
+#[async_test]
+async fn test_get_rtc_transports_without_permission() {
+    let (_, _mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!([])).await;
+
+    send_request(
+        &driver_handle,
+        "get-rtc-transports",
+        "org.matrix.msc4515.get_rtc_transports",
+        json!({}),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["api"], "fromWidget");
+    assert_eq!(response["action"], "org.matrix.msc4515.get_rtc_transports");
+    assert_eq!(
+        response["response"]["error"]["message"].as_str().unwrap(),
+        "Not allowed: missing the org.matrix.msc4515.rtc_transports capability."
+    );
+}
+
 async fn negotiate_capabilities(driver_handle: &WidgetDriverHandle, caps: JsonValue) {
     {
         // Receive toWidget capabilities request


### PR DESCRIPTION
<!-- description of the changes in this PR -->

~~Draft because depends on https://github.com/matrix-org/matrix-rust-sdk/pull/6789~~

Mostly plumbing to get the new WidgetAction [RtcTransportsAction](https://github.com/matrix-org/matrix-widget-api/blob/master/src/interfaces/RtcTransportsAction.ts) to call the new client API `Client::rtc_transports` introduced in #6789

**And** a change on the ffi bindings to make the `is_livekit_rtc_supported` to use this new rtc discover API.
There is a boolean added to decide if it can fallback to the old well-known, it is set with a default value, 
so it is not technically a source breaking change, we want to enforce the new way of getting transport but we leave an option to steal fallback to well-known

Implements [MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
