### PR TITLE
Update x509 signatures when our signer has a later expiry than the existing signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,7 +5159,6 @@ checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -8331,7 +8330,6 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -338,7 +338,7 @@ pub trait RawX509Signer: SyncOutsideWasm + SendOutsideWasm + Debug {
 
     /// Return the "not after" time for the certificate's validity period as a
     /// UNIX timestamp.
-    fn validity_not_after(&self) -> u64;
+    fn validity_not_after(&self) -> Result<u64, ClientError>;
 }
 
 /// A foreign trait for low-level types which can verify messages which were

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -335,6 +335,10 @@ pub trait RawX509Signer: SyncOutsideWasm + SendOutsideWasm + Debug {
     ///
     /// Returns (key ID, signature)
     fn sign(&self, message: Vec<u8>) -> Result<RawX509Signature, ClientError>;
+
+    /// Return the "not after" time for the certificate's validity period as a
+    /// UNIX timestamp.
+    fn validity_not_after(&self) -> u64;
 }
 
 /// A foreign trait for low-level types which can verify messages which were

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -582,10 +582,11 @@ impl ClientBuilder {
                 }
 
                 fn validity_not_after(&self) -> Result<DateTime, ValidityError> {
-                    DateTime::from_unix_duration(std::time::Duration::from_secs(
-                        self.0.validity_not_after(),
-                    ))
-                    .or(Err(ValidityError))
+                    let Ok(validity_not_after) = self.0.validity_not_after() else {
+                        return Err(ValidityError);
+                    };
+                    DateTime::from_unix_duration(std::time::Duration::from_secs(validity_not_after))
+                        .or(Err(ValidityError))
                 }
             }
 

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -39,7 +39,7 @@ use matrix_sdk::{
     },
 };
 #[cfg(feature = "experimental-x509-identity-verification")]
-use matrix_sdk_base::crypto::x509::RawX509Signature;
+use matrix_sdk_base::crypto::x509::{DateTime, RawX509Signature, ValidityError};
 use matrix_sdk_base::{
     DmRoomDefinition,
     crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
@@ -579,6 +579,13 @@ impl ClientBuilder {
                             e.into(),
                         ))
                     })
+                }
+
+                fn validity_not_after(&self) -> Result<DateTime, ValidityError> {
+                    DateTime::from_unix_duration(std::time::Duration::from_secs(
+                        self.0.validity_not_after(),
+                    ))
+                    .or(Err(ValidityError))
                 }
             }
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -120,7 +120,7 @@ matrix-sdk-test.workspace = true
 matrix-sdk-test-utils.workspace = true
 proptest.workspace = true
 rmp-serde.workspace = true
-rcgen = { workspace = true, features = ["ring", "x509-parser"] }
+rcgen = { workspace = true, features = ["pem", "aws_lc_rs", "x509-parser"] }
 similar-asserts.workspace = true
 # required for async_test macro
 stream_assert.workspace = true

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -29,6 +29,8 @@ use ruma::{
 use tokio::sync::Mutex;
 use tracing::{Level, debug, enabled, info, instrument, trace, warn};
 
+#[cfg(feature = "experimental-x509-identity-verification")]
+use crate::types::requests::OutgoingRequest;
 use crate::{
     CryptoStoreError, LocalTrust, OwnUserIdentity, SignatureError, UserIdentity,
     error::OlmResult,
@@ -76,6 +78,25 @@ pub(crate) struct IdentityManager {
 
     /// Details of the current "in-flight" key query request, if any
     keys_query_request_details: Arc<Mutex<Option<KeysQueryRequestDetails>>>,
+
+    /// The current X.509 signature re-upload request, if any.
+    ///
+    /// We re-sign our master cross-signing key with X.509 if our signer has a
+    /// later validity period than the current signature on our master
+    /// cross-signing key.  The outer `Option` indicates whether we have checked
+    /// whether the key needs re-signing or not, ad the inner `Option` indicates
+    /// the result of that check, if it was done.  In other words, this value
+    /// will be `None` if we have not yet checked the cross-signing key, it will
+    /// be `Some(None)` if we have checked the cross-signing key and it does not
+    /// need to be re-signed, and will be `Some(request)` if the cross-signing
+    /// key has been re-signed.  `request` will be an outgoing signature upload
+    /// request.
+    ///
+    /// We check whether we need to re-sign when
+    /// `get_x509_signature_upload_request` is first called, or when we receive
+    /// a master signing key from a `/keys/query` request.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    x509_signature_upload_request: Arc<Mutex<Option<Option<OutgoingRequest>>>>,
 }
 
 /// Details of an in-flight key query request
@@ -109,6 +130,8 @@ impl IdentityManager {
             key_query_manager: Default::default(),
             failures: Default::default(),
             keys_query_request_details: keys_query_request_details.into(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_signature_upload_request: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -436,6 +459,16 @@ impl IdentityManager {
             if private_identity.has_master_key().await && !identity.is_verified() {
                 trace!("Marked our own identity as verified");
                 identity.mark_as_verified()
+            }
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            {
+                // Check if we need to re-sign our identity with the X.509 signer.
+                *self.x509_signature_upload_request.lock().await = Some(
+                    identity
+                        .refresh_x509_signature(&self.store)
+                        .unwrap_or(None)
+                        .map(|upload_request| upload_request.into()),
+                );
             }
 
             None
@@ -814,6 +847,48 @@ impl IdentityManager {
         // We assume that there aren't too many users here; if we find a usecase that
         // requires lots of users to be up-to-date we may need to rethink this.
         (TransactionId::new(), KeysQueryRequest::new(users.into_iter().map(|u| u.to_owned())))
+    }
+
+    /// Return the current signature upload request, if any, needed for updating
+    /// the X.509 signature.
+    ///
+    /// We re-sign our master cross-signing key with X.509 if our signer has a
+    /// later validity period than the current signature on our master
+    /// cross-signing key.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) async fn get_x509_signature_upload_request(&self) -> Option<OutgoingRequest> {
+        let mut upload_request = self.x509_signature_upload_request.lock().await;
+        if upload_request.is_none() {
+            // We haven't yet checked if our identity needs re-signing, so check
+            // it now and remember the result.
+            if let Some(identity) = self
+                .store
+                .get_user_identity(self.user_id())
+                .await
+                .unwrap_or(None)
+                .and_then(UserIdentityData::into_own)
+            {
+                *upload_request = Some(
+                    identity
+                        .refresh_x509_signature(&self.store)
+                        .unwrap_or(None)
+                        .map(|upload_request| upload_request.into()),
+                );
+            }
+        }
+        upload_request.clone().unwrap_or(None)
+    }
+
+    /// Mark the outgoing X.509 signature upload request as sent.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) async fn mark_x509_signature_request_as_sent(&self, request_id: &TransactionId) {
+        let mut x509_signature_upload_request = self.x509_signature_upload_request.lock().await;
+
+        if let Some(Some(request)) = x509_signature_upload_request.as_ref()
+            && request.request_id() == request_id
+        {
+            *x509_signature_upload_request = Some(None);
+        }
     }
 
     /// Get a list of key query requests needed.
@@ -1521,6 +1596,8 @@ pub(crate) mod testing {
 #[cfg(test)]
 pub(crate) mod tests {
     use std::ops::Deref;
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    use std::sync::Arc;
 
     use futures_util::pin_mut;
     use matrix_sdk_test::{async_test, ruma_response_from_json, test_json};
@@ -1530,10 +1607,16 @@ pub(crate) mod tests {
     };
     use serde_json::json;
     use stream_assert::{assert_closed, assert_pending, assert_ready};
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    use tokio::sync::Mutex;
 
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    use super::IdentityManager;
     use super::testing::{
         device_id, key_query, manager_test_helper, other_key_query, other_user_id, user_id,
     };
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    use crate::olm::Account;
     use crate::{
         CrossSigningKeyExport, OlmMachine,
         identities::manager::testing::{other_key_query_cross_signed, own_key_query},
@@ -2519,5 +2602,180 @@ pub(crate) mod tests {
                 .unwrap();
             igs
         }
+    }
+
+    #[async_test]
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    async fn test_refresh_x509_signature_after_keys_query() {
+        // Test that we check the X.509 signature on our identity to see if it
+        // needs re-signing when it is received from a `/keys/query` response.
+        let user_id = user_id!("@example1:localhost");
+        let device_id = device_id!("DEVICEID");
+
+        // We create three signers with different validity dates: an "old"
+        // signer, a "current" signer, and a "new" signer.
+        let (x509_signer_old, x509_signer_current, x509_signer_new) =
+            crate::x509::tests::signers_with_different_validity();
+
+        // We create an `IdentityManager` that uses the "current" X.509 signer
+        let manager = {
+            let account = Account::with_device_id(&user_id, device_id);
+            let identity =
+                PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current))
+                    .unwrap();
+            manager_with_private_identity_and_x509(identity, account, x509_signer_current.clone())
+                .await
+        };
+
+        assert!(manager.get_x509_signature_upload_request().await.is_none());
+
+        let private_identity = manager.store.private_identity();
+        let master_key =
+            private_identity.lock().await.master_public_key().await.unwrap().as_ref().clone();
+        let identity_request = {
+            let private_identity = manager.store.private_identity();
+            let private_identity = private_identity.lock().await;
+            private_identity.as_upload_request().await
+        };
+        let device_keys = manager.store.static_account().unsigned_device_keys();
+
+        // Make a `/keys/query` response where the master key is signed by the
+        // given X.509 signer.
+        let make_response = |x509_signer: &crate::x509::X509Signer| {
+            let mut master_key = master_key.clone();
+            x509_signer.sign_cross_signing_key(user_id, &mut master_key).unwrap();
+
+            let response = json!({
+                "device_keys": {
+                    user_id: {
+                        device_keys.device_id.to_string(): device_keys
+                    }
+                },
+                "master_keys": {
+                    user_id: master_key,
+                },
+                "self_signing_keys": {
+                    user_id: identity_request.self_signing_key,
+                },
+                "user_signing_keys": {
+                    user_id: identity_request.user_signing_key,
+                }
+            });
+
+            ruma_response_from_json(&response)
+        };
+
+        // We receive a master key signed by the old signer.  In this case, we
+        // should re-sign the key, since our signer has a newer validity period.
+        let response = make_response(&x509_signer_old);
+        manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
+        assert!(manager.get_x509_signature_upload_request().await.is_some());
+
+        // We receive a master key signed by the same signer, so we don't need
+        // to re-sign.
+        let response = make_response(&x509_signer_current);
+        manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
+        assert!(manager.get_x509_signature_upload_request().await.is_none());
+
+        // We receive a master key signed by a newer signer, so we don't need to
+        // re-sign.
+        let response = make_response(&x509_signer_new);
+        manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
+        assert!(manager.get_x509_signature_upload_request().await.is_none());
+    }
+
+    #[async_test]
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    async fn test_refresh_x509_signature_on_startup() {
+        // Test that we check if we need to re-sign our master key with X.509
+        // without having a `/keys/query` response.
+        let user_id = user_id!("@example1:localhost");
+        let device_id = device_id!("DEVICEID");
+
+        // We create three signers with different validity dates: an "old"
+        // signer, a "current" signer, and a "new" signer.
+        let (x509_signer_old, x509_signer_current, x509_signer_new) =
+            crate::x509::tests::signers_with_different_validity();
+
+        // We create a cross-signing identity signed with the current signer.
+        let account = Account::with_device_id(&user_id, device_id);
+        let identity =
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current)).unwrap();
+
+        // If we have an identity manager with an old signer, then it won't try
+        // to re-sign the master key.
+        let manager_old = manager_with_private_identity_and_x509(
+            identity.clone(),
+            account.deep_clone(),
+            x509_signer_old,
+        )
+        .await;
+        assert!(manager_old.get_x509_signature_upload_request().await.is_none());
+
+        // If we have an identity manager with the same signer, then it won't try
+        // to re-sign the master key.
+        let manager_current = manager_with_private_identity_and_x509(
+            identity.clone(),
+            account.deep_clone(),
+            x509_signer_current,
+        )
+        .await;
+        assert!(manager_current.get_x509_signature_upload_request().await.is_none());
+
+        // If we have an identity manager with a new signer, then it will
+        // re-sign the master key.
+        let manager_new = manager_with_private_identity_and_x509(
+            identity.clone(),
+            account.deep_clone(),
+            x509_signer_new,
+        )
+        .await;
+        assert!(manager_new.get_x509_signature_upload_request().await.is_some());
+    }
+
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    async fn manager_with_private_identity_and_x509(
+        identity: PrivateCrossSigningIdentity,
+        account: Account,
+        x509_signer: crate::x509::X509Signer,
+    ) -> IdentityManager {
+        use crate::{
+            store::{
+                CryptoStoreWrapper, MemoryStore, Store,
+                types::{Changes, IdentityChanges, PendingChanges},
+            },
+            verification::VerificationMachine,
+        };
+
+        let user_identity_data = identity.to_public_identity().await.unwrap();
+        let identity = Arc::new(Mutex::new(identity));
+        let static_account = account.static_data().clone();
+        let store = Arc::new(CryptoStoreWrapper::new(
+            account.user_id(),
+            account.device_id(),
+            MemoryStore::new(),
+        ));
+        let verification =
+            VerificationMachine::new(static_account.clone(), identity.clone(), store.clone());
+        let store = Store::new_with_x509(
+            static_account,
+            identity,
+            store,
+            verification,
+            None,
+            Some(x509_signer),
+        );
+        store
+            .save_changes(Changes {
+                identities: IdentityChanges {
+                    new: vec![user_identity_data.into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        store.save_pending_changes(PendingChanges { account: Some(account) }).await.unwrap();
+        IdentityManager::new(store)
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -84,13 +84,13 @@ pub(crate) struct IdentityManager {
     /// We re-sign our master cross-signing key with X.509 if our signer has a
     /// later validity period than the current signature on our master
     /// cross-signing key.  The outer `Option` indicates whether we have checked
-    /// whether the key needs re-signing or not, ad the inner `Option` indicates
-    /// the result of that check, if it was done.  In other words, this value
-    /// will be `None` if we have not yet checked the cross-signing key, it will
-    /// be `Some(None)` if we have checked the cross-signing key and it does not
-    /// need to be re-signed, and will be `Some(request)` if the cross-signing
-    /// key has been re-signed.  `request` will be an outgoing signature upload
-    /// request.
+    /// whether the key needs re-signing or not, and the inner `Option`
+    /// indicates the result of that check, if it was done.  In other words,
+    /// this value will be `None` if we have not yet checked the cross-signing
+    /// key, it will be `Some(None)` if we have checked the cross-signing key
+    /// and it does not need to be re-signed, and will be `Some(request)` if the
+    /// cross-signing key has been re-signed.  `request` will be an outgoing
+    /// signature upload request.
     ///
     /// We check whether we need to re-sign when
     /// `get_x509_signature_upload_request` is first called, or when we receive

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -22,6 +22,8 @@ use std::{
 use futures_util::future::join_all;
 use itertools::Itertools;
 use matrix_sdk_common::{executor::spawn, failures_cache::FailuresCache};
+#[cfg(feature = "experimental-x509-identity-verification")]
+use ruma::api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest;
 use ruma::{
     OwnedDeviceId, OwnedServerName, OwnedTransactionId, OwnedUserId, ServerName, TransactionId,
     UserId, api::client::keys::get_keys::v3::Response as KeysQueryResponse, serde::Raw,
@@ -65,6 +67,36 @@ enum IdentityUpdateResult {
     Unchanged(UserIdentityData),
 }
 
+/// This enum tracks the status of the outgoing X.509 signature upload request,
+/// if any.
+#[cfg(feature = "experimental-x509-identity-verification")]
+#[derive(Debug)]
+enum X509SignatureUploadRequest {
+    /// We have not yet checked if we need to upload a new signature.
+    Unknown,
+    /// We do not need to upload a new signature.
+    None,
+    /// We have a new signature to upload.
+    Some(OutgoingRequest),
+}
+
+#[cfg(feature = "experimental-x509-identity-verification")]
+impl X509SignatureUploadRequest {
+    fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
+#[cfg(feature = "experimental-x509-identity-verification")]
+impl From<Option<SignatureUploadRequest>> for X509SignatureUploadRequest {
+    fn from(request: Option<SignatureUploadRequest>) -> Self {
+        match request {
+            None => Self::None,
+            Some(request) => Self::Some(request.into()),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct IdentityManager {
     /// Servers that have previously appeared in the `failures` section of a
@@ -81,22 +113,11 @@ pub(crate) struct IdentityManager {
 
     /// The current X.509 signature re-upload request, if any.
     ///
-    /// We re-sign our master cross-signing key with X.509 if our signer has a
-    /// later validity period than the current signature on our master
-    /// cross-signing key.  The outer `Option` indicates whether we have checked
-    /// whether the key needs re-signing or not, and the inner `Option`
-    /// indicates the result of that check, if it was done.  In other words,
-    /// this value will be `None` if we have not yet checked the cross-signing
-    /// key, it will be `Some(None)` if we have checked the cross-signing key
-    /// and it does not need to be re-signed, and will be `Some(request)` if the
-    /// cross-signing key has been re-signed.  `request` will be an outgoing
-    /// signature upload request.
-    ///
     /// We check whether we need to re-sign when
     /// `get_x509_signature_upload_request` is first called, or when we receive
     /// a master signing key from a `/keys/query` request.
     #[cfg(feature = "experimental-x509-identity-verification")]
-    x509_signature_upload_request: Arc<Mutex<Option<Option<OutgoingRequest>>>>,
+    x509_signature_upload_request: Arc<Mutex<X509SignatureUploadRequest>>,
 }
 
 /// Details of an in-flight key query request
@@ -131,7 +152,9 @@ impl IdentityManager {
             failures: Default::default(),
             keys_query_request_details: keys_query_request_details.into(),
             #[cfg(feature = "experimental-x509-identity-verification")]
-            x509_signature_upload_request: Arc::new(Mutex::new(None)),
+            x509_signature_upload_request: Arc::new(Mutex::new(
+                X509SignatureUploadRequest::Unknown,
+            )),
         }
     }
 
@@ -463,12 +486,8 @@ impl IdentityManager {
             #[cfg(feature = "experimental-x509-identity-verification")]
             {
                 // Check if we need to re-sign our identity with the X.509 signer.
-                *self.x509_signature_upload_request.lock().await = Some(
-                    identity
-                        .refresh_x509_signature(&self.store)
-                        .unwrap_or(None)
-                        .map(|upload_request| upload_request.into()),
-                );
+                *self.x509_signature_upload_request.lock().await =
+                    identity.refresh_x509_signature(&self.store).unwrap_or(None).into();
             }
 
             None
@@ -858,7 +877,7 @@ impl IdentityManager {
     #[cfg(feature = "experimental-x509-identity-verification")]
     pub(crate) async fn get_x509_signature_upload_request(&self) -> Option<OutgoingRequest> {
         let mut upload_request = self.x509_signature_upload_request.lock().await;
-        if upload_request.is_none() {
+        if upload_request.is_unknown() {
             // We haven't yet checked if our identity needs re-signing, so check
             // it now and remember the result.
             if let Some(identity) = self
@@ -868,15 +887,14 @@ impl IdentityManager {
                 .unwrap_or(None)
                 .and_then(UserIdentityData::into_own)
             {
-                *upload_request = Some(
-                    identity
-                        .refresh_x509_signature(&self.store)
-                        .unwrap_or(None)
-                        .map(|upload_request| upload_request.into()),
-                );
+                *upload_request =
+                    identity.refresh_x509_signature(&self.store).unwrap_or(None).into();
             }
         }
-        upload_request.clone().unwrap_or(None)
+        match &*upload_request {
+            X509SignatureUploadRequest::Some(request) => Some(request.clone()),
+            _ => None,
+        }
     }
 
     /// Mark the outgoing X.509 signature upload request as sent.
@@ -884,10 +902,10 @@ impl IdentityManager {
     pub(crate) async fn mark_x509_signature_request_as_sent(&self, request_id: &TransactionId) {
         let mut x509_signature_upload_request = self.x509_signature_upload_request.lock().await;
 
-        if let Some(Some(request)) = x509_signature_upload_request.as_ref()
+        if let X509SignatureUploadRequest::Some(request) = &*x509_signature_upload_request
             && request.request_id() == request_id
         {
-            *x509_signature_upload_request = Some(None);
+            *x509_signature_upload_request = X509SignatureUploadRequest::None;
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1185,6 +1185,43 @@ impl OwnUserIdentityData {
         *self.verified.read() == OwnUserIdentityVerifiedState::VerificationViolation
     }
 
+    /// Sign our own identity again, if our current X.509 signer has a later
+    /// expiry than our existing X.509 signature.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) fn refresh_x509_signature(
+        &self,
+        store: &Store,
+    ) -> Result<Option<SignatureUploadRequest>, SignatureError> {
+        if !self.is_verified() {
+            return Ok(None);
+        }
+
+        let cross_signing_key: &CrossSigningKey = (*self.master_key).as_ref();
+
+        if let Some(x509_signer) = store.x509_signer()
+            && x509_signer.has_later_expiry_than(&self.user_id, &cross_signing_key.signatures)
+        {
+            let mut cross_signing_key = cross_signing_key.clone();
+            cross_signing_key.signatures.clear();
+            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key)?;
+
+            let public_key = self
+                .master_key
+                .get_first_key()
+                .ok_or(SignatureError::MissingSigningKey)?
+                .to_base64()
+                .into();
+
+            let mut user_signed_keys = SignedKeys::new();
+            user_signed_keys.add_cross_signing_keys(public_key, cross_signing_key.to_raw());
+
+            let signed_keys = [(self.user_id.to_owned(), user_signed_keys)].into();
+            Ok(Some(SignatureUploadRequest::new(signed_keys)))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Update the identity with a new master key and self signing key.
     ///
     /// Note: This will reset the verification state if the master keys differ.
@@ -2140,6 +2177,61 @@ pub(crate) mod tests {
         assert!(bobs_view_of_alice.is_verified());
     }
 
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    #[async_test]
+    async fn test_refresh_signature() {
+        let user_id = user_id!("@own_user:localhost");
+        let account = Account::with_device_id(user_id, device_id!("DEV123"));
+
+        // We create three signers with different validity periods: an "old" signer, a
+        // "current" signer, and a "new" signer
+        let (x509_signer_old, x509_signer_current, x509_signer_new) =
+            crate::x509::tests::signers_with_different_validity();
+
+        // We sign our identity with the current signer.
+        let private_identity =
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current)).unwrap();
+
+        // If we create a store with the old signer, it should not try to
+        // re-sign our identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_old.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+
+        // If we create a store with the same signer, it should not try to
+        // re-sign our identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_current.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+
+        // If we create a store with the newer signer, it should re-sign our
+        // identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_new.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_some());
+    }
+
     /// Generate a key pair and cert, signed by the supplied certificate
     /// authority, and return a new user's [`OtherUserIdentityData`] whose
     /// master signing key is signed by them.
@@ -2215,7 +2307,8 @@ pub(crate) mod tests {
 
     /**
      * Creates a crypto store, backed by a [`MemoryStore`], for the given
-     * account, with an X.509 verifier and signer.
+     * account, with an X.509 verifier and signer.  The private identity
+     * will not be signed by X.509.
      */
     #[cfg(feature = "experimental-x509-identity-verification")]
     async fn create_store_with_x509(
@@ -2223,11 +2316,31 @@ pub(crate) mod tests {
         x509_verifier: X509Verifier,
         x509_signer: X509Signer,
     ) -> Store {
+        let private_identity = PrivateCrossSigningIdentity::for_account(&account, None).unwrap();
+
+        create_store_with_private_identity_and_x509(
+            account,
+            private_identity,
+            Some(x509_verifier),
+            Some(x509_signer),
+        )
+        .await
+    }
+
+    /**
+     * Creates a crypto store, backed by a [`MemoryStore`], for the given
+     * account and private identity, with an X.509 verifier and signer.
+     */
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    async fn create_store_with_private_identity_and_x509(
+        account: Account,
+        private_identity: PrivateCrossSigningIdentity,
+        x509_verifier: Option<X509Verifier>,
+        x509_signer: Option<X509Signer>,
+    ) -> Store {
         use crate::store::types::{Changes, IdentityChanges, PendingChanges};
 
         let account_static_data = account.static_data().clone();
-        let private_identity = PrivateCrossSigningIdentity::for_account(&account, None).unwrap();
-
         let crypto_store_wrapper =
             CryptoStoreWrapper::new(account.user_id(), account.device_id(), MemoryStore::new());
         crypto_store_wrapper
@@ -2257,8 +2370,8 @@ pub(crate) mod tests {
             private_identity,
             crypto_store_wrapper,
             verification_machine,
-            Some(x509_verifier),
-            Some(x509_signer),
+            x509_verifier,
+            x509_signer,
         )
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1185,20 +1185,43 @@ impl OwnUserIdentityData {
         *self.verified.read() == OwnUserIdentityVerifiedState::VerificationViolation
     }
 
-    /// Update the identity with a new master key and self signing key.
-    ///
-    /// Note: This will reset the verification state if the master keys differ.
-    ///
-    /// # Arguments
-    ///
-    /// * `master_key` - The new master key of the user identity.
-    ///
-    /// * `self_signing_key` - The new self signing key of user identity.
-    ///
-    /// * `user_signing_key` - The new user signing key of user identity.
-    ///
-    /// Returns a `SignatureError` if we failed to update the identity.
-    /// Otherwise, returns `true` if there was a change to the identity and
+    /// Sign our own identity again, if our current X.509 signer has a later
+    /// expiry than our existing X.509 signature.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) fn refresh_x509_signature(
+        &self,
+        store: &Store,
+    ) -> Result<Option<SignatureUploadRequest>, SignatureError> {
+        if !self.is_verified() {
+            return Ok(None);
+        }
+
+        let cross_signing_key: &CrossSigningKey = (*self.master_key).as_ref();
+
+        if let Some(x509_signer) = store.x509_signer()
+            && x509_signer.has_later_expiry_than(&self.user_id, &cross_signing_key.signatures)
+        {
+            let mut cross_signing_key = cross_signing_key.clone();
+            cross_signing_key.signatures.clear();
+            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key)?;
+
+            let public_key = self
+                .master_key
+                .get_first_key()
+                .ok_or(SignatureError::MissingSigningKey)?
+                .to_base64()
+                .into();
+
+            let mut user_signed_keys = SignedKeys::new();
+            user_signed_keys.add_cross_signing_keys(public_key, cross_signing_key.to_raw());
+
+            let signed_keys = [(self.user_id.to_owned(), user_signed_keys)].into();
+            Ok(Some(SignatureUploadRequest::new(signed_keys)))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// `false` if the identity is unchanged.
     pub(crate) fn update(
         &mut self,
@@ -2140,6 +2163,61 @@ pub(crate) mod tests {
         assert!(bobs_view_of_alice.is_verified());
     }
 
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    #[async_test]
+    async fn test_refresh_signature() {
+        let user_id = user_id!("@own_user:localhost");
+        let account = Account::with_device_id(user_id, device_id!("DEV123"));
+
+        // We create three signers with different validity periods: an "old" signer, a
+        // "current" signer, and a "new" signer
+        let (x509_signer_old, x509_signer_current, x509_signer_new) =
+            crate::x509::tests::signers_with_different_validity();
+
+        // We sign our identity with the current signer.
+        let private_identity =
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current)).unwrap();
+
+        // If we create a store with the old signer, it should not try to
+        // re-sign our identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_old.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+
+        // If we create a store with the same signer, it should not try to
+        // re-sign our identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_current.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+
+        // If we create a store with the newer signer, it should re-sign our
+        // identity.
+        let store = create_store_with_private_identity_and_x509(
+            account.deep_clone(),
+            private_identity.clone(),
+            None,
+            Some(x509_signer_new.clone()),
+        )
+        .await;
+
+        let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
+        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_some());
+    }
+
     /// Generate a key pair and cert, signed by the supplied certificate
     /// authority, and return a new user's [`OtherUserIdentityData`] whose
     /// master signing key is signed by them.
@@ -2215,7 +2293,8 @@ pub(crate) mod tests {
 
     /**
      * Creates a crypto store, backed by a [`MemoryStore`], for the given
-     * account, with an X.509 verifier and signer.
+     * account, with an X.509 verifier and signer.  The private identity
+     * will not be signed by X.509.
      */
     #[cfg(feature = "experimental-x509-identity-verification")]
     async fn create_store_with_x509(
@@ -2223,11 +2302,31 @@ pub(crate) mod tests {
         x509_verifier: X509Verifier,
         x509_signer: X509Signer,
     ) -> Store {
+        let private_identity = PrivateCrossSigningIdentity::for_account(&account, None).unwrap();
+
+        create_store_with_private_identity_and_x509(
+            account,
+            private_identity,
+            Some(x509_verifier),
+            Some(x509_signer),
+        )
+        .await
+    }
+
+    /**
+     * Creates a crypto store, backed by a [`MemoryStore`], for the given
+     * account and private identity, with an X.509 verifier and signer.
+     */
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    async fn create_store_with_private_identity_and_x509(
+        account: Account,
+        private_identity: PrivateCrossSigningIdentity,
+        x509_verifier: Option<X509Verifier>,
+        x509_signer: Option<X509Signer>,
+    ) -> Store {
         use crate::store::types::{Changes, IdentityChanges, PendingChanges};
 
         let account_static_data = account.static_data().clone();
-        let private_identity = PrivateCrossSigningIdentity::for_account(&account, None).unwrap();
-
         let crypto_store_wrapper =
             CryptoStoreWrapper::new(account.user_id(), account.device_id(), MemoryStore::new());
         crypto_store_wrapper
@@ -2257,8 +2356,8 @@ pub(crate) mod tests {
             private_identity,
             crypto_store_wrapper,
             verification_machine,
-            Some(x509_verifier),
-            Some(x509_signer),
+            x509_verifier,
+            x509_signer,
         )
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1222,6 +1222,20 @@ impl OwnUserIdentityData {
         }
     }
 
+    /// Update the identity with a new master key and self signing key.
+    ///
+    /// Note: This will reset the verification state if the master keys differ.
+    ///
+    /// # Arguments
+    ///
+    /// * `master_key` - The new master key of the user identity.
+    ///
+    /// * `self_signing_key` - The new self signing key of user identity.
+    ///
+    /// * `user_signing_key` - The new user signing key of user identity.
+    ///
+    /// Returns a `SignatureError` if we failed to update the identity.
+    /// Otherwise, returns `true` if there was a change to the identity and
     /// `false` if the identity is unchanged.
     pub(crate) fn update(
         &mut self,

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1187,11 +1187,22 @@ impl OwnUserIdentityData {
 
     /// Sign our own identity again, if our current X.509 signer has a later
     /// expiry than our existing X.509 signature.
+    ///
+    /// Returns the signature upload request to upload the new X.509 signature
+    /// if a new one is needed.
+    ///
+    /// Note that this function does not update our own copy of the signature
+    /// immediately.  Rather, after we upload the new signature, the server will
+    /// notify us of the changed key, we will re-fetch it, and then store the
+    /// new result at that point.
     #[cfg(feature = "experimental-x509-identity-verification")]
     pub(crate) fn refresh_x509_signature(
         &self,
         store: &Store,
     ) -> Result<Option<SignatureUploadRequest>, SignatureError> {
+        // We only re-sign our identity our identity is already verified.  If it
+        // isn't already verified, then our identity should be signed by
+        // `OwnUserIdentity::verify()` instead.
         if !self.is_verified() {
             return Ok(None);
         }

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -676,6 +676,13 @@ impl OlmMachine {
         requests.append(&mut self.inner.verification_machine.outgoing_messages());
         requests.append(&mut self.inner.key_request_machine.outgoing_to_device_requests().await?);
 
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        if let Some(signature_upload_request) =
+            self.inner.identity_manager.get_x509_signature_upload_request().await
+        {
+            requests.push(signature_upload_request);
+        }
+
         Ok(requests)
     }
 
@@ -742,6 +749,8 @@ impl OlmMachine {
             AnyIncomingResponse::SignatureUpload(_) => {
                 self.inner.verification_machine.mark_request_as_sent(request_id);
                 self.inner.key_request_machine.mark_outgoing_request_as_sent(request_id).await?;
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                self.inner.identity_manager.mark_x509_signature_request_as_sent(request_id).await;
             }
             AnyIncomingResponse::RoomMessage(_) => {
                 self.inner.verification_machine.mark_request_as_sent(request_id);

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -336,4 +336,46 @@ pub(crate) mod tests {
         // Ignore errors: they just mean that this method was called before.
         let _ = rustls::crypto::ring::default_provider().install_default();
     }
+
+    // Create three X.509 signers with different validity periods.
+    pub(crate) fn signers_with_different_validity() -> (X509Signer, X509Signer, X509Signer) {
+        let signing_key =
+            KeyPair::generate_for(&rcgen::PKCS_RSA_SHA512).expect("Failed to generate key pair");
+
+        let mut cert_params = CertificateParams::default();
+        cert_params.use_authority_key_identifier_extension = true;
+        cert_params.custom_extensions.push(subject_key_identifier_extension(&signing_key));
+
+        // We create three signers with different validity dates
+        cert_params.not_after = rcgen::date_time_ymd(2025, 7, 1);
+        let cert_old =
+            cert_params.self_signed(&signing_key).expect("Failed to generate certificate");
+        let x509_signer_old = {
+            let rust_raw_x509_signer =
+                RustRawX509Signer::new_from_pem_data(&cert_old.pem(), &signing_key.serialize_pem())
+                    .unwrap();
+            X509Signer::new(Arc::new(rust_raw_x509_signer))
+        };
+
+        cert_params.not_after = rcgen::date_time_ymd(2026, 7, 1);
+        let cert = cert_params.self_signed(&signing_key).expect("Failed to generate certificate");
+        let x509_signer_current = {
+            let rust_raw_x509_signer =
+                RustRawX509Signer::new_from_pem_data(&cert.pem(), &signing_key.serialize_pem())
+                    .unwrap();
+            X509Signer::new(Arc::new(rust_raw_x509_signer))
+        };
+
+        cert_params.not_after = rcgen::date_time_ymd(2027, 7, 1);
+        let cert_new =
+            cert_params.self_signed(&signing_key).expect("Failed to generate certificate");
+        let x509_signer_new = {
+            let rust_raw_x509_signer =
+                RustRawX509Signer::new_from_pem_data(&cert_new.pem(), &signing_key.serialize_pem())
+                    .unwrap();
+            X509Signer::new(Arc::new(rust_raw_x509_signer))
+        };
+
+        (x509_signer_old, x509_signer_current, x509_signer_new)
+    }
 }

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -113,12 +113,13 @@ mod raw_x509_signature;
 mod x509_signer;
 mod x509_verify;
 
+pub use cms::cert::x509::der::DateTime;
 pub use errors::{
     IntoX509SignatureError, X509SignatureSigningError, X509SignatureVerificationError,
 };
 pub use raw_x509_signature::RawX509Signature;
-pub use x509_signer::RawX509Signer;
 pub(crate) use x509_signer::X509Signer;
+pub use x509_signer::{RawX509Signer, ValidityError};
 pub use x509_verify::RawX509Verifier;
 pub(crate) use x509_verify::X509Verifier;
 

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use cms::cert::x509::{Certificate, der};
 use rustls::{
     SignatureScheme,
     crypto::ring,
@@ -42,6 +43,9 @@ pub struct RustRawX509Signer {
 
     /// The private signing key for this device.
     signing_key: Arc<dyn SigningKey>,
+
+    /// The "not after" time for the certificate's validity period.
+    validity_not_after: der::DateTime,
 }
 
 /// An enum of possible errors that can occur while instantiating
@@ -50,7 +54,7 @@ pub struct RustRawX509Signer {
 pub enum RustX509SignError {
     /// There was an error parsing the certificate chain.
     #[error("failed to parse certificate chain {0}")]
-    CertificateParse(rustls::pki_types::pem::Error),
+    CertificateParse(der::Error),
 
     /// No certificates were found.
     #[error("no certificates found in chain")]
@@ -80,7 +84,22 @@ impl RustRawX509Signer {
             .load_private_key(private_key)
             .map_err(RustX509SignError::PrivateKeyLoad)?;
 
-        Ok(Self { certificate_chain: certificate_chain_pem.to_owned(), signing_key })
+        let cert_chain = Certificate::load_pem_chain(certificate_chain_pem.as_bytes())
+            .map_err(RustX509SignError::CertificateParse)?;
+
+        // Pick the minimum "not after" date in the certificate chain, since the
+        // chain itself will not be valid after that time.
+        let validity_not_after = cert_chain
+            .into_iter()
+            .map(|cert| cert.tbs_certificate.validity.not_after.to_date_time())
+            .min()
+            .ok_or(RustX509SignError::CertificateNotFound)?;
+
+        Ok(Self {
+            certificate_chain: certificate_chain_pem.to_owned(),
+            signing_key,
+            validity_not_after,
+        })
     }
 }
 
@@ -104,6 +123,10 @@ impl RawX509Signer for RustRawX509Signer {
             signature_scheme: X509SignatureScheme::RsaPssSha512,
         })
     }
+
+    fn validity_not_after(&self) -> der::DateTime {
+        self.validity_not_after
+    }
 }
 
 impl std::fmt::Debug for RustRawX509Signer {
@@ -117,6 +140,8 @@ impl std::fmt::Debug for RustRawX509Signer {
 
 #[cfg(test)]
 mod tests {
+    use cms::cert::x509::der;
+
     use crate::x509::{
         RawX509Signer, raw_x509_signature::X509SignatureScheme,
         rust_raw_x509_signer::RustRawX509Signer,
@@ -132,6 +157,17 @@ mod tests {
         assert_eq!(sig.certificate_chain, TEST_CERT_CHAIN);
         assert_eq!(sig.signature_scheme, X509SignatureScheme::RsaPssSha512);
         assert_eq!(sig.signature_bytes.len(), 256);
+    }
+
+    #[test]
+    fn test_can_get_validity() {
+        let x509_sign =
+            RustRawX509Signer::new_from_pem_data(TEST_CERT_CHAIN, TEST_CERT_KEY).unwrap();
+
+        assert_eq!(
+            x509_sign.validity_not_after,
+            der::DateTime::new(2027, 6, 5, 15, 2, 16).unwrap()
+        );
     }
 
     /// A leaf and intermediate CA cert, generated with openssl

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 use crate::{
     SignatureError,
     x509::{
-        X509SignatureSigningError,
+        ValidityError, X509SignatureSigningError,
         raw_x509_signature::{RawX509Signature, X509SignatureScheme},
         x509_signer::RawX509Signer,
     },
@@ -126,8 +126,8 @@ impl RawX509Signer for RustRawX509Signer {
         })
     }
 
-    fn validity_not_after(&self) -> der::DateTime {
-        self.validity_not_after
+    fn validity_not_after(&self) -> Result<der::DateTime, ValidityError> {
+        Ok(self.validity_not_after)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -45,6 +45,9 @@ pub struct RustRawX509Signer {
     signing_key: Arc<dyn SigningKey>,
 
     /// The "not after" time for the certificate's validity period.
+    ///
+    /// We pre-calculate this on creation to avoid needing to re-parse the
+    /// certificate chain every time.
     validity_not_after: der::DateTime,
 }
 
@@ -54,7 +57,7 @@ pub struct RustRawX509Signer {
 pub enum RustX509SignError {
     /// There was an error parsing the certificate chain.
     #[error("failed to parse certificate chain {0}")]
-    CertificateParse(der::Error),
+    CertificateParse(#[from] der::Error),
 
     /// No certificates were found.
     #[error("no certificates found in chain")]
@@ -84,8 +87,7 @@ impl RustRawX509Signer {
             .load_private_key(private_key)
             .map_err(RustX509SignError::PrivateKeyLoad)?;
 
-        let cert_chain = Certificate::load_pem_chain(certificate_chain_pem.as_bytes())
-            .map_err(RustX509SignError::CertificateParse)?;
+        let cert_chain = Certificate::load_pem_chain(certificate_chain_pem.as_bytes())?;
 
         // Pick the minimum "not after" date in the certificate chain, since the
         // chain itself will not be valid after that time.

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -14,13 +14,15 @@
 
 use std::sync::Arc;
 
+use cms::cert::x509::der;
 use ruma::{DeviceKeyId, UserId, canonical_json::to_canonical_value};
+use tracing::info;
 
 use crate::{
     SignatureError,
     olm::utility::to_signable_json,
-    types::{CrossSigningKey, X509_SIGNATURE_ALGORITHM},
-    x509::raw_x509_signature::RawX509Signature,
+    types::{CrossSigningKey, Signature, Signatures, X509_SIGNATURE_ALGORITHM},
+    x509::raw_x509_signature::{RawX509Signature, RawX509SignatureAndFirstCertificate},
 };
 
 /// Hold one of these if you want to sign cross-signing keys, and call
@@ -70,6 +72,43 @@ impl X509Signer {
 
         Ok(())
     }
+
+    /// Check if the signer's certificates have a later expiry than the
+    /// certificates in the existing signatures.
+    ///
+    /// Returns `true` if no X.509 signatures are found.  Returns `false` if the
+    /// expiry is the same.  Only the validity period is checked -- no other
+    /// verification or validation is done.
+    pub fn has_later_expiry_than(&self, user_id: &UserId, signatures: &Signatures) -> bool {
+        let Some(this_user_sigs) = signatures.get(user_id) else {
+            info!("X509: has_later_expiry_than(): no signatures on object");
+            return true;
+        };
+
+        // We check all the available X.509 signatures.  If any of them has a
+        // later or equal expiry, then we return `false`.  Otherwise, all of
+        // them have a strictly earlier expiry, so we return `true`.
+        for sig in this_user_sigs.values() {
+            if let Ok(Signature::X509(sig)) = sig {
+                let res: RawX509SignatureAndFirstCertificate = match sig.try_into() {
+                    Ok(res) => res,
+                    Err(e) => {
+                        tracing::warn!(
+                            "X509: has_later_expiry_than(): unable to parse X509 signature: {}",
+                            e
+                        );
+                        continue;
+                    }
+                };
+                // FIXME: should we get the minimum validity of all the certs?
+                let validity = res.leaf_cert.tbs_certificate.validity;
+                if self.x509_sign.validity_not_after() <= validity.not_after.to_date_time() {
+                    return false;
+                }
+            }
+        }
+        true
+    }
 }
 
 /// A low-level interface for signing messages with a private key. We have Rust
@@ -79,6 +118,9 @@ pub trait RawX509Signer: std::fmt::Debug + Send + Sync {
     ///
     /// Returns (key ID, signature)
     fn sign(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError>;
+
+    /// Return the "not after" time for the certificate's validity period.
+    fn validity_not_after(&self) -> der::DateTime;
 }
 
 #[cfg(test)]
@@ -86,12 +128,16 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
+    use rcgen::{CertificateParams, KeyPair};
     use ruma::{DeviceKeyAlgorithm, DeviceKeyId, encryption::KeyUsage, user_id};
     use vodozemac::Ed25519SecretKey;
 
     use crate::{
         types::{CrossSigningKey, Signature, SigningKeys},
-        x509::{X509Signer, rust_raw_x509_signer::RustRawX509Signer},
+        x509::{
+            X509Signer, rust_raw_x509_signer::RustRawX509Signer,
+            tests::subject_key_identifier_extension,
+        },
     };
 
     #[test]
@@ -133,6 +179,53 @@ mod tests {
                 .unwrap(),
             Ok(Signature::X509(_))
         );
+    }
+
+    #[test]
+    fn test_can_compare_validity() {
+        let signing_key = KeyPair::from_pem(TEST_CERT_KEY).unwrap();
+
+        let mut cert_params = CertificateParams::default();
+        cert_params.use_authority_key_identifier_extension = true;
+        cert_params.custom_extensions.push(subject_key_identifier_extension(&signing_key));
+
+        // We create three signers with different validity dates: an "old" signer, a
+        // "current" signer, and a "new" signer.
+        let (x509_signer_old, x509_signer_current, x509_signer_new) =
+            crate::x509::tests::signers_with_different_validity();
+
+        // We sign something with the current signer.
+        let user_id = user_id!("@user:localhost");
+        let signatures = {
+            let mut cross_signing_key = {
+                let secret_key = Ed25519SecretKey::new();
+                let public_key = secret_key.public_key();
+                let keys = SigningKeys::from([(
+                    DeviceKeyId::from_parts(
+                        DeviceKeyAlgorithm::Ed25519,
+                        public_key.to_base64().as_str().into(),
+                    ),
+                    public_key.into(),
+                )]);
+
+                CrossSigningKey::new(
+                    user_id.to_owned(),
+                    vec![KeyUsage::Master],
+                    keys,
+                    Default::default(),
+                )
+            };
+
+            x509_signer_current.sign_cross_signing_key(user_id, &mut cross_signing_key).unwrap();
+
+            cross_signing_key.signatures
+        };
+
+        // The signers should be able to determine whether they have a later
+        // expiry than the certificate in the signature.
+        assert!(!x509_signer_old.has_later_expiry_than(user_id, &signatures));
+        assert!(!x509_signer_current.has_later_expiry_than(user_id, &signatures));
+        assert!(x509_signer_new.has_later_expiry_than(user_id, &signatures));
     }
 
     /// A leaf and intermediate CA cert, generated with openssl

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -22,7 +22,7 @@ use crate::{
     SignatureError,
     olm::utility::to_signable_json,
     types::{CrossSigningKey, Signature, Signatures, X509_SIGNATURE_ALGORITHM},
-    x509::raw_x509_signature::{RawX509Signature, RawX509SignatureAndFirstCertificate},
+    x509::raw_x509_signature::RawX509Signature,
 };
 
 /// Hold one of these if you want to sign cross-signing keys, and call
@@ -90,19 +90,38 @@ impl X509Signer {
         // them have a strictly earlier expiry, so we return `true`.
         for sig in this_user_sigs.values() {
             if let Ok(Signature::X509(sig)) = sig {
-                let res: RawX509SignatureAndFirstCertificate = match sig.try_into() {
-                    Ok(res) => res,
-                    Err(e) => {
-                        tracing::warn!(
-                            "X509: has_later_expiry_than(): unable to parse X509 signature: {}",
-                            e
-                        );
-                        continue;
-                    }
+                // We get the earliest expiry date from all the certificates in the signature.
+                let data: cms::signed_data::SignedData =
+                    match sig.get_signature().content.decode_as() {
+                        Ok(res) => res,
+                        Err(e) => {
+                            tracing::warn!(
+                                "X509: has_later_expiry_than(): unable to parse X509 signature: {}",
+                                e
+                            );
+                            continue;
+                        }
+                    };
+                let Some(certificate_set) = data.certificates else {
+                    tracing::warn!("X509: has_later_expiry_than(): no certificates found");
+                    continue;
                 };
-                // FIXME: should we get the minimum validity of all the certs?
-                let validity = res.leaf_cert.tbs_certificate.validity;
-                if validity.not_after.to_date_time() >= self.x509_sign.validity_not_after() {
+                let Some(validity_not_after) = certificate_set
+                    .0
+                    .iter()
+                    .filter_map(|cert| match cert {
+                        cms::cert::CertificateChoices::Certificate(c) => {
+                            Some(c.tbs_certificate.validity.not_after.to_date_time())
+                        }
+                        _ => None,
+                    })
+                    .min()
+                else {
+                    tracing::warn!("X509: has_later_expiry_than(): no certificates found");
+                    continue;
+                };
+
+                if validity_not_after >= self.x509_sign.validity_not_after() {
                     // We found a signature with a certificate that has a
                     // later-or-equal validity period.
                     return false;

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use cms::cert::x509::der;
 use ruma::{DeviceKeyId, UserId, canonical_json::to_canonical_value};
+use thiserror::Error;
 use tracing::info;
 
 use crate::{
@@ -85,6 +86,14 @@ impl X509Signer {
             return true;
         };
 
+        let Ok(signer_validity_not_after) = self.x509_sign.validity_not_after() else {
+            // If we can't get our own signer's validity period, we return
+            // `false` which will result in the signer not being used to re-sign
+            // any key.
+            info!("X509: has_later_expiry_than(): signer has invalid validity period");
+            return false;
+        };
+
         // We check all the available X.509 signatures.  If any of them has a
         // later or equal expiry, then we return `false`.  Otherwise, all of
         // them have a strictly earlier expiry, so we return `true`.
@@ -121,7 +130,7 @@ impl X509Signer {
                     continue;
                 };
 
-                if validity_not_after >= self.x509_sign.validity_not_after() {
+                if validity_not_after >= signer_validity_not_after {
                     // We found a signature with a certificate that has a
                     // later-or-equal validity period.
                     return false;
@@ -141,8 +150,13 @@ pub trait RawX509Signer: std::fmt::Debug + Send + Sync {
     fn sign(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError>;
 
     /// Return the "not after" time for the certificate's validity period.
-    fn validity_not_after(&self) -> der::DateTime;
+    fn validity_not_after(&self) -> Result<der::DateTime, ValidityError>;
 }
+
+/// Failure to get the validity period of the X.509 certificate.
+#[derive(Error, Debug)]
+#[error("Failed to get X.509 certificate validity period")]
+pub struct ValidityError;
 
 #[cfg(test)]
 mod tests {

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -74,7 +74,7 @@ impl X509Signer {
     }
 
     /// Check if the signer's certificates have a later expiry than the
-    /// certificates in the existing signatures.
+    /// certificates in the provided signatures.
     ///
     /// Returns `true` if no X.509 signatures are found.  Returns `false` if the
     /// expiry is the same.  Only the validity period is checked -- no other
@@ -102,7 +102,9 @@ impl X509Signer {
                 };
                 // FIXME: should we get the minimum validity of all the certs?
                 let validity = res.leaf_cert.tbs_certificate.validity;
-                if self.x509_sign.validity_not_after() <= validity.not_after.to_date_time() {
+                if validity.not_after.to_date_time() >= self.x509_sign.validity_not_after() {
+                    // We found a signature with a certificate that has a
+                    // later-or-equal validity period.
                     return false;
                 }
             }


### PR DESCRIPTION
(includes the commit from https://github.com/matrix-org/matrix-rust-sdk/pull/6792)

Checks whether our X.509 signer has a later expiry than the existing X.509 signature, and if so, upload a new signature to the server.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
