### PR TITLE
feat(widget): Implement MSC3819 `encrypted` flag or to-device

### DIFF
--- a/crates/matrix-sdk/changelog.d/6795.changed.md
+++ b/crates/matrix-sdk/changelog.d/6795.changed.md
@@ -1,0 +1,4 @@
+- To-device messages forwarded to widgets now include the MSC3819 `encrypted`
+  boolean in their `data`, indicating whether the original to-device message was
+  received encrypted.
+  ([MSC3819](https://github.com/matrix-org/matrix-spec-proposals/pull/3819))

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -254,9 +254,9 @@ impl MatrixDriver {
 
         let room_id = self.room.room_id().to_owned();
         let to_device_handle = self.room.client().add_event_handler(
-
-            async move |raw: Raw<AnyToDeviceEvent>, encryption_info: Option<EncryptionInfo>, client: Client| {
-
+            async move |raw: Raw<AnyToDeviceEvent>,
+                        encryption_info: Option<EncryptionInfo>,
+                        client: Client| {
                 // Some to-device traffic is used by the SDK for internal machinery.
                 // They should not be exposed to widgets.
                 if Self::should_filter_message_to_widget(&raw) {
@@ -270,48 +270,62 @@ impl MatrixDriver {
                     return;
                 };
 
-                let room_encrypted = room.latest_encryption_state().await
+                let room_encrypted = room
+                    .latest_encryption_state()
+                    .await
                     .map(|s| s.is_encrypted())
                     // Default consider encrypted
                     .unwrap_or(true);
-                if room_encrypted {
+
+                // Whether the to-device message reached us encrypted. `encryption_info` is
+                // `Some(..)` only when the message arrived as `m.room.encrypted` and was
+                // successfully Olm-decrypted by the SDK; clear (and UTD) messages carry `None`.
+                let encrypted = encryption_info.is_some();
+
+                if room_encrypted && !encrypted {
                     // The room is encrypted so the to-device traffic should be too.
-                    if encryption_info.is_none() {
-                        warn!(
-                            ?room_id,
-                            "Received to-device event in clear for a widget in an e2e room, dropping."
-                        );
-                        return;
-                    }
-
-                    // There are no per-room specific decryption settings (trust requirements), so we can just send it to the
-                    // widget.
-
-                    // The raw to-device event contains more fields than the widget needs, so we need to clean it up
-                    // to only type/content/sender.
-                    #[derive(Deserialize, Serialize)]
-                    struct CleanEventHelper<'a> {
-                        #[serde(rename = "type")]
-                        event_type: String,
-                        #[serde(borrow)]
-                        content: &'a RawJsonValue,
-                        sender: String,
-                    }
-
-                    let _ = serde_json::from_str::<CleanEventHelper<'_>>(raw.json().get())
-                        .and_then(|clean_event_helper| {
-                            serde_json::value::to_raw_value(&clean_event_helper)
-                        })
-                        .map_err(|err| warn!(?room_id, "Unable to process to-device message for widget: {err}"))
-                        .map(|box_value | {
-                            tx.send(Raw::from_json(box_value))
-                        });
-
-                } else {
-                    // forward to the widget
-                    // It is ok to send an encrypted to-device message even if the room is clear.
-                    let _ = tx.send(raw);
+                    warn!(
+                        ?room_id,
+                        "Received to-device event in clear for a widget in an e2e room, dropping."
+                    );
+                    return;
                 }
+
+                // There are no per-room specific decryption settings (trust requirements), so
+                // we can just send it to the widget.
+
+                // The raw to-device event contains more fields than the widget needs, so we
+                // clean it up to only type/content/sender and add the MSC3819 `encrypted`
+                // flag. It is ok to forward an encrypted to-device message even if the room is
+                // clear, so both cases go through the same path.
+                #[derive(Deserialize, Serialize)]
+                struct CleanEventHelper<'a> {
+                    #[serde(rename = "type")]
+                    event_type: String,
+                    #[serde(borrow)]
+                    content: &'a RawJsonValue,
+                    sender: String,
+                    // Never populated from the wire: it is always overwritten with the value
+                    // the SDK computed, so a remote sender cannot spoof it. (MSC3819 puts this
+                    // flag in the event's top-level namespace, this is not ideal;
+                    // ignoring any inbound value is the safe handling)
+                    #[serde(skip_deserializing)]
+                    encrypted: bool,
+                }
+
+                let _ = serde_json::from_str::<CleanEventHelper<'_>>(raw.json().get())
+                    .map(|mut clean_event_helper| {
+                        // Important, always set the `encrypted` flag based on encryption_info
+                        clean_event_helper.encrypted = encrypted;
+                        clean_event_helper
+                    })
+                    .and_then(|clean_event_helper| {
+                        serde_json::value::to_raw_value(&clean_event_helper)
+                    })
+                    .map_err(|err| {
+                        warn!(?room_id, "Unable to process to-device message for widget: {err}")
+                    })
+                    .map(|box_value| tx.send(Raw::from_json(box_value)));
             },
         );
 

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -111,13 +111,28 @@ async fn run_test_driver(
 async fn run_test_driver_e2e(
     init_on_content_load: bool,
 ) -> (Client, Client, MatrixMockServer, WidgetDriverHandle) {
+    run_test_driver_e2e_with_room_encryption(init_on_content_load, true).await
+}
+
+/// Like [`run_test_driver_e2e`], but lets the caller decide whether the room
+/// the widget lives in is end-to-end encrypted. The crypto machinery for Alice
+/// and Bob is always set up, so encrypted to-device messages can be exchanged
+/// even when the room itself is in the clear.
+async fn run_test_driver_e2e_with_room_encryption(
+    init_on_content_load: bool,
+    is_room_e2ee: bool,
+) -> (Client, Client, MatrixMockServer, WidgetDriverHandle) {
     let mock_server = MatrixMockServer::new().await;
     mock_server.mock_crypto_endpoints_preset().await;
     let (alice, bob) = mock_server.set_up_alice_and_bob_for_encryption().await;
 
     let room = mock_server.sync_joined_room(&alice, &ROOM_ID).await;
 
-    mock_server.mock_room_state_encryption().encrypted().mount().await;
+    if is_room_e2ee {
+        mock_server.mock_room_state_encryption().encrypted().mount().await;
+    } else {
+        mock_server.mock_room_state_encryption().plain().mount().await;
+    }
     let (driver, handle) = WidgetDriver::new(
         WidgetSettings::new(WIDGET_ID.to_owned(), init_on_content_load, "https://foo.bar/widget")
             .unwrap(),
@@ -565,6 +580,9 @@ async fn test_receive_live_events() {
     assert_eq!(to_device["api"], "toWidget");
     assert_eq!(to_device["action"], "send_to_device");
     assert_eq!(to_device["data"]["type"], "my.custom.to.device");
+    // The message was received in the clear, so the widget is told it is not
+    // encrypted.
+    assert_eq!(to_device["data"]["encrypted"], false);
 
     // No more messages from the driver
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
@@ -651,9 +669,105 @@ async fn test_accept_encrypted_to_device_in_e2ee_room() {
     assert_eq!(data["type"], "my.custom.to.device");
     assert_eq!(data["content"]["call_id"], "");
     assert_eq!(data["sender"], "@bob:example.org");
-    // Only these 3 fields should be exposed to the widget (no
+    // The message was received encrypted, so the widget is told so.
+    assert_eq!(data["encrypted"], true);
+    // Only these 4 fields should be exposed to the widget (no
     // `sender_device_keys`/`keys`/..)
-    assert_eq!(data.len(), 3);
+    assert_eq!(data.len(), 4);
+}
+
+/// The `encrypted` flag tracks the message, not the room: an encrypted
+/// to-device message received in a clear room must still be forwarded with
+/// `encrypted: true`.
+#[async_test]
+async fn test_encrypted_to_device_flag_in_clear_room() {
+    let (alice, bob, mock_server, driver_handle) =
+        run_test_driver_e2e_with_room_encryption(false, false).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc3819.receive.to_device:my.custom.to.device"]),
+    )
+    .await;
+
+    let bob_alice_device = bob
+        .encryption()
+        .get_device(alice.user_id().unwrap(), alice.device_id().unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+
+    let content_raw = Raw::new(&json!({
+        "call_id": "",
+    }))
+    .unwrap()
+    .cast_unchecked();
+
+    let event_synced_future =
+        mock_server.mock_capture_put_to_device_then_sync_back(bob.user_id().unwrap(), &alice).await;
+
+    bob.encryption()
+        .encrypt_and_send_raw_to_device(
+            vec![&bob_alice_device],
+            "my.custom.to.device",
+            content_raw,
+            CollectStrategy::AllDevices,
+        )
+        .await
+        .unwrap();
+
+    event_synced_future.await;
+
+    let msg = recv_message(&driver_handle).await;
+    assert_eq!(msg["api"], "toWidget");
+    assert_eq!(msg["action"], "send_to_device");
+
+    let data = msg["data"].as_object().unwrap();
+    assert_eq!(data["type"], "my.custom.to.device");
+    assert_eq!(data["sender"], "@bob:example.org");
+    // Even though the room is in the clear, the message arrived encrypted.
+    assert_eq!(data["encrypted"], true);
+    assert_eq!(data.len(), 4);
+}
+
+/// A clear to-device event that carries a forged top-level `encrypted: true`
+/// must not be able to spoof the flag: the SDK's own value (`false`, since the
+/// message was received in the clear) wins.
+#[async_test]
+async fn test_spoofed_encrypted_flag_is_ignored() {
+    let (client, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc3819.receive.to_device:my.custom.to.device"]),
+    )
+    .await;
+
+    assert_matches!(recv_message(&driver_handle).now_or_never(), None);
+
+    mock_server
+        .mock_sync()
+        .ok_and_run(&client, |sync_builder| {
+            sync_builder.add_to_device_event(json!({
+                "sender": "@alice:example.com",
+                "type": "my.custom.to.device",
+                // Forged flag that a malicious sender might inject.
+                "encrypted": true,
+                "content": {
+                    "a": "test",
+                }
+            }));
+        })
+        .await;
+
+    let msg = recv_message(&driver_handle).await;
+    assert_eq!(msg["action"], "send_to_device");
+
+    let data = msg["data"].as_object().unwrap();
+    assert_eq!(data["type"], "my.custom.to.device");
+    // The wire value must be ignored; the message was received in the clear.
+    assert_eq!(data["encrypted"], false);
+    assert_eq!(data.len(), 4);
 }
 
 /// Test that "internal" to-device messages are never forwarded to the widgets.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

[MSC3829](https://github.com/matrix-org/matrix-spec-proposals/pull/3819) - to-device messages for widgets - says that the action data should carry an `encrypted` flag that should be true if the to-device was encrypted
```json
 "data": {
    "type": "m.call.invite",
    "sender": "@source:example.org",
    "encrypted": true,
    "content": { ... }
  }
```

This was not implemented in the rust widget driver.
This PR is adding it.



- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
