### PR TITLE
fix(search): use a manual reload policy for the Tantivy IndexReader

### DIFF
--- a/crates/matrix-sdk-search/changelog.d/6798.fixed.md
+++ b/crates/matrix-sdk-search/changelog.d/6798.fixed.md
@@ -1,0 +1,4 @@
+Use `ReloadPolicy::Manual` for the Tantivy `IndexReader` of a `RoomIndex`.
+Tantivy's default policy spawns a meta file watcher thread per index, i.e. one
+per room, and panics if the thread cannot be spawned. Commits already reload the
+reader explicitly, so the watcher was pure overhead.

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -23,8 +23,8 @@ use std::{
 use once_cell::sync::OnceCell;
 use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId};
 use tantivy::{
-    Index, IndexReader, TantivyDocument, collector::TopDocs, directory::error::OpenDirectoryError,
-    query::QueryParser, schema::Value,
+    Index, IndexReader, ReloadPolicy, TantivyDocument, collector::TopDocs,
+    directory::error::OpenDirectoryError, query::QueryParser, schema::Value,
 };
 use tracing::{debug, error, warn};
 
@@ -120,8 +120,16 @@ impl RoomIndex {
     }
 
     /// Get or create the cached [`IndexReader`] for this index.
+    ///
+    /// The reload policy is [`ReloadPolicy::Manual`]: we are the only writer of
+    /// this index, and every commit goes through
+    /// [`RoomIndex::commit_and_reload`], which reloads explicitly. Tantivy's
+    /// default policy would instead spawn one meta file watcher thread per
+    /// index, i.e. one per room, and panics if that thread cannot be spawned.
     fn reader(&self) -> Result<&IndexReader, IndexError> {
-        self.reader.get_or_try_init(|| Ok(self.index.reader_builder().try_into()?))
+        self.reader.get_or_try_init(|| {
+            Ok(self.index.reader_builder().reload_policy(ReloadPolicy::Manual).try_into()?)
+        })
     }
 
     /// Commit added events to [`RoomIndex`]. The changes are not reflected in


### PR DESCRIPTION
Use `ReloadPolicy::Manual` for the Tantivy `IndexReader` of a `RoomIndex`. Tantivy's default policy spawns a meta file watcher thread per index, i.e. one per room, and panics if the thread cannot be spawned. Commits already reload the reader explicitly, so the watcher is pure overhead.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.
