### PR TITLE
doc: Remove aquamarine usage

### DIFF
--- a/.cargo/mermaid.html
+++ b/.cargo/mermaid.html
@@ -1,0 +1,11 @@
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: false });
+  document.querySelectorAll(".language-mermaid").forEach((elem) => {
+    const diagram = document.createElement("div");
+    diagram.className = "mermaid";
+    diagram.textContent = elem.innerText;
+    elem.parentElement.replaceWith(diagram);
+  });
+  await mermaid.run();
+</script>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,20 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,25 +2906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,7 +3403,6 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "anymap2",
- "aquamarine",
  "as_variant",
  "assert-json-diff",
  "assert_matches",
@@ -3605,7 +3571,6 @@ version = "0.18.0"
 dependencies = [
  "aes",
  "anyhow",
- "aquamarine",
  "as_variant",
  "assert_matches",
  "assert_matches2",
@@ -4757,27 +4722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rust-version = "1.93"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.100", default-features = false }
-aquamarine = { version = "0.6.0", default-features = false }
 as_variant = { version = "1.3.0", default-features = false }
 assert-json-diff = { version = "2.0.2", default-features = false }
 assert_matches = { version = "1.5.0", default-features = false }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -61,7 +61,6 @@ rust-x509-verifier-impl = ["experimental-x509-identity-verification", "dep:rustl
 
 [dependencies]
 aes = { version = "0.8.4", default-features = false }
-aquamarine.workspace = true
 as_variant.workspace = true
 async-trait.workspace = true
 bs58 = { version = "0.5.1", default-features = false, features = ["std"] }

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -164,7 +164,7 @@ pub enum RoomEventDecryptionResult {
     UnableToDecrypt(UnableToDecryptInfo),
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(doc, doc = include_str!("../../../.cargo/mermaid.html"))]
 /// A step by step guide that explains how to include [end-to-end-encryption]
 /// support in a [Matrix] client library.
 ///

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -102,7 +102,6 @@ experimental-x509-identity-verification = ["e2e-encryption", "matrix-sdk-base/ex
 [dependencies]
 anyhow = { workspace = true, optional = true }
 anymap2 = { version = "0.13.0", default-features = false }
-aquamarine.workspace = true
 as_variant.workspace = true
 assert_matches2 = { workspace = true, optional = true }
 async-channel = "2.5.0"

--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -33,7 +33,7 @@ use zeroize::Zeroize;
 use super::{DecryptionError, Result, SecretStorageError};
 use crate::{Client, encryption::backups::EnableBackupError};
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
+#[cfg_attr(doc, doc = include_str!("../../../../../.cargo/mermaid.html"))]
 /// Secure key/value storage for Matrix users.
 ///
 /// The `SecretStore` struct encapsulates the secret storage mechanism for


### PR DESCRIPTION
`aquamarine` depends on [unmaintained `proc-macro-error2`](https://rustsec.org/advisories/RUSTSEC-2026-0173), also will likely fail to compile with later Rust versions:

```
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

Unfortunately email contact and [GitHub issue mention](https://github.com/mersinvald/aquamarine/issues/58) failed to let the author do proper actions, so remove it in place of another way of adding Mermaid graphs.

No public API changes.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Yorusaka Miyabi <23130178+ShadowRZ@users.noreply.github.com>
