### PR TITLE
feat(ffi): expose Room::send_single_receipt

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6810.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6810.added.md
@@ -1,0 +1,5 @@
+`Room` gained a `send_single_receipt()` method, exposing the existing SDK API
+of the same name: it sends a receipt of the given type for the given event id,
+optionally scoped to a thread (`ReceiptThread`). This allows e.g. sending
+threaded read receipts without instantiating a thread-focused timeline per
+thread.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -741,6 +741,28 @@ impl Room {
             }))
     }
 
+    /// Send a single receipt of the given type for the given event, optionally
+    /// scoped to a thread.
+    ///
+    /// This allows sending receipts for events without instantiating the
+    /// [`Timeline`] they belong to, e.g. marking a thread as read from its
+    /// root and latest event ids. Note that this won't check whether sending
+    /// the receipt is necessary or valid (i.e. it can move a receipt
+    /// backwards); prefer [`Timeline::send_single_receipt`] when a timeline
+    /// is available.
+    pub async fn send_single_receipt(
+        &self,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: String,
+    ) -> Result<(), ClientError> {
+        let event_id = EventId::parse(event_id)?;
+
+        self.inner.send_single_receipt(receipt_type.into(), thread.try_into()?, event_id).await?;
+
+        Ok(())
+    }
+
     /// Mark a room as fully read, by attaching a read receipt to the provided
     /// `event_id`.
     ///


### PR DESCRIPTION
Follow-up to #6787: that PR exposed reading receipts back from the store; this one exposes sending them. `Room::send_single_receipt `already exists in the Rust SDK with exactly the needed shape `(receipt type + thread + event id)` but wasn't reachable through the FFI — the only way to send a threaded receipt was to instantiate a thread-focused Timeline per thread.

Use case: marking threads as read. With the room's thread list (which carries each thread's latest event id) this allows sending a threaded read receipt per thread without building a timeline for each. The doc comment carries the same caution as mark_as_fully_read_unchecked: no validity checking, prefer Timeline::send_single_receipt when a timeline is available.

Reuses the ReceiptType/ReceiptThread conversions introduced in #6787.