### PR TITLE
fix(ffi): delete the state store's actual -wal/-shm sidecar files in clear_caches

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6811.bugfix.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6811.bugfix.md
@@ -1,0 +1,6 @@
+`Client::clear_caches()` now deletes the state store's actual SQLite sidecar
+files: it looked for `.wal`/`.shm` suffixes while SQLite names them
+`-wal`/`-shm`, so the stale write-ahead log survived the cache clear. The
+rebuilt client then opened a fresh, empty state store next to the previous
+database's journal, which could fail with "disk I/O error" (reproducible when
+clearing caches while sync is active).

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2112,8 +2112,8 @@ impl Client {
 
                 for file_name in [
                     PathBuf::from(STATE_STORE_DATABASE_NAME),
-                    PathBuf::from(format!("{STATE_STORE_DATABASE_NAME}.wal")),
-                    PathBuf::from(format!("{STATE_STORE_DATABASE_NAME}.shm")),
+                    PathBuf::from(format!("{STATE_STORE_DATABASE_NAME}-wal")),
+                    PathBuf::from(format!("{STATE_STORE_DATABASE_NAME}-shm")),
                 ] {
                     let file_path = store_path.join(file_name);
                     if file_path.exists() {


### PR DESCRIPTION
`Client::clear_caches` deletes the state store database and intends to delete its `WAL/SHM` sidecars too, but looks for `.wal/.shm` suffixes — SQLite names them `-wal/-shm`, so the deletions never match and the previous database's journal survives the cache clear.

The rebuilt client then opens a fresh, empty state store next to the stale journal. On opening, SQLite detects the mismatched WAL and unlinks it — while connections from the previous, winding-down client may still hold it open. On iOS/macOS the system's SQLite file protection reacts to that unlink-while-in-use by invalidating every fd on the vnode, including the new client's, after which every statement fails with disk I/O error (`"Failed to run migrations: disk I/O error"`).

Reproducible by calling clearCaches while sync is actively writing (non-empty WAL) and then rebuilding the client — on the iOS simulator the console also prints` BUG IN CLIENT OF libsqlite3.dylib: … vnode unlinked while in use`. 

Element X's clear-cache feature is exposed to the same race.