### PR TITLE
feat: allow attaching custom fields to outgoing messages and media

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6812.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6812.added.md
@@ -1,0 +1,5 @@
+`UploadParameters` gained an optional `extra_content_json` field, and `Timeline`
+a `send_with_extra_content()` method (leaving `send()` unchanged), allowing
+additional top-level fields (a serialized JSON object) to be included in an
+event's content, e.g. vendor-prefixed keys matched by server-side push rules.
+Fields of the event itself take precedence.

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -119,12 +119,19 @@ impl Timeline {
             assign!(TextMessageEventContent::plain(caption), { formatted })
         });
 
+        let extra_content: Option<serde_json::Map<String, serde_json::Value>> = params
+            .extra_content_json
+            .map(|json| serde_json::from_str(&json))
+            .transpose()
+            .map_err(|_| RoomError::InvalidAttachmentData)?;
+
         let attachment_config = AttachmentConfig {
             info: Some(attachment_info),
             thumbnail,
             caption,
             mentions: params.mentions.map(Into::into),
             in_reply_to: in_reply_to_event_id,
+            extra_content,
             ..Default::default()
         };
 
@@ -201,6 +208,10 @@ pub struct UploadParameters {
     mentions: Option<Mentions>,
     /// Optional Event ID to reply to.
     in_reply_to: Option<String>,
+    /// Optional additional top-level fields for the media event's content,
+    /// as a serialized JSON object.
+    #[uniffi(default = None)]
+    extra_content_json: Option<String>,
 }
 
 /// A source for uploading a file
@@ -390,7 +401,23 @@ impl Timeline {
         self: Arc<Self>,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
     ) -> Result<Arc<SendHandle>, ClientError> {
-        match self.inner.send((*msg).to_owned().with_relation(None).into()).await {
+        self.send_with_extra_content(msg, None).await
+    }
+
+    /// Like [`Self::send`], but merges the given additional top-level fields
+    /// (a JSON object, encoded as a string) into the outgoing event's content.
+    pub async fn send_with_extra_content(
+        self: Arc<Self>,
+        msg: Arc<RoomMessageEventContentWithoutRelation>,
+        extra_content_json: Option<String>,
+    ) -> Result<Arc<SendHandle>, ClientError> {
+        let extra_content: Option<serde_json::Map<String, serde_json::Value>> =
+            extra_content_json.map(|json| serde_json::from_str(&json)).transpose()?;
+        match self
+            .inner
+            .send_with_extra_content((*msg).to_owned().with_relation(None).into(), extra_content)
+            .await
+        {
             Ok(handle) => Ok(Arc::new(SendHandle::new(handle))),
             Err(err) => {
                 error!("error when sending a message: {err}");

--- a/crates/matrix-sdk-base/changelog.d/6812.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6812.added.md
@@ -1,0 +1,4 @@
+`DependentQueuedRequestKind::FinishUpload` gained an optional
+`extra_content` field, carrying additional top-level fields to merge into the
+final media event content before sending. Old serialized values deserialize
+unchanged.

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -270,6 +270,11 @@ pub enum DependentQueuedRequestKind {
 
         /// Information about the thumbnail, if present.
         thumbnail_info: Option<FinishUploadThumbnailInfo>,
+
+        /// Additional top-level fields to merge into the final event content
+        /// before it is sent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
     },
 
     /// Finish a gallery upload by updating references to the media cache and

--- a/crates/matrix-sdk-ui/changelog.d/6812.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6812.added.md
@@ -1,0 +1,3 @@
+The timeline's `AttachmentConfig` gained an `extra_content` field, and the
+timeline a `send_with_extra_content()` method, forwarded to the underlying
+send queue. Extra fields never override the fields of the event itself.

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -80,6 +80,7 @@ impl<'a> IntoFuture for SendAttachment<'a> {
                 thumbnail: config.thumbnail,
                 caption: config.caption,
                 mentions: config.mentions,
+                extra_content: config.extra_content,
                 reply,
             };
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -218,6 +218,7 @@ pub struct AttachmentConfig {
     pub caption: Option<TextMessageEventContent>,
     pub mentions: Option<Mentions>,
     pub in_reply_to: Option<OwnedEventId>,
+    pub extra_content: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl Timeline {
@@ -325,7 +326,21 @@ impl Timeline {
     ///
     /// * `content` - The content of the message event.
     #[instrument(skip(self, content), fields(room_id = ?self.room().room_id()))]
-    pub async fn send(&self, mut content: AnyMessageLikeEventContent) -> Result<SendHandle, Error> {
+    pub async fn send(&self, content: AnyMessageLikeEventContent) -> Result<SendHandle, Error> {
+        self.send_with_extra_content(content, None).await
+    }
+
+    /// Queues an event in this room's send queue, with additional top-level
+    /// fields merged into its content. The event's own fields take precedence
+    /// on conflicts.
+    ///
+    /// See [`Self::send`] for more details.
+    #[instrument(skip(self, content, extra_content), fields(room_id = ?self.room().room_id()))]
+    pub async fn send_with_extra_content(
+        &self,
+        mut content: AnyMessageLikeEventContent,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<SendHandle, Error> {
         // If this is a room event we're sending in a threaded timeline, we add the
         // thread relation ourselves.
         if content.relation().is_none()
@@ -368,7 +383,13 @@ impl Timeline {
             }
         }
 
-        Ok(self.room().send_queue().send(content).await?)
+        let queue = self.room().send_queue();
+        let send = queue.send(content);
+        let send = match extra_content {
+            Some(extra_content) => send.with_extra_content(extra_content),
+            None => send,
+        };
+        Ok(send.await?)
     }
 
     /// Send a reply to the given event.

--- a/crates/matrix-sdk/changelog.d/6812.added.md
+++ b/crates/matrix-sdk/changelog.d/6812.added.md
@@ -1,0 +1,8 @@
+`AttachmentConfig` gained an `extra_content` field and `RoomSendQueue::send()`
+now returns a builder-style future with `with_extra_content()`, allowing
+additional top-level fields to be
+included in an event's content — e.g. vendor-prefixed keys that server-side
+push rules can match on (in lieu of
+[MSC3664](https://github.com/matrix-org/matrix-spec-proposals/pull/3664)).
+Extra fields never override the fields of the event itself. Supported by the
+send queue and the direct `Room::send_attachment` path.

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -200,6 +200,10 @@ pub struct AttachmentConfig {
     /// Reply parameters for the attachment (replied-to event and thread-related
     /// metadata).
     pub reply: Option<Reply>,
+
+    /// Additional top-level fields to include in the media event's content.
+    /// The event's own fields take precedence on conflicts.
+    pub extra_content: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl AttachmentConfig {
@@ -272,6 +276,19 @@ impl AttachmentConfig {
     /// * `reply` - The reply information of the message.
     pub fn reply(mut self, reply: Option<Reply>) -> Self {
         self.reply = reply;
+        self
+    }
+
+    /// Set additional top-level fields for the media event's content.
+    ///
+    /// # Arguments
+    ///
+    /// * `extra_content` - The additional fields.
+    pub fn extra_content(
+        mut self,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Self {
+        self.extra_content = extra_content;
         self
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2698,6 +2698,7 @@ impl Room {
         self.ensure_room_joined()?;
 
         let txn_id = config.txn_id.take();
+        let extra_content = config.extra_content.take();
         let mentions = config.mentions.take();
 
         let thumbnail = config.thumbnail.take();
@@ -2787,6 +2788,37 @@ impl Room {
                 config.reply,
             )
             .await?;
+
+        // With extra content, the event is sent raw so the custom fields can be
+        // included; fields of the media event itself take precedence over
+        // extra fields with the same name.
+        if let Some(extra_content) = extra_content.filter(|extra| !extra.is_empty()) {
+            let serde_json::Value::Object(mut object) = serde_json::to_value(&content)
+                .map_err(|error| Error::UnknownError(Box::new(error)))?
+            else {
+                unreachable!("a room message event content always serializes to a JSON object");
+            };
+            for (key, value) in extra_content {
+                match object.entry(key) {
+                    serde_json::map::Entry::Occupied(entry) => {
+                        warn!(
+                            key = entry.key(),
+                            "extra content field shadowed by the event's own field"
+                        );
+                    }
+                    serde_json::map::Entry::Vacant(entry) => {
+                        entry.insert(value);
+                    }
+                }
+            }
+
+            let event_type = content.event_type().to_string();
+            let mut fut = self.send_raw(&event_type, serde_json::Value::Object(object));
+            if let Some(txn_id) = &txn_id {
+                fut = fut.with_transaction_id(txn_id);
+            }
+            return fut.await.map(|result| result.response);
+        }
 
         let mut fut = self.send(content);
         if let Some(txn_id) = txn_id {

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -130,6 +130,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    future::IntoFuture,
     ops::Not,
     str::FromStr as _,
     sync::{
@@ -156,7 +157,7 @@ use matrix_sdk_base::{
     },
     task_monitor::BackgroundTaskHandle,
 };
-use matrix_sdk_common::locks::Mutex as SyncMutex;
+use matrix_sdk_common::{boxed_into_future, locks::Mutex as SyncMutex};
 use mime::Mime;
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
@@ -570,15 +571,8 @@ impl RoomSendQueue {
     /// client's sending queue will be disabled, and it will need to be
     /// manually re-enabled by the caller (e.g. after network is back, or when
     /// something has been done about the faulty requests).
-    pub async fn send(
-        &self,
-        content: AnyMessageLikeEventContent,
-    ) -> Result<SendHandle, RoomSendQueueError> {
-        self.send_raw(
-            Raw::new(&content).map_err(RoomSendQueueStorageError::JsonSerialization)?,
-            content.event_type().to_string(),
-        )
-        .await
+    pub fn send(&self, content: AnyMessageLikeEventContent) -> SendEvent<'_> {
+        SendEvent { queue: self, content, extra_content: None }
     }
 
     /// Queues a redaction of another event for sending it to this room.
@@ -1681,6 +1675,7 @@ impl QueueStorage {
         upload_file_txn: OwnedTransactionId,
         file_media_request: MediaRequestParameters,
         thumbnail: Option<QueueThumbnailInfo>,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> Result<(), RoomSendQueueStorageError> {
         let guard = self.store.lock().await;
         let client = guard.client()?;
@@ -1712,6 +1707,7 @@ impl QueueStorage {
                     local_echo: Box::new(event),
                     file_upload: upload_file_txn.clone(),
                     thumbnail_info,
+                    extra_content,
                 },
             )
             .await?;
@@ -2057,13 +2053,17 @@ impl QueueStorage {
                     local_echo,
                     file_upload,
                     thumbnail_info,
+                    extra_content,
                 } => {
                     // Materialize as an event local echo.
                     Some(LocalEcho {
                         transaction_id: dep.own_transaction_id.clone().into(),
                         content: LocalEchoContent::Event {
-                            serialized_event: SerializableEventContent::new(&(*local_echo).into())
-                                .ok()?,
+                            serialized_event: upload::merge_extra_content(
+                                SerializableEventContent::new(&(*local_echo).into()).ok()?,
+                                extra_content,
+                            )
+                            .ok()?,
                             send_handle: SendHandle {
                                 room: room.clone(),
                                 transaction_id: dep.own_transaction_id.into(),
@@ -2330,6 +2330,7 @@ impl QueueStorage {
                 local_echo,
                 file_upload,
                 thumbnail_info,
+                extra_content,
             } => {
                 let Some(parent_key) = parent_key else {
                     // Not finished yet, we should retry later => false.
@@ -2342,6 +2343,7 @@ impl QueueStorage {
                     *local_echo,
                     file_upload,
                     thumbnail_info,
+                    extra_content,
                     new_updates,
                 )
                 .await?;
@@ -2690,6 +2692,44 @@ struct MediaHandles {
 
     /// Transaction id used when uploading the media itself.
     upload_file_txn: OwnedTransactionId,
+}
+
+/// Future returned by [`RoomSendQueue::send`].
+#[allow(missing_debug_implementations)]
+pub struct SendEvent<'a> {
+    queue: &'a RoomSendQueue,
+    content: AnyMessageLikeEventContent,
+    extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl<'a> SendEvent<'a> {
+    /// Merge additional top-level fields into the outgoing event's content.
+    ///
+    /// The event's own fields take precedence on conflicts.
+    pub fn with_extra_content(
+        mut self,
+        extra_content: serde_json::Map<String, serde_json::Value>,
+    ) -> Self {
+        self.extra_content = Some(extra_content);
+        self
+    }
+}
+
+impl<'a> IntoFuture for SendEvent<'a> {
+    type Output = Result<SendHandle, RoomSendQueueError>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let serialized = upload::merge_extra_content(
+                SerializableEventContent::new(&self.content)
+                    .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+                self.extra_content,
+            )?;
+            let (raw, event_type) = serialized.into_raw();
+            self.queue.send_raw(raw, event_type).await
+        })
+    }
 }
 
 /// A handle to manipulate an event that was scheduled to be sent to a room.

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -212,6 +212,7 @@ impl RoomSendQueue {
         }
 
         let filename = filename.into();
+        let extra_content = config.extra_content.take();
         let upload_file_txn = TransactionId::new();
         let send_event_txn = config.txn_id.map_or_else(ChildTransactionId::new, Into::into);
 
@@ -254,6 +255,7 @@ impl RoomSendQueue {
                 upload_file_txn.clone(),
                 file_media_request,
                 queue_thumbnail_info,
+                extra_content.clone(),
             )
             .await?;
 
@@ -271,8 +273,11 @@ impl RoomSendQueue {
         self.send_update(RoomSendQueueUpdate::NewLocalEvent(LocalEcho {
             transaction_id: send_event_txn.clone().into(),
             content: LocalEchoContent::Event {
-                serialized_event: SerializableEventContent::new(&event_content.into())
-                    .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+                serialized_event: merge_extra_content(
+                    SerializableEventContent::new(&event_content.into())
+                        .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+                    extra_content,
+                )?,
                 send_handle: send_handle.clone(),
                 send_error: None,
             },
@@ -480,6 +485,44 @@ impl RoomSendQueue {
     }
 }
 
+/// Merge additional top-level fields into serialized event content.
+///
+/// Fields already present in the serialized content always win over extra
+/// fields with the same name.
+pub(super) fn merge_extra_content(
+    content: SerializableEventContent,
+    extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<SerializableEventContent, RoomSendQueueStorageError> {
+    let Some(extra_content) = extra_content else {
+        return Ok(content);
+    };
+    if extra_content.is_empty() {
+        return Ok(content);
+    }
+
+    let (raw, event_type) = content.into_raw();
+    let mut object: serde_json::Map<String, serde_json::Value> =
+        raw.deserialize_as().map_err(RoomSendQueueStorageError::JsonSerialization)?;
+
+    for (key, value) in extra_content {
+        match object.entry(key) {
+            serde_json::map::Entry::Occupied(entry) => {
+                warn!(key = entry.key(), "extra content field shadowed by the event's own field");
+            }
+            serde_json::map::Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+        }
+    }
+
+    let raw = ruma::serde::Raw::from_json(
+        serde_json::value::to_raw_value(&object)
+            .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+    );
+
+    Ok(SerializableEventContent::from_raw(raw, event_type))
+}
+
 impl QueueStorage {
     /// Consumes a finished upload and queues sending of the final media event.
     #[allow(clippy::too_many_arguments)]
@@ -491,6 +534,7 @@ impl QueueStorage {
         mut local_echo: RoomMessageEventContent,
         file_upload_txn: OwnedTransactionId,
         thumbnail_info: Option<FinishUploadThumbnailInfo>,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
         new_updates: &mut Vec<RoomSendQueueUpdate>,
     ) -> Result<(), RoomSendQueueError> {
         // Both uploads are ready: enqueue the event with its final data.
@@ -502,8 +546,11 @@ impl QueueStorage {
             .await?;
         update_media_event_after_upload(&mut local_echo, sent_media);
 
-        let new_content = SerializableEventContent::new(&local_echo.into())
-            .map_err(RoomSendQueueStorageError::JsonSerialization)?;
+        let new_content = merge_extra_content(
+            SerializableEventContent::new(&local_echo.into())
+                .map_err(RoomSendQueueStorageError::JsonSerialization)?,
+            extra_content,
+        )?;
 
         // Indicates observers that the upload finished, by editing the local echo for
         // the event into its final form before sending.
@@ -839,6 +886,7 @@ impl QueueStorage {
                     mut local_echo,
                     file_upload,
                     thumbnail_info,
+                    extra_content,
                 } = found.kind
                 else {
                     return Err(InvalidMediaCaptionEdit);
@@ -852,6 +900,7 @@ impl QueueStorage {
                     local_echo: local_echo.clone(),
                     file_upload,
                     thumbnail_info,
+                    extra_content,
                 };
                 store
                     .update_dependent_queued_request(

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -668,3 +668,48 @@ async fn test_room_attachment_send_is_animated() {
 
     assert_eq!(expected_event_id, response.event_id)
 }
+
+#[async_test]
+async fn test_room_attachment_send_extra_content() {
+    let mock = MatrixMockServer::new().await;
+
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+
+    let expected_event_id = event_id!("$h29iv0s8:example.com");
+
+    // The custom field must be present on the sent event, while the extra
+    // field colliding with a real event field must have been ignored.
+    mock.mock_room_send()
+        .body_matches_partial_json(json!({
+            "msgtype": "m.image",
+            "com.example.custom": "custom value",
+        }))
+        .ok(expected_event_id)
+        .mock_once()
+        .mount()
+        .await;
+
+    mock.mock_upload()
+        .expect_mime_type("image/jpeg")
+        .ok(mxc_uri!("mxc://example.com/AQwafuaFswefuhsfAFAgsw"))
+        .mock_once()
+        .mount()
+        .await;
+
+    let client = mock.client_builder().build().await;
+    let room = mock.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
+    mock.mock_room_state_encryption().plain().mount().await;
+
+    let config = AttachmentConfig::new().extra_content(Some(serde_json::Map::from_iter([
+        ("com.example.custom".to_owned(), "custom value".into()),
+        // The event's own fields take precedence over extra fields.
+        ("msgtype".to_owned(), "com.example.overridden".into()),
+    ])));
+
+    let response = room
+        .send_attachment("image", &mime::IMAGE_JPEG, b"Hello world".to_vec(), config)
+        .await
+        .unwrap();
+
+    assert_eq!(expected_event_id, response.event_id);
+}

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -2757,6 +2757,72 @@ async fn test_gallery_uploads() {
 }
 
 #[async_test]
+async fn test_media_upload_with_extra_content() {
+    let mock = MatrixMockServer::new().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+    let client = mock.client_builder().build().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+
+    let q = room.send_queue();
+    let mut global_watch = client.send_queue().subscribe();
+
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+
+    // ----------------------
+    // Create the media to send, with extra content fields.
+    let mut extra_content = serde_json::Map::new();
+    extra_content.insert("com.example.key".to_owned(), json!("@alice:example.org"));
+    // Extra fields must never override the fields of the media event itself.
+    extra_content.insert("body".to_owned(), json!("override attempt"));
+
+    let config = AttachmentConfig::new()
+        .caption(Some(TextMessageEventContent::plain("caption")))
+        .extra_content(Some(extra_content));
+
+    // ----------------------
+    // Prepare endpoints, capturing the body of the send request.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+    mock.mock_room_state_encryption().plain().mount().await;
+    mock.mock_upload().ok(mxc_uri!("mxc://sdk.rs/media")).mock_once().mount().await;
+
+    let sent_body = Arc::new(std::sync::Mutex::new(None));
+    let sent_body_clone = sent_body.clone();
+    mock.mock_room_send()
+        .respond_with(move |req: &Request| {
+            *sent_body_clone.lock().unwrap() =
+                Some(serde_json::from_slice::<serde_json::Value>(&req.body).unwrap());
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$1" }))
+        })
+        .mock_once()
+        .mount()
+        .await;
+
+    // ----------------------
+    // Send the media and wait for it to be sent.
+    q.send_attachment("village.jpg", mime::IMAGE_JPEG, b"hello world".to_vec(), config)
+        .await
+        .expect("queuing the attachment works");
+
+    let (txn, _send_handle, _content) = assert_update!((global_watch, watch) => local echo event);
+    assert_update!((global_watch, watch) => uploaded {
+        related_to = txn,
+        mxc = mxc_uri!("mxc://sdk.rs/media")
+    });
+    assert_update!((global_watch, watch) => edit local echo { txn = txn });
+    assert_update!((global_watch, watch) => sent { txn = txn, event_id = event_id!("$1") });
+
+    // The extra field was included in the sent event, and the media event's own
+    // fields were left untouched.
+    let body = sent_body.lock().unwrap().take().unwrap();
+    assert_eq!(body["com.example.key"], json!("@alice:example.org"));
+    assert_eq!(body["body"], json!("caption"));
+    assert_eq!(body["url"], json!("mxc://sdk.rs/media"));
+}
+
+#[async_test]
 async fn test_media_upload_retry() {
     let mock = MatrixMockServer::new().await;
 


### PR DESCRIPTION
Clients coming from matrix-js-sdk or matrix-ios-sdk could always add vendor-namespaced fields (e.g. `com.example.*`) to the content of regular messages and media, since both SDKs take free-form content. Some existing deployments depend on such fields (in our case a push gateway reads one to classify notifications), and those events need to stay ordinary messages/media: same event types, captions, thread and reply relations, encryption, local echo, send queue.

For plain messages this can be approximated today with `send_raw`, which does encrypt and where relations can be written by hand, but that bypasses the send queue's retries and the timeline's local echo. For media there's no workaround at all: the media event's content is built inside the send queue after the upload finishes, so there's nothing to attach custom fields to from the outside, short of reimplementing encrypted media upload client side.

This adds an optional `extra_content` (a map of additional top-level content fields) to both paths: `AttachmentConfig::extra_content` in the base SDK, `Timeline::send_with_extra_content` in the UI crate, and an `extra_content` parameter on the `FFI Timeline::send` plus a field on `UploadParameters`. The fields are merged into the outgoing event's content; for media they're persisted through the send queue (serde-defaulted on `FinishUpload`, so already-queued events deserialize fine) and survive restarts.

Added an integration test (`test_media_upload_with_extra_content`) checking the fields end up on the media event after going through the send queue.