### PR TITLE
fix(search): Fix a panic in Tantivy when event's timestamp is malformed

### DIFF
--- a/crates/matrix-sdk-search/changelog.d/6813.fixed.md
+++ b/crates/matrix-sdk-search/changelog.d/6813.fixed.md
@@ -1,0 +1,5 @@
+Fix a possible overflow panic in Tantivy when a malformed timestamp is
+converted from milliseconds to nanoseconds. If the timestamp is too large,
+the conversion to nanoseconds was panicking. The timestamp now comes from
+`TimelineEvent::timestamp`, which already deals with malformed timestamp. In
+addition, the timestamp is capped in case the API is misused.

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -21,7 +21,9 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
-use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId};
+use ruma::{
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UInt,
+};
 use tantivy::{
     Index, IndexReader, TantivyDocument, collector::TopDocs, directory::error::OpenDirectoryError,
     query::QueryParser, schema::Value,
@@ -58,15 +60,34 @@ pub struct IndexableEvent {
     pub(crate) body: String,
 }
 
+/// Maximum value for the timestamp to not overflow when converted to
+/// nanoseconds by Tantivy. See [`IndexableEvent::new`] to learn more.
+///
+/// This is the value of `i64::MAX / 1_000_000` but folded as a `u64`.
+const MAX_MILLISECONDS: u64 = 9_223_372_036_854;
+
 impl IndexableEvent {
     /// Create a new [`IndexableEvent`].
     pub fn new(
         event_id: OwnedEventId,
         original_event_id: OwnedEventId,
         sender: OwnedUserId,
-        timestamp: Option<MilliSecondsSinceUnixEpoch>,
+        mut timestamp: Option<MilliSecondsSinceUnixEpoch>,
         body: String,
     ) -> Self {
+        // Tantivy will transform the number of milliseconds to nanoseconds
+        // by multiplying by 1_000_000 [1]. If the number of milliseconds is too
+        // big, the multiplication will overflow.
+        //
+        // To avoid this panic, we cap the number of milliseconds to a maximum value.
+        //
+        // [1]: https://github.com/quickwit-oss/tantivy/blob/31ca1a8ba290b425f871d2e2384592045ec01b8d/common/src/datetime.rs#L62-L67
+        if let Some(timestamp) = &mut timestamp {
+            *timestamp = MilliSecondsSinceUnixEpoch(
+                timestamp.get().min(UInt::new_saturating(MAX_MILLISECONDS)),
+            );
+        }
+
         Self { event_id, original_event_id, sender, timestamp, body }
     }
 }
@@ -411,10 +432,11 @@ mod tests {
         room_id, user_id,
     };
 
-    use crate::{
-        error::IndexError,
-        index::{IndexableEvent, RoomIndex, RoomIndexOperation, builder::RoomIndexBuilder},
+    use super::{
+        IndexableEvent, MAX_MILLISECONDS, MilliSecondsSinceUnixEpoch, RoomIndex,
+        RoomIndexOperation, UInt, builder::RoomIndexBuilder,
     };
+    use crate::error::IndexError;
 
     /// Build an [`IndexableEvent`] from a text room message (tests only handle
     /// text).
@@ -471,6 +493,12 @@ mod tests {
         index.execute(RoomIndexOperation::Edit(event_id.to_owned(), to_indexable(&new)))
     }
 
+    /// Ensure `MAX_MILLISECONDS` is correctly set to `i64::MAX / 1_000_000`.
+    #[test]
+    fn test_max_milliseconds() {
+        assert_eq!(u64::try_from(i64::MAX / 1_000_000).unwrap(), MAX_MILLISECONDS);
+    }
+
     #[test]
     fn test_add_event() {
         let room_id = room_id!("!room_id:localhost");
@@ -502,8 +530,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_add_event_with_raw_malformed_timestamp_must_panic() {
+    fn test_add_event_with_raw_malformed_timestamp_must_not_panic() {
         let mut index = RoomIndexBuilder::new_in_memory(room_id!("!r")).build();
 
         index
@@ -511,7 +538,7 @@ mod tests {
                 event_id!("$ev").to_owned(),
                 event_id!("$ev").to_owned(),
                 user_id!("@mnt_io:matrix.org").to_owned(),
-                Some(ruma::MilliSecondsSinceUnixEpoch(ruma::UInt::new(151393755000000).unwrap())),
+                Some(MilliSecondsSinceUnixEpoch(UInt::new(151393755000000).unwrap())),
                 "body".to_owned(),
             )))
             .expect("failed to add event");
@@ -540,6 +567,33 @@ mod tests {
                 body,
             )))
             .expect("failed to add event");
+    }
+
+    #[test]
+    fn test_indexable_event_timestamp_is_capped() {
+        let event_id = event_id!("$ev").to_owned();
+        let sender = user_id!("@mnt_io:matrix.org").to_owned();
+        let body = "body".to_owned();
+
+        // Not capped.
+        let event = IndexableEvent::new(
+            event_id.clone(),
+            event_id.clone(),
+            sender.clone(),
+            Some(MilliSecondsSinceUnixEpoch(UInt::new(MAX_MILLISECONDS).unwrap())),
+            body.clone(),
+        );
+        assert_eq!(event.timestamp.unwrap().get(), UInt::new(MAX_MILLISECONDS).unwrap());
+
+        // Capped!
+        let event = IndexableEvent::new(
+            event_id.clone(),
+            event_id,
+            sender,
+            Some(MilliSecondsSinceUnixEpoch(UInt::new(MAX_MILLISECONDS + 42).unwrap())),
+            body,
+        );
+        assert_eq!(event.timestamp.unwrap().get(), UInt::new(MAX_MILLISECONDS).unwrap());
     }
 
     #[test]

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -42,16 +42,29 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct IndexableEvent {
     /// The event's own id (primary key).
-    pub event_id: OwnedEventId,
+    pub(crate) event_id: OwnedEventId,
     /// The id used as the deletion key: the original event id for edits,
     /// otherwise the event's own id.
-    pub original_event_id: OwnedEventId,
+    pub(crate) original_event_id: OwnedEventId,
     /// The sender of the event.
-    pub sender: OwnedUserId,
+    pub(crate) sender: OwnedUserId,
     /// The origin server timestamp of the event.
-    pub timestamp: MilliSecondsSinceUnixEpoch,
+    pub(crate) timestamp: MilliSecondsSinceUnixEpoch,
     /// The text to index for this event.
-    pub body: String,
+    pub(crate) body: String,
+}
+
+impl IndexableEvent {
+    /// Create a new [`IndexableEvent`].
+    pub fn new(
+        event_id: OwnedEventId,
+        original_event_id: OwnedEventId,
+        sender: OwnedUserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+        body: String,
+    ) -> Self {
+        Self { event_id, original_event_id, sender, timestamp, body }
+    }
 }
 
 /// A struct to represent the operations on a [`RoomIndex`]
@@ -409,19 +422,21 @@ mod tests {
             Some(Relation::Replacement(replacement)) => replacement.event_id.clone(),
             _ => event.event_id.clone(),
         };
-        IndexableEvent {
-            event_id: event.event_id.clone(),
+
+        IndexableEvent::new(
+            event.event_id.clone(),
             original_event_id,
-            sender: event.sender.clone(),
-            timestamp: event.origin_server_ts,
-            body: content.body.clone(),
-        }
+            event.sender.clone(),
+            event.origin_server_ts,
+            content.body.clone(),
+        )
     }
 
     /// Helper function to add a regular message to the index
     ///
     /// # Panic
-    /// Panics when event is not a [`OriginalSyncRoomMessageEvent`] with no
+    ///
+    /// Panics when event is not an [`OriginalSyncRoomMessageEvent`] with no
     /// relations.
     fn index_message(
         index: &mut RoomIndex,

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -62,9 +62,7 @@ pub struct IndexableEvent {
 
 /// Maximum value for the timestamp to not overflow when converted to
 /// nanoseconds by Tantivy. See [`IndexableEvent::new`] to learn more.
-///
-/// This is the value of `i64::MAX / 1_000_000` but folded as a `u64`.
-const MAX_MILLISECONDS: u64 = 9_223_372_036_854;
+const MAX_MILLISECONDS: u64 = (i64::MAX / 1_000_000).cast_unsigned();
 
 impl IndexableEvent {
     /// Create a new [`IndexableEvent`].
@@ -491,12 +489,6 @@ mod tests {
         new: OriginalSyncRoomMessageEvent,
     ) -> Result<(), IndexError> {
         index.execute(RoomIndexOperation::Edit(event_id.to_owned(), to_indexable(&new)))
-    }
-
-    /// Ensure `MAX_MILLISECONDS` is correctly set to `i64::MAX / 1_000_000`.
-    #[test]
-    fn test_max_milliseconds() {
-        assert_eq!(u64::try_from(i64::MAX / 1_000_000).unwrap(), MAX_MILLISECONDS);
     }
 
     #[test]

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -483,7 +483,63 @@ mod tests {
             .sender(user_id!("@user_id:localhost"))
             .into_any_sync_message_like_event();
 
-        index_message(&mut index, event).expect("failed to add event: {res:?}");
+        index_message(&mut index, event).expect("failed to add event");
+    }
+
+    #[test]
+    fn test_add_event_with_no_timestamp() {
+        let mut index = RoomIndexBuilder::new_in_memory(room_id!("!r")).build();
+
+        index
+            .execute(RoomIndexOperation::Add(IndexableEvent::new(
+                event_id!("$ev").to_owned(),
+                event_id!("$ev").to_owned(),
+                user_id!("@mnt_io:matrix.org").to_owned(),
+                None,
+                "body".to_owned(),
+            )))
+            .expect("failed to add event");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_add_event_with_raw_malformed_timestamp_must_panic() {
+        let mut index = RoomIndexBuilder::new_in_memory(room_id!("!r")).build();
+
+        index
+            .execute(RoomIndexOperation::Add(IndexableEvent::new(
+                event_id!("$ev").to_owned(),
+                event_id!("$ev").to_owned(),
+                user_id!("@mnt_io:matrix.org").to_owned(),
+                Some(ruma::MilliSecondsSinceUnixEpoch(ruma::UInt::new(151393755000000).unwrap())),
+                "body".to_owned(),
+            )))
+            .expect("failed to add event");
+    }
+
+    #[test]
+    fn test_add_event_with_malformed_timestamp_must_not_panic() {
+        let room_id = room_id!("!r");
+        let mut index = RoomIndexBuilder::new_in_memory(room_id).build();
+
+        let body = "body".to_owned();
+        let event = EventFactory::new()
+            .server_ts(151393755000000)
+            .text_msg(body.clone())
+            .event_id(event_id!("$ev"))
+            .room(room_id)
+            .sender(user_id!("@mnt_io:matrix.org"))
+            .into_event();
+
+        index
+            .execute(RoomIndexOperation::Add(IndexableEvent::new(
+                event.event_id().unwrap().to_owned(),
+                event.event_id().unwrap().to_owned(),
+                event.sender().unwrap(),
+                event.timestamp(),
+                body,
+            )))
+            .expect("failed to add event");
     }
 
     #[test]

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -49,7 +49,11 @@ pub struct IndexableEvent {
     /// The sender of the event.
     pub(crate) sender: OwnedUserId,
     /// The origin server timestamp of the event.
-    pub(crate) timestamp: MilliSecondsSinceUnixEpoch,
+    ///
+    /// Please use the `matrix_sdk_common::TimelineEvent::timestamp` as much as
+    /// possible as it protects against malformed `origin_server_ts`. At worst,
+    /// use the `matrix_sdk_common::serde_helpers::extract_timestamp` function.
+    pub(crate) timestamp: Option<MilliSecondsSinceUnixEpoch>,
     /// The text to index for this event.
     pub(crate) body: String,
 }
@@ -60,7 +64,7 @@ impl IndexableEvent {
         event_id: OwnedEventId,
         original_event_id: OwnedEventId,
         sender: OwnedUserId,
-        timestamp: MilliSecondsSinceUnixEpoch,
+        timestamp: Option<MilliSecondsSinceUnixEpoch>,
         body: String,
     ) -> Self {
         Self { event_id, original_event_id, sender, timestamp, body }
@@ -427,7 +431,7 @@ mod tests {
             event.event_id.clone(),
             original_event_id,
             event.sender.clone(),
-            event.origin_server_ts,
+            Some(event.origin_server_ts),
             content.body.clone(),
         )
     }

--- a/crates/matrix-sdk-search/src/schema.rs
+++ b/crates/matrix-sdk-search/src/schema.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use tantivy::{
-    DateTime, TantivyDocument, doc,
+    DateTime, TantivyDocument,
     schema::{DateOptions, DateTimePrecision, Field, INDEXED, STORED, STRING, Schema, TEXT},
 };
 
@@ -96,21 +96,36 @@ impl MatrixSearchIndexSchema for RoomMessageSchema {
 
     /// Given an [`IndexableEvent`] return a [`TantivyDocument`].
     fn make_doc(&self, event: IndexableEvent) -> Result<TantivyDocument, IndexError> {
-        let timestamp = DateTime::from_timestamp_millis(
-            event
-                .timestamp
-                .map(|timestamp| timestamp.get().into())
-                // If the timestamp is missing, use 0 as the “no value”.
-                .unwrap_or(0),
-        );
+        let mut document = TantivyDocument::default();
 
-        let document = doc!(
-            self.event_id_field => event.event_id.to_string(),
-            self.body_field => event.body,
-            self.date_field => timestamp,
-            self.sender_field => event.sender.to_string(),
-            self.original_event_id_field => event.original_event_id.to_string(),
+        let Self {
+            event_id_field,
+            body_field,
+            date_field,
+            sender_field,
+            original_event_id_field,
+
+            inner: _,
+            default_search_fields: _,
+        } = self;
+
+        let IndexableEvent { event_id, body, timestamp, sender, original_event_id } = event;
+
+        document.add_text(*event_id_field, event_id);
+        document.add_text(*body_field, body);
+        document.add_date(
+            *date_field,
+            DateTime::from_timestamp_millis(
+                timestamp
+                    .map(|timestamp| timestamp.get().into())
+                    // If the timestamp is missing, use 0 as the “no value”.
+                    .unwrap_or(0),
+            ),
         );
+        document.add_text(*sender_field, sender);
+        document.add_text(*original_event_id_field, original_event_id);
+
+        document.shrink_to_fit();
 
         Ok(document)
     }

--- a/crates/matrix-sdk-search/src/schema.rs
+++ b/crates/matrix-sdk-search/src/schema.rs
@@ -96,11 +96,18 @@ impl MatrixSearchIndexSchema for RoomMessageSchema {
 
     /// Given an [`IndexableEvent`] return a [`TantivyDocument`].
     fn make_doc(&self, event: IndexableEvent) -> Result<TantivyDocument, IndexError> {
+        let timestamp = DateTime::from_timestamp_millis(
+            event
+                .timestamp
+                .map(|timestamp| timestamp.get().into())
+                // If the timestamp is missing, use 0 as the “no value”.
+                .unwrap_or(0),
+        );
+
         let document = doc!(
             self.event_id_field => event.event_id.to_string(),
             self.body_field => event.body,
-            self.date_field =>
-                DateTime::from_timestamp_millis(event.timestamp.get().into()),
+            self.date_field => timestamp,
             self.sender_field => event.sender.to_string(),
             self.original_event_id_field => event.original_event_id.to_string(),
         );

--- a/crates/matrix-sdk/src/search_index/mod.rs
+++ b/crates/matrix-sdk/src/search_index/mod.rs
@@ -290,13 +290,14 @@ fn indexable_from_room_message(event: &OriginalSyncRoomMessageEvent) -> Option<I
         Some(Relation::Replacement(replacement)) => replacement.event_id.clone(),
         _ => event.event_id.clone(),
     };
-    Some(IndexableEvent {
-        event_id: event.event_id.clone(),
+
+    Some(IndexableEvent::new(
+        event.event_id.clone(),
         original_event_id,
-        sender: event.sender.clone(),
-        timestamp: event.origin_server_ts,
+        event.sender.clone(),
+        event.origin_server_ts,
         body,
-    })
+    ))
 }
 
 /// If the given [`OriginalSyncRoomMessageEvent`] is an edit we make an
@@ -369,13 +370,14 @@ async fn handle_room_redaction(
 /// Return a [`RoomIndexOperation::Add`] indexing a sticker's descriptive text.
 fn handle_sticker(event: SyncStickerEvent) -> Option<RoomIndexOperation> {
     let event = event.as_original()?;
-    Some(RoomIndexOperation::Add(IndexableEvent {
-        event_id: event.event_id.clone(),
-        original_event_id: event.event_id.clone(),
-        sender: event.sender.clone(),
-        timestamp: event.origin_server_ts,
-        body: event.content.body.clone(),
-    }))
+
+    Some(RoomIndexOperation::Add(IndexableEvent::new(
+        event.event_id.clone(),
+        event.event_id.clone(),
+        event.sender.clone(),
+        event.origin_server_ts,
+        event.content.body.clone(),
+    )))
 }
 
 /// Return a [`RoomIndexOperation::Add`] indexing an unstable poll's question
@@ -398,13 +400,13 @@ fn handle_unstable_poll_start(event: SyncUnstablePollStartEvent) -> Option<RoomI
         body.push_str(&answer.text);
     }
 
-    Some(RoomIndexOperation::Add(IndexableEvent {
-        event_id: event.event_id.clone(),
-        original_event_id: event.event_id.clone(),
-        sender: event.sender.clone(),
-        timestamp: event.origin_server_ts,
+    Some(RoomIndexOperation::Add(IndexableEvent::new(
+        event.event_id.clone(),
+        event.event_id.clone(),
+        event.sender.clone(),
+        event.origin_server_ts,
         body,
-    }))
+    )))
 }
 
 /// Return a [`RoomIndexOperation::Add`] indexing a stable poll's question and
@@ -429,13 +431,13 @@ fn handle_poll_start(event: SyncPollStartEvent) -> Option<RoomIndexOperation> {
         }
     }
 
-    Some(RoomIndexOperation::Add(IndexableEvent {
-        event_id: event.event_id.clone(),
-        original_event_id: event.event_id.clone(),
-        sender: event.sender.clone(),
-        timestamp: event.origin_server_ts,
+    Some(RoomIndexOperation::Add(IndexableEvent::new(
+        event.event_id.clone(),
+        event.event_id.clone(),
+        event.sender.clone(),
+        event.origin_server_ts,
         body,
-    }))
+    )))
 }
 
 /// Prepare a [`TimelineEvent`] into a [`RoomIndexOperation`] for search

--- a/crates/matrix-sdk/src/search_index/mod.rs
+++ b/crates/matrix-sdk/src/search_index/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk_search::{
     index::{IndexableEvent, RoomIndex, RoomIndexOperation, builder::RoomIndexBuilder},
 };
 use ruma::{
-    EventId, OwnedEventId, OwnedRoomId, RoomId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, RoomId,
     events::{
         AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         poll::{
@@ -284,7 +284,10 @@ fn room_message_body(msgtype: &MessageType) -> Option<String> {
 
 /// Build an [`IndexableEvent`] from a room message, or `None` if its type
 /// carries no searchable text.
-fn indexable_from_room_message(event: &OriginalSyncRoomMessageEvent) -> Option<IndexableEvent> {
+fn indexable_from_room_message(
+    event: &OriginalSyncRoomMessageEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> Option<IndexableEvent> {
     let body = room_message_body(&event.content.msgtype)?;
     let original_event_id = match &event.content.relates_to {
         Some(Relation::Replacement(replacement)) => replacement.event_id.clone(),
@@ -295,7 +298,7 @@ fn indexable_from_room_message(event: &OriginalSyncRoomMessageEvent) -> Option<I
         event.event_id.clone(),
         original_event_id,
         event.sender.clone(),
-        event.origin_server_ts,
+        timestamp,
         body,
     ))
 }
@@ -305,12 +308,13 @@ fn indexable_from_room_message(event: &OriginalSyncRoomMessageEvent) -> Option<I
 /// original.
 async fn handle_possible_edit(
     event: &OriginalSyncRoomMessageEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
     cache: &RoomEventCache,
 ) -> Option<RoomIndexOperation> {
     if let Some(Relation::Replacement(replacement_data)) = &event.content.relates_to {
         if let Some(recent) = get_most_recent_edit(cache, &replacement_data.event_id).await {
             return Some(
-                indexable_from_room_message(&recent).map_or(
+                indexable_from_room_message(&recent, timestamp).map_or(
                     RoomIndexOperation::Noop,
                     |indexable| {
                         RoomIndexOperation::Edit(replacement_data.event_id.clone(), indexable)
@@ -328,15 +332,18 @@ async fn handle_possible_edit(
 /// depending on the message.
 async fn handle_room_message(
     event: SyncRoomMessageEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
     cache: &RoomEventCache,
 ) -> Option<RoomIndexOperation> {
     if let Some(event) = event.as_original() {
-        return handle_possible_edit(event, cache).await.or(get_most_recent_edit(
+        return handle_possible_edit(event, timestamp, cache).await.or(get_most_recent_edit(
             cache,
             &event.event_id,
         )
         .await
-        .and_then(|recent| indexable_from_room_message(&recent).map(RoomIndexOperation::Add)));
+        .and_then(|recent| {
+            indexable_from_room_message(&recent, timestamp).map(RoomIndexOperation::Add)
+        }));
     }
     None
 }
@@ -345,6 +352,7 @@ async fn handle_room_message(
 /// re-adding the most recent remaining version if an edit was redacted.
 async fn handle_room_redaction(
     event: SyncRoomRedactionEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
     cache: &RoomEventCache,
     rules: &RedactionRules,
 ) -> Option<RoomIndexOperation> {
@@ -357,7 +365,7 @@ async fn handle_room_redaction(
             redacted_event,
         ))) = redacted_event.raw().deserialize()
         && let Some(redacted_event) = redacted_event.as_original()
-        && let Some(operation) = handle_possible_edit(redacted_event, cache).await
+        && let Some(operation) = handle_possible_edit(redacted_event, timestamp, cache).await
     {
         return Some(operation);
     }
@@ -368,14 +376,17 @@ async fn handle_room_redaction(
 }
 
 /// Return a [`RoomIndexOperation::Add`] indexing a sticker's descriptive text.
-fn handle_sticker(event: SyncStickerEvent) -> Option<RoomIndexOperation> {
+fn handle_sticker(
+    event: SyncStickerEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> Option<RoomIndexOperation> {
     let event = event.as_original()?;
 
     Some(RoomIndexOperation::Add(IndexableEvent::new(
         event.event_id.clone(),
         event.event_id.clone(),
         event.sender.clone(),
-        event.origin_server_ts,
+        timestamp,
         event.content.body.clone(),
     )))
 }
@@ -386,7 +397,10 @@ fn handle_sticker(event: SyncStickerEvent) -> Option<RoomIndexOperation> {
 /// ponytail: only indexes the initial `New` poll — edits (`Replacement`) and
 /// poll ends are ignored. Add edit handling if editing a poll needs to update
 /// search results.
-fn handle_unstable_poll_start(event: SyncUnstablePollStartEvent) -> Option<RoomIndexOperation> {
+fn handle_unstable_poll_start(
+    event: SyncUnstablePollStartEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> Option<RoomIndexOperation> {
     let event = event.as_original()?;
 
     let UnstablePollStartEventContent::New(content) = &event.content else {
@@ -404,7 +418,7 @@ fn handle_unstable_poll_start(event: SyncUnstablePollStartEvent) -> Option<RoomI
         event.event_id.clone(),
         event.event_id.clone(),
         event.sender.clone(),
-        event.origin_server_ts,
+        timestamp,
         body,
     )))
 }
@@ -414,7 +428,10 @@ fn handle_unstable_poll_start(event: SyncUnstablePollStartEvent) -> Option<RoomI
 ///
 /// ponytail: like [`handle_unstable_poll_start`], edits and poll ends are
 /// ignored — only the initial poll is indexed.
-fn handle_poll_start(event: SyncPollStartEvent) -> Option<RoomIndexOperation> {
+fn handle_poll_start(
+    event: SyncPollStartEvent,
+    timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> Option<RoomIndexOperation> {
     let event = event.as_original()?;
 
     // Skip poll edits, matching the unstable poll handling.
@@ -435,7 +452,7 @@ fn handle_poll_start(event: SyncPollStartEvent) -> Option<RoomIndexOperation> {
         event.event_id.clone(),
         event.event_id.clone(),
         event.sender.clone(),
-        event.origin_server_ts,
+        timestamp,
         body,
     )))
 }
@@ -453,19 +470,21 @@ async fn parse_timeline_event(
         return None;
     }
 
+    let timestamp = event.timestamp();
+
     match event.raw().deserialize() {
         Ok(event) => match event {
             AnySyncTimelineEvent::MessageLike(event) => match event {
                 AnySyncMessageLikeEvent::RoomMessage(event) => {
-                    handle_room_message(event, cache).await
+                    handle_room_message(event, timestamp, cache).await
                 }
                 AnySyncMessageLikeEvent::RoomRedaction(event) => {
-                    handle_room_redaction(event, cache, redaction_rules).await
+                    handle_room_redaction(event, timestamp, cache, redaction_rules).await
                 }
-                AnySyncMessageLikeEvent::Sticker(event) => handle_sticker(event),
-                AnySyncMessageLikeEvent::PollStart(event) => handle_poll_start(event),
+                AnySyncMessageLikeEvent::Sticker(event) => handle_sticker(event, timestamp),
+                AnySyncMessageLikeEvent::PollStart(event) => handle_poll_start(event, timestamp),
                 AnySyncMessageLikeEvent::UnstablePollStart(event) => {
-                    handle_unstable_poll_start(event)
+                    handle_unstable_poll_start(event, timestamp)
                 }
                 _ => None,
             },


### PR DESCRIPTION
This patch ensures Tantivy doesn't panic when a malformed event's timestamp is too large and cannot be converted to nanoseconds without an overflow.

This PR addresses the issues in two ways:

- Ensure `TimelineEvent::timestamp()` is used to avoid malformed timestamps,
- Ensure `IndexableEvent` caps the timestamp if the API is misused.

Better to review patch-by-patch.

---

- Fix https://github.com/matrix-org/matrix-rust-sdk/issues/6772

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
