### PR TITLE
Use new OutgoingRequest::Body as intended

### DIFF
--- a/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/download/encrypted.rs
@@ -16,15 +16,19 @@ use matrix_sdk::RumaApiError;
 use matrix_sdk_crypto::olm::Curve25519PublicKey;
 use ruma::{
     api::{
-        BytesBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        Metadata, OutgoingBodyJson, OutgoingRequest, auth_scheme::AccessTokenOptional,
         error::IntoHttpError, path_builder::PathBuilder,
     },
     events::room::EncryptedFile,
     exports::http::Request,
     metadata,
 };
+use serde::Serialize;
 
-use crate::api::{DownloadAndScanMediaResponse, encrypted_file_request_from};
+use crate::{
+    EncryptedFileRequest,
+    api::{DownloadAndScanMediaResponse, encrypted_file_request_from},
+};
 
 metadata! {
     @for DownloadAndScanEncryptedMediaRequest,
@@ -55,8 +59,12 @@ impl DownloadAndScanEncryptedMediaRequest {
     }
 }
 
+#[derive(Serialize, OutgoingBodyJson)]
+#[serde(transparent)]
+pub(crate) struct RequestBody(EncryptedFileRequest);
+
 impl OutgoingRequest for DownloadAndScanEncryptedMediaRequest {
-    type Body = BytesBody;
+    type Body = RequestBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = DownloadAndScanMediaResponse;
 
@@ -66,10 +74,7 @@ impl OutgoingRequest for DownloadAndScanEncryptedMediaRequest {
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
     ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
-
         let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
-        let body = BytesBody(ruma::serde::json_to_buf(&body)?);
-
-        Ok(Request::builder().method(Self::METHOD).uri(url).body(body)?)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(RequestBody(body))?)
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/encrypted.rs
@@ -15,15 +15,19 @@
 use matrix_sdk::{RumaApiError, encryption::vodozemac::Curve25519PublicKey};
 use ruma::{
     api::{
-        BytesBody, Metadata, OutgoingRequest, auth_scheme::AccessTokenOptional,
+        Metadata, OutgoingBodyJson, OutgoingRequest, auth_scheme::AccessTokenOptional,
         error::IntoHttpError, path_builder::PathBuilder,
     },
     events::room::EncryptedFile,
     exports::http::Request,
     metadata,
 };
+use serde::Serialize;
 
-use crate::api::{encrypted_file_request_from, scan::MediaScanResponse};
+use crate::{
+    EncryptedFileRequest,
+    api::{encrypted_file_request_from, scan::MediaScanResponse},
+};
 
 metadata! {
     @for EncryptedMediaScanRequest,
@@ -54,8 +58,13 @@ impl EncryptedMediaScanRequest {
     }
 }
 
+#[doc(hidden)]
+#[derive(Serialize, OutgoingBodyJson)]
+#[serde(transparent)]
+pub struct RequestBody(EncryptedFileRequest);
+
 impl OutgoingRequest for EncryptedMediaScanRequest {
-    type Body = BytesBody;
+    type Body = RequestBody;
     type EndpointError = RumaApiError;
     type IncomingResponse = MediaScanResponse;
 
@@ -65,10 +74,7 @@ impl OutgoingRequest for EncryptedMediaScanRequest {
         path_builder_input: <Self::PathBuilder as PathBuilder>::Input<'_>,
     ) -> Result<Request<Self::Body>, IntoHttpError> {
         let url = Self::make_endpoint_url(path_builder_input, &self.scanner_url, &[], "")?;
-
         let body = encrypted_file_request_from(self.public_key, &self.encrypted_file)?;
-        let body = BytesBody(ruma::serde::json_to_buf(&body)?);
-
-        Ok(Request::builder().method(Self::METHOD).uri(url).body(body)?)
+        Ok(Request::builder().method(Self::METHOD).uri(url).body(RequestBody(body))?)
     }
 }


### PR DESCRIPTION
I didn't realize Ruma had already been upgraded here after my recent `OutgoingRequest` refactor. I reviewed https://github.com/matrix-org/matrix-rust-sdk/commit/d643e115b0406cfb79f93f10f3c67907333dff57 after getting merge conflicts and found two places where `BytesBody` was being used despite the endpoints in question not being media-related. While this works, it's not how the API was meant to be used and notably, if we ever added more useful functionality to `OutgoingBody` like error-tracking serialization, these requests would bypass that for no good reason.

- No public API changes
- This PR was made with the help of Rust-Analyzer, VSCode with all "AI" features disabled, arch linux, and the Lenovo IdeaPad I've been using since 2021

Signed-off-by: Jonas Platte
