### PR TITLE
fix(common): keep `RingBuffer`'s capacity across (de)serialization

### DIFF
--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1592,7 +1592,10 @@ mod tests {
                 "num_mentions": 0,
                 "num_notifications": 0,
                 "latest_active": null,
-                "pending": [],
+                "pending": {
+                    "items": [],
+                    "capacity": 10,
+                },
             },
             "recency_stamp": 42,
         });

--- a/crates/matrix-sdk-common/changelog.d/6815.fixed.md
+++ b/crates/matrix-sdk-common/changelog.d/6815.fixed.md
@@ -1,0 +1,3 @@
+`RingBuffer` now preserves its logical capacity when serializing and
+deserializing. Older serialized sequence-form buffers remain readable and use
+a legacy fallback capacity.

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -21,7 +21,7 @@ use std::{
     ops::RangeBounds,
 };
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// The capacity assigned to buffers written by older versions, which did not
 /// include the logical capacity in their serialized form.
@@ -32,20 +32,26 @@ const LEGACY_DEFAULT_CAPACITY: NonZeroUsize = NonZeroUsize::new(10).unwrap();
 /// A size is provided on creation, and the ring buffer reserves that much
 /// space, and never reallocates. The logical capacity is included in the
 /// serialized representation so it survives a round trip.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RingBuffer<T> {
+    #[serde(rename = "items")]
     inner: VecDeque<T>,
 
-    /// The maximum number of items to hold.
-    ///
-    /// Tracked separately from the `VecDeque`'s own allocation capacity.
+    /// The capacity to restore for the backing `VecDeque` during
+    /// deserialization.
     capacity: NonZeroUsize,
 }
 
 impl<T> RingBuffer<T> {
     fn from_parts(mut inner: VecDeque<T>, capacity: NonZeroUsize) -> Self {
-        while inner.len() > capacity.get() {
+        let capacity_as_usize = capacity.get();
+
+        for _ in capacity_as_usize..inner.len() {
             inner.pop_front();
+        }
+
+        if let Some(extra_space) = capacity_as_usize.checked_sub(inner.len()) {
+            inner.reserve_exact(extra_space);
         }
 
         Self { inner, capacity }
@@ -81,7 +87,7 @@ impl<T> RingBuffer<T> {
     /// Appends an element to the back of the ring buffer, dropping elements
     /// from the front if it is full.
     pub fn push(&mut self, value: T) {
-        while self.inner.len() >= self.capacity.get() {
+        if self.inner.len() == self.inner.capacity() {
             self.inner.pop_front();
         }
 
@@ -129,7 +135,7 @@ impl<T> RingBuffer<T> {
 
     /// Returns the total number of elements the `RingBuffer` can hold.
     pub fn capacity(&self) -> usize {
-        self.capacity.get()
+        self.inner.capacity()
     }
 
     /// Retains only the elements specified by the predicate.
@@ -141,27 +147,8 @@ impl<T> RingBuffer<T> {
     }
 }
 
-// We implement this manually because `capacity` is part of the ring buffer's
-// logical state but was not included in the old transparent sequence format.
-// The new representation stores both the items and their capacity.
-impl<T: Serialize> Serialize for RingBuffer<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        #[derive(Serialize)]
-        struct SerializedRingBuffer<'a, T> {
-            items: &'a VecDeque<T>,
-            capacity: NonZeroUsize,
-        }
-
-        SerializedRingBuffer { items: &self.inner, capacity: self.capacity }.serialize(serializer)
-    }
-}
-
-// Accept both the new representation and the old transparent sequence format.
-// The latter is needed to read RingBuffers persisted by older SDK versions;
-// deriving `Deserialize` would only handle the new object representation.
+// Migrate from the old RingBuffer type without the capacity field to the new
+// type.
 impl<'a, T: Deserialize<'a>> Deserialize<'a> for RingBuffer<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -425,14 +412,20 @@ mod tests {
         // Then I get back the same items and capacity I started with
         assert_eq!(ring_buffer, new_ring_buffer);
         assert_eq!(new_ring_buffer.capacity(), 3);
+        assert_eq!(new_ring_buffer.inner.capacity(), 3);
     }
 
     #[test]
     fn test_deserializes_the_legacy_sequence_format() {
-        let ring_buffer: RingBuffer<i32> = serde_json::from_str("[1,2]").unwrap();
+        let mut ring_buffer: RingBuffer<i32> = serde_json::from_str("[1,2]").unwrap();
 
         assert_eq!(ring_buffer.iter().copied().collect::<Vec<_>>(), vec![1, 2]);
         assert_eq!(ring_buffer.capacity(), 10);
+        assert_eq!(ring_buffer.inner.capacity(), 10);
+
+        // A partially filled legacy buffer must retain room for new items.
+        ring_buffer.push(3);
+        assert_eq!(ring_buffer.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
     }
 
     #[test]
@@ -519,6 +512,7 @@ mod tests {
 
         // Then it still has its original capacity and room for two more items.
         assert_eq!(ring_buffer.capacity(), 3);
+        assert_eq!(ring_buffer.inner.capacity(), 3);
         ring_buffer.push(2);
         ring_buffer.push(3);
 

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -21,23 +21,40 @@ use std::{
     ops::RangeBounds,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// The capacity assigned to buffers written by older versions, which did not
+/// include the logical capacity in their serialized form.
+const LEGACY_DEFAULT_CAPACITY: NonZeroUsize = NonZeroUsize::new(10).unwrap();
 
 /// A simple fixed-size ring buffer implementation.
 ///
 /// A size is provided on creation, and the ring buffer reserves that much
-/// space, and never reallocates.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(transparent)]
+/// space, and never reallocates. The logical capacity is included in the
+/// serialized representation so it survives a round trip.
+#[derive(Clone, Debug, PartialEq)]
 pub struct RingBuffer<T> {
     inner: VecDeque<T>,
+
+    /// The maximum number of items to hold.
+    ///
+    /// Tracked separately from the `VecDeque`'s own allocation capacity.
+    capacity: NonZeroUsize,
 }
 
 impl<T> RingBuffer<T> {
+    fn from_parts(mut inner: VecDeque<T>, capacity: NonZeroUsize) -> Self {
+        while inner.len() > capacity.get() {
+            inner.pop_front();
+        }
+
+        Self { inner, capacity }
+    }
+
     /// Create a ring buffer with the supplied capacity, reserving it so we
     /// never need to reallocate.
     pub fn new(size: NonZeroUsize) -> Self {
-        Self { inner: VecDeque::with_capacity(size.into()) }
+        Self::from_parts(VecDeque::with_capacity(size.into()), size)
     }
 
     /// Returns the number of items that are stored in this ring buffer.
@@ -61,9 +78,10 @@ impl<T> RingBuffer<T> {
         self.inner.get(index)
     }
 
-    /// Appends an element to the back of the ring buffer
+    /// Appends an element to the back of the ring buffer, dropping elements
+    /// from the front if it is full.
     pub fn push(&mut self, value: T) {
-        if self.inner.len() == self.inner.capacity() {
+        while self.inner.len() >= self.capacity.get() {
             self.inner.pop_front();
         }
 
@@ -111,7 +129,7 @@ impl<T> RingBuffer<T> {
 
     /// Returns the total number of elements the `RingBuffer` can hold.
     pub fn capacity(&self) -> usize {
-        self.inner.capacity()
+        self.capacity.get()
     }
 
     /// Retains only the elements specified by the predicate.
@@ -120,6 +138,52 @@ impl<T> RingBuffer<T> {
         F: FnMut(&T) -> bool,
     {
         self.inner.retain(predicate)
+    }
+}
+
+// We implement this manually because `capacity` is part of the ring buffer's
+// logical state but was not included in the old transparent sequence format.
+// The new representation stores both the items and their capacity.
+impl<T: Serialize> Serialize for RingBuffer<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct SerializedRingBuffer<'a, T> {
+            items: &'a VecDeque<T>,
+            capacity: NonZeroUsize,
+        }
+
+        SerializedRingBuffer { items: &self.inner, capacity: self.capacity }.serialize(serializer)
+    }
+}
+
+// Accept both the new representation and the old transparent sequence format.
+// The latter is needed to read RingBuffers persisted by older SDK versions;
+// deriving `Deserialize` would only handle the new object representation.
+impl<'a, T: Deserialize<'a>> Deserialize<'a> for RingBuffer<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum SerializedRingBuffer<T> {
+            WithCapacity { items: VecDeque<T>, capacity: NonZeroUsize },
+            Legacy(VecDeque<T>),
+        }
+
+        match SerializedRingBuffer::deserialize(deserializer)? {
+            SerializedRingBuffer::WithCapacity { items, capacity } => {
+                Ok(Self::from_parts(items, capacity))
+            }
+            SerializedRingBuffer::Legacy(items) => {
+                let capacity = NonZeroUsize::new(items.len().max(LEGACY_DEFAULT_CAPACITY.get()))
+                    .expect("legacy capacity is non-zero");
+                Ok(Self::from_parts(items, capacity))
+            }
+        }
     }
 }
 
@@ -351,15 +415,24 @@ mod tests {
 
         // When I serialize it
         let json = serde_json::to_string(&ring_buffer).expect("serialisation failed");
-        // Sanity: the JSON looks as we expect
-        assert_eq!(json, r#"["1","2"]"#);
+        // Sanity: the JSON includes the logical capacity
+        assert_eq!(json, r#"{"items":["1","2"],"capacity":3}"#);
 
         // And deserialize it
         let new_ring_buffer: RingBuffer<String> =
             serde_json::from_str(&json).expect("deserialisation failed");
 
-        // Then I get back the same as I started with
+        // Then I get back the same items and capacity I started with
         assert_eq!(ring_buffer, new_ring_buffer);
+        assert_eq!(new_ring_buffer.capacity(), 3);
+    }
+
+    #[test]
+    fn test_deserializes_the_legacy_sequence_format() {
+        let ring_buffer: RingBuffer<i32> = serde_json::from_str("[1,2]").unwrap();
+
+        assert_eq!(ring_buffer.iter().copied().collect::<Vec<_>>(), vec![1, 2]);
+        assert_eq!(ring_buffer.capacity(), 10);
     }
 
     #[test]
@@ -432,6 +505,24 @@ mod tests {
 
         // Then only the last N items remain
         assert_eq!(ring_buffer.iter().map(String::as_str).collect::<Vec<_>>(), vec!["6", "7"]);
+    }
+
+    #[test]
+    fn test_capacity_survives_a_serialization_round_trip() {
+        // Given a partially filled ring buffer with a non-default capacity,
+        let mut ring_buffer = RingBuffer::new(NonZeroUsize::new(3).unwrap());
+        ring_buffer.push(1);
+
+        // When it's deserialized back,
+        let json = serde_json::to_string(&ring_buffer).unwrap();
+        let mut ring_buffer: RingBuffer<i32> = serde_json::from_str(&json).unwrap();
+
+        // Then it still has its original capacity and room for two more items.
+        assert_eq!(ring_buffer.capacity(), 3);
+        ring_buffer.push(2);
+        ring_buffer.push(3);
+
+        assert_eq!(ring_buffer.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes `RingBuffer` capacity being lost across serialization and deserialization. The buffer previously relied on the backing `VecDeque`’s allocation capacity as its logical capacity. Since serde only serialized the items, deserialization recreated the `VecDeque` with capacity equal to the number of stored items. A partially filled buffer could therefore come back effectively full, causing every subsequent push to evict an existing item.

`RoomReadReceipts::pending` uses a `RingBuffer` to retain read receipts whose target events are not currently known by the timeline. This can happen when a receipt arrives before the corresponding event, for example with limited sync responses or federation delays. Those pending receipts are persisted as part of `RoomInfo`. After restoring them, the old implementation could shrink the ring buffer to the number of currently stored receipts. Once that happened, newly received pending receipts would evict older ones immediately. In particular, the receipt needed to advance `latest_active` could be lost, leaving unread counts incorrect even though the client had received the relevant receipt.

By preserving the logical capacity, pending read receipts survive persistence and can continue to be matched when their corresponding events become available.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.