### PR TITLE
perf(sdk): Revisit the `Redecryptor::on_resolved_utds` flow by resolving only once per event

### DIFF
--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1044,8 +1044,8 @@ impl fmt::Debug for TimelineEventKind {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
 /// A successfully-decrypted encrypted event.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DecryptedRoomEvent {
     /// The decrypted event.
     ///

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -662,7 +662,7 @@ impl EventFocusedCache {
     /// list of decrypted events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
-    pub async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
+    pub async fn replace_in_memory_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
         let mut guard = self.inner.write().await?;
 
         if guard.chunk.replace_utds(events) {

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -42,6 +42,8 @@ use ruma::{OwnedEventId, UInt, api::Direction};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{instrument, trace};
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::{MaybeResolvedEvent, TryResolveEvents};
 use super::{
     super::{
         EventCacheError, EventsOrigin, Result, RoomEventCacheLinkedChunkUpdate,
@@ -660,10 +662,20 @@ impl EventFocusedCache {
     /// list of resolved events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
-    pub async fn replace_in_memory_utds(&self, resolved_events: &[Event]) -> Result<()> {
+    pub(in super::super) async fn replace_in_memory_utds(
+        &self,
+        resolved_events: &[MaybeResolvedEvent],
+    ) -> Result<()> {
         let mut state = self.inner.write().await?;
 
-        if state.chunk.replace_utds(resolved_events) {
+        // `Redecryptor` tried to resolve the events partly based on in-store events.
+        // Because this cache doesn't persist anything in the store, `Redecryptor` is
+        // unable to resolve some events present here. To address that, let's try to
+        // resolve events here with the current `EventLinkedChunk`.
+        let new_resolved_events = resolved_events.try_resolve_events(&state.chunk);
+
+        if state.chunk.replace_utds(&new_resolved_events) {
+            state.propagate_changes();
             state.notify_subscribers(EventsOrigin::Cache);
         }
 

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -42,8 +42,6 @@ use ruma::{OwnedEventId, UInt, api::Direction};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{instrument, trace};
 
-#[cfg(feature = "e2e-encryption")]
-use super::super::redecryptor::ResolvedUtd;
 use super::{
     super::{
         EventCacheError, EventsOrigin, Result, RoomEventCacheLinkedChunkUpdate,
@@ -659,15 +657,14 @@ impl EventFocusedCache {
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given
-    /// list of decrypted events, and replace them, while alerting observers
+    /// list of resolved events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
-    pub async fn replace_in_memory_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
-        let mut guard = self.inner.write().await?;
+    pub async fn replace_in_memory_utds(&self, resolved_events: &[Event]) -> Result<()> {
+        let mut state = self.inner.write().await?;
 
-        if guard.chunk.replace_utds(events) {
-            guard.propagate_changes();
-            guard.notify_subscribers(EventsOrigin::Cache);
+        if state.chunk.replace_utds(resolved_events) {
+            state.notify_subscribers(EventsOrigin::Cache);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "e2e-encryption")]
-use std::collections::BTreeSet;
-
 use as_variant::as_variant;
 use eyeball_im::VectorDiff;
-#[cfg(feature = "e2e-encryption")]
-use matrix_sdk_base::deserialized_responses::TimelineEventKind;
 pub use matrix_sdk_base::event_cache::{Event, Gap};
 use matrix_sdk_base::{
     event_cache::store::DEFAULT_CHUNK_CAPACITY,
@@ -32,9 +27,6 @@ use matrix_sdk_common::linked_chunk::{
     Position,
 };
 use tracing::{instrument, trace};
-
-#[cfg(feature = "e2e-encryption")]
-use crate::event_cache::redecryptor::ResolvedUtd;
 
 /// This type represents a linked chunk of events for a single room or thread.
 #[derive(Debug)]
@@ -478,38 +470,25 @@ impl EventLinkedChunk {
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given
-    /// list of decrypted events, and replace them.
+    /// list of resolved events, and replace them.
     ///
     /// Returns true if at least one event has been replaced, false otherwise.
     #[cfg(feature = "e2e-encryption")]
-    pub fn replace_utds(&mut self, events: &[ResolvedUtd]) -> bool {
-        let event_set = self
-            .events()
-            .filter_map(|(_pos, ev)| ev.event_id().map(ToOwned::to_owned))
-            .collect::<BTreeSet<_>>();
-
+    pub fn replace_utds(&mut self, resolved_events: &[Event]) -> bool {
         let mut replaced_some = false;
 
-        for (event_id, decrypted, actions) in events {
-            // As a performance optimization, do a lookup in the current pinned events
-            // check, before looking for the event in the linked chunk.
-
-            if !event_set.contains(event_id) {
-                continue;
-            }
-
-            // The event should be in the linked chunk.
-            let Some((position, mut target_event)) = self.find_event(event_id) else {
+        for resolved_event in resolved_events {
+            let Some(event_id) = resolved_event.event_id() else {
+                // No event ID? Let's skip it.
                 continue;
             };
 
-            target_event.kind = TimelineEventKind::Decrypted(decrypted.clone());
+            // The event should be in the linked chunk.
+            let Some((position, _)) = self.find_event(event_id) else {
+                continue;
+            };
 
-            if let Some(actions) = actions {
-                target_event.set_push_actions(actions.clone());
-            }
-
-            self.replace_event_at(position, target_event.clone())
+            self.replace_event_at(position, resolved_event.clone())
                 .expect("position should be valid");
 
             replaced_some = true;

--- a/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
@@ -28,6 +28,9 @@ use matrix_sdk_common::linked_chunk::{
 };
 use tracing::{instrument, trace};
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::MaybeResolvedEvent;
+
 /// This type represents a linked chunk of events for a single room or thread.
 #[derive(Debug)]
 pub(in crate::event_cache) struct EventLinkedChunk {
@@ -474,10 +477,12 @@ impl EventLinkedChunk {
     ///
     /// Returns true if at least one event has been replaced, false otherwise.
     #[cfg(feature = "e2e-encryption")]
-    pub fn replace_utds(&mut self, resolved_events: &[Event]) -> bool {
+    pub fn replace_utds(&mut self, resolved_events: &[MaybeResolvedEvent]) -> bool {
         let mut replaced_some = false;
 
-        for resolved_event in resolved_events {
+        for resolved_event in
+            resolved_events.iter().filter_map(|resolved_event| resolved_event.as_resolved())
+        {
             let Some(event_id) = resolved_event.event_id() else {
                 // No event ID? Let's skip it.
                 continue;

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -510,7 +510,10 @@ impl PinnedEventsCache {
     /// list of decrypted events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
-    pub(in super::super) async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<()> {
+    pub(in super::super) async fn replace_in_memory_utds(
+        &self,
+        events: &[ResolvedUtd],
+    ) -> Result<()> {
         let mut guard = self.inner.state.write().await?;
 
         if guard.state.chunk.replace_utds(events) {

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -36,8 +36,6 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{debug, instrument, trace, warn};
 
 pub(super) use self::updates::PinnedEventsCacheUpdateSender;
-#[cfg(feature = "e2e-encryption")]
-use super::super::redecryptor::ResolvedUtd;
 use super::{
     super::{
         EventCacheError, EventsOrigin, Result,
@@ -507,18 +505,22 @@ impl PinnedEventsCache {
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given
-    /// list of decrypted events, and replace them, while alerting observers
+    /// list of resolved events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
     pub(in super::super) async fn replace_in_memory_utds(
         &self,
-        events: &[ResolvedUtd],
+        resolved_events: &[Event],
     ) -> Result<()> {
-        let mut guard = self.inner.state.write().await?;
+        let mut state = self.inner.state.write().await?;
 
-        if guard.state.chunk.replace_utds(events) {
-            guard.propagate_changes().await?;
-            guard.notify_subscribers(EventsOrigin::Cache);
+        // Drain the updates to the store, events have already been updated before
+        // calling this method.
+        let _ = state.state.chunk.store_updates().take();
+
+        if state.state.chunk.replace_utds(resolved_events) {
+            state.propagate_changes().await?;
+            state.notify_subscribers(EventsOrigin::Cache);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -36,6 +36,8 @@ use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{debug, instrument, trace, warn};
 
 pub(super) use self::updates::PinnedEventsCacheUpdateSender;
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::MaybeResolvedEvent;
 use super::{
     super::{
         EventCacheError, EventsOrigin, Result,
@@ -510,7 +512,7 @@ impl PinnedEventsCache {
     #[cfg(feature = "e2e-encryption")]
     pub(in super::super) async fn replace_in_memory_utds(
         &self,
-        resolved_events: &[Event],
+        resolved_events: &[MaybeResolvedEvent],
     ) -> Result<()> {
         let mut state = self.inner.state.write().await?;
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -39,6 +39,8 @@ use ruma::{
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace, warn};
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::super::redecryptor::MaybeResolvedEvent;
 use super::{
     super::{
         super::{
@@ -779,7 +781,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
     pub(in super::super::super) fn replace_in_memory_utds(
         &mut self,
-        resolved_events: &[Event],
+        resolved_events: &[MaybeResolvedEvent],
     ) -> Result<Option<Vec<VectorDiff<Event>>>, EventCacheError> {
         Ok(if self.room_linked_chunk_mut().replace_utds(resolved_events) {
             // Drain the updates to the store, events have already been updated with

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -772,6 +772,26 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         Ok(())
     }
 
+    /// Try to locate the events in the linked chunk corresponding to the given
+    /// list of resolved events, and replace them, while alerting observers
+    /// about the update.
+    #[cfg(feature = "e2e-encryption")]
+    #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
+    pub(in super::super::super) fn replace_in_memory_utds(
+        &mut self,
+        resolved_events: &[Event],
+    ) -> Result<Option<Vec<VectorDiff<Event>>>, EventCacheError> {
+        Ok(if self.room_linked_chunk_mut().replace_utds(resolved_events) {
+            // Drain the updates to the store, events have already been updated with
+            // `save_events`!
+            let _ = self.room_linked_chunk_mut().store_updates().take();
+
+            Some(self.room_linked_chunk_mut().updates_as_vector_diffs())
+        } else {
+            None
+        })
+    }
+
     /// Save events into the database, without notifying observers.
     pub async fn save_events(
         &mut self,

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -287,9 +287,12 @@ impl ThreadEventCache {
     ///
     /// Return `true` if at least one event has been updated.
     #[cfg(feature = "e2e-encryption")]
-    pub(in super::super) async fn replace_utds(&self, events: &[ResolvedUtd]) -> Result<bool> {
+    pub(in super::super) async fn replace_in_memory_utds(
+        &self,
+        events: &[ResolvedUtd],
+    ) -> Result<bool> {
         let mut state = self.inner.state.write().await?;
-        let timeline_event_diffs = state.replace_utds(events).await?;
+        let timeline_event_diffs = state.replace_in_memory_utds(events).await?;
 
         Ok(
             if let Some(timeline_event_diffs) = timeline_event_diffs

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -34,6 +34,8 @@ use tracing::{instrument, trace};
 use self::pagination::ThreadPagination;
 pub(in super::super) use self::state::ThreadEventCacheState;
 pub(super) use self::updates::ThreadEventCacheUpdateSender;
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::MaybeResolvedEvent;
 use super::{
     super::{
         Result,
@@ -287,7 +289,7 @@ impl ThreadEventCache {
     #[cfg(feature = "e2e-encryption")]
     pub(in super::super) async fn replace_in_memory_utds(
         &self,
-        resolved_events: &[Event],
+        resolved_events: &[MaybeResolvedEvent],
     ) -> Result<bool> {
         let mut state = self.inner.state.write().await?;
         let timeline_event_diffs = state.replace_in_memory_utds(resolved_events)?;

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -34,8 +34,6 @@ use tracing::{instrument, trace};
 use self::pagination::ThreadPagination;
 pub(in super::super) use self::state::ThreadEventCacheState;
 pub(super) use self::updates::ThreadEventCacheUpdateSender;
-#[cfg(feature = "e2e-encryption")]
-use super::super::redecryptor::ResolvedUtd;
 use super::{
     super::{
         Result,
@@ -282,17 +280,21 @@ impl ThreadEventCache {
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given
-    /// list of decrypted events, and replace them, while alerting observers
+    /// list of resolved events, and replace them, while alerting observers
     /// about the update.
     ///
     /// Return `true` if at least one event has been updated.
     #[cfg(feature = "e2e-encryption")]
     pub(in super::super) async fn replace_in_memory_utds(
         &self,
-        events: &[ResolvedUtd],
+        resolved_events: &[Event],
     ) -> Result<bool> {
         let mut state = self.inner.state.write().await?;
-        let timeline_event_diffs = state.replace_in_memory_utds(events).await?;
+        let timeline_event_diffs = state.replace_in_memory_utds(resolved_events)?;
+
+        // Drain the updates to the store, events have already been updated before
+        // calling this method.
+        let _ = state.thread_linked_chunk_mut().store_updates().take();
 
         Ok(
             if let Some(timeline_event_diffs) = timeline_event_diffs

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -691,7 +691,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
     #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
-    pub(in super::super) async fn replace_utds(
+    pub(in super::super) async fn replace_in_memory_utds(
         &mut self,
         events: &[ResolvedUtd],
     ) -> Result<Option<Vec<VectorDiff<Event>>>> {

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -32,8 +32,6 @@ use ruma::{
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
 
-#[cfg(feature = "e2e-encryption")]
-use super::super::super::redecryptor::ResolvedUtd;
 use super::{
     super::{
         super::{
@@ -687,17 +685,15 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given
-    /// list of decrypted events, and replace them, while alerting observers
+    /// list of resolved events, and replace them, while alerting observers
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
     #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
-    pub(in super::super) async fn replace_in_memory_utds(
+    pub(in super::super) fn replace_in_memory_utds(
         &mut self,
-        events: &[ResolvedUtd],
+        resolved_events: &[Event],
     ) -> Result<Option<Vec<VectorDiff<Event>>>> {
-        Ok(if self.thread_linked_chunk_mut().replace_utds(events) {
-            self.state.propagate_changes(&self.store).await?;
-
+        Ok(if self.thread_linked_chunk_mut().replace_utds(resolved_events) {
             Some(self.thread_linked_chunk_mut().updates_as_vector_diffs())
         } else {
             None

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -32,6 +32,8 @@ use ruma::{
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::super::redecryptor::MaybeResolvedEvent;
 use super::{
     super::{
         super::{
@@ -691,7 +693,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
     pub(in super::super) fn replace_in_memory_utds(
         &mut self,
-        resolved_events: &[Event],
+        resolved_events: &[MaybeResolvedEvent],
     ) -> Result<Option<Vec<VectorDiff<Event>>>> {
         Ok(if self.thread_linked_chunk_mut().replace_utds(resolved_events) {
             Some(self.thread_linked_chunk_mut().updates_as_vector_diffs())

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -716,7 +716,9 @@ impl EventCacheInner {
         }
 
         // Invited rooms.
-        // TODO: we don't anything with `updates.invite` at this point.
+        //
+        // We don't handle `updates.invite` because they contain stripped-state events,
+        // which is not handled by the Event Cache for the moment.
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -352,7 +352,7 @@ impl EventCache {
         timer!("Resolving UTDs");
 
         let event_ids: BTreeSet<_> =
-            resolved_utds.iter().cloned().map(|(event_id, _, _)| event_id).collect();
+            resolved_utds.iter().map(|(event_id, _, _)| event_id.clone()).collect();
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
         let mut resolved_events = Vec::with_capacity(resolved_utds.len());

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -155,7 +155,8 @@ use tracing::{info, instrument, trace, warn};
 use super::RoomEventCache;
 use super::{
     EventCache, EventCacheError, EventCacheInner, EventsOrigin, RoomEventCacheGenericUpdate,
-    RoomEventCacheUpdate, TimelineVectorDiffs, caches::room::RoomEventCacheLinkedChunkUpdate,
+    RoomEventCacheUpdate, TimelineVectorDiffs,
+    caches::{EventLocation, room::RoomEventCacheLinkedChunkUpdate},
 };
 use crate::{Client, Result, Room, encryption::backups::BackupState, room::PushContext};
 
@@ -164,8 +165,7 @@ type OwnedSessionId = String;
 
 type EventIdAndUtd = (OwnedEventId, Raw<AnySyncTimelineEvent>);
 type EventIdAndEvent = (OwnedEventId, DecryptedRoomEvent);
-pub(in crate::event_cache) type ResolvedUtd =
-    (OwnedEventId, DecryptedRoomEvent, Option<Vec<Action>>);
+type ResolvedUtd = (OwnedEventId, DecryptedRoomEvent, Option<Vec<Action>>);
 
 /// The information sent across the channel to the long-running task requesting
 /// that the supplied set of sessions be retried.
@@ -355,16 +355,19 @@ impl EventCache {
             resolved_utds.iter().cloned().map(|(event_id, _, _)| event_id).collect();
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
+        let mut resolved_events = Vec::with_capacity(resolved_utds.len());
 
-        // Resolve in-store and in-memory UTDs with the room cache.
+        // For each resolved UTD, find the corresponding event, build the resolved
+        // event, and replace it in the store. We use the room cache for that
+        // because it contains all events so far.
         {
             let room_cache = &all_caches.room;
             let mut state = room_cache.state().write().await?;
 
-            let mut new_events = Vec::with_capacity(resolved_utds.len());
+            let mut in_memory_resolved_events = Vec::new();
 
-            for (event_id, decrypted_event, actions) in &resolved_utds {
-                if let Some((location, mut event)) = state.find_event(event_id).await?
+            for (event_id, decrypted_event, actions) in resolved_utds {
+                if let Some((location, mut event)) = state.find_event(&event_id).await?
                     && (
                         // There is a race between the multiple sources of updates. It's possible
                         // that two sources trigger a decryption for the same event (for example,
@@ -380,18 +383,26 @@ impl EventCache {
                             || event.encryption_info() != Some(&decrypted_event.encryption_info)
                     )
                 {
-                    event.kind = TimelineEventKind::Decrypted(decrypted_event.clone());
+                    event.kind = TimelineEventKind::Decrypted(decrypted_event);
 
                     if let Some(actions) = actions {
-                        event.set_push_actions(actions.clone());
+                        event.set_push_actions(actions);
                     }
 
-                    // TODO: `replace_event_at()` propagates changes to the store for every
-                    // event, we should probably have a bulk version of this?
-                    state.replace_event_at(location, event.clone()).await?;
-                    new_events.push(event);
+                    if matches!(location, EventLocation::Memory(_)) {
+                        in_memory_resolved_events.push(event.clone());
+                    }
+
+                    resolved_events.push(event);
                 }
             }
+
+            // Replace all resolved events in the store.
+            state.save_events(resolved_events.iter().cloned()).await?;
+
+            // Now, replace the in-memory events.
+            let mut timeline_event_diffs =
+                state.replace_in_memory_utds(&in_memory_resolved_events)?.unwrap_or_default();
 
             // Read receipt events aren't encrypted, so we can't have decrypted a new
             // one here. As a result, we don't have any new receipt events to
@@ -402,14 +413,14 @@ impl EventCache {
             // unreads.
             let receipt_event = None;
 
-            state.post_process_new_events(new_events, receipt_event).await?;
+            state.post_process_new_events(resolved_events.clone(), receipt_event).await?;
 
-            let updates_as_vector_diffs = state.room_linked_chunk_mut().updates_as_vector_diffs();
+            timeline_event_diffs.extend(state.room_linked_chunk_mut().updates_as_vector_diffs());
 
-            if !updates_as_vector_diffs.is_empty() {
-                room_cache.update_sender().send(
+            if !timeline_event_diffs.is_empty() {
+                state.update_sender.send(
                     RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
-                        diffs: updates_as_vector_diffs,
+                        diffs: timeline_event_diffs,
                         origin: EventsOrigin::Cache,
                     }),
                     Some(RoomEventCacheGenericUpdate { room_id: room_id.to_owned() }),
@@ -432,7 +443,7 @@ impl EventCache {
                         // If at least one event has been replaced, return the `thread_id` and the
                         // `thread_cache` to update the thread summary later.
                         thread_cache
-                            .replace_in_memory_utds(&resolved_utds)
+                            .replace_in_memory_utds(&resolved_events)
                             .await?
                             .then(|| (thread_id.clone(), thread_cache.clone())),
                     )
@@ -452,7 +463,7 @@ impl EventCache {
 
         // Resolve in-memory UTDs on the pinned-events cache.
         if let Some(pinned_events_cache) = all_caches.pinned_events.get() {
-            pinned_events_cache.replace_in_memory_utds(&resolved_utds).await?;
+            pinned_events_cache.replace_in_memory_utds(&resolved_events).await?;
         }
 
         // Resolve in-memory UTDs on the event-focused caches.
@@ -462,7 +473,7 @@ impl EventCache {
             // accumulate over time. Consider keeping track of which linked chunk
             // contains which event ID, to avoid doing the linear searches here.
             try_join_all(all_caches.event_focused.read().await.values().map(
-                |event_focused_cache| event_focused_cache.replace_in_memory_utds(&resolved_utds),
+                |event_focused_cache| event_focused_cache.replace_in_memory_utds(&resolved_events),
             ))
             .await?;
         }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -732,13 +732,11 @@ impl EventCache {
             }
         }
 
-        if !decrypted_events.is_empty() {
-            if tracing::level_enabled!(tracing::Level::TRACE) {
-                let event_ids: BTreeSet<_> =
-                    decrypted_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
+        if !decrypted_events.is_empty() && tracing::level_enabled!(tracing::Level::TRACE) {
+            let event_ids: BTreeSet<_> =
+                decrypted_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
 
-                trace!(?event_ids, "Successfully redecrypted events");
-            }
+            trace!(?event_ids, "Successfully redecrypted events");
         }
 
         // Replace the events and notify listeners that UTDs have been replaced with
@@ -776,13 +774,11 @@ impl EventCache {
             }
         }
 
-        if !updated_events.is_empty() {
-            if tracing::level_enabled!(tracing::Level::TRACE) {
-                let event_ids: BTreeSet<_> =
-                    updated_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
+        if !updated_events.is_empty() && tracing::level_enabled!(tracing::Level::TRACE) {
+            let event_ids: BTreeSet<_> =
+                updated_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
 
-                trace!(?event_ids, "Replacing the encryption info of some events");
-            }
+            trace!(?event_ids, "Replacing the encryption info of some events");
         }
 
         self.on_resolved_utds(room.room_id(), updated_events).await

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -165,7 +165,12 @@ type OwnedSessionId = String;
 
 type EventIdAndUtd = (OwnedEventId, Raw<AnySyncTimelineEvent>);
 type EventIdAndEvent = (OwnedEventId, DecryptedRoomEvent);
-type ResolvedUtd = (OwnedEventId, DecryptedRoomEvent, Option<Vec<Action>>);
+
+struct ResolvedUtd {
+    event_id: OwnedEventId,
+    decrypted_event: DecryptedRoomEvent,
+    actions: Option<Vec<Action>>,
+}
 
 /// The information sent across the channel to the long-running task requesting
 /// that the supplied set of sessions be retried.
@@ -352,7 +357,7 @@ impl EventCache {
         timer!("Resolving UTDs");
 
         let event_ids: BTreeSet<_> =
-            resolved_utds.iter().map(|(event_id, _, _)| event_id.clone()).collect();
+            resolved_utds.iter().map(|resolved_utd| resolved_utd.event_id.clone()).collect();
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
         let mut resolved_events = Vec::with_capacity(resolved_utds.len());
@@ -366,7 +371,7 @@ impl EventCache {
 
             let mut in_memory_resolved_events = Vec::new();
 
-            for (event_id, decrypted_event, actions) in resolved_utds {
+            for ResolvedUtd { event_id, decrypted_event, actions } in resolved_utds {
                 if let Some((location, mut event)) = state.find_event(&event_id).await?
                     && (
                         // There is a race between the multiple sources of updates. It's possible
@@ -601,7 +606,7 @@ impl EventCache {
         for (event_id, event) in events {
             // If we managed to decrypt the event, and we should have to since we received
             // the room key for this specific event, then replace the event.
-            if let Some((decrypted, actions)) = self
+            if let Some((decrypted_event, actions)) = self
                 .decrypt_event(
                     room_id,
                     room.as_ref(),
@@ -610,14 +615,14 @@ impl EventCache {
                 )
                 .await
             {
-                decrypted_events.push((event_id, decrypted, actions));
+                decrypted_events.push(ResolvedUtd { event_id, decrypted_event, actions });
             }
         }
 
         if !decrypted_events.is_empty() {
             if tracing::level_enabled!(tracing::Level::TRACE) {
                 let event_ids: BTreeSet<_> =
-                    decrypted_events.iter().map(|(event_id, _, _)| event_id).collect();
+                    decrypted_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
 
                 trace!(?event_ids, "Successfully redecrypted events");
             }
@@ -649,7 +654,11 @@ impl EventCache {
                     && event.encryption_info != new_encryption_info
                 {
                     event.encryption_info = new_encryption_info;
-                    updated_events.push((event_id, event, None));
+                    updated_events.push(ResolvedUtd {
+                        event_id,
+                        decrypted_event: event,
+                        actions: None,
+                    });
                 }
             }
         }
@@ -657,7 +666,7 @@ impl EventCache {
         if !updated_events.is_empty() {
             if tracing::level_enabled!(tracing::Level::TRACE) {
                 let event_ids: BTreeSet<_> =
-                    updated_events.iter().map(|(event_id, _, _)| event_id).collect();
+                    updated_events.iter().map(|resolved_utd| &resolved_utd.event_id).collect();
 
                 trace!(?event_ids, "Replacing the encryption info of some events");
             }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -114,6 +114,7 @@
 //! [MSC3061]: https://github.com/matrix-org/matrix-spec/pull/1655#issuecomment-2213152255
 
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet},
     pin::Pin,
     sync::Weak,
@@ -158,7 +159,10 @@ use super::{
     RoomEventCacheUpdate, TimelineVectorDiffs,
     caches::{EventLocation, room::RoomEventCacheLinkedChunkUpdate},
 };
-use crate::{Client, Result, Room, encryption::backups::BackupState, room::PushContext};
+use crate::{
+    Client, Result, Room, encryption::backups::BackupState,
+    event_cache::caches::event_linked_chunk::EventLinkedChunk, room::PushContext,
+};
 
 type SessionId<'a> = &'a str;
 type OwnedSessionId = String;
@@ -166,10 +170,110 @@ type OwnedSessionId = String;
 type EventIdAndUtd = (OwnedEventId, Raw<AnySyncTimelineEvent>);
 type EventIdAndEvent = (OwnedEventId, DecryptedRoomEvent);
 
-struct ResolvedUtd {
-    event_id: OwnedEventId,
+#[derive(Clone)]
+pub(super) struct ResolvedUtd {
+    pub event_id: OwnedEventId,
     decrypted_event: DecryptedRoomEvent,
     actions: Option<Vec<Action>>,
+}
+
+#[derive(Clone)]
+pub(super) enum MaybeResolvedEvent {
+    NotYet(ResolvedUtd),
+    Resolved(TimelineEvent),
+}
+
+impl MaybeResolvedEvent {
+    pub fn try_resolve_event(self, mut unresolved_event: TimelineEvent) -> Self {
+        match self {
+            Self::NotYet(resolved_utd) => {
+                // There is a race between the multiple sources of updates. It's possible
+                // that two sources trigger a decryption for the same event (for example,
+                // the room key stream and the event cache updates). It is then likely that
+                // the event has been already resolved. This race is fine, but we should
+                // avoid to replace an event that has already been resolved as it is a
+                // non-negligible operation.
+                //
+                // Note that a simple check like “event's kind is `UnableToDecrypt`” is not
+                // enough. The event can already be decrypted but its encryption info can
+                // change. So we must ensure they are also different.
+                if matches!(unresolved_event.kind, TimelineEventKind::UnableToDecrypt { .. })
+                    || unresolved_event.encryption_info()
+                        != Some(&resolved_utd.decrypted_event.encryption_info)
+                {
+                    unresolved_event.kind =
+                        TimelineEventKind::Decrypted(resolved_utd.decrypted_event);
+
+                    if let Some(actions) = resolved_utd.actions {
+                        unresolved_event.set_push_actions(actions);
+                    }
+
+                    // The unresolved event becomes resolved :-].
+                    Self::Resolved(unresolved_event)
+                } else {
+                    Self::NotYet(resolved_utd)
+                }
+            }
+
+            Self::Resolved(event) => Self::Resolved(event),
+        }
+    }
+
+    pub fn as_resolved(&self) -> Option<&TimelineEvent> {
+        if let Self::Resolved(event) = self { Some(event) } else { None }
+    }
+}
+
+/// Internal trait to resolve events on a `&[MaybeResolvedEvent]` with the help
+/// of `Cow` to avoid copying if no event is newly resolved.
+pub(super) trait TryResolveEvents {
+    fn try_resolve_events(
+        &self,
+        event_linked_chunk: &EventLinkedChunk,
+    ) -> Cow<'_, [MaybeResolvedEvent]>;
+}
+
+impl TryResolveEvents for [MaybeResolvedEvent] {
+    fn try_resolve_events(
+        &self,
+        event_linked_chunk: &EventLinkedChunk,
+    ) -> Cow<'_, [MaybeResolvedEvent]> {
+        let mut new_resolved_events = Cow::Borrowed(self);
+
+        for (nth, resolved_event) in self.iter().enumerate() {
+            match resolved_event {
+                MaybeResolvedEvent::NotYet(resolved_utd) => {
+                    // Event has not been resolved. Let's try to locate the corresponding event with
+                    // the provided `EventLinkedChunk` and try to resolve it.
+
+                    if let Some((_location, event)) =
+                        event_linked_chunk.find_event(&resolved_utd.event_id)
+                    {
+                        let new_resolved_event = MaybeResolvedEvent::NotYet(resolved_utd.clone())
+                            .try_resolve_event(event);
+
+                        if matches!(new_resolved_event, MaybeResolvedEvent::Resolved(_)) {
+                            // Use `slice::get_unchecked_mut` to avoid a bounds check.
+                            //
+                            // SAFETY: `self` and `new_resolved_events` have the same size and
+                            // represent the same data. Thus, the index `nth` exists in
+                            // `new_resolved_events`.
+                            unsafe {
+                                *new_resolved_events.to_mut().get_unchecked_mut(nth) =
+                                    new_resolved_event;
+                            }
+                        }
+                    }
+                }
+
+                MaybeResolvedEvent::Resolved(_event) => {
+                    // Event has already been resolved. Nothing to do.
+                }
+            }
+        }
+
+        new_resolved_events
+    }
 }
 
 /// The information sent across the channel to the long-running task requesting
@@ -360,54 +464,61 @@ impl EventCache {
             resolved_utds.iter().map(|resolved_utd| resolved_utd.event_id.clone()).collect();
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
-        let mut resolved_events = Vec::with_capacity(resolved_utds.len());
+        let mut maybe_resolved_events = Vec::with_capacity(resolved_utds.len());
 
-        // For each resolved UTD, find the corresponding event, build the resolved
-        // event, and replace it in the store. We use the room cache for that
-        // because it contains all events so far.
+        // # Room cache, thread caches, and pinned-event cache
+        //
+        // For each resolved UTD, find the corresponding event (either in-store or
+        // in-memory of the room cache), build the resolved event, and replace it in the
+        // store. We use the room cache for that because it contains all events (there
+        // is an exception with the event-focused cache, see below).
+        //
+        // # Event-focused cache
+        //
+        // Events received by the sync or pagination are not forwarded to the
+        // event-focused cache: it handles its own set of events. All of them live
+        // in-memory, there are not put in the store by any cache. So this cache will
+        // miss all UTD resolutions. To address that, the event-focused cache
+        // resolves UTD on its own, without the general logic described above.
         {
             let room_cache = &all_caches.room;
             let mut state = room_cache.state().write().await?;
 
-            let mut in_memory_resolved_events = Vec::new();
+            let mut maybe_resolved_in_memory_events = Vec::new();
 
-            for ResolvedUtd { event_id, decrypted_event, actions } in resolved_utds {
-                if let Some((location, mut event)) = state.find_event(&event_id).await?
-                    && (
-                        // There is a race between the multiple sources of updates. It's possible
-                        // that two sources trigger a decryption for the same event (for example,
-                        // the room key stream and the event cache updates). It is then likely that
-                        // the event has been already resolved. This race is fine, but we should
-                        // avoid to replace an event that has already been resolved as it is a
-                        // non-negligible operation.
-                        //
-                        // Note that a simple check like “event's kind is `UnableToDecrypt`” is not
-                        // enough. The event can already be decrypted but its encryption info can
-                        // change. So we must ensure they are also different.
-                        matches!(event.kind, TimelineEventKind::UnableToDecrypt { .. })
-                            || event.encryption_info() != Some(&decrypted_event.encryption_info)
-                    )
-                {
-                    event.kind = TimelineEventKind::Decrypted(decrypted_event);
+            for resolved_utd in resolved_utds {
+                // Try to locate the event (either in-store or in-memory).
+                if let Some((location, event)) = state.find_event(&resolved_utd.event_id).await? {
+                    let maybe_resolved_event =
+                        MaybeResolvedEvent::NotYet(resolved_utd).try_resolve_event(event);
 
-                    if let Some(actions) = actions {
-                        event.set_push_actions(actions);
-                    }
-
+                    // It is an in-memory event, let's keep it apart to replace in-memory UTDs.
                     if matches!(location, EventLocation::Memory(_)) {
-                        in_memory_resolved_events.push(event.clone());
+                        maybe_resolved_in_memory_events.push(maybe_resolved_event.clone());
                     }
 
-                    resolved_events.push(event);
+                    // Even is known, let's keep it for later, even if unresolved.
+                    maybe_resolved_events.push(maybe_resolved_event);
+                } else {
+                    // Event is unknown by the room cache, the thread caches, nor the pinned-events
+                    // cache. However, it might be known by an event-focused cache! So let's keep it
+                    // for later.
+                    maybe_resolved_events.push(MaybeResolvedEvent::NotYet(resolved_utd));
                 }
             }
 
+            let resolved_events = maybe_resolved_events
+                .iter()
+                .filter_map(|resolved_event| resolved_event.as_resolved())
+                .cloned()
+                .collect::<Vec<_>>();
+
             // Replace all resolved events in the store.
-            state.save_events(resolved_events.iter().cloned()).await?;
+            state.save_events(resolved_events.clone().into_iter()).await?;
 
             // Now, replace the in-memory events.
             let mut timeline_event_diffs =
-                state.replace_in_memory_utds(&in_memory_resolved_events)?.unwrap_or_default();
+                state.replace_in_memory_utds(&maybe_resolved_in_memory_events)?.unwrap_or_default();
 
             // Read receipt events aren't encrypted, so we can't have decrypted a new
             // one here. As a result, we don't have any new receipt events to
@@ -418,7 +529,7 @@ impl EventCache {
             // unreads.
             let receipt_event = None;
 
-            state.post_process_new_events(resolved_events.clone(), receipt_event).await?;
+            state.post_process_new_events(resolved_events, receipt_event).await?;
 
             timeline_event_diffs.extend(state.room_linked_chunk_mut().updates_as_vector_diffs());
 
@@ -448,7 +559,7 @@ impl EventCache {
                         // If at least one event has been replaced, return the `thread_id` and the
                         // `thread_cache` to update the thread summary later.
                         thread_cache
-                            .replace_in_memory_utds(&resolved_events)
+                            .replace_in_memory_utds(&maybe_resolved_events)
                             .await?
                             .then(|| (thread_id.clone(), thread_cache.clone())),
                     )
@@ -468,7 +579,7 @@ impl EventCache {
 
         // Resolve in-memory UTDs on the pinned-events cache.
         if let Some(pinned_events_cache) = all_caches.pinned_events.get() {
-            pinned_events_cache.replace_in_memory_utds(&resolved_events).await?;
+            pinned_events_cache.replace_in_memory_utds(&maybe_resolved_events).await?;
         }
 
         // Resolve in-memory UTDs on the event-focused caches.
@@ -478,7 +589,9 @@ impl EventCache {
             // accumulate over time. Consider keeping track of which linked chunk
             // contains which event ID, to avoid doing the linear searches here.
             try_join_all(all_caches.event_focused.read().await.values().map(
-                |event_focused_cache| event_focused_cache.replace_in_memory_utds(&resolved_events),
+                |event_focused_cache| {
+                    event_focused_cache.replace_in_memory_utds(&maybe_resolved_events)
+                },
             ))
             .await?;
         }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -614,11 +614,13 @@ impl EventCache {
             }
         }
 
-        let event_ids: BTreeSet<_> =
-            decrypted_events.iter().map(|(event_id, _, _)| event_id).collect();
+        if !decrypted_events.is_empty() {
+            if tracing::level_enabled!(tracing::Level::TRACE) {
+                let event_ids: BTreeSet<_> =
+                    decrypted_events.iter().map(|(event_id, _, _)| event_id).collect();
 
-        if !event_ids.is_empty() {
-            trace!(?event_ids, "Successfully redecrypted events");
+                trace!(?event_ids, "Successfully redecrypted events");
+            }
         }
 
         // Replace the events and notify listeners that UTDs have been replaced with
@@ -652,11 +654,13 @@ impl EventCache {
             }
         }
 
-        let event_ids: BTreeSet<_> =
-            updated_events.iter().map(|(event_id, _, _)| event_id).collect();
+        if !updated_events.is_empty() {
+            if tracing::level_enabled!(tracing::Level::TRACE) {
+                let event_ids: BTreeSet<_> =
+                    updated_events.iter().map(|(event_id, _, _)| event_id).collect();
 
-        if !event_ids.is_empty() {
-            trace!(?event_ids, "Replacing the encryption info of some events");
+                trace!(?event_ids, "Replacing the encryption info of some events");
+            }
         }
 
         self.on_resolved_utds(room.room_id(), updated_events).await

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -157,12 +157,11 @@ use super::RoomEventCache;
 use super::{
     EventCache, EventCacheError, EventCacheInner, EventsOrigin, RoomEventCacheGenericUpdate,
     RoomEventCacheUpdate, TimelineVectorDiffs,
-    caches::{EventLocation, room::RoomEventCacheLinkedChunkUpdate},
+    caches::{
+        EventLocation, event_linked_chunk::EventLinkedChunk, room::RoomEventCacheLinkedChunkUpdate,
+    },
 };
-use crate::{
-    Client, Result, Room, encryption::backups::BackupState,
-    event_cache::caches::event_linked_chunk::EventLinkedChunk, room::PushContext,
-};
+use crate::{Client, Result, Room, encryption::backups::BackupState, room::PushContext};
 
 type SessionId<'a> = &'a str;
 type OwnedSessionId = String;

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -356,7 +356,7 @@ impl EventCache {
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
 
-        // Resolve on the room cache.
+        // Resolve in-store and in-memory UTDs with the room cache.
         {
             let room_cache = &all_caches.room;
             let mut state = room_cache.state().write().await?;
@@ -417,7 +417,7 @@ impl EventCache {
             }
         }
 
-        // Resolve on the thread caches.
+        // Resolve in-memory UTDs on the thread caches.
         {
             // TODO: This ain't great for performance; there shouldn't be
             // that many thread caches alive at the same time, but they could
@@ -432,7 +432,7 @@ impl EventCache {
                         // If at least one event has been replaced, return the `thread_id` and the
                         // `thread_cache` to update the thread summary later.
                         thread_cache
-                            .replace_utds(&events)
+                            .replace_in_memory_utds(&events)
                             .await?
                             .then(|| (thread_id.clone(), thread_cache.clone())),
                     )
@@ -450,12 +450,12 @@ impl EventCache {
             }
         }
 
-        // Resolve on the pinned-events cache.
+        // Resolve in-memory UTDs on the pinned-events cache.
         if let Some(pinned_events_cache) = all_caches.pinned_events.get() {
-            pinned_events_cache.replace_utds(&events).await?;
+            pinned_events_cache.replace_in_memory_utds(&events).await?;
         }
 
-        // Resolve on the event-focused caches.
+        // Resolve in-memory UTDs on the event-focused caches.
         {
             // TODO: This ain't great for performance; there shouldn't be that many
             // event-focused caches alive at the same time, but they could
@@ -467,7 +467,7 @@ impl EventCache {
                     .read()
                     .await
                     .values()
-                    .map(|event_focused_cache| event_focused_cache.replace_utds(&events)),
+                    .map(|event_focused_cache| event_focused_cache.replace_in_memory_utds(&events)),
             )
             .await?;
         }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -342,9 +342,9 @@ impl EventCache {
     async fn on_resolved_utds(
         &self,
         room_id: &RoomId,
-        events: Vec<ResolvedUtd>,
+        resolved_utds: Vec<ResolvedUtd>,
     ) -> Result<(), EventCacheError> {
-        if events.is_empty() {
+        if resolved_utds.is_empty() {
             trace!("No events were redecrypted or updated, nothing to replace");
             return Ok(());
         }
@@ -352,7 +352,7 @@ impl EventCache {
         timer!("Resolving UTDs");
 
         let event_ids: BTreeSet<_> =
-            events.iter().cloned().map(|(event_id, _, _)| event_id).collect();
+            resolved_utds.iter().cloned().map(|(event_id, _, _)| event_id).collect();
 
         let all_caches = self.inner.all_caches_for_room(room_id).await?;
 
@@ -361,10 +361,10 @@ impl EventCache {
             let room_cache = &all_caches.room;
             let mut state = room_cache.state().write().await?;
 
-            let mut new_events = Vec::with_capacity(events.len());
+            let mut new_events = Vec::with_capacity(resolved_utds.len());
 
-            for (event_id, decrypted, actions) in &events {
-                if let Some((location, mut target_event)) = state.find_event(event_id).await?
+            for (event_id, decrypted_event, actions) in &resolved_utds {
+                if let Some((location, mut event)) = state.find_event(event_id).await?
                     && (
                         // There is a race between the multiple sources of updates. It's possible
                         // that two sources trigger a decryption for the same event (for example,
@@ -376,20 +376,20 @@ impl EventCache {
                         // Note that a simple check like “event's kind is `UnableToDecrypt`” is not
                         // enough. The event can already be decrypted but its encryption info can
                         // change. So we must ensure they are also different.
-                        matches!(target_event.kind, TimelineEventKind::UnableToDecrypt { .. })
-                            || target_event.encryption_info() != Some(&decrypted.encryption_info)
+                        matches!(event.kind, TimelineEventKind::UnableToDecrypt { .. })
+                            || event.encryption_info() != Some(&decrypted_event.encryption_info)
                     )
                 {
-                    target_event.kind = TimelineEventKind::Decrypted(decrypted.clone());
+                    event.kind = TimelineEventKind::Decrypted(decrypted_event.clone());
 
                     if let Some(actions) = actions {
-                        target_event.set_push_actions(actions.clone());
+                        event.set_push_actions(actions.clone());
                     }
 
                     // TODO: `replace_event_at()` propagates changes to the store for every
                     // event, we should probably have a bulk version of this?
-                    state.replace_event_at(location, target_event.clone()).await?;
-                    new_events.push(target_event);
+                    state.replace_event_at(location, event.clone()).await?;
+                    new_events.push(event);
                 }
             }
 
@@ -432,7 +432,7 @@ impl EventCache {
                         // If at least one event has been replaced, return the `thread_id` and the
                         // `thread_cache` to update the thread summary later.
                         thread_cache
-                            .replace_in_memory_utds(&events)
+                            .replace_in_memory_utds(&resolved_utds)
                             .await?
                             .then(|| (thread_id.clone(), thread_cache.clone())),
                     )
@@ -452,7 +452,7 @@ impl EventCache {
 
         // Resolve in-memory UTDs on the pinned-events cache.
         if let Some(pinned_events_cache) = all_caches.pinned_events.get() {
-            pinned_events_cache.replace_in_memory_utds(&events).await?;
+            pinned_events_cache.replace_in_memory_utds(&resolved_utds).await?;
         }
 
         // Resolve in-memory UTDs on the event-focused caches.
@@ -461,14 +461,9 @@ impl EventCache {
             // event-focused caches alive at the same time, but they could
             // accumulate over time. Consider keeping track of which linked chunk
             // contains which event ID, to avoid doing the linear searches here.
-            try_join_all(
-                all_caches
-                    .event_focused
-                    .read()
-                    .await
-                    .values()
-                    .map(|event_focused_cache| event_focused_cache.replace_in_memory_utds(&events)),
-            )
+            try_join_all(all_caches.event_focused.read().await.values().map(
+                |event_focused_cache| event_focused_cache.replace_in_memory_utds(&resolved_utds),
+            ))
             .await?;
         }
 


### PR DESCRIPTION
This patch simplifies the `Redecryptor::on_resolved_utds` flow. The goal is to resolve events only once if possible, and to avoid as many look ups as possible.

The new workflow is the following:

- Collect all resolved events,
- Use `RoomEventCache::save_events` to do a bulk update of all resolved events,
- Update in-memory events in each cache individually, taking care of draining the updates for the store (because `save_events` handled that already).

This new workflow fixes the problem where the same resolved event can be updated in the store multiple times by different cache. This was inefficient.

Best to review one patch at a time. They are not very complicated. I've tried to cut patches as small as possible to help following the reasoning behind the changes. I took a tiny detour by undoing some parts of the code, and redoing them later, but with a different approach, expressing the solution to a problem a bit more elegantly.
Edit: actually, reviewing the entire diff at once doesn't look too bad neither!

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
