### PR TITLE
Automatically mirror MatrixRTC participation into m.call profile field

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6807.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6807.added.md
@@ -1,1 +1,0 @@
-Add `Client::set_call_status` and `Client::clear_call_status` to update the current user's [MSC4426] `m.call` profile field through the FFI. `set_call_status` advertises that the user is in a call, optionally carrying the Unix-epoch seconds when they joined; `clear_call_status` removes the field when the call ends.

--- a/bindings/matrix-sdk-ffi/changelog.d/6825.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6825.added.md
@@ -1,0 +1,2 @@
+Added `Client::enable_automatic_call_status(bool)` on the FFI. Opts in to
+auto-syncing this device's MatrixRTC participation into the [MSC4426] `m.call` profile field.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -78,8 +78,7 @@ use matrix_sdk_ui::{
 use mime::Mime;
 use oauth2::Scope;
 use ruma::{
-    OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId, RoomOrAliasId, SecondsSinceUnixEpoch,
-    ServerName,
+    OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId, RoomOrAliasId, ServerName,
     api::{
         FeatureFlag,
         client::{
@@ -2642,25 +2641,10 @@ impl Client {
         Ok(())
     }
 
-    /// Set the current user's call indicator (MSC4426 `m.call` profile field).
-    ///
-    /// Presence of a value indicates the user is in a call. The optional
-    /// `call_joined_ts` on [`UserCall`] carries the Unix-epoch seconds when
-    /// the user joined the call, if known. Use [`Self::clear_call_status`] to
-    /// remove it when the call ends.
-    pub async fn set_call_status(&self, call: UserCall) -> Result<(), ClientError> {
-        let call_joined_ts = call
-            .call_joined_ts
-            .map(|secs| SecondsSinceUnixEpoch(UInt::try_from(secs).unwrap_or_default()));
-        self.inner.account().set_call(call_joined_ts).await?;
-        Ok(())
-    }
-
-    /// Clear the current user's call indicator (MSC4426 `m.call` profile
-    /// field).
-    pub async fn clear_call_status(&self) -> Result<(), ClientError> {
-        self.inner.account().clear_call().await?;
-        Ok(())
+    /// Enable or disable automatic mirroring of this device's MatrixRTC
+    /// participation into the MSC4426 `m.call` profile field.
+    pub fn enable_automatic_call_status(&self, enabled: bool) {
+        self.inner.enable_automatic_call_status(enabled);
     }
 }
 

--- a/crates/matrix-sdk-base/src/room/call.rs
+++ b/crates/matrix-sdk-base/src/room/call.rs
@@ -59,6 +59,17 @@ impl Room {
         self.info.read().active_room_call_participants()
     }
 
+    /// See [`RoomInfo::is_device_in_active_room_call`].
+    ///
+    /// [`RoomInfo::is_device_in_active_room_call`]: crate::RoomInfo::is_device_in_active_room_call
+    pub fn is_device_in_active_room_call(
+        &self,
+        user_id: &ruma::UserId,
+        device_id: &ruma::DeviceId,
+    ) -> bool {
+        self.info.read().is_device_in_active_room_call(user_id, device_id)
+    }
+
     /// Get the consensus call intent for the current call, based on what
     /// members are advertising.
     pub fn active_room_call_consensus_intent(&self) -> CallIntentConsensus {
@@ -450,5 +461,34 @@ mod tests {
             let consensus_intent = room.active_room_call_consensus_intent();
             assert_eq!(expected, consensus_intent, "Failed case: {}", description);
         }
+    }
+
+    #[test]
+    fn is_device_in_active_room_call_matches_own_device_only() {
+        let (_, room) = make_room_test_helper(RoomState::Joined);
+
+        let alice_a = session_member_state_event(
+            event_id!("$alice_a"),
+            &ALICE,
+            Some(InitData { device_id: device_id!("DEVICE_A"), minutes_ago: 1 }),
+        );
+        let alice_b = session_member_state_event(
+            event_id!("$alice_b"),
+            &ALICE,
+            Some(InitData { device_id: device_id!("DEVICE_B"), minutes_ago: 1 }),
+        );
+        let bob_a = session_member_state_event(
+            event_id!("$bob_a"),
+            &BOB,
+            Some(InitData { device_id: device_id!("DEVICE_A"), minutes_ago: 1 }),
+        );
+
+        receive_state_events(&room, vec![alice_a, alice_b, bob_a]);
+
+        assert!(room.is_device_in_active_room_call(&ALICE, device_id!("DEVICE_A")));
+        assert!(room.is_device_in_active_room_call(&ALICE, device_id!("DEVICE_B")));
+        assert!(!room.is_device_in_active_room_call(&ALICE, device_id!("DEVICE_C")));
+        assert!(room.is_device_in_active_room_call(&BOB, device_id!("DEVICE_A")));
+        assert!(!room.is_device_in_active_room_call(&BOB, device_id!("DEVICE_B")));
     }
 }

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1137,6 +1137,22 @@ impl RoomInfo {
         !self.active_room_call_memberships().is_empty()
     }
 
+    /// Whether the given `(user_id, device_id)` tuple is currently a
+    /// participant in this room's active MatrixRTC call.
+    ///
+    /// Distinct from [`Self::active_room_call_participants`] which returns
+    /// only user IDs. Callers that must not conflate multiple devices of
+    /// the same user (e.g. profile-field mirroring) should use this.
+    pub fn is_device_in_active_room_call(
+        &self,
+        user_id: &ruma::UserId,
+        device_id: &ruma::DeviceId,
+    ) -> bool {
+        self.active_room_call_memberships().iter().any(|(state_key, membership)| {
+            state_key.user_id() == user_id && membership.device_id() == device_id
+        })
+    }
+
     /// Get the call intent consensus for the current call, based on what
     /// members are advertising.
     ///

--- a/crates/matrix-sdk/changelog.d/6825.added.md
+++ b/crates/matrix-sdk/changelog.d/6825.added.md
@@ -1,0 +1,5 @@
+Added `Client::enable_automatic_call_status(bool)` an opt-in auto-sync that
+mirrors this device's MatrixRTC participation into the [MSC4426] `m.call`
+profile field. Gated behind the `unstable-msc4426` feature.
+
+Also adds `Room::is_device_in_active_room_call(user_id, device_id)` for device-scoped participation checks.

--- a/crates/matrix-sdk/src/automatic_call_status.rs
+++ b/crates/matrix-sdk/src/automatic_call_status.rs
@@ -1,0 +1,147 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Automatic mirroring of this device's MatrixRTC participation into the
+//! [MSC4426] `m.call` profile field.
+//!
+//! [MSC4426]: https://github.com/matrix-org/matrix-spec-proposals/pull/4426
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+
+use matrix_sdk_common::executor::spawn;
+use ruma::{
+    OwnedRoomId, SecondsSinceUnixEpoch,
+    events::{OriginalSyncStateEvent, call::member::CallMemberEventContent},
+};
+use tracing::warn;
+
+use crate::{Client, Room, client::WeakClient, event_handler::EventHandlerHandle};
+
+/// Owns the `m.call.member` event handler for auto-syncing the `m.call`
+/// profile field. Dropping this struct deregisters the handler.
+/// Holds a [`WeakClient`] rather than a strong `Client` to avoid a
+/// reference cycle.
+pub(crate) struct AutomaticCallStatus {
+    handle: EventHandlerHandle,
+    client: WeakClient,
+}
+
+/// Rooms in which this device is currently participating in an active
+/// MatrixRTC call. Maintained incrementally from `m.call.member` events.
+type ActiveCallRooms = Arc<Mutex<HashSet<OwnedRoomId>>>;
+
+impl Client {
+    /// Enable or disable automatic mirroring of this device's MatrixRTC
+    /// participation into the [MSC4426] `m.call` profile field. Off by
+    /// default.
+    ///
+    /// Toggling `false -> true` registers a typed event handler for
+    /// `m.call.member` state events. Toggling `true -> false` deregisters
+    /// it.
+    ///
+    /// Toggling `true -> false` does NOT clear `m.call` on the server, you
+    /// should call [`crate::Account::clear_call`] explicitly if that is
+    /// desired.
+    ///
+    /// [MSC4426]: https://github.com/matrix-org/matrix-spec-proposals/pull/4426
+    pub fn enable_automatic_call_status(&self, enabled: bool) {
+        let mut automatic_call_status = self.inner.automatic_call_status.lock().unwrap();
+        match (enabled, automatic_call_status.is_some()) {
+            (true, false) => {
+                *automatic_call_status = Some(AutomaticCallStatus::new(self));
+            }
+            (false, true) => *automatic_call_status = None,
+            _ => {}
+        }
+    }
+}
+
+impl AutomaticCallStatus {
+    fn new(client: &Client) -> Self {
+        // Start empty: `m.call` is shared across the user's devices, so we
+        // deliberately don't reconcile from current room state on start-up
+        // to avoid stomping on a status set by another device. The
+        // trade-off is that a crash/kill while on a call leaves `m.call`
+        // set until the user clears it manually.
+        let rooms: ActiveCallRooms = Arc::new(Mutex::new(HashSet::new()));
+        let handle = client.add_event_handler(
+            async move |event: OriginalSyncStateEvent<CallMemberEventContent>,
+                        room: Room,
+                        client: Client| {
+                on_event(&rooms, event, room, client);
+            },
+        );
+        let weak_client = WeakClient::from_client(client);
+        Self { handle, client: weak_client }
+    }
+}
+
+impl Drop for AutomaticCallStatus {
+    fn drop(&mut self) {
+        if let Some(client) = self.client.get() {
+            client.remove_event_handler(self.handle.clone());
+        }
+    }
+}
+
+fn on_event(
+    rooms: &ActiveCallRooms,
+    event: OriginalSyncStateEvent<CallMemberEventContent>,
+    room: Room,
+    client: Client,
+) {
+    let Some(own_user_id) = client.user_id() else { return };
+    let Some(own_device_id) = client.device_id() else { return };
+
+    // Ignore events for other users' memberships.
+    if event.state_key.user_id() != own_user_id {
+        return;
+    }
+
+    // Update the aggregate for this room, then return early if the "in any
+    // call" boolean didn't flip.
+    let is_device_in_room_call = room.is_device_in_active_room_call(own_user_id, own_device_id);
+    let room_id = room.room_id().to_owned();
+    let (was_in_call, now_in_call) = {
+        let mut rooms = rooms.lock().unwrap();
+        let was_in_call = !rooms.is_empty();
+        if is_device_in_room_call {
+            rooms.insert(room_id);
+        } else {
+            rooms.remove(&room_id);
+        }
+        (was_in_call, !rooms.is_empty())
+    };
+    // Return early if no change.
+    if was_in_call == now_in_call {
+        return;
+    }
+    let active_call_rooms = rooms.clone();
+    spawn(async move {
+        let in_call = !active_call_rooms.lock().unwrap().is_empty();
+        let result = if in_call {
+            let joined_ts = SecondsSinceUnixEpoch::from_system_time(SystemTime::now());
+            client.account().set_call(joined_ts).await
+        } else {
+            client.account().clear_call().await
+        };
+        if let Err(error) = result {
+            warn!(?error, in_call, "m.call auto-sync request failed");
+        }
+    });
+}

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -419,6 +419,18 @@ pub(crate) struct ClientInner {
         broadcast::Sender<Option<DuplicateOneTimeKeyErrorMessage>>,
 
     pub(crate) media_fetcher: RwLock<Arc<dyn MediaFetcher>>,
+
+    /// When `Some`, `m.call` auto-sync is enabled and the held
+    /// [`AutomaticCallStatus`] owns the event handler registration.
+    /// Dropping the `Option` (via
+    /// [`Client::enable_automatic_call_status`]) drops the syncer,
+    /// which drops its `EventHandlerDropGuard`, which deregisters the
+    /// handler.
+    ///
+    /// [`AutomaticCallStatus`]: crate::automatic_call_status::AutomaticCallStatus
+    #[cfg(feature = "unstable-msc4426")]
+    pub(crate) automatic_call_status:
+        StdMutex<Option<crate::automatic_call_status::AutomaticCallStatus>>,
 }
 
 impl ClientInner {
@@ -494,6 +506,8 @@ impl ClientInner {
             #[cfg(feature = "e2e-encryption")]
             duplicate_key_upload_error_sender: broadcast::channel(1).0,
             media_fetcher: RwLock::new(media_fetcher),
+            #[cfg(feature = "unstable-msc4426")]
+            automatic_call_status: StdMutex::new(None),
         };
 
         #[allow(clippy::let_and_return)]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -101,6 +101,10 @@ pub use sliding_sync::{
 uniffi::setup_scaffolding!();
 
 pub mod live_locations_observer;
+
+#[cfg(feature = "unstable-msc4426")]
+mod automatic_call_status;
+
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 

--- a/crates/matrix-sdk/tests/integration/automatic_call_status.rs
+++ b/crates/matrix-sdk/tests/integration/automatic_call_status.rs
@@ -1,0 +1,256 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::{
+    Client,
+    ruma::{
+        DeviceId, UserId,
+        api::MatrixVersion,
+        events::{
+            AnySyncStateEvent,
+            call::member::{CallMemberEventContent, CallMemberStateKey},
+        },
+        profile::ProfileFieldName,
+        serde::Raw,
+    },
+    test_utils::mocks::MatrixMockServer,
+};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use ruma::room_id;
+
+/// A join-shaped `m.call.member` state event for `(user_id, device_id)`.
+fn join_call_event(user_id: &UserId, device_id: &DeviceId) -> Raw<AnySyncStateEvent> {
+    EventFactory::new()
+        .call_membership_state(user_id.to_owned(), device_id.to_string())
+        .into_raw_sync_state()
+}
+
+/// A leave-shaped `m.call.member` state event for `(user_id, device_id)`.
+fn leave_call_event(user_id: &UserId, device_id: &DeviceId) -> Raw<AnySyncStateEvent> {
+    let state_key = CallMemberStateKey::new(user_id.to_owned(), Some(device_id.to_string()), true);
+    EventFactory::new()
+        .event(CallMemberEventContent::new_empty(None))
+        .sender(user_id)
+        .state_key(state_key.as_ref())
+        .into_raw_sync_state()
+}
+
+async fn make_client() -> (MatrixMockServer, Client) {
+    let mock_server = MatrixMockServer::new().await;
+    // V1_16 is required so the SDK picks the stable
+    // `/v3/profile/{user}/{field}` endpoint path (which is what
+    // `mock_set_profile_field` intercepts) rather than the unstable
+    // `/unstable/uk.tcpip.msc4133/profile/...` variant.
+    let client =
+        mock_server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    (mock_server, client)
+}
+
+#[async_test]
+async fn test_auto_sync_sets_m_call_when_own_device_joins_a_room_call() {
+    let (mock_server, client) = make_client().await;
+    let own_user_id = client.user_id().unwrap().to_owned();
+    let own_device_id = client.device_id().unwrap().to_owned();
+
+    client.enable_automatic_call_status(true);
+
+    let _put = mock_server
+        .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+        .ok()
+        .mock_once()
+        .named("PUT on join")
+        .mount_as_scoped()
+        .await;
+
+    let room_id = room_id!("!room:example.org");
+    let joined = JoinedRoomBuilder::new(room_id)
+        .add_state_event(join_call_event(&own_user_id, &own_device_id));
+    mock_server.sync_room(&client, joined).await;
+}
+
+#[async_test]
+async fn test_auto_sync_clears_m_call_when_own_device_leaves_the_room_call() {
+    let (mock_server, client) = make_client().await;
+    let own_user_id = client.user_id().unwrap().to_owned();
+    let own_device_id = client.device_id().unwrap().to_owned();
+
+    client.enable_automatic_call_status(true);
+
+    let room_id = room_id!("!room:example.org");
+
+    {
+        let _put = mock_server
+            .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .mock_once()
+            .named("PUT on join")
+            .mount_as_scoped()
+            .await;
+
+        let joined = JoinedRoomBuilder::new(room_id)
+            .add_state_event(join_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, joined).await;
+    }
+
+    {
+        let _delete = mock_server
+            .mock_delete_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .mock_once()
+            .named("DELETE on leave")
+            .mount_as_scoped()
+            .await;
+
+        let leaving = JoinedRoomBuilder::new(room_id)
+            .add_state_event(leave_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, leaving).await;
+    }
+}
+
+#[async_test]
+async fn test_auto_sync_does_nothing_when_disabled() {
+    let (mock_server, client) = make_client().await;
+    let own_user_id = client.user_id().unwrap().to_owned();
+    let own_device_id = client.device_id().unwrap().to_owned();
+
+    // Deliberately do NOT enable auto-sync.
+    let _no_put = mock_server
+        .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+        .ok()
+        .expect(0)
+        .named("no PUT while disabled")
+        .mount_as_scoped()
+        .await;
+
+    let _no_delete = mock_server
+        .mock_delete_profile_field(&own_user_id, ProfileFieldName::Call)
+        .ok()
+        .expect(0)
+        .named("no DELETE while disabled")
+        .mount_as_scoped()
+        .await;
+
+    let room_id = room_id!("!room:example.org");
+    let joined = JoinedRoomBuilder::new(room_id)
+        .add_state_event(join_call_event(&own_user_id, &own_device_id));
+    mock_server.sync_room(&client, joined).await;
+}
+
+#[async_test]
+async fn test_auto_sync_still_fires_delete_after_failed_put() {
+    // After a failed PUT the state machine must NOT get stuck: the next
+    // real transition (join → leave) should still fire. We update
+    // `was_in_call` optimistically for exactly this reason.
+    use wiremock::ResponseTemplate;
+
+    let (mock_server, client) = make_client().await;
+    let own_user_id = client.user_id().unwrap().to_owned();
+    let own_device_id = client.device_id().unwrap().to_owned();
+
+    client.enable_automatic_call_status(true);
+
+    let room_id = room_id!("!room:example.org");
+
+    {
+        let _fail = mock_server
+            .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .named("PUT fails")
+            .mount_as_scoped()
+            .await;
+
+        let joined = JoinedRoomBuilder::new(room_id)
+            .add_state_event(join_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, joined).await;
+    }
+
+    {
+        let _delete = mock_server
+            .mock_delete_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .mock_once()
+            .named("DELETE on leave after prior PUT failed")
+            .mount_as_scoped()
+            .await;
+
+        let leaving = JoinedRoomBuilder::new(room_id)
+            .add_state_event(leave_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, leaving).await;
+    }
+}
+
+#[async_test]
+async fn test_runtime_toggle_off_stops_writes_and_on_resumes_them() {
+    let (mock_server, client) = make_client().await;
+    let own_user_id = client.user_id().unwrap().to_owned();
+    let own_device_id = client.device_id().unwrap().to_owned();
+
+    let room_id = room_id!("!room:example.org");
+
+    // Phase 1: enable + join → one PUT.
+    client.enable_automatic_call_status(true);
+    {
+        let _put = mock_server
+            .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .mock_once()
+            .named("phase 1: PUT on join while enabled")
+            .mount_as_scoped()
+            .await;
+
+        let joined = JoinedRoomBuilder::new(room_id)
+            .add_state_event(join_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, joined).await;
+    }
+
+    // Phase 2: disable + leave → no writes.
+    client.enable_automatic_call_status(false);
+    {
+        let _no_put = mock_server
+            .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .expect(0)
+            .named("phase 2: no PUT while disabled")
+            .mount_as_scoped()
+            .await;
+        let _no_delete = mock_server
+            .mock_delete_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .expect(0)
+            .named("phase 2: no DELETE while disabled")
+            .mount_as_scoped()
+            .await;
+
+        let leaving = JoinedRoomBuilder::new(room_id)
+            .add_state_event(leave_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, leaving).await;
+    }
+
+    // Phase 3: re-enable + rejoin → one PUT
+    client.enable_automatic_call_status(true);
+    {
+        let _put = mock_server
+            .mock_set_profile_field(&own_user_id, ProfileFieldName::Call)
+            .ok()
+            .mock_once()
+            .named("phase 3: PUT on rejoin after re-enable")
+            .mount_as_scoped()
+            .await;
+
+        let rejoined = JoinedRoomBuilder::new(room_id)
+            .add_state_event(join_call_event(&own_user_id, &own_device_id));
+        mock_server.sync_room(&client, rejoined).await;
+    }
+}

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -8,6 +8,8 @@ use wiremock::{
 };
 
 mod account;
+#[cfg(feature = "unstable-msc4426")]
+mod automatic_call_status;
 mod client;
 mod edit_validation;
 #[cfg(feature = "e2e-encryption")]


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Adds Client::enable_automatic_call_status(bool) opt-in event handler that watches own-user m.call.member state events and mirrors the resulting "am I in a call on this device?" boolean into the MSC4426 m.call profile field on every transition.

Replaces the manual set_call_status / clear_call_status FFI methods so callers no longer bridge Element Call widget events themselves.

  How

  - AutomaticCallStatus owns an add_event_handler registration
  - Aggregates rooms-in-call in a HashSet<OwnedRoomId>.
  - Device-scoped: uses new Room::is_device_in_active_room_call(user_id, device_id) primitive so multi-device accounts don't stomp on each other via the shared user profile field.

  Non-goals

  - No reconciliation at enable / after crash. m.call is shared across a user's devices. 
  - No retry on same-state failure. Next real transition fires the correct request.

- [X] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
