### PR TITLE
fix(indexeddb): serialize media content as Uint8Array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,6 +3895,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde-wasm-bindgen",
+ "serde_bytes",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "db24422e03aea7c7974230098f
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }
 serde = { version = "1.0.229", default-features = false, features = ["std", "rc", "derive"] }
+serde_bytes = { version = "0.11.19", default-features = false, features = ["std"] }
 serde_html_form = { version = "0.4.1", default-features = false }
 serde_json = { version = "1.0.151", default-features = false, features = ["std"] }
 sha2 = "0.11.0"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2024"
 rust-version.workspace = true
 readme = "README.md"
 
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"] # Used in the indexed types, by the IndexedMediaContentData (aka media content).
+
 [package.metadata.docs.rs]
 all-features = true
 default-target = "wasm32-unknown-unknown"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -50,6 +50,7 @@ matrix-sdk-store-encryption.workspace = true
 rmp-serde.workspace = true
 ruma.workspace = true
 serde.workspace = true
+serde_bytes.workspace = true
 serde-wasm-bindgen = { version = "0.6.5", default-features = false }
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/matrix-sdk-indexeddb/changelog.d/6826.fixed.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6826.fixed.md
@@ -1,0 +1,1 @@
+Fix large attachment uploads failing with `Invalid array length` on WASM. IndexedDB media content is now serialized as a compact `Uint8Array` instead of a JavaScript `Array` containing one element per byte.

--- a/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/serializer/indexed_types.rs
@@ -657,6 +657,7 @@ pub struct IndexedMediaContent {
     /// The primary key of the object store
     pub id: IndexedMediaContentIdKey,
     /// The (possibly) encrypted content - i.e., [`MediaContent::data`]
+    #[serde(with = "serde_bytes")]
     pub content: IndexedMediaContentData,
 }
 

--- a/crates/matrix-sdk-indexeddb/src/serializer/indexed_type/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer/indexed_type/mod.rs
@@ -22,7 +22,6 @@ pub mod constants;
 pub mod range;
 pub mod traits;
 
-use gloo_utils::format::JsValueSerdeExt;
 use indexed_db_futures::KeyRange;
 use range::IndexedKeyRange;
 use serde::{Serialize, de::DeserializeOwned};
@@ -190,7 +189,7 @@ impl IndexedTypeSerializer {
         T: Indexed,
         T::IndexedType: DeserializeOwned,
     {
-        let indexed: T::IndexedType = value.into_serde()?;
+        let indexed: T::IndexedType = serde_wasm_bindgen::from_value(value)?;
         T::from_indexed(indexed, &self.inner).map_err(IndexedTypeSerializerError::Indexing)
     }
 }


### PR DESCRIPTION
Hello! This PR updates how media content is serialized by the IndexedDB media store.

`IndexedMediaContent::content` is represented as a `Vec<u8>`. When passed directly to `serde_wasm_bindgen`, it is serialized as a generic JavaScript `Array`, with one JavaScript array element created for every byte. This introduces substantial memory overhead for large media files and eventually causes serialization to fail with an `Invalid array length` error. This issue was spotted while trying to upload files that were 130 MB or larger, using the FFI SDK in WASM.

This PR uses `serde_bytes` so that media content is serialized as a compact `Uint8Array`. It also updates the deserialization path to support this representation while remaining compatible with existing records stored as regular JavaScript arrays.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
