### PR TITLE
Allow the disabling of the minimum rotation period of the crypto crate from the bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3832,6 +3832,7 @@ dependencies = [
  "matrix-sdk-base",
  "matrix-sdk-common",
  "matrix-sdk-contentscanner",
+ "matrix-sdk-crypto",
  "matrix-sdk-ffi-macros",
  "matrix-sdk-ui",
  "mime",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -42,6 +42,10 @@ experimental-element-recent-emojis = ["matrix-sdk/experimental-element-recent-em
 experimental-push-secrets = ["matrix-sdk/experimental-push-secrets"]
 experimental-x509-identity-verification = ["matrix-sdk-base/experimental-x509-identity-verification", "matrix-sdk/experimental-x509-identity-verification"]
 
+# Disable the minimum rotation period of Megolm sessions (room keys), this is
+# used by complement-crypto, **DO NOT** enable if you're not complement-crypto.
+_only-for-testing-disable-megolm-minimum-rotation-period-ms = ["dep:matrix-sdk-crypto", "matrix-sdk-crypto/_disable-minimum-rotation-period-ms"]
+
 rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs", "matrix-sdk-ui/rustls-aws-lc-rs", "matrix-sdk-contentscanner/rustls-aws-lc-rs"]
 
 [dependencies]
@@ -67,6 +71,7 @@ matrix-sdk-common.workspace = true
 matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-contentscanner = { workspace = true, features = ["uniffi", "e2e-encryption"] }
 matrix-sdk-ui = { workspace = true, features = ["uniffi", "unstable-msc4426"] }
+matrix-sdk-crypto = { workspace = true, optional = true }
 mime = { version = "0.3.17", default-features = false }
 ruma = { workspace = true, features = [
     "html",


### PR DESCRIPTION
This will make the SDK rebuild script for complement-crypto much simpler, it won't need to rewrite the Cargo.toml file anymore.