### PR TITLE
fix(call): Active call timeline info lost on timeline rebuild

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -193,6 +193,11 @@ impl TimelineBuilder {
         )
         .await?;
 
+        let initial_active_call_info = ActiveCallInfo::from_info(initial_info, owned_user_id);
+        if initial_active_call_info.is_some() {
+            controller.handle_active_call_update(initial_active_call_info.clone()).await;
+        }
+
         let InitFocusResult { focus_task, has_events } = controller.init_focus().await?;
 
         let room_update_join_handle = room
@@ -258,10 +263,6 @@ impl TimelineBuilder {
             )
             .abort_on_drop();
 
-        let initial_active_call_info = ActiveCallInfo::from_info(initial_info, owned_user_id);
-        if initial_active_call_info.is_some() {
-            controller.handle_active_call_update(initial_active_call_info).await;
-        }
         let rtc_membership_listener_handle = {
             let room_info_subscriber = room.subscribe_info();
             room.client()
@@ -274,7 +275,7 @@ impl TimelineBuilder {
                     );
                     span.follows_from(Span::current());
 
-                    rtc_membership_update_task(room_info_subscriber, controller.clone())
+                    rtc_membership_update_task(room_info_subscriber, controller.clone(), initial_active_call_info)
                         .instrument(span)
                 })
                 .abort_on_drop()

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -275,8 +275,12 @@ impl TimelineBuilder {
                     );
                     span.follows_from(Span::current());
 
-                    rtc_membership_update_task(room_info_subscriber, controller.clone(), initial_active_call_info)
-                        .instrument(span)
+                    rtc_membership_update_task(
+                        room_info_subscriber,
+                        controller.clone(),
+                        initial_active_call_info,
+                    )
+                    .instrument(span)
                 })
                 .abort_on_drop()
         };

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -351,8 +351,9 @@ pub(in crate::timeline) async fn room_send_queue_update_task(
 pub(in crate::timeline) async fn rtc_membership_update_task(
     mut room_info: EyeballSubscriber<RoomInfo>,
     timeline_controller: TimelineController,
+    initial_call_info: Option<ActiveCallInfo>,
 ) {
-    let mut prev_info = None;
+    let mut prev_info = initial_call_info;
     let own_user = timeline_controller.room().own_user_id().to_owned();
 
     while let Some(info) = room_info.next().await {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -351,7 +351,6 @@ async fn test_active_call_info_is_restored_when_the_timeline_is_rebuilt() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-
     let items = timeline.items().await;
     let notification = items.iter().filter_map(|item| item.as_event()).next().unwrap();
     assert_eq!(notification.event_id().unwrap(), notification_event_id);
@@ -380,9 +379,9 @@ async fn test_active_call_info_is_restored_when_the_timeline_is_rebuilt() {
     let items = timeline.items().await;
     let notification = items.iter().filter_map(|item| item.as_event()).next().unwrap();
     assert_let!(
-            TimelineItemContent::RtcNotification { active_call_info: None, .. } =
-                notification.content()
-        );
+        TimelineItemContent::RtcNotification { active_call_info: None, .. } =
+            notification.content()
+    );
 }
 
 // There is an order in which the initial events are sent, first the membership

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -288,6 +288,103 @@ async fn test_active_call_info() {
     assert!(active_members.contains(&ALICE.to_owned()));
 }
 
+// Leaving the room and coming back to it rebuilds a brand new `Timeline` out of
+// the event cache. The pre-existing `rtc.notification` item must still be
+// decorated with the active call info, and the call start timestamp must be the
+// one of the notification event, not something else.
+#[async_test]
+async fn test_active_call_info_is_restored_when_the_timeline_is_rebuilt() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let notification_event_id = event_id!("$notify");
+    let notification_timestamp = MilliSecondsSinceUnixEpoch::now();
+
+    let f = EventFactory::new();
+
+    {
+        // Enter the room a first time, and observe an active call.
+        let timeline = room.timeline().await.unwrap();
+        let (_, mut timeline_stream) = timeline.subscribe().await;
+
+        server
+            .sync_room(
+                &client,
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(
+                        f.call_membership_state(BOB.to_owned(), "BOB_DEVICE".to_owned())
+                            .set_livekit_focus(
+                                room_id.into(),
+                                "https://livekit.example.org".to_owned(),
+                            )
+                            .event_id(event_id!("$bob-joined")),
+                    )
+                    .add_timeline_event(
+                        f.rtc_notification(NotificationType::Ring)
+                            .sender(&BOB)
+                            .server_ts(notification_timestamp)
+                            .event_id(notification_event_id),
+                    ),
+            )
+            .await;
+
+        assert_let_timeout!(Some(_timeline_updates) = timeline_stream.next());
+
+        let items = timeline.items().await;
+        let notification = items.iter().filter_map(|item| item.as_event()).next().unwrap();
+        assert_let!(
+            TimelineItemContent::RtcNotification { active_call_info: Some(active_call_info), .. } =
+                notification.content()
+        );
+        assert!(active_call_info.active_members.contains(&BOB.to_owned()));
+        assert_eq!(active_call_info.call_started_ts_millis.unwrap(), notification_timestamp);
+
+        // the timeline is dropped here with closure.
+    }
+
+    // Come back to the room: a new timeline is built from the event cache.
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+
+    let items = timeline.items().await;
+    let notification = items.iter().filter_map(|item| item.as_event()).next().unwrap();
+    assert_eq!(notification.event_id().unwrap(), notification_event_id);
+
+    assert_let!(
+        TimelineItemContent::RtcNotification { active_call_info: Some(active_call_info), .. } =
+            notification.content()
+    );
+    assert!(active_call_info.active_members.contains(&BOB.to_owned()));
+    assert_eq!(active_call_info.call_started_ts_millis.unwrap(), notification_timestamp);
+
+    // Simulate call ending
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_state_event(
+                f.call_membership_state(BOB.to_owned(), "BOB_DEVICE".to_owned())
+                    .leave()
+                    .event_id(event_id!("$bob-left")),
+            ),
+        )
+        .await;
+
+    assert_let_timeout!(Some(_timeline_updates) = timeline_stream.next());
+
+    let items = timeline.items().await;
+    let notification = items.iter().filter_map(|item| item.as_event()).next().unwrap();
+    assert_let!(
+            TimelineItemContent::RtcNotification { active_call_info: None, .. } =
+                notification.content()
+        );
+}
+
 // There is an order in which the initial events are sent, first the membership
 // event is sent, then the notification event is sent.
 // When the membership event is received this will trigger an active call info


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/element-hq/element-x-ios/issues/5962

When the timeline is rebuilt and the event are fetch from the cache, the current call timeline computation was wrong.
In order to fix it, i had to:
- Ensure to set the active call info before processing the events from cache
- When listening to changes the active call can be already set, remember the current state (instead of None by default)

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
