### PR TITLE
Improvements to propagation of tracing spans

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6833.feature.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6833.feature.md
@@ -1,0 +1,1 @@
+Add `SyncServiceBuilder::with_parent_span`.

--- a/bindings/matrix-sdk-ffi/src/platform/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/tracing.rs
@@ -227,6 +227,12 @@ impl Span {
     }
 }
 
+impl Span {
+    pub(crate) fn inner(&self) -> &tracing::Span {
+        &self.0
+    }
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, uniffi::Enum)]
 pub enum LogLevel {
     Error,

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -26,8 +26,8 @@ use matrix_sdk_ui::{
 };
 
 use crate::{
-    TaskHandle, error::ClientError, helpers::unwrap_or_clone_arc, room_list::RoomListService,
-    runtime::get_runtime_handle,
+    TaskHandle, error::ClientError, helpers::unwrap_or_clone_arc, platform::tracing::Span,
+    room_list::RoomListService, runtime::get_runtime_handle,
 };
 
 #[derive(uniffi::Enum)]
@@ -157,6 +157,13 @@ impl SyncServiceBuilder {
     pub fn with_room_list_timeline_limit(self: Arc<Self>, limit: u32) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.with_room_list_timeline_limit(limit);
+        Arc::new(Self { builder, ..this })
+    }
+
+    /// Set a parent tracing Span for the tasks within this sync service.
+    pub fn with_parent_span(self: Arc<Self>, span: Arc<Span>) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_parent_span(span.inner().clone());
         Arc::new(Self { builder, ..this })
     }
 

--- a/crates/matrix-sdk-common/changelog.d/6833.feature.md
+++ b/crates/matrix-sdk-common/changelog.d/6833.feature.md
@@ -1,0 +1,1 @@
+Propagate the tracing `Span` into tasks spawned via `TaskMonitor`.

--- a/crates/matrix-sdk-common/src/task_monitor.rs
+++ b/crates/matrix-sdk-common/src/task_monitor.rs
@@ -80,6 +80,7 @@ use std::{
 
 use futures_util::FutureExt;
 use tokio::sync::broadcast;
+use tracing::{Instrument, Span};
 
 use crate::{
     SendOutsideWasm,
@@ -333,7 +334,8 @@ impl TaskMonitor {
 
             // Forward failure to observers (ignore if there's none).
             let _ = failure_sender.send(failure);
-        };
+        }
+        .instrument(Span::current());
 
         let join_handle = spawn(wrapped);
         let abort_handle = join_handle.abort_handle();
@@ -409,7 +411,8 @@ impl TaskMonitor {
             // Send failure (ignore if no receivers).
             let _ = failure_sender
                 .send(BackgroundTaskFailure { task: task_info, reason: failure_reason });
-        };
+        }
+        .instrument(Span::current());
 
         let join_handle = spawn(wrapped);
         let abort_handle = join_handle.abort_handle();

--- a/crates/matrix-sdk/changelog.d/6833.feature.md
+++ b/crates/matrix-sdk/changelog.d/6833.feature.md
@@ -1,0 +1,1 @@
+Propagate the current tracing `Span` into the E2EE setup task.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -84,7 +84,7 @@ use serde::{Deserialize, de::Error as _};
 use tasks::BundleReceiverTask;
 use tokio::sync::{Mutex, RwLockReadGuard};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::{Span, debug, error, instrument, warn};
+use tracing::{Instrument, Span, debug, error, instrument, warn};
 use url::Url;
 use vodozemac::Curve25519PublicKey;
 
@@ -2012,24 +2012,27 @@ impl Encryption {
 
         let this = self.clone();
 
-        tasks.setup_e2ee = Some(spawn(async move {
-            // Update the current state first, so we don't have to wait for the result of
-            // network requests
-            this.update_verification_state().await;
+        tasks.setup_e2ee = Some(spawn(
+            async move {
+                // Update the current state first, so we don't have to wait for the result of
+                // network requests
+                this.update_verification_state().await;
 
-            if this.settings().auto_enable_cross_signing
-                && let Err(e) = this.bootstrap_cross_signing_if_needed(auth_data).await
-            {
-                error!("Couldn't bootstrap cross signing {e:?}");
-            }
+                if this.settings().auto_enable_cross_signing
+                    && let Err(e) = this.bootstrap_cross_signing_if_needed(auth_data).await
+                {
+                    error!("Couldn't bootstrap cross signing {e:?}");
+                }
 
-            if let Err(e) = this.backups().setup_and_resume().await {
-                error!("Couldn't setup and resume backups {e:?}");
+                if let Err(e) = this.backups().setup_and_resume().await {
+                    error!("Couldn't setup and resume backups {e:?}");
+                }
+                if let Err(e) = this.recovery().setup().await {
+                    error!("Couldn't setup and resume recovery {e:?}");
+                }
             }
-            if let Err(e) = this.recovery().setup().await {
-                error!("Couldn't setup and resume recovery {e:?}");
-            }
-        }));
+            .instrument(Span::current()),
+        ));
 
         tasks.receive_historic_room_key_bundles = bundle_receiver_task;
 


### PR DESCRIPTION
Some progress towards making it possible to have a separate `Span` per client, so if you have two, you know which one is doing the logging.



<!-- description of the changes in this PR -->

- [X] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: