### PR TITLE
ci: Bump the complement-crypto workflow file

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -194,7 +194,7 @@ jobs:
 
   complement-crypto:
     name: "Run Complement Crypto tests"
-    uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@1b1f86348079608fbc5276fe77c54dd66638a622 # main
+    uses: matrix-org/complement-crypto/.github/workflows/single_sdk_tests.yml@6a66de0c450cbf5e1dddecb381a6a8ab08c71e13 # main
     with:
         use_rust_sdk: "." # use local checkout
         use_complement_crypto: "MATCHING_BRANCH"


### PR DESCRIPTION
The workflow tries to build complement crypto from main, but the scrips to build the Rust SDK have been converted into just recipes.

So we need to use the updated workflow file as well.