### PR TITLE
fix(event cache): avoid deadlock in thread aggregation

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -20,11 +20,7 @@ use matrix_sdk_base::{
 };
 use ruma::{OwnedEventId, events::relation::RelationType, room_version_rules::RedactionRules};
 
-use super::{
-    super::{Result, states::StateLockReadGuard},
-    room::RoomEventCacheState,
-    thread::ThreadEventCache,
-};
+use super::{super::Result, room::RoomEventCache, thread::ThreadEventCache};
 
 pub fn aggregate_timeline_for_room(timeline: Timeline) -> Timeline {
     timeline
@@ -33,7 +29,7 @@ pub fn aggregate_timeline_for_room(timeline: Timeline) -> Timeline {
 pub async fn aggregate_timeline_for_threads(
     timeline: &Timeline,
     existing_threads: &HashMap<OwnedEventId, ThreadEventCache>,
-    room_event_cache: StateLockReadGuard<'_, RoomEventCacheState>,
+    room: &RoomEventCache,
     redaction_rules: &RedactionRules,
 ) -> Result<HashMap<OwnedEventId, Timeline>> {
     let mut new_events_by_thread = HashMap::new();
@@ -77,9 +73,10 @@ pub async fn aggregate_timeline_for_threads(
 
                         // Not in `timeline`, okay, look for the related event in the `room` as it
                         // knows about all the events, and then extract its thread root.
-                        None => room_event_cache.find_event(&related_event_id).await?.and_then(
-                            |(_location, related_event)| extract_thread_root(related_event.raw()),
-                        ),
+                        None => room
+                            .find_event(&related_event_id)
+                            .await?
+                            .and_then(|related_event| extract_thread_root(related_event.raw())),
                     } {
                         new_events_by_thread
                             .entry(thread_root)
@@ -106,7 +103,7 @@ pub async fn aggregate_timeline_for_threads(
                 // Otherwise, this event might be a redaction that applies to a thread.
                 else if let Some(redaction_target) =
                     extract_redaction_target(event.raw(), redaction_rules)
-                    && room_event_cache.find_event(&redaction_target).await?.is_some()
+                    && room.find_event(&redaction_target).await?.is_some()
                 {
                     // The redacted event exists (in the room, because it contains _all_ the
                     // events) **but** the event has been redacted (in

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -308,7 +308,7 @@ impl Caches {
             let timeline_for_threads = aggregator::aggregate_timeline_for_threads(
                 &updates.timeline,
                 threads.read().await.deref(),
-                room.state().read().await?,
+                room,
                 &internals.room_version_rules.redaction,
             )
             .await?;
@@ -370,7 +370,7 @@ impl Caches {
             let timeline_for_threads = aggregator::aggregate_timeline_for_threads(
                 &updates.timeline,
                 threads.read().await.deref(),
-                room.state().read().await?,
+                room,
                 &internals.room_version_rules.redaction,
             )
             .await?;

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -887,6 +887,77 @@ mod tests {
     }
 
     #[async_test]
+    async fn test_redaction_of_in_thread_event_is_applied_to_thread() {
+        let client = logged_in_client(None).await;
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        let sender = user_id!("@alice:localhost");
+        let room_id = room_id!("!a:localhost");
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+        let f = EventFactory::new().room(room_id).sender(sender);
+
+        let root = event_id!("$root");
+        let reply = event_id!("$reply");
+
+        // Seed a thread: a root plus an in-thread reply. This creates the thread cache
+        // and stores the reply in the room cache.
+        let mut setup = RoomUpdates::default();
+        setup.joined.insert(
+            room_id.to_owned(),
+            JoinedRoomUpdate {
+                timeline: Timeline {
+                    events: vec![
+                        f.text_msg("root").event_id(root).into(),
+                        f.text_msg("reply").in_thread(root, reply).event_id(reply).into(),
+                    ],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        event_cache.inner.handle_room_updates(setup).await.unwrap();
+
+        // Precondition: the reply is present in the thread as a normal (non-redacted)
+        // message.
+        let (thread_cache, _drop_handles) = event_cache.thread(room_id, root).await.unwrap();
+        let (before, _sub) = thread_cache.subscribe().await.unwrap();
+        let reply_before = before
+            .iter()
+            .find(|event| event.event_id() == Some(reply))
+            .expect("the in-thread reply should be in the thread before redaction");
+        assert_event_matches_msg(reply_before, "reply");
+
+        // Redact the in-thread reply via a room update. For it to be applied to the
+        // thread, `aggregate_timeline_for_threads` must route the redaction into the
+        // thread's timeline.
+        let mut redaction = RoomUpdates::default();
+        redaction.joined.insert(
+            room_id.to_owned(),
+            JoinedRoomUpdate {
+                timeline: Timeline {
+                    events: vec![f.redaction(reply).into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        event_cache.inner.handle_room_updates(redaction).await.unwrap();
+
+        // The redaction reached the thread: the thread's own copy of the reply is now
+        // redacted.
+        let (after, _sub) = thread_cache.subscribe().await.unwrap();
+        let reply_after = after
+            .iter()
+            .find(|event| event.event_id() == Some(reply))
+            .expect("the in-thread reply should still be present after redaction");
+        assert!(
+            reply_after.raw().deserialize().unwrap().is_redacted(),
+            "the redaction of an in-thread event must be applied to the thread's copy"
+        );
+    }
+
+    #[async_test]
     async fn test_generic_update_when_loading_rooms() {
         // Create 2 rooms. One of them has data in the event cache storage.
         let user = user_id!("@mnt_io:matrix.org");


### PR DESCRIPTION
Pass `&RoomEventCache` to `aggregate_timeline_for_threads` instead of a held `StateLockReadGuard`, so `find_event` can re-acquire the state lock without deadlocking.

Should fix deadlock which was randomly happening, preventing event_cache to be updated (and so the room list and timeline).

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
