### PR TITLE
Automatic backpagination - Part II

### DIFF
--- a/crates/matrix-sdk/changelog.d/6840.changed.md
+++ b/crates/matrix-sdk/changelog.d/6840.changed.md
@@ -1,0 +1,1 @@
+The latest event of a room is now computed with automatic back-pagination: when no suitable candidate is in memory, the room's history is back-paginated until a candidate is found or the start of the timeline is reached. Requires `ClientBuilder::with_enable_automatic_back_pagination(true)`.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -56,7 +56,7 @@ use crate::{
     paginators::PaginatorError,
 };
 
-mod back_pagination_queue;
+pub(crate) mod back_pagination_queue;
 mod caches;
 mod deduplicator;
 mod persistence;
@@ -68,7 +68,6 @@ mod tasks;
 #[cfg(feature = "e2e-encryption")]
 pub use redecryptor::{DecryptionRetryRequest, RedecryptorReport};
 
-pub(crate) use self::back_pagination_queue::{BATCH_SIZE, BackPaginationRequest, Priority};
 pub use self::{
     back_pagination_queue::BackPaginationQueue,
     caches::{

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -68,6 +68,9 @@ mod tasks;
 #[cfg(feature = "e2e-encryption")]
 pub use redecryptor::{DecryptionRetryRequest, RedecryptorReport};
 
+pub(crate) use self::back_pagination_queue::{
+    BATCH_SIZE, BackPaginationRequest, BackPaginationStopReason, Priority,
+};
 pub use self::{
     back_pagination_queue::BackPaginationQueue,
     caches::{

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -67,6 +67,9 @@ mod tasks;
 #[cfg(feature = "e2e-encryption")]
 pub use redecryptor::{DecryptionRetryRequest, RedecryptorReport};
 
+pub(crate) use self::back_pagination_queue::{
+    BATCH_SIZE, BackPaginationRequest, BackPaginationRunResult, Priority, RoomBackPaginationEnd,
+};
 pub use self::{
     back_pagination_queue::BackPaginationQueue,
     caches::{

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -68,9 +68,7 @@ mod tasks;
 #[cfg(feature = "e2e-encryption")]
 pub use redecryptor::{DecryptionRetryRequest, RedecryptorReport};
 
-pub(crate) use self::back_pagination_queue::{
-    BATCH_SIZE, BackPaginationRequest, BackPaginationStopReason, Priority,
-};
+pub(crate) use self::back_pagination_queue::{BATCH_SIZE, BackPaginationRequest, Priority};
 pub use self::{
     back_pagination_queue::BackPaginationQueue,
     caches::{

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -28,6 +28,14 @@ use tracing::{error, info, instrument, trace, warn};
 
 use crate::{Room, event_cache::RoomEventCache, room::WeakRoom, send_queue::RoomSendQueueUpdate};
 
+/// Whether back-paginating a room could give its latest event a value it
+/// cannot compute from what's currently in memory.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum NeedMoreEvents {
+    Yes,
+    No,
+}
+
 /// The latest event of a room or a thread.
 ///
 /// Use [`LatestEvent::subscribe`] to get a stream of updates.
@@ -80,29 +88,6 @@ impl LatestEvent {
         self.current_value.get().await
     }
 
-    /// Whether back-paginating the room could give this latest event a value it
-    /// cannot compute from what's currently in memory.
-    ///
-    /// `false` when a remote candidate is already in reach, and when a local
-    /// latest event value is waiting: the send queue has the priority, so the
-    /// event cache isn't consulted at all in that case.
-    pub(super) async fn needs_back_pagination(
-        &self,
-        room_event_cache: &RoomEventCache,
-        own_user_id: &UserId,
-        power_levels: Option<&RoomPowerLevels>,
-    ) -> bool {
-        if self.buffer_of_values_for_local_events.is_empty().not() {
-            return false;
-        }
-
-        let current_event = self.current_value.get().await;
-        let new_value =
-            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
-
-        !matches!(new_value, Some(LatestEventValue::Remote(_)))
-    }
-
     /// Update the inner latest event value, based on the event cache
     /// (specifically with the [`RoomEventCache`]), if and only if there is no
     /// local latest event value waiting.
@@ -112,17 +97,20 @@ impl LatestEvent {
     /// send queue. Indeed, anything coming from the send queue has the priority
     /// over the anything coming from the event cache. We believe it provides a
     /// better user experience.
+    ///
+    /// Returns whether back-paginating the room could yield a value that can't
+    /// be computed from what's currently in memory.
     pub async fn update_with_event_cache(
         &mut self,
         room_event_cache: &RoomEventCache,
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
-    ) {
+    ) -> NeedMoreEvents {
         if self.buffer_of_values_for_local_events.is_empty().not() {
             // At least one `LatestEventValue` exists for local events (i.e. coming from the
             // send queue). In this case, we don't overwrite the current value with a newly
             // computed one from the event cache.
-            return;
+            return NeedMoreEvents::No;
         }
 
         let current_event = self.current_value.get().await;
@@ -131,9 +119,16 @@ impl LatestEvent {
 
         trace!(value = ?new_value, "Computed a remote `LatestEventValue`");
 
+        let need_more_events = match new_value {
+            Some(LatestEventValue::Remote(_)) => NeedMoreEvents::No,
+            _ => NeedMoreEvents::Yes,
+        };
+
         if let Some(new_value) = new_value {
             self.update(new_value).await;
         }
+
+        need_more_events
     }
 
     /// Update the inner latest event value, based on the send queue

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -111,8 +111,19 @@ impl LatestEvent {
         }
 
         let current_event = self.current_value.get().await;
-        let new_value =
-            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
+        let mut new_value =
+            Builder::new_remote(room_event_cache, current_event.clone(), own_user_id, power_levels)
+                .await;
+
+        // No remote candidate in memory: back-paginate this room's history until a
+        // suitable event surfaces (or the timeline start is reached), then recompute.
+        if !matches!(new_value, Some(LatestEventValue::Remote(_)))
+            && self.backfill_for_candidate(room_event_cache, own_user_id, power_levels).await
+        {
+            new_value =
+                Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels)
+                    .await;
+        }
 
         trace!(value = ?new_value, "Computed a remote `LatestEventValue`");
 
@@ -468,6 +479,78 @@ mod tests_latest_event {
             );
             assert!(is_none.not());
         }
+    }
+
+    /// When no latest-event candidate is present in memory, but one exists
+    /// behind a gap, `update_with_event_cache` back-paginates to surface it.
+    #[async_test]
+    async fn test_update_with_event_cache_backfills_for_a_candidate() {
+        use matrix_sdk_base::event_cache::Gap;
+        use ruma::event_id;
+
+        use crate::test_utils::mocks::RoomMessagesResponseTemplate;
+
+        let room_id = room_id!("!r0");
+        let sender = user_id!("@bob:example.org");
+
+        let server = MatrixMockServer::new().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.with_enable_automatic_back_pagination(true))
+            .build()
+            .await;
+        let weak_client = WeakClient::from_client(&client);
+
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+        // A linked chunk with a single gap: no events in memory (so no candidate),
+        // but a token to paginate from. Set up directly so no sync (and thus no
+        // competing read-receipt pagination) races the backfill.
+        client
+            .event_cache_store()
+            .lock()
+            .await
+            .unwrap()
+            .as_clean()
+            .unwrap()
+            .handle_linked_chunk_updates(
+                LinkedChunkId::Room(room_id),
+                vec![Update::NewGapChunk {
+                    previous: None,
+                    new: ChunkIdentifier::new(0),
+                    next: None,
+                    gap: Gap { token: "prev_batch".to_owned() },
+                }],
+            )
+            .await
+            .unwrap();
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        let (room_event_cache, _drop_handles) = event_cache.room(room_id).await.unwrap();
+
+        // A displayable message lives behind the gap.
+        let f = EventFactory::new().room(room_id).sender(sender);
+        server
+            .mock_room_messages()
+            .match_from("prev_batch")
+            .ok(RoomMessagesResponseTemplate::default()
+                .events(vec![f.text_msg("hello").event_id(event_id!("$1"))]))
+            .mock_once()
+            .mount()
+            .await;
+
+        let weak_room = WeakRoom::new(weak_client, room_id.to_owned());
+        let (mut latest_event, _) = With::unzip(LatestEvent::new(&weak_room, None));
+
+        // No candidate in memory yet.
+        assert_matches!(latest_event.current_value.get().await, LatestEventValue::None);
+
+        latest_event.update_with_event_cache(&room_event_cache, sender, None).await;
+
+        // The backfill surfaced the message; the latest event resolved to it.
+        assert_matches!(latest_event.current_value.get().await, LatestEventValue::Remote(_));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -14,7 +14,7 @@
 
 mod builder;
 
-use std::ops::{ControlFlow, Deref, DerefMut, Not};
+use std::ops::{Deref, DerefMut, Not};
 
 pub use builder::filter_timeline_event;
 use builder::{BufferOfValuesForLocalEvents, Builder};
@@ -24,17 +24,9 @@ pub use matrix_sdk_base::latest_event::{
 };
 use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{error, info, instrument, trace, warn};
 
-use crate::{
-    Room,
-    event_cache::{
-        BATCH_SIZE, BackPaginationOutcome, BackPaginationRequest, BackPaginationStopReason,
-        Priority, RoomEventCache,
-    },
-    room::WeakRoom,
-    send_queue::RoomSendQueueUpdate,
-};
+use crate::{Room, event_cache::RoomEventCache, room::WeakRoom, send_queue::RoomSendQueueUpdate};
 
 /// The latest event of a room or a thread.
 ///
@@ -88,6 +80,29 @@ impl LatestEvent {
         self.current_value.get().await
     }
 
+    /// Whether back-paginating the room could give this latest event a value it
+    /// cannot compute from what's currently in memory.
+    ///
+    /// `false` when a remote candidate is already in reach, and when a local
+    /// latest event value is waiting: the send queue has the priority, so the
+    /// event cache isn't consulted at all in that case.
+    pub(super) async fn needs_back_pagination(
+        &self,
+        room_event_cache: &RoomEventCache,
+        own_user_id: &UserId,
+        power_levels: Option<&RoomPowerLevels>,
+    ) -> bool {
+        if self.buffer_of_values_for_local_events.is_empty().not() {
+            return false;
+        }
+
+        let current_event = self.current_value.get().await;
+        let new_value =
+            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
+
+        !matches!(new_value, Some(LatestEventValue::Remote(_)))
+    }
+
     /// Update the inner latest event value, based on the event cache
     /// (specifically with the [`RoomEventCache`]), if and only if there is no
     /// local latest event value waiting.
@@ -111,93 +126,14 @@ impl LatestEvent {
         }
 
         let current_event = self.current_value.get().await;
-        let mut new_value =
-            Builder::new_remote(room_event_cache, current_event.clone(), own_user_id, power_levels)
-                .await;
-
-        // No remote candidate in memory: back-paginate this room's history until a
-        // suitable event surfaces (or the timeline start is reached), then recompute.
-        if !matches!(new_value, Some(LatestEventValue::Remote(_)))
-            && self.backfill_for_candidate(room_event_cache, own_user_id, power_levels).await
-        {
-            new_value =
-                Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels)
-                    .await;
-        }
+        let new_value =
+            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
 
         trace!(value = ?new_value, "Computed a remote `LatestEventValue`");
 
         if let Some(new_value) = new_value {
             self.update(new_value).await;
         }
-    }
-
-    /// Back-paginate the room until a suitable latest-event candidate is loaded
-    /// into memory or the start of the timeline is reached.
-    ///
-    /// Enqueues a high-priority request on the shared [`BackPaginationQueue`],
-    /// with a stop predicate that fires as soon as a freshly loaded batch
-    /// contains a suitable latest-event candidate, and awaits it. No-ops if
-    /// automatic backpagination is disabled.
-    ///
-    /// Returns `true` if a candidate was surfaced (so it's worth recomputing
-    /// the value), `false` otherwise.
-    async fn backfill_for_candidate(
-        &self,
-        room_event_cache: &RoomEventCache,
-        own_user_id: &UserId,
-        power_levels: Option<&RoomPowerLevels>,
-    ) -> bool {
-        let Some(room) = self.weak_room.get() else {
-            return false;
-        };
-        let Some(queue) = room.client().event_cache().back_pagination_queue() else {
-            return false;
-        };
-
-        let own_user_id = own_user_id.to_owned();
-        let power_levels = power_levels.cloned();
-        let stop = move |outcome: &BackPaginationOutcome| {
-            let found = outcome.events.iter().any(|event| {
-                matches!(
-                    filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()),
-                    ControlFlow::Break(())
-                )
-            });
-
-            if found { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
-        };
-
-        let room_id = room_event_cache.room_id().to_owned();
-        debug!(%room_id, "started backfill request for latest events");
-
-        let handle = match queue.enqueue(BackPaginationRequest {
-            room_id: room_id.clone(),
-            priority: Priority::High,
-            stop: Box::new(stop),
-            batch_size: BATCH_SIZE,
-            max_batches: None,
-        }) {
-            Ok(handle) => handle,
-            Err(err) => {
-                warn!(%room_id, "couldn't enqueue a latest-event backfill request: {err}");
-                return false;
-            }
-        };
-
-        let reason = handle.join().await.reason;
-
-        debug!(%room_id, "finished backfill request for latest events");
-
-        // Both outcomes may have loaded events into memory: `StopConditionMet` found
-        // a candidate, and `ReachedTimelineStart` means the remaining history (which
-        // can include the candidate) was pulled in a final batch. The other end
-        // states loaded nothing worth recomputing for.
-        matches!(
-            reason,
-            BackPaginationStopReason::StopConditionMet
-                | BackPaginationStopReason::ReachedTimelineStart
-        )
     }
 
     /// Update the inner latest event value, based on the send queue
@@ -491,78 +427,6 @@ mod tests_latest_event {
             );
             assert!(is_none.not());
         }
-    }
-
-    /// When no latest-event candidate is present in memory, but one exists
-    /// behind a gap, `update_with_event_cache` back-paginates to surface it.
-    #[async_test]
-    async fn test_update_with_event_cache_backfills_for_a_candidate() {
-        use matrix_sdk_base::event_cache::Gap;
-        use ruma::event_id;
-
-        use crate::test_utils::mocks::RoomMessagesResponseTemplate;
-
-        let room_id = room_id!("!r0");
-        let sender = user_id!("@bob:example.org");
-
-        let server = MatrixMockServer::new().await;
-        let client = server
-            .client_builder()
-            .on_builder(|builder| builder.with_enable_automatic_back_pagination(true))
-            .build()
-            .await;
-        let weak_client = WeakClient::from_client(&client);
-
-        client.base_client().get_or_create_room(room_id, RoomState::Joined);
-
-        // A linked chunk with a single gap: no events in memory (so no candidate),
-        // but a token to paginate from. Set up directly so no sync (and thus no
-        // competing read-receipt pagination) races the backfill.
-        client
-            .event_cache_store()
-            .lock()
-            .await
-            .unwrap()
-            .as_clean()
-            .unwrap()
-            .handle_linked_chunk_updates(
-                LinkedChunkId::Room(room_id),
-                vec![Update::NewGapChunk {
-                    previous: None,
-                    new: ChunkIdentifier::new(0),
-                    next: None,
-                    gap: Gap { token: "prev_batch".to_owned() },
-                }],
-            )
-            .await
-            .unwrap();
-
-        let event_cache = client.event_cache();
-        event_cache.subscribe().unwrap();
-
-        let (room_event_cache, _drop_handles) = event_cache.room(room_id).await.unwrap();
-
-        // A displayable message lives behind the gap.
-        let f = EventFactory::new().room(room_id).sender(sender);
-        server
-            .mock_room_messages()
-            .match_from("prev_batch")
-            .ok(RoomMessagesResponseTemplate::default()
-                .events(vec![f.text_msg("hello").event_id(event_id!("$1"))]))
-            .mock_once()
-            .mount()
-            .await;
-
-        let weak_room = WeakRoom::new(weak_client, room_id.to_owned());
-        let (mut latest_event, _) = With::unzip(LatestEvent::new(&weak_room, None));
-
-        // No candidate in memory yet.
-        assert_matches!(latest_event.current_value.get().await, LatestEventValue::None);
-
-        latest_event.update_with_event_cache(&room_event_cache, sender, None).await;
-
-        // The backfill surfaced the message; the latest event resolved to it.
-        assert_matches!(latest_event.current_value.get().await, LatestEventValue::Remote(_));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -14,7 +14,7 @@
 
 mod builder;
 
-use std::ops::{Deref, DerefMut, Not};
+use std::ops::{ControlFlow, Deref, DerefMut, Not};
 
 pub use builder::filter_timeline_event;
 use builder::{BufferOfValuesForLocalEvents, Builder};
@@ -24,9 +24,17 @@ pub use matrix_sdk_base::latest_event::{
 };
 use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
-use tracing::{error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
-use crate::{Room, event_cache::RoomEventCache, room::WeakRoom, send_queue::RoomSendQueueUpdate};
+use crate::{
+    Room,
+    event_cache::{
+        BATCH_SIZE, BackPaginationOutcome, BackPaginationRequest, BackPaginationStopReason,
+        Priority, RoomEventCache,
+    },
+    room::WeakRoom,
+    send_queue::RoomSendQueueUpdate,
+};
 
 /// The latest event of a room or a thread.
 ///
@@ -111,6 +119,74 @@ impl LatestEvent {
         if let Some(new_value) = new_value {
             self.update(new_value).await;
         }
+    }
+
+    /// Back-paginate the room until a suitable latest-event candidate is loaded
+    /// into memory or the start of the timeline is reached.
+    ///
+    /// Enqueues a high-priority request on the shared [`BackPaginationQueue`],
+    /// with a stop predicate that fires as soon as a freshly loaded batch
+    /// contains a suitable latest-event candidate, and awaits it. No-ops if
+    /// automatic backpagination is disabled.
+    ///
+    /// Returns `true` if a candidate was surfaced (so it's worth recomputing
+    /// the value), `false` otherwise.
+    async fn backfill_for_candidate(
+        &self,
+        room_event_cache: &RoomEventCache,
+        own_user_id: &UserId,
+        power_levels: Option<&RoomPowerLevels>,
+    ) -> bool {
+        let Some(room) = self.weak_room.get() else {
+            return false;
+        };
+        let Some(queue) = room.client().event_cache().back_pagination_queue() else {
+            return false;
+        };
+
+        let own_user_id = own_user_id.to_owned();
+        let power_levels = power_levels.cloned();
+        let stop = move |outcome: &BackPaginationOutcome| {
+            let found = outcome.events.iter().any(|event| {
+                matches!(
+                    filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()),
+                    ControlFlow::Break(())
+                )
+            });
+
+            if found { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
+        };
+
+        let room_id = room_event_cache.room_id().to_owned();
+        debug!(%room_id, "started backfill request for latest events");
+
+        let handle = match queue.enqueue(BackPaginationRequest {
+            room_id: room_id.clone(),
+            priority: Priority::High,
+            stop: Box::new(stop),
+            batch_size: BATCH_SIZE,
+            max_batches: None,
+        }) {
+            Ok(handle) => handle,
+            Err(err) => {
+                warn!(%room_id, "couldn't enqueue a latest-event backfill request: {err}");
+                return false;
+            }
+        };
+
+        let reason = handle.join().await.reason;
+
+        debug!(%room_id, "finished backfill request for latest events");
+
+        // Both outcomes may have loaded events into memory: `StopConditionMet` found
+        // a candidate, and `ReachedTimelineStart` means the remaining history (which
+        // can include the candidate) was pulled in a final batch. The other end
+        // states loaded nothing worth recomputing for.
+        matches!(
+            reason,
+            BackPaginationStopReason::StopConditionMet
+                | BackPaginationStopReason::ReachedTimelineStart
+        )
     }
 
     /// Update the inner latest event value, based on the send queue

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -111,8 +111,19 @@ impl LatestEvent {
         }
 
         let current_event = self.current_value.get().await;
-        let new_value =
-            Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels).await;
+        let mut new_value =
+            Builder::new_remote(room_event_cache, current_event.clone(), own_user_id, power_levels)
+                .await;
+
+        // No remote candidate in memory: back-paginate this room's history until a
+        // suitable event surfaces (or the timeline start is reached), then recompute.
+        if !matches!(new_value, Some(LatestEventValue::Remote(_)))
+            && self.backfill_for_candidate(room_event_cache, own_user_id, power_levels).await
+        {
+            new_value =
+                Builder::new_remote(room_event_cache, current_event, own_user_id, power_levels)
+                    .await;
+        }
 
         trace!(value = ?new_value, "Computed a remote `LatestEventValue`");
 
@@ -480,6 +491,78 @@ mod tests_latest_event {
             );
             assert!(is_none.not());
         }
+    }
+
+    /// When no latest-event candidate is present in memory, but one exists
+    /// behind a gap, `update_with_event_cache` back-paginates to surface it.
+    #[async_test]
+    async fn test_update_with_event_cache_backfills_for_a_candidate() {
+        use matrix_sdk_base::event_cache::Gap;
+        use ruma::event_id;
+
+        use crate::test_utils::mocks::RoomMessagesResponseTemplate;
+
+        let room_id = room_id!("!r0");
+        let sender = user_id!("@bob:example.org");
+
+        let server = MatrixMockServer::new().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.with_enable_automatic_back_pagination(true))
+            .build()
+            .await;
+        let weak_client = WeakClient::from_client(&client);
+
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+        // A linked chunk with a single gap: no events in memory (so no candidate),
+        // but a token to paginate from. Set up directly so no sync (and thus no
+        // competing read-receipt pagination) races the backfill.
+        client
+            .event_cache_store()
+            .lock()
+            .await
+            .unwrap()
+            .as_clean()
+            .unwrap()
+            .handle_linked_chunk_updates(
+                LinkedChunkId::Room(room_id),
+                vec![Update::NewGapChunk {
+                    previous: None,
+                    new: ChunkIdentifier::new(0),
+                    next: None,
+                    gap: Gap { token: "prev_batch".to_owned() },
+                }],
+            )
+            .await
+            .unwrap();
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        let (room_event_cache, _drop_handles) = event_cache.room(room_id).await.unwrap();
+
+        // A displayable message lives behind the gap.
+        let f = EventFactory::new().room(room_id).sender(sender);
+        server
+            .mock_room_messages()
+            .match_from("prev_batch")
+            .ok(RoomMessagesResponseTemplate::default()
+                .events(vec![f.text_msg("hello").event_id(event_id!("$1"))]))
+            .mock_once()
+            .mount()
+            .await;
+
+        let weak_room = WeakRoom::new(weak_client, room_id.to_owned());
+        let (mut latest_event, _) = With::unzip(LatestEvent::new(&weak_room, None));
+
+        // No candidate in memory yet.
+        assert_matches!(latest_event.current_value.get().await, LatestEventValue::None);
+
+        latest_event.update_with_event_cache(&room_event_cache, sender, None).await;
+
+        // The backfill surfaced the message; the latest event resolved to it.
+        assert_matches!(latest_event.current_value.get().await, LatestEventValue::Remote(_));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -14,7 +14,7 @@
 
 mod builder;
 
-use std::ops::{Deref, DerefMut, Not};
+use std::ops::{ControlFlow, Deref, DerefMut, Not};
 
 pub use builder::filter_timeline_event;
 use builder::{BufferOfValuesForLocalEvents, Builder};
@@ -24,9 +24,17 @@ pub use matrix_sdk_base::latest_event::{
 };
 use matrix_sdk_base::{RoomInfoNotableUpdateReasons, RoomState};
 use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
-use tracing::{error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
-use crate::{Room, event_cache::RoomEventCache, room::WeakRoom, send_queue::RoomSendQueueUpdate};
+use crate::{
+    Room,
+    event_cache::{
+        BATCH_SIZE, BackPaginationOutcome, BackPaginationRequest, BackPaginationRunResult,
+        Priority, RoomBackPaginationEnd, RoomEventCache,
+    },
+    room::WeakRoom,
+    send_queue::RoomSendQueueUpdate,
+};
 
 /// The latest event of a room or a thread.
 ///
@@ -111,6 +119,68 @@ impl LatestEvent {
         if let Some(new_value) = new_value {
             self.update(new_value).await;
         }
+    }
+
+    /// Back-paginate the room until a suitable latest-event candidate is loaded
+    /// into memory or the start of the timeline is reached.
+    ///
+    /// Enqueues a high-priority request on the shared [`BackPaginationQueue`],
+    /// with a stop predicate that fires as soon as a freshly loaded batch
+    /// contains a suitable latest-event candidate, and awaits it. No-ops if
+    /// automatic backpagination is disabled.
+    ///
+    /// Returns `true` if a candidate was surfaced (so it's worth recomputing
+    /// the value), `false` otherwise.
+    async fn backfill_for_candidate(
+        &self,
+        room_event_cache: &RoomEventCache,
+        own_user_id: &UserId,
+        power_levels: Option<&RoomPowerLevels>,
+    ) -> bool {
+        let Some(room) = self.weak_room.get() else {
+            return false;
+        };
+        let Some(queue) = room.client().event_cache().back_pagination_queue() else {
+            return false;
+        };
+
+        let own_user_id = own_user_id.to_owned();
+        let power_levels = power_levels.cloned();
+        let stop = move |outcome: &BackPaginationOutcome| {
+            let found = outcome.events.iter().any(|event| {
+                matches!(
+                    filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()),
+                    ControlFlow::Break(())
+                )
+            });
+
+            if found { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
+        };
+
+        let room_id = room_event_cache.room_id().to_owned();
+        debug!(%room_id, "started backfill request for latest events");
+
+        let BackPaginationRunResult { end, .. } = queue
+            .enqueue(BackPaginationRequest {
+                room_id: room_id.clone(),
+                priority: Priority::High,
+                stop: Box::new(stop),
+                batch_size: BATCH_SIZE,
+                max_batches: None,
+            })
+            .join()
+            .await;
+
+        debug!(%room_id, "finished backfill request for latest events");
+
+        // Both outcomes may have loaded events into memory: `StopConditionMet` found
+        // a candidate, and `ReachedTimelineStart` means the remaining history (which
+        // can include the candidate) was pulled in a final batch. The other end
+        // states loaded nothing worth recomputing for.
+        matches!(
+            end,
+            RoomBackPaginationEnd::StopConditionMet | RoomBackPaginationEnd::ReachedTimelineStart
+        )
     }
 
     /// Update the inner latest event value, based on the send queue

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -21,7 +21,7 @@ use tracing::{debug, error, instrument, warn};
 
 use super::{
     LatestEvent, filter_timeline_event,
-    latest_event::{IsLatestEventValueNone, With},
+    latest_event::{IsLatestEventValueNone, NeedMoreEvents, With},
 };
 use crate::{
     Room,
@@ -189,15 +189,14 @@ impl RoomLatestEventsWriteGuard {
             }
         };
 
-        // No remote candidate in memory: back-paginate this room's history until a
-        // suitable event surfaces (or the timeline start is reached), and only then
-        // compute the value, so it's computed and applied once. Skip the check
-        // entirely when automatic back-pagination is disabled, so this path costs
-        // nothing beyond what it did before the feature existed.
-        if room.client().event_cache().back_pagination_queue().is_some()
-            && for_the_room
-                .needs_back_pagination(room_event_cache, own_user_id, power_levels.as_ref())
-                .await
+        // The room is left without a latest event so back-paginate its history
+        // until a suitable event surfaces, then recompute.
+        if matches!(
+            for_the_room
+                .update_with_event_cache(room_event_cache, own_user_id, power_levels.as_ref())
+                .await,
+            NeedMoreEvents::Yes
+        ) && room.client().event_cache().back_pagination_queue().is_some()
         {
             Self::back_paginate_for_candidate(
                 &room,
@@ -206,11 +205,11 @@ impl RoomLatestEventsWriteGuard {
                 power_levels.as_ref(),
             )
             .await;
-        }
 
-        for_the_room
-            .update_with_event_cache(room_event_cache, own_user_id, power_levels.as_ref())
-            .await;
+            for_the_room
+                .update_with_event_cache(room_event_cache, own_user_id, power_levels.as_ref())
+                .await;
+        }
 
         for latest_event in per_thread.values_mut() {
             latest_event

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -12,19 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::ControlFlow, sync::Arc};
 
 use matrix_sdk_base::RoomInfoNotableUpdateReasons;
-use ruma::{EventId, OwnedEventId};
+use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
 use tokio::sync::{OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
-use tracing::error;
+use tracing::{debug, error, warn};
 
 use super::{
-    LatestEvent,
+    LatestEvent, filter_timeline_event,
     latest_event::{IsLatestEventValueNone, With},
 };
 use crate::{
-    event_cache::{EventCache, EventCacheError, RoomEventCache},
+    Room,
+    event_cache::{
+        BATCH_SIZE, BackPaginationOutcome, BackPaginationRequest, EventCache, EventCacheError,
+        Priority, RoomEventCache,
+    },
     room::WeakRoom,
     send_queue::RoomSendQueueUpdate,
 };
@@ -185,6 +189,25 @@ impl RoomLatestEventsWriteGuard {
             }
         };
 
+        // No remote candidate in memory: back-paginate this room's history until a
+        // suitable event surfaces (or the timeline start is reached), and only then
+        // compute the value, so it's computed and applied once. Skip the check
+        // entirely when automatic back-pagination is disabled, so this path costs
+        // nothing beyond what it did before the feature existed.
+        if room.client().event_cache().back_pagination_queue().is_some()
+            && for_the_room
+                .needs_back_pagination(room_event_cache, own_user_id, power_levels.as_ref())
+                .await
+        {
+            Self::back_paginate_for_candidate(
+                &room,
+                room_event_cache,
+                own_user_id,
+                power_levels.as_ref(),
+            )
+            .await;
+        }
+
         for_the_room
             .update_with_event_cache(room_event_cache, own_user_id, power_levels.as_ref())
             .await;
@@ -266,5 +289,149 @@ impl RoomLatestEventsWriteGuard {
         };
 
         self.inner.for_the_room.update_with_room_info(room, reasons).await;
+    }
+
+    /// Back-paginate the room until a suitable latest-event candidate is loaded
+    /// into memory or the start of the timeline is reached.
+    ///
+    /// Enqueues a high-priority request on the shared [`BackPaginationQueue`],
+    /// with a stop predicate that fires as soon as a freshly loaded batch
+    /// contains a suitable latest-event candidate, and awaits it. No-ops if
+    /// automatic backpagination is disabled.
+    ///
+    /// [`BackPaginationQueue`]: crate::event_cache::BackPaginationQueue
+    async fn back_paginate_for_candidate(
+        room: &Room,
+        room_event_cache: &RoomEventCache,
+        own_user_id: &UserId,
+        power_levels: Option<&RoomPowerLevels>,
+    ) {
+        let Some(queue) = room.client().event_cache().back_pagination_queue() else {
+            return;
+        };
+
+        let own_user_id = own_user_id.to_owned();
+        let power_levels = power_levels.cloned();
+        let stop = move |outcome: &BackPaginationOutcome| {
+            let found = outcome.events.iter().any(|event| {
+                matches!(
+                    filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()),
+                    ControlFlow::Break(())
+                )
+            });
+
+            if found { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
+        };
+
+        let room_id = room_event_cache.room_id().to_owned();
+        debug!(%room_id, "started backfill request for latest events");
+
+        let handle = match queue.enqueue(BackPaginationRequest {
+            room_id: room_id.clone(),
+            priority: Priority::High,
+            stop: Box::new(stop),
+            batch_size: BATCH_SIZE,
+            max_batches: None,
+        }) {
+            Ok(handle) => handle,
+            Err(err) => {
+                warn!(%room_id, "couldn't enqueue a latest-event backfill request: {err}");
+                return;
+            }
+        };
+
+        handle.join().await;
+
+        debug!(%room_id, "finished backfill request for latest events");
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use assert_matches::assert_matches;
+    use matrix_sdk_base::{
+        RoomState,
+        event_cache::Gap,
+        linked_chunk::{ChunkIdentifier, LinkedChunkId, Update},
+    };
+    use matrix_sdk_test::{async_test, event_factory::EventFactory};
+    use ruma::{event_id, room_id, user_id};
+
+    use super::RoomLatestEvents;
+    use crate::{
+        client::WeakClient,
+        latest_events::LatestEventValue,
+        room::WeakRoom,
+        test_utils::mocks::{MatrixMockServer, RoomMessagesResponseTemplate},
+    };
+
+    /// When no latest-event candidate is present in memory, but one exists
+    /// behind a gap, `update_with_event_cache` back-paginates to surface it.
+    #[async_test]
+    async fn test_update_with_event_cache_backfills_for_a_candidate() {
+        let room_id = room_id!("!r0");
+        let sender = user_id!("@bob:example.org");
+
+        let server = MatrixMockServer::new().await;
+        let client = server
+            .client_builder()
+            .on_builder(|builder| builder.with_enable_automatic_back_pagination(true))
+            .build()
+            .await;
+
+        client.base_client().get_or_create_room(room_id, RoomState::Joined);
+
+        // A linked chunk with a single gap: no events in memory (so no candidate),
+        // but a token to paginate from. Set up directly so no sync (and thus no
+        // competing read-receipt pagination) races the backfill.
+        client
+            .event_cache_store()
+            .lock()
+            .await
+            .unwrap()
+            .as_clean()
+            .unwrap()
+            .handle_linked_chunk_updates(
+                LinkedChunkId::Room(room_id),
+                vec![Update::NewGapChunk {
+                    previous: None,
+                    new: ChunkIdentifier::new(0),
+                    next: None,
+                    gap: Gap { token: "prev_batch".to_owned() },
+                }],
+            )
+            .await
+            .unwrap();
+
+        let event_cache = client.event_cache();
+        event_cache.subscribe().unwrap();
+
+        // A displayable message lives behind the gap.
+        let f = EventFactory::new().room(room_id).sender(sender);
+        server
+            .mock_room_messages()
+            .match_from("prev_batch")
+            .ok(RoomMessagesResponseTemplate::default()
+                .events(vec![f.text_msg("hello").event_id(event_id!("$1"))]))
+            .mock_once()
+            .mount()
+            .await;
+
+        let weak_room = WeakRoom::new(WeakClient::from_client(&client), room_id.to_owned());
+        let room_latest_events = RoomLatestEvents::new(weak_room, event_cache);
+
+        // No candidate in memory yet.
+        assert_matches!(
+            room_latest_events.read().await.for_room().get().await,
+            LatestEventValue::None
+        );
+
+        room_latest_events.write().await.update_with_event_cache().await;
+
+        // The backfill surfaced the message; the latest event resolved to it.
+        assert_matches!(
+            room_latest_events.read().await.for_room().get().await,
+            LatestEventValue::Remote(_)
+        );
     }
 }

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -26,8 +26,8 @@ use super::{
 use crate::{
     Room,
     event_cache::{
-        BATCH_SIZE, BackPaginationOutcome, BackPaginationRequest, EventCache, EventCacheError,
-        Priority, RoomEventCache,
+        BackPaginationOutcome, EventCache, EventCacheError, RoomEventCache,
+        back_pagination_queue::{self, BackPaginationRequest},
     },
     room::WeakRoom,
     send_queue::RoomSendQueueUpdate,
@@ -328,9 +328,9 @@ impl RoomLatestEventsWriteGuard {
 
         let handle = match queue.enqueue(BackPaginationRequest {
             room_id: room_id.clone(),
-            priority: Priority::High,
+            priority: back_pagination_queue::Priority::High,
             stop: Box::new(stop),
-            batch_size: BATCH_SIZE,
+            batch_size: back_pagination_queue::BATCH_SIZE,
             max_batches: None,
         }) {
             Ok(handle) => handle,

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -198,13 +198,7 @@ impl RoomLatestEventsWriteGuard {
             NeedMoreEvents::Yes
         ) && room.client().event_cache().back_pagination_queue().is_some()
         {
-            Self::back_paginate_for_candidate(
-                &room,
-                room_event_cache,
-                own_user_id,
-                power_levels.as_ref(),
-            )
-            .await;
+            Self::back_paginate_for_candidate(&room, own_user_id, power_levels.as_ref()).await;
 
             for_the_room
                 .update_with_event_cache(room_event_cache, own_user_id, power_levels.as_ref())
@@ -299,10 +293,9 @@ impl RoomLatestEventsWriteGuard {
     /// automatic backpagination is disabled.
     ///
     /// [`BackPaginationQueue`]: crate::event_cache::BackPaginationQueue
-    #[instrument(skip_all, fields(room_id = %room_event_cache.room_id()))]
+    #[instrument(skip_all, fields(room_id = %room.room_id()))]
     async fn back_paginate_for_candidate(
         room: &Room,
-        room_event_cache: &RoomEventCache,
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) {
@@ -328,7 +321,7 @@ impl RoomLatestEventsWriteGuard {
         debug!("started backfill request for latest events");
 
         let handle = match queue.enqueue(BackPaginationRequest {
-            room_id: room_event_cache.room_id().to_owned(),
+            room_id: room.room_id().to_owned(),
             priority: back_pagination_queue::Priority::High,
             stop: Box::new(stop),
             batch_size: back_pagination_queue::BATCH_SIZE,

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -17,7 +17,7 @@ use std::{collections::HashMap, ops::ControlFlow, sync::Arc};
 use matrix_sdk_base::RoomInfoNotableUpdateReasons;
 use ruma::{EventId, OwnedEventId, UserId, events::room::power_levels::RoomPowerLevels};
 use tokio::sync::{OnceCell, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, instrument, warn};
 
 use super::{
     LatestEvent, filter_timeline_event,
@@ -300,6 +300,7 @@ impl RoomLatestEventsWriteGuard {
     /// automatic backpagination is disabled.
     ///
     /// [`BackPaginationQueue`]: crate::event_cache::BackPaginationQueue
+    #[instrument(skip_all, fields(room_id = %room_event_cache.room_id()))]
     async fn back_paginate_for_candidate(
         room: &Room,
         room_event_cache: &RoomEventCache,
@@ -314,20 +315,16 @@ impl RoomLatestEventsWriteGuard {
         let power_levels = power_levels.cloned();
         let stop = move |outcome: &BackPaginationOutcome| {
             let found = outcome.events.iter().any(|event| {
-                matches!(
-                    filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()),
-                    ControlFlow::Break(())
-                )
+                filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()).is_break()
             });
 
             if found { ControlFlow::Break(()) } else { ControlFlow::Continue(()) }
         };
 
-        let room_id = room_event_cache.room_id().to_owned();
-        debug!(%room_id, "started backfill request for latest events");
+        debug!("started backfill request for latest events");
 
         let handle = match queue.enqueue(BackPaginationRequest {
-            room_id: room_id.clone(),
+            room_id: room_event_cache.room_id().to_owned(),
             priority: back_pagination_queue::Priority::High,
             stop: Box::new(stop),
             batch_size: back_pagination_queue::BATCH_SIZE,
@@ -335,14 +332,14 @@ impl RoomLatestEventsWriteGuard {
         }) {
             Ok(handle) => handle,
             Err(err) => {
-                warn!(%room_id, "couldn't enqueue a latest-event backfill request: {err}");
+                warn!("couldn't enqueue a latest-event backfill request: {err}");
                 return;
             }
         };
 
         handle.join().await;
 
-        debug!(%room_id, "finished backfill request for latest events");
+        debug!("finished backfill request for latest events");
     }
 }
 

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -313,6 +313,11 @@ impl RoomLatestEventsWriteGuard {
 
         let own_user_id = own_user_id.to_owned();
         let power_levels = power_levels.cloned();
+
+        // This filters each batch to spot a candidate and `Builder::new_remote`
+        // filters the same events again when it computes the value afterwards. That
+        // second pass can't be skipped though as an event's edits are newer than it
+        // and a stop condition only ever sees the batch it just loaded.
         let stop = move |outcome: &BackPaginationOutcome| {
             let found = outcome.events.iter().any(|event| {
                 filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()).is_break()


### PR DESCRIPTION
Split from https://github.com/matrix-org/matrix-rust-sdk/pull/6805

This second part leverages the `BackPaginationQueue` introduced previously to resolve `LatestEvent`s when no suitable candidate is found in memory, paginating the room's history until a candidate is found or the start of the timeline is reached.

Requires `ClientBuilder::with_enable_automatic_back_pagination(true)`.

---

(Edited by @Hywan)

- Address https://github.com/matrix-org/matrix-rust-sdk/issues/6014

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.
