### PR TITLE
send queue: preserve ordering when a request fails to send

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- changelog start -->
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- The send queue now sends requests strictly in the order they were queued, in
+  a given room: a request that failed with an unrecoverable error (and got
+  marked as wedged) blocks subsequent requests in the same room from being
+  sent, until it's either retried with `SendHandle::unwedge()` or removed with
+  `SendHandle::abort()`. Previously, a wedged request was skipped over, causing
+  later messages to be sent before it, i.e. out of order.
+- An HTTP 520 status code (a non-standard "unknown server error", returned by
+  Cloudflare and other reverse proxies) is now considered a transient error
+  again, like the other 5xx status codes: requests failing with it will be
+  retried, and the send queue treats it as a recoverable error (keeping the
+  failed request in the queue) instead of wedging the request.
+
 ## [0.18.0](https://github.com/matrix-org/matrix-rust-sdk/tree/0.18.0) - 2026-06-02
 
 ### Added

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -10,10 +10,16 @@ All notable changes to this project will be documented in this file.
 
 - The send queue now sends requests strictly in the order they were queued, in
   a given room: a request that failed with an unrecoverable error (and got
-  marked as wedged) blocks subsequent requests in the same room from being
-  sent, until it's either retried with `SendHandle::unwedge()` or removed with
-  `SendHandle::abort()`. Previously, a wedged request was skipped over, causing
-  later messages to be sent before it, i.e. out of order.
+  marked as wedged) blocks subsequent requests of the same priority in the same
+  room from being sent, until it's either retried with `SendHandle::unwedge()`
+  or removed with `SendHandle::abort()`. Previously, a wedged request was
+  skipped over, causing later messages to be sent before it, i.e. out of order.
+  Requests of other priorities aren't blocked, so e.g. a wedged edit or
+  reaction (sent at a high priority once its target event is sent) doesn't
+  prevent regular messages from being sent, nor vice versa.
+- A failed media upload's send error is now reflected on the media event's
+  local echo returned by `RoomSendQueue::subscribe()`, instead of the echo
+  claiming the media is still being sent.
 - An HTTP 520 status code (a non-standard "unknown server error", returned by
   Cloudflare and other reverse proxies) is now considered a transient error
   again, like the other 5xx status codes: requests failing with it will be

--- a/crates/matrix-sdk/changelog.d/6843.changed.md
+++ b/crates/matrix-sdk/changelog.d/6843.changed.md
@@ -1,0 +1,14 @@
+- The send queue now sends requests strictly in the order they were queued, in
+  a given room: a request that failed with an unrecoverable error (and got
+  marked as wedged) blocks all the subsequent requests in the same room from
+  being sent, until it's either retried with `SendHandle::unwedge()` or removed
+  with `SendHandle::abort()`. Previously, a wedged request was skipped over,
+  causing later messages to be sent before it, i.e. out of order.
+- A failed media upload's send error is now reflected on the media event's
+  local echo returned by `RoomSendQueue::subscribe()`, instead of the echo
+  claiming the media is still being sent.
+- An HTTP 520 status code (a non-standard "unknown server error", returned by
+  Cloudflare and other reverse proxies) is now considered a transient error
+  again, like the other 5xx status codes: requests failing with it will be
+  retried, and the send queue treats it as a recoverable error (keeping the
+  failed request in the queue) instead of wedging the request.

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -228,14 +228,15 @@ impl RetryKind {
     /// if we received an error from a reverse proxy while the Matrix
     /// homeserver is down.
     fn from_status_code(status_code: StatusCode) -> Self {
-        if status_code.as_u16() == 520 {
-            // Cloudflare or some other proxy server sent this, meaning the actual
-            // homeserver sent some unknown error back
-            RetryKind::Permanent
-        } else if status_code == StatusCode::TOO_MANY_REQUESTS || status_code.is_server_error() {
-            // If the status code is 429, this is requesting a retry in HTTP, without the
-            // custom `errcode`. Treat that as a retriable request with no specified
-            // retry_after delay.
+        // If the status code is 429, this is requesting a retry in HTTP, without the
+        // custom `errcode`. Treat that as a retriable request with no specified
+        // retry_after delay.
+        //
+        // All 5xx errors are considered transient, including non-standard ones like
+        // 520 ("web server returned an unknown error", from Cloudflare or another
+        // reverse proxy): they reflect the state of the server at the time of the
+        // request, and the request may well succeed when retried later.
+        if status_code == StatusCode::TOO_MANY_REQUESTS || status_code.is_server_error() {
             RetryKind::Transient { retry_after: None }
         } else {
             RetryKind::Permanent

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -1997,48 +1997,61 @@ impl QueueStorage {
         let client = guard.client()?;
         let store = client.state_store();
 
-        let local_requests =
-            store.load_send_queue_requests(&self.room_id).await?.into_iter().filter_map(|queued| {
-                Some(LocalEcho {
-                    transaction_id: queued.transaction_id.clone(),
-                    content: match queued.kind {
-                        QueuedRequestKind::Event { content } => LocalEchoContent::Event {
-                            serialized_event: content,
-                            send_handle: SendHandle {
+        let queued_requests = store.load_send_queue_requests(&self.room_id).await?;
+
+        // Media upload requests aren't returned as echoes themselves (the media event,
+        // represented as a dependent request, is), so carry their send errors over to
+        // the dependent request's echo: a wedged upload wedges the media event.
+        let mut media_upload_errors: HashMap<OwnedTransactionId, QueueWedgeError> = queued_requests
+            .iter()
+            .filter_map(|queued| match queued.kind {
+                QueuedRequestKind::MediaUpload { .. } => {
+                    queued.error.clone().map(|error| (queued.transaction_id.clone(), error))
+                }
+                _ => None,
+            })
+            .collect();
+
+        let local_requests = queued_requests.into_iter().filter_map(|queued| {
+            Some(LocalEcho {
+                transaction_id: queued.transaction_id.clone(),
+                content: match queued.kind {
+                    QueuedRequestKind::Event { content } => LocalEchoContent::Event {
+                        serialized_event: content,
+                        send_handle: SendHandle {
+                            room: room.clone(),
+                            transaction_id: queued.transaction_id,
+                            media_handles: vec![],
+                            created_at: queued.created_at,
+                        },
+                        send_error: queued.error,
+                    },
+
+                    QueuedRequestKind::MediaUpload { .. } => {
+                        // Don't return uploaded medias as their own things; the accompanying
+                        // event represented as a dependent request should be sufficient.
+                        return None;
+                    }
+
+                    QueuedRequestKind::Redaction { redacts, reason } => {
+                        LocalEchoContent::Redaction {
+                            redacts,
+                            reason,
+                            send_handle: SendRedactionHandle {
                                 room: room.clone(),
                                 transaction_id: queued.transaction_id,
-                                media_handles: vec![],
-                                created_at: queued.created_at,
                             },
                             send_error: queued.error,
-                        },
-
-                        QueuedRequestKind::MediaUpload { .. } => {
-                            // Don't return uploaded medias as their own things; the accompanying
-                            // event represented as a dependent request should be sufficient.
-                            return None;
                         }
+                    }
+                },
+            })
+        });
 
-                        QueuedRequestKind::Redaction { redacts, reason } => {
-                            LocalEchoContent::Redaction {
-                                redacts,
-                                reason,
-                                send_handle: SendRedactionHandle {
-                                    room: room.clone(),
-                                    transaction_id: queued.transaction_id,
-                                },
-                                send_error: queued.error,
-                            }
-                        }
-                    },
-                })
-            });
+        let dependent_requests = store.load_dependent_queued_requests(&self.room_id).await?;
 
-        let reactions_and_medias = store
-            .load_dependent_queued_requests(&self.room_id)
-            .await?
-            .into_iter()
-            .filter_map(|dep| match dep.kind {
+        let reactions_and_medias =
+            dependent_requests.into_iter().filter_map(|dep| match dep.kind {
                 DependentQueuedRequestKind::EditEvent { .. }
                 | DependentQueuedRequestKind::RedactEvent => {
                     // TODO: reflect local edits/redacts too?
@@ -2068,6 +2081,15 @@ impl QueueStorage {
                     thumbnail_info,
                     extra_content,
                 } => {
+                    let upload_thumbnail_txn = thumbnail_info.map(|info| info.txn);
+
+                    // If one of the uploads wedged, the media event is wedged too.
+                    let send_error = media_upload_errors.remove(&file_upload).or_else(|| {
+                        upload_thumbnail_txn
+                            .as_ref()
+                            .and_then(|txn| media_upload_errors.remove(&**txn))
+                    });
+
                     // Materialize as an event local echo.
                     Some(LocalEcho {
                         transaction_id: dep.own_transaction_id.clone().into(),
@@ -2081,12 +2103,12 @@ impl QueueStorage {
                                 room: room.clone(),
                                 transaction_id: dep.own_transaction_id.into(),
                                 media_handles: vec![MediaHandles {
-                                    upload_thumbnail_txn: thumbnail_info.map(|info| info.txn),
+                                    upload_thumbnail_txn,
                                     upload_file_txn: file_upload,
                                 }],
                                 created_at: dep.created_at,
                             },
-                            send_error: None,
+                            send_error,
                         },
                     })
                 }
@@ -2100,6 +2122,7 @@ impl QueueStorage {
                         dep.created_at,
                         local_echo,
                         item_infos,
+                        &mut media_upload_errors,
                     )
                 }
             });
@@ -2116,7 +2139,15 @@ impl QueueStorage {
         created_at: MilliSecondsSinceUnixEpoch,
         local_echo: Box<RoomMessageEventContent>,
         item_infos: Vec<FinishGalleryItemInfo>,
+        media_upload_errors: &mut HashMap<OwnedTransactionId, QueueWedgeError>,
     ) -> Option<LocalEcho> {
+        // If any of the uploads wedged, the gallery event is wedged too.
+        let send_error = item_infos.iter().find_map(|i| {
+            media_upload_errors.remove(&i.file_upload).or_else(|| {
+                i.thumbnail_info.as_ref().and_then(|info| media_upload_errors.remove(&*info.txn))
+            })
+        });
+
         Some(LocalEcho {
             transaction_id: transaction_id.clone().into(),
             content: LocalEchoContent::Event {
@@ -2133,7 +2164,7 @@ impl QueueStorage {
                         .collect(),
                     created_at,
                 },
-                send_error: None,
+                send_error,
             },
         })
     }

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -143,6 +143,7 @@ use std::{
         Arc, RwLock,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 
 use eyeball::SharedObservable;
@@ -194,6 +195,10 @@ mod progress;
 mod upload;
 
 pub use progress::AbstractProgress;
+
+/// How long to wait before retrying, when loading the next request to send
+/// failed against the state store.
+const STORE_ERROR_BACKOFF: Duration = Duration::from_millis(250);
 
 /// A client-wide send queue, for all the rooms known by a client.
 pub struct SendQueue {
@@ -707,6 +712,8 @@ impl RoomSendQueue {
 
                 Err(err) => {
                     warn!("error when loading next request to send: {err}");
+                    // Don't hammer a failing store; back off a bit before retrying.
+                    matrix_sdk_common::sleep::sleep(STORE_ERROR_BACKOFF).await;
                     continue;
                 }
             };

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -28,10 +28,13 @@
 //! paragraph below) or using [`RoomSendQueue::subscribe()`].
 //!
 //! Requests are sent in the order they were queued. A request that failed with
-//! an unrecoverable error is marked as "wedged", and blocks all the requests
-//! queued after it (in the same room) from being sent, so events are never sent
-//! out of order; the queue resumes when the wedged request is retried (with
-//! [`SendHandle::unwedge`]) or removed (with [`SendHandle::abort`]).
+//! an unrecoverable error is marked as "wedged", and blocks the requests of the
+//! same priority queued after it (in the same room) from being sent, so events
+//! are never sent out of order; the queue resumes when the wedged request is
+//! retried (with [`SendHandle::unwedge`]) or removed (with
+//! [`SendHandle::abort`]). Requests of other priorities aren't blocked: e.g. a
+//! wedged edit or reaction (sent at a high priority once their target event is
+//! sent) doesn't prevent messages from being sent.
 //!
 //! It is possible to control whether a single room is enabled using
 //! [`RoomSendQueue::set_enabled()`].
@@ -143,6 +146,7 @@ use std::{
         Arc, RwLock,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 
 use eyeball::SharedObservable;
@@ -699,7 +703,7 @@ impl RoomSendQueue {
                 Ok(Some(request)) => request,
 
                 Ok(None) => {
-                    trace!("queue is empty, sleeping");
+                    trace!("queue is empty or blocked on a wedged request, sleeping");
                     // Wait for an explicit wakeup.
                     notifier.notified().await;
                     continue;
@@ -707,6 +711,8 @@ impl RoomSendQueue {
 
                 Err(err) => {
                     warn!("error when loading next request to send: {err}");
+                    // Don't hammer a failing store; back off a bit before retrying.
+                    matrix_sdk_common::sleep::sleep(Duration::from_millis(250)).await;
                     continue;
                 }
             };
@@ -1467,17 +1473,31 @@ impl QueueStorage {
         let queued_requests =
             guard.client()?.state_store().load_send_queue_requests(&self.room_id).await?;
 
-        // Only ever consider the head of the queue: requests must be sent in the
-        // order they were queued, so a wedged request (which failed to be sent with an
-        // unrecoverable error) blocks all the requests queued after it. Otherwise,
-        // messages would be sent out of order, until the wedged request is either
-        // manually unwedged or removed (both of which will wake up the sending task).
+        // Requests must be sent in the order they were queued within a given
+        // priority class: a wedged request (which failed to be sent with an
+        // unrecoverable error) blocks the requests of the same priority queued after
+        // it, otherwise messages would be sent out of order. It doesn't block
+        // requests of *other* priorities: higher-priority requests (edits/reactions
+        // to already-sent events, later stages of a media upload chain) legitimately
+        // jump the queue relative to newer events, and conversely a request that
+        // wedged after being promoted to a high priority must not block events that
+        // were queued before it (which were never ordered after it).
         //
-        // Note: requests are ordered by priority first, so a high-priority request
-        // (e.g. an edit or a reaction to an already-sent event) may still be sent
-        // while a lower-priority request is wedged; that doesn't reorder the queued
-        // events themselves.
-        if let Some(request) = queued_requests.first().filter(|queued| !queued.is_wedged()) {
+        // The load order is priority first (descending), then FIFO, so entries of
+        // the same priority are contiguous and in queue order: pick the first
+        // non-wedged request not preceded by a wedged request of the same priority.
+        // The queue resumes when a wedged request is either manually unwedged or
+        // removed (both of which will wake up the sending task).
+        let mut wedged_priorities = Vec::new();
+        let candidate = queued_requests.iter().find(|queued| {
+            if queued.is_wedged() {
+                wedged_priorities.push(queued.priority);
+                return false;
+            }
+            !wedged_priorities.contains(&queued.priority)
+        });
+
+        if let Some(request) = candidate {
             let (cancel_upload_tx, cancel_upload_rx) =
                 if matches!(request.kind, QueuedRequestKind::MediaUpload { .. }) {
                     let (tx, rx) = oneshot::channel();
@@ -2002,42 +2022,54 @@ impl QueueStorage {
         let client = guard.client()?;
         let store = client.state_store();
 
-        let local_requests =
-            store.load_send_queue_requests(&self.room_id).await?.into_iter().filter_map(|queued| {
-                Some(LocalEcho {
-                    transaction_id: queued.transaction_id.clone(),
-                    content: match queued.kind {
-                        QueuedRequestKind::Event { content } => LocalEchoContent::Event {
-                            serialized_event: content,
-                            send_handle: SendHandle {
+        let queued_requests = store.load_send_queue_requests(&self.room_id).await?;
+
+        // Media upload requests aren't returned as echoes themselves (the media event,
+        // represented as a dependent request, is), so carry their send errors over to
+        // the dependent request's echo: a wedged upload wedges the media event.
+        let media_upload_errors: HashMap<OwnedTransactionId, QueueWedgeError> = queued_requests
+            .iter()
+            .filter(|queued| matches!(queued.kind, QueuedRequestKind::MediaUpload { .. }))
+            .filter_map(|queued| {
+                queued.error.clone().map(|error| (queued.transaction_id.clone(), error))
+            })
+            .collect();
+
+        let local_requests = queued_requests.into_iter().filter_map(|queued| {
+            Some(LocalEcho {
+                transaction_id: queued.transaction_id.clone(),
+                content: match queued.kind {
+                    QueuedRequestKind::Event { content } => LocalEchoContent::Event {
+                        serialized_event: content,
+                        send_handle: SendHandle {
+                            room: room.clone(),
+                            transaction_id: queued.transaction_id,
+                            media_handles: vec![],
+                            created_at: queued.created_at,
+                        },
+                        send_error: queued.error,
+                    },
+
+                    QueuedRequestKind::MediaUpload { .. } => {
+                        // Don't return uploaded medias as their own things; the accompanying
+                        // event represented as a dependent request should be sufficient.
+                        return None;
+                    }
+
+                    QueuedRequestKind::Redaction { redacts, reason } => {
+                        LocalEchoContent::Redaction {
+                            redacts,
+                            reason,
+                            send_handle: SendRedactionHandle {
                                 room: room.clone(),
                                 transaction_id: queued.transaction_id,
-                                media_handles: vec![],
-                                created_at: queued.created_at,
                             },
                             send_error: queued.error,
-                        },
-
-                        QueuedRequestKind::MediaUpload { .. } => {
-                            // Don't return uploaded medias as their own things; the accompanying
-                            // event represented as a dependent request should be sufficient.
-                            return None;
                         }
-
-                        QueuedRequestKind::Redaction { redacts, reason } => {
-                            LocalEchoContent::Redaction {
-                                redacts,
-                                reason,
-                                send_handle: SendRedactionHandle {
-                                    room: room.clone(),
-                                    transaction_id: queued.transaction_id,
-                                },
-                                send_error: queued.error,
-                            }
-                        }
-                    },
-                })
-            });
+                    }
+                },
+            })
+        });
 
         let reactions_and_medias = store
             .load_dependent_queued_requests(&self.room_id)
@@ -2073,6 +2105,15 @@ impl QueueStorage {
                     thumbnail_info,
                     extra_content,
                 } => {
+                    let upload_thumbnail_txn = thumbnail_info.map(|info| info.txn);
+
+                    // If one of the uploads wedged, the media event is wedged too.
+                    let send_error = media_upload_errors.get(&file_upload).cloned().or_else(|| {
+                        upload_thumbnail_txn
+                            .as_ref()
+                            .and_then(|txn| media_upload_errors.get(&**txn).cloned())
+                    });
+
                     // Materialize as an event local echo.
                     Some(LocalEcho {
                         transaction_id: dep.own_transaction_id.clone().into(),
@@ -2086,12 +2127,12 @@ impl QueueStorage {
                                 room: room.clone(),
                                 transaction_id: dep.own_transaction_id.into(),
                                 media_handles: vec![MediaHandles {
-                                    upload_thumbnail_txn: thumbnail_info.map(|info| info.txn),
+                                    upload_thumbnail_txn,
                                     upload_file_txn: file_upload,
                                 }],
                                 created_at: dep.created_at,
                             },
-                            send_error: None,
+                            send_error,
                         },
                     })
                 }

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -27,6 +27,12 @@
 //! a notification that can be listened to with the global send queue (see
 //! paragraph below) or using [`RoomSendQueue::subscribe()`].
 //!
+//! Requests are sent in the order they were queued. A request that failed with
+//! an unrecoverable error is marked as "wedged", and blocks all the requests
+//! queued after it (in the same room) from being sent, so events are never sent
+//! out of order; the queue resumes when the wedged request is retried (with
+//! [`SendHandle::unwedge`]) or removed (with [`SendHandle::abort`]).
+//!
 //! It is possible to control whether a single room is enabled using
 //! [`RoomSendQueue::set_enabled()`].
 //!
@@ -1020,7 +1026,9 @@ impl RoomSendQueue {
                     } else {
                         warn!(txn_id = %txn_id, error = ?err, "Unrecoverable error when sending request: {err}");
 
-                        // Mark the request as wedged, so it's not picked at any future point.
+                        // Mark the request as wedged, so it's not picked at any future point;
+                        // it will also block subsequent requests in the same room from being
+                        // sent, until it's unwedged or removed, so as to preserve ordering.
                         if let Err(storage_error) =
                             queue.mark_as_wedged(&txn_id, QueueWedgeError::from(&err)).await
                         {
@@ -1459,7 +1467,17 @@ impl QueueStorage {
         let queued_requests =
             guard.client()?.state_store().load_send_queue_requests(&self.room_id).await?;
 
-        if let Some(request) = queued_requests.iter().find(|queued| !queued.is_wedged()) {
+        // Only ever consider the head of the queue: requests must be sent in the
+        // order they were queued, so a wedged request (which failed to be sent with an
+        // unrecoverable error) blocks all the requests queued after it. Otherwise,
+        // messages would be sent out of order, until the wedged request is either
+        // manually unwedged or removed (both of which will wake up the sending task).
+        //
+        // Note: requests are ordered by priority first, so a high-priority request
+        // (e.g. an edit or a reaction to an already-sent event) may still be sent
+        // while a lower-priority request is wedged; that doesn't reorder the queued
+        // events themselves.
+        if let Some(request) = queued_requests.first().filter(|queued| !queued.is_wedged()) {
             let (cancel_upload_tx, cancel_upload_rx) =
                 if matches!(request.kind, QueuedRequestKind::MediaUpload { .. }) {
                     let (tx, rx) = oneshot::channel();
@@ -2782,6 +2800,9 @@ impl SendHandle {
 
         for handles in &self.media_handles {
             if queue.abort_upload(&self.transaction_id, handles).await? {
+                // Wake up the queue, in case it was blocked on this request being wedged.
+                self.room.inner.notifier.notify_one();
+
                 // Propagate a cancelled update.
                 self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {
                     transaction_id: self.transaction_id.clone(),
@@ -2797,6 +2818,9 @@ impl SendHandle {
 
         if queue.cancel_event(&self.transaction_id).await? {
             trace!("successful abort");
+
+            // Wake up the queue, in case it was blocked on this request being wedged.
+            self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
             self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {
@@ -3058,6 +3082,9 @@ impl SendRedactionHandle {
 
         if queue.cancel_event(&self.transaction_id).await? {
             trace!("successful redaction abort");
+
+            // Wake up the queue, in case it was blocked on this request being wedged.
+            self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
             self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -27,6 +27,12 @@
 //! a notification that can be listened to with the global send queue (see
 //! paragraph below) or using [`RoomSendQueue::subscribe()`].
 //!
+//! Requests are sent in the order they were queued. A request that failed with
+//! an unrecoverable error is marked as "wedged", and blocks all the requests
+//! queued after it (in the same room) from being sent, so events are never sent
+//! out of order; the queue resumes when the wedged request is retried (with
+//! [`SendHandle::unwedge`]) or removed (with [`SendHandle::abort`]).
+//!
 //! It is possible to control whether a single room is enabled using
 //! [`RoomSendQueue::set_enabled()`].
 //!
@@ -693,7 +699,7 @@ impl RoomSendQueue {
                 Ok(Some(request)) => request,
 
                 Ok(None) => {
-                    trace!("queue is empty, sleeping");
+                    trace!("queue is empty or blocked on a wedged request, sleeping");
                     // Wait for an explicit wakeup.
                     notifier.notified().await;
                     continue;
@@ -1020,7 +1026,9 @@ impl RoomSendQueue {
                     } else {
                         warn!(txn_id = %txn_id, error = ?err, "Unrecoverable error when sending request: {err}");
 
-                        // Mark the request as wedged, so it's not picked at any future point.
+                        // Mark the request as wedged, so it's not picked at any future point;
+                        // it will also block subsequent requests in the same room from being
+                        // sent, until it's unwedged or removed, so as to preserve ordering.
                         if let Err(storage_error) =
                             queue.mark_as_wedged(&txn_id, QueueWedgeError::from(&err)).await
                         {
@@ -1459,7 +1467,12 @@ impl QueueStorage {
         let queued_requests =
             guard.client()?.state_store().load_send_queue_requests(&self.room_id).await?;
 
-        if let Some(request) = queued_requests.iter().find(|queued| !queued.is_wedged()) {
+        // Only ever consider the head of the queue: requests must be sent in the
+        // order they were queued, so a wedged request (which failed to be sent with an
+        // unrecoverable error) blocks all the requests queued after it. Otherwise,
+        // messages would be sent out of order, until the wedged request is either
+        // manually unwedged or removed (both of which will wake up the sending task).
+        if let Some(request) = queued_requests.first().filter(|queued| !queued.is_wedged()) {
             let (cancel_upload_tx, cancel_upload_rx) =
                 if matches!(request.kind, QueuedRequestKind::MediaUpload { .. }) {
                     let (tx, rx) = oneshot::channel();
@@ -2782,6 +2795,9 @@ impl SendHandle {
 
         for handles in &self.media_handles {
             if queue.abort_upload(&self.transaction_id, handles).await? {
+                // Wake up the queue, in case it was blocked on this request being wedged.
+                self.room.inner.notifier.notify_one();
+
                 // Propagate a cancelled update.
                 self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {
                     transaction_id: self.transaction_id.clone(),
@@ -2797,6 +2813,9 @@ impl SendHandle {
 
         if queue.cancel_event(&self.transaction_id).await? {
             trace!("successful abort");
+
+            // Wake up the queue, in case it was blocked on this request being wedged.
+            self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
             self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {
@@ -3058,6 +3077,9 @@ impl SendRedactionHandle {
 
         if queue.cancel_event(&self.transaction_id).await? {
             trace!("successful redaction abort");
+
+            // Wake up the queue, in case it was blocked on this request being wedged.
+            self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
             self.room.send_update(RoomSendQueueUpdate::CancelledLocalEvent {

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1544,7 +1544,8 @@ async fn test_unrecoverable_errors() {
     mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
 
     // Queue two messages.
-    q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
+    let handle1 =
+        q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
     q.send(RoomMessageEventContent::text_plain("aloha").into()).await.unwrap();
 
     // First message is seen as a local echo.
@@ -1567,6 +1568,15 @@ async fn test_unrecoverable_errors() {
     // The permanent error disables the room send queue.
     assert!(!room.send_queue().is_enabled());
     room.send_queue().set_enabled(true);
+
+    // The second message is NOT sent: the wedged first message blocks the queue,
+    // so messages aren't sent out of order.
+    sleep(Duration::from_millis(500)).await;
+    assert!(watch.is_empty());
+
+    // Cancelling the wedged message unblocks the queue.
+    assert!(handle1.abort().await.unwrap());
+    assert_update!((global_watch, watch) => cancelled { txn = txn1 });
 
     // The second message will be properly sent.
     assert_update!((global_watch, watch) => sent { txn=txn2, event_id=event_id!("$42") });
@@ -2920,12 +2930,13 @@ async fn test_media_upload_retry_with_520_http_status_code() {
 
     mock.mock_authenticated_media_config().ok_default().mount().await;
 
-    // Fail with a 520 http status code
+    // Fail with a 520 http status code, for the first three (in-request retry)
+    // attempts.
     mock.mock_upload()
         .expect_mime_type("image/jpeg")
         .respond_with(ResponseTemplate::new(520).set_body_json(json!({})))
-        .up_to_n_times(1)
-        .expect(1)
+        .up_to_n_times(3)
+        .expect(3)
         .mount()
         .await;
 
@@ -2939,11 +2950,40 @@ async fn test_media_upload_retry_with_520_http_status_code() {
     assert_let!(MessageType::Image(img_content) = content.msgtype);
     assert_eq!(img_content.body, filename);
 
-    // Let the upload stumble and the queue disable itself.
-    let error = assert_update!((global_watch, watch) => error { recoverable=false, txn=event_txn });
+    // A 520 is a transient (recoverable) server error: let the upload stumble and
+    // the queue disable itself, keeping the request in the queue.
+    let error = assert_update!((global_watch, watch) => error { recoverable=true, txn=event_txn });
     let error = error.as_client_api_error().unwrap();
     assert_eq!(error.status_code, 520);
     assert!(q.is_enabled().not());
+
+    // Mount the mock for the upload and sending the event.
+    mock.mock_upload()
+        .expect_mime_type("image/jpeg")
+        .ok(mxc_uri!("mxc://sdk.rs/media"))
+        .mock_once()
+        .mount()
+        .await;
+    mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
+
+    // Restarting the send queue retries the upload, which succeeds this time.
+    q.set_enabled(true);
+
+    assert_update!((global_watch, watch) => uploaded {
+        related_to = event_txn,
+        mxc = mxc_uri!("mxc://sdk.rs/media")
+    });
+
+    assert_update!((global_watch, watch) => edit local echo { txn = event_txn });
+
+    // The event is sent, at some point.
+    assert_update!((global_watch, watch) => sent {
+        txn = event_txn,
+        event_id = event_id!("$1")
+    });
+
+    // That's all, folks!
+    assert!(watch.is_empty());
 }
 
 #[async_test]
@@ -3082,10 +3122,14 @@ async fn test_media_event_is_sent_in_order() {
     {
         // 1. Send a text message that will get wedged.
         mock.mock_room_send().error_too_large().mock_once().mount().await;
-        q.send(RoomMessageEventContent::text_plain("error").into()).await.unwrap();
+        let handle = q.send(RoomMessageEventContent::text_plain("error").into()).await.unwrap();
         let (text_txn, _send_handle) =
             assert_update!((global_watch, watch) => local echo { body = "error" });
         assert_update!((global_watch, watch) => error { recoverable = false, txn = text_txn });
+
+        // The wedged message would block the queue, so cancel it.
+        assert!(handle.abort().await.unwrap());
+        assert_update!((global_watch, watch) => cancelled { txn = text_txn });
     }
 
     // Re-enable the send queue after the permanent error.
@@ -3127,11 +3171,9 @@ async fn test_media_event_is_sent_in_order() {
     // That's all, folks!
     assert!(watch.is_empty());
 
-    // When reopening the send queue, we still see the wedged event.
+    // When reopening the send queue, everything has been sent or cancelled.
     let (local_echoes, _watch) = q.subscribe().await.unwrap();
-    assert_eq!(local_echoes.len(), 1);
-    assert_let!(LocalEchoContent::Event { send_error, .. } = &local_echoes[0].content);
-    assert!(send_error.is_some());
+    assert!(local_echoes.is_empty());
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1538,13 +1538,14 @@ async fn test_unrecoverable_errors() {
 
     mock.mock_room_state_encryption().plain().mount().await;
 
-    // Respond to the first /send with an unrecoverable error.
+    // Respond to the first /send with an unrecoverable error. The success mock for
+    // the second message is only mounted after the wedged message gets cancelled,
+    // so a request sneaking past the wedge fails loudly regardless of timing.
     mock.mock_room_send().error_too_large().mock_once().mount().await;
-    // Respond to the second /send with an OK response.
-    mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
 
     // Queue two messages.
-    q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
+    let handle1 =
+        q.send(RoomMessageEventContent::text_plain("i'm too big for ya").into()).await.unwrap();
     q.send(RoomMessageEventContent::text_plain("aloha").into()).await.unwrap();
 
     // First message is seen as a local echo.
@@ -1567,6 +1568,15 @@ async fn test_unrecoverable_errors() {
     // The permanent error disables the room send queue.
     assert!(!room.send_queue().is_enabled());
     room.send_queue().set_enabled(true);
+
+    // The second message is NOT sent: the wedged first message blocks the queue, so
+    // messages aren't sent out of order. Its success mock is only mounted below, so
+    // a request sneaking past the wedge fails loudly.
+    //
+    // Cancelling the wedged message unblocks the queue.
+    mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
+    assert!(handle1.abort().await.unwrap());
+    assert_update!((global_watch, watch) => cancelled { txn = txn1 });
 
     // The second message will be properly sent.
     assert_update!((global_watch, watch) => sent { txn=txn2, event_id=event_id!("$42") });
@@ -2920,12 +2930,13 @@ async fn test_media_upload_retry_with_520_http_status_code() {
 
     mock.mock_authenticated_media_config().ok_default().mount().await;
 
-    // Fail with a 520 http status code
+    // Fail with a 520 http status code, for the first three (in-request retry)
+    // attempts.
     mock.mock_upload()
         .expect_mime_type("image/jpeg")
         .respond_with(ResponseTemplate::new(520).set_body_json(json!({})))
-        .up_to_n_times(1)
-        .expect(1)
+        .up_to_n_times(3)
+        .expect(3)
         .mount()
         .await;
 
@@ -2939,11 +2950,40 @@ async fn test_media_upload_retry_with_520_http_status_code() {
     assert_let!(MessageType::Image(img_content) = content.msgtype);
     assert_eq!(img_content.body, filename);
 
-    // Let the upload stumble and the queue disable itself.
-    let error = assert_update!((global_watch, watch) => error { recoverable=false, txn=event_txn });
+    // A 520 is a transient (recoverable) server error: let the upload stumble and
+    // the queue disable itself, keeping the request in the queue.
+    let error = assert_update!((global_watch, watch) => error { recoverable=true, txn=event_txn });
     let error = error.as_client_api_error().unwrap();
     assert_eq!(error.status_code, 520);
     assert!(q.is_enabled().not());
+
+    // Mount the mock for the upload and sending the event.
+    mock.mock_upload()
+        .expect_mime_type("image/jpeg")
+        .ok(mxc_uri!("mxc://sdk.rs/media"))
+        .mock_once()
+        .mount()
+        .await;
+    mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
+
+    // Restarting the send queue retries the upload, which succeeds this time.
+    q.set_enabled(true);
+
+    assert_update!((global_watch, watch) => uploaded {
+        related_to = event_txn,
+        mxc = mxc_uri!("mxc://sdk.rs/media")
+    });
+
+    assert_update!((global_watch, watch) => edit local echo { txn = event_txn });
+
+    // The event is sent, at some point.
+    assert_update!((global_watch, watch) => sent {
+        txn = event_txn,
+        event_id = event_id!("$1")
+    });
+
+    // That's all, folks!
+    assert!(watch.is_empty());
 }
 
 #[async_test]
@@ -3082,10 +3122,14 @@ async fn test_media_event_is_sent_in_order() {
     {
         // 1. Send a text message that will get wedged.
         mock.mock_room_send().error_too_large().mock_once().mount().await;
-        q.send(RoomMessageEventContent::text_plain("error").into()).await.unwrap();
+        let handle = q.send(RoomMessageEventContent::text_plain("error").into()).await.unwrap();
         let (text_txn, _send_handle) =
             assert_update!((global_watch, watch) => local echo { body = "error" });
         assert_update!((global_watch, watch) => error { recoverable = false, txn = text_txn });
+
+        // The wedged message would block the queue, so cancel it.
+        assert!(handle.abort().await.unwrap());
+        assert_update!((global_watch, watch) => cancelled { txn = text_txn });
     }
 
     // Re-enable the send queue after the permanent error.
@@ -3127,11 +3171,9 @@ async fn test_media_event_is_sent_in_order() {
     // That's all, folks!
     assert!(watch.is_empty());
 
-    // When reopening the send queue, we still see the wedged event.
+    // When reopening the send queue, everything has been sent or cancelled.
     let (local_echoes, _watch) = q.subscribe().await.unwrap();
-    assert_eq!(local_echoes.len(), 1);
-    assert_let!(LocalEchoContent::Event { send_error, .. } = &local_echoes[0].content);
-    assert!(send_error.is_some());
+    assert!(local_echoes.is_empty());
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1538,10 +1538,10 @@ async fn test_unrecoverable_errors() {
 
     mock.mock_room_state_encryption().plain().mount().await;
 
-    // Respond to the first /send with an unrecoverable error.
+    // Respond to the first /send with an unrecoverable error. The success mock for
+    // the second message is only mounted after the wedged message gets cancelled,
+    // so a request sneaking past the wedge fails loudly regardless of timing.
     mock.mock_room_send().error_too_large().mock_once().mount().await;
-    // Respond to the second /send with an OK response.
-    mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
 
     // Queue two messages.
     let handle1 =
@@ -1575,6 +1575,7 @@ async fn test_unrecoverable_errors() {
     assert!(watch.is_empty());
 
     // Cancelling the wedged message unblocks the queue.
+    mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
     assert!(handle1.abort().await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn1 });
 
@@ -1655,6 +1656,60 @@ async fn test_unwedge_unrecoverable_errors() {
 
     // Then eventually sent and a remote echo received
     assert_update!((global_watch, watch) => sent { txn=txn1, event_id=event_id!("$42") });
+}
+
+#[async_test]
+async fn test_wedged_promoted_request_does_not_block_other_priorities() {
+    let mock = MatrixMockServer::new().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+    let client = mock.client_builder().build().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+
+    let q = room.send_queue();
+    let mut global_watch = client.send_queue().subscribe();
+
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+    assert!(watch.is_empty());
+
+    mock.mock_room_state_encryption().plain().mount().await;
+
+    // The first message sends fine.
+    mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
+    // The reaction, promoted to a high-priority request once the message is sent,
+    // fails with an unrecoverable error and wedges.
+    mock.mock_room_send().error_too_large().mock_once().mount().await;
+
+    let msg_handle = q.send(RoomMessageEventContent::text_plain("hello").into()).await.unwrap();
+    let reaction_handle =
+        msg_handle.react("💯".to_owned()).await.unwrap().expect("the reaction was queued");
+
+    let (txn1, _) = assert_update!((global_watch, watch) => local echo { body = "hello" });
+    let reaction_txn =
+        assert_update!((global_watch, watch) => local reaction { key = "💯", parent = txn1 });
+
+    assert_update!((global_watch, watch) => sent { txn = txn1, event_id = event_id!("$1") });
+
+    // The promoted reaction fails permanently, wedges and disables the queue.
+    assert_update!((global_watch, watch) => error { recoverable = false, txn = reaction_txn });
+    assert!(!q.is_enabled());
+    q.set_enabled(true);
+
+    // A regular message must still be sent while the high-priority reaction is
+    // wedged: a wedged request only blocks requests of the same priority.
+    mock.mock_room_send().ok(event_id!("$2")).mock_once().mount().await;
+    q.send(RoomMessageEventContent::text_plain("not blocked").into()).await.unwrap();
+
+    let (txn2, _) = assert_update!((global_watch, watch) => local echo { body = "not blocked" });
+    assert_update!((global_watch, watch) => sent { txn = txn2, event_id = event_id!("$2") });
+
+    // The wedged reaction can still be cleaned up.
+    assert!(reaction_handle.abort().await.unwrap());
+    assert_update!((global_watch, watch) => cancelled { txn = reaction_txn });
+
+    assert!(watch.is_empty());
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -3026,6 +3026,13 @@ async fn test_unwedging_media_upload() {
     assert_eq!(error.status_code, 413);
     assert!(!q.is_enabled());
 
+    // The wedged upload is reflected on the media event's local echo: a client
+    // restarting here must see the media as failed, not as still being sent.
+    let (local_echoes, _) = q.subscribe().await.unwrap();
+    assert_eq!(local_echoes.len(), 1);
+    assert_let!(LocalEchoContent::Event { send_error, .. } = &local_echoes[0].content);
+    assert!(send_error.is_some());
+
     // Mount the mock for the upload and sending the event.
     mock.mock_upload().ok(mxc_uri!("mxc://sdk.rs/media")).mock_once().mount().await;
     mock.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
@@ -3052,6 +3059,59 @@ async fn test_unwedging_media_upload() {
 
     // That's all, folks!
     assert!(watch.is_empty());
+}
+
+#[cfg(feature = "unstable-msc4274")]
+#[async_test]
+async fn test_wedged_gallery_upload_error_is_reflected_on_local_echo() {
+    let mock = MatrixMockServer::new().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+    let client = mock.client_builder().build().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+
+    let q = room.send_queue();
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+
+    let mut global_watch = client.send_queue().subscribe();
+
+    // Prepare endpoints.
+    mock.mock_authenticated_media_config().ok_default().mount().await;
+    mock.mock_room_state_encryption().plain().mount().await;
+
+    // The upload fails with an error indicating the media's too large, wedging it.
+    mock.mock_upload().error_too_large().mock_once().mount().await;
+
+    // Send a single-item gallery, without a thumbnail.
+    let gallery = GalleryConfig::new().add_item(GalleryItemInfo {
+        attachment_info: AttachmentInfo::Image(BaseImageInfo::default()),
+        content_type: mime::IMAGE_JPEG,
+        filename: "surprise.jpeg.exe".into(),
+        data: b"hello world".to_vec(),
+        thumbnail: None,
+        caption: None,
+    });
+
+    assert!(watch.is_empty());
+    q.send_gallery(gallery).await.expect("queuing the gallery works");
+
+    let (event_txn, _send_handle, _content) =
+        assert_update!((global_watch, watch) => local echo event);
+
+    // Although the actual error happens on the file upload transaction id, it must
+    // be reported with the *event* transaction id.
+    let error = assert_update!((global_watch, watch) => error { recoverable=false, txn=event_txn });
+    assert_eq!(error.as_client_api_error().unwrap().status_code, 413);
+    assert!(!q.is_enabled());
+
+    // The wedged upload is reflected on the gallery event's local echo: a client
+    // restarting here must see the gallery as failed, not as still being sent.
+    let (local_echoes, _) = q.subscribe().await.unwrap();
+    assert_eq!(local_echoes.len(), 1);
+    assert_let!(LocalEchoContent::Event { send_error, .. } = &local_echoes[0].content);
+    assert!(send_error.is_some());
 }
 
 /// Aborts an ongoing media upload and checks post-conditions:


### PR DESCRIPTION
## Motivation

Dogfooding Element X (macOS Nightly) during a matrix.org blip: a queued message failed with a Cloudflare **HTTP 520** (HTML error page), was classified as *unrecoverable* and wedged with the red (!), and the messages queued behind it were then sent past it - so the conversation went out out of order, and the failed message was never retried. Logs showed a `TimedOut` two minutes later was correctly treated as recoverable, so the sender was healthy; the 520 classification and the skip-past-wedged behaviour were the problems.

## Changes

- **A wedged request now blocks the room's send queue.** `peek_next_to_send` only ever considers the head of the queue: it no longer skips wedged entries, so a wedged request blocks everything queued behind it, and the queue resumes when it's retried (`SendHandle::unwedge`) or removed (`SendHandle::abort`) - the abort paths now wake the sending task. Editing a wedged event already unwedges it, so the existing edit-retries-immediately behaviour is preserved.
- **HTTP 520 is a transient error again**, like the other 5xx codes: in-request retries (`short_retry`) absorb momentary blips, and if it still fails the send queue treats it as recoverable - the request stays in the queue, in order, and is retried when the queue is re-enabled.
- **A wedged media upload is now visible after a restart**: `local_echoes()` reflects the upload's send error on the media event's local echo instead of hardcoding `send_error: None`, so a failed upload no longer looks like it's still sending.
- **Back off instead of busy-looping** when `peek_next_to_send` fails against the state store (separate commit).

## Why block on the head, rather than per priority class

An earlier revision of this PR scoped the blocking to a priority class, so that a wedged *high-priority* request (a promoted edit or reaction) wouldn't stall regular messages. That's unsound: priority doesn't distinguish "this request targets an already-sent event" from "this request *is* the event everything else is queued behind". Concretely:

1. User sends an image → `MediaUpload` queued at low priority.
2. User sends a text message → queued at low priority, after the image.
3. The upload succeeds → the media event is re-queued at **high** priority, so it keeps its place ahead of the text.
4. The media event send wedges.
5. Queue is `[media-event(high, wedged), text(low)]` → under per-priority blocking the text is sent, and the image lands *after* it.

That's exactly the reordering this PR exists to fix. Over-blocking (a wedged reaction stalling unrelated messages) is loud and the user has two explicit ways out; under-blocking silently breaks ordering. So: head-of-line blocking, unconditionally.

Ordering is the user-visible contract of a message queue: replies make no sense before the message they answer. Skipping a wedged request trades correctness for progress, silently - the user only finds out when the conversation reads nonsensically on the other side. Blocking on the wedged head makes the failure loud (red !) and gives the user two explicit ways out (retry or remove), both of which resume the queue; recoverable errors already behaved this way (queue disabled, order preserved), so this also makes the two failure classes consistent.

Note for reviewers: this reverts the 520-is-permanent special case from 79c47b447, which was motivated by media uploads (a persistently-520ing upload should surface as failed rather than retry forever). With this change such an upload now surfaces as a recoverable error and pauses the queue rather than wedging. Feedback welcome on whether uploads need different treatment.

## Testing

- Updated/added integration tests: a wedged message blocks a queued one until aborted (and the abort resumes the queue); 520 on an upload is recoverable and the upload succeeds on retry; the media multi-request ordering test updated for the new semantics. Full `matrix-sdk` suite passes (1209 tests), each commit builds standalone.
- Validated end-to-end against a real synapse with Element X iOS driving the UI: an M_TOO_LARGE-wedged message visibly blocks a second message ("Sending…" persists), retrying re-attempts the send, and removing the wedged message unblocks the queue and delivers the second message (see element-hq/element-x-ios companion PR).

## Known gaps / follow-ups

- Head-of-line blocking means a wedged *reaction* or *redaction* now stalls the room's queue, and the timeline (matrix-sdk-ui) drops `SendingFailed` updates for aggregations - so clients would show a stalled queue with nothing explaining it. `SendReactionHandle`/`SendRedactionHandle` also expose `abort()` but no `unwedge()`. Both are worth follow-ups so clients can surface retry/abort affordances for wedged aggregations.
- Requests queued behind a wedged head emit no update, so they render as ordinary "sending" with nothing explaining what they're waiting for; a queue-blocked signal (or a marker on blocked echoes) could help clients.
- The wake-on-removal invariant lives in call sites; `QueueStorage` owning the `Notify` would make it structural.

*This code was drafted by Claude (Claude Code), reviewed and directed by @ara4n.*

Signed-off-by: Matthew Hodgson <matthew@matrix.org>