### PR TITLE
Ensure `Event`s can be in multiple positions in a `LinkedChunk`

### DIFF
--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -162,6 +162,9 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test removing a chunk.
     async fn test_linked_chunk_remove_chunk(&self);
 
+    /// Test pushing items onto a linked chunk.
+    async fn test_linked_chunk_push_items(&self);
+
     /// Test replacing an item in a linked chunk.
     async fn test_linked_chunk_replace_item(&self);
 
@@ -944,6 +947,149 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_matches!(c.content, ChunkContent::Gap(gap) => {
             assert_eq!(gap.token, "tartiflette");
         });
+    }
+
+    async fn test_linked_chunk_push_items(&self) {
+        let room_id = *DEFAULT_TEST_ROOM_ID;
+
+        // Create every kind of linked chunk id in the room, as well as
+        // a linked chunk id in a different room.
+        let linked_chunk_ids = [
+            LinkedChunkId::Room(room_id),
+            LinkedChunkId::Thread(room_id, event_id!("$thread_root")),
+            LinkedChunkId::PinnedEvents(room_id),
+            LinkedChunkId::EventFocused(room_id, event_id!("$focus_root")),
+            LinkedChunkId::Room(room_id!("!other_room:localhost")),
+        ];
+
+        // Add the same event to every linked chunk
+        let event_id_a = event_id!("$a");
+        let event_a = make_test_event_with_event_id(room_id, "a", Some(event_id_a));
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![
+                    Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                    Update::PushItems {
+                        at: Position::new(CId::new(0), 0),
+                        items: vec![event_a.clone()],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 1);
+                check_test_event(&events[0], "a");
+            });
+        }
+
+        let event_b = make_test_event_with_event_id(room_id, "b", Some(event_id!("$b")));
+        // Pushing an event to an occupied position should fail in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec![event_b.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event to an occupied position");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 1);
+                check_test_event(&events[0], "a");
+            });
+        }
+
+        // Pushing an event to an unoccupied position should succeed in every linked
+        // chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 1),
+                    items: vec![event_b.clone()],
+                }],
+            )
+            .await
+            .unwrap();
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Create an updated version of event a
+        let updated_event_a = make_test_event_with_event_id(room_id, "updated_a", Some(event_id_a));
+
+        // Pushing an updated event to a position occupied by an event with a different
+        // event id should fail in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 1),
+                    items: vec![updated_event_a.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event to an occupied position");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Pushing an updated event to an unoccupied position in a linked chunk should
+        // succeed and also update the event content across all linked chunks in all
+        // rooms.
+        self.handle_linked_chunk_updates(
+            linked_chunk_ids[0],
+            vec![Update::PushItems {
+                at: Position::new(CId::new(0), 2),
+                items: vec![updated_event_a.clone()],
+            }],
+        )
+        .await
+        .unwrap();
+
+        let mut chunks = self.load_all_chunks(linked_chunk_ids[0]).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk = chunks.remove(0);
+        assert_matches!(chunk.content, ChunkContent::Items(events) => {
+            check_test_event(&events[0], "updated_a");
+            check_test_event(&events[1], "b");
+            check_test_event(&events[2], "updated_a");
+        });
+
+        for linked_chunk_id in &linked_chunk_ids[1..] {
+            let mut chunks = self.load_all_chunks(*linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                check_test_event(&events[0], "updated_a");
+                check_test_event(&events[1], "b");
+            });
+        }
     }
 
     async fn test_linked_chunk_replace_item(&self) {
@@ -2424,6 +2570,13 @@ macro_rules! event_cache_store_integration_tests {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_linked_chunk_remove_chunk().await;
+            }
+
+            #[async_test]
+            async fn test_linked_chunk_push_items() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_linked_chunk_push_items().await;
             }
 
             #[async_test]

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -98,6 +98,10 @@ pub enum RelationalLinkedChunkError {
         /// The chunk identifier.
         identifier: ChunkIdentifier,
     },
+    /// A position in a linked chunk is already occupied by
+    /// an event
+    #[error("position already occupied")]
+    PositionAlreadyOccupied,
 }
 
 /// The [`IndexableItem`] trait is used to mark items that can be indexed into a
@@ -121,7 +125,7 @@ impl IndexableItem for TimelineEvent {
 
 impl<ItemId, Item, Gap> RelationalLinkedChunk<ItemId, Item, Gap>
 where
-    Item: IndexableItem<ItemId = ItemId>,
+    Item: IndexableItem<ItemId = ItemId> + Clone,
     ItemId: Hash + PartialEq + Eq + Clone + Ord,
 {
     /// Create a new relational linked chunk.
@@ -198,15 +202,35 @@ where
                 Update::PushItems { mut at, items } => {
                     for item in items {
                         let item_id = item.id();
-                        self.items
-                            .entry(linked_chunk_id.to_owned())
-                            .or_default()
-                            .insert(item_id.clone(), (item, Some(at)));
+                        let linked_chunk_items =
+                            self.items.entry(linked_chunk_id.to_owned()).or_default();
+
+                        // Ensure position is not occupied by another item
+                        for (_, position) in linked_chunk_items.values() {
+                            if let Some(position) = position
+                                && *position == at
+                            {
+                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
+                            }
+                        }
+                        for row in &self.items_chunks {
+                            if row.linked_chunk_id == linked_chunk_id && row.position == at {
+                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
+                            }
+                        }
+
+                        linked_chunk_items.insert(item_id.clone(), (item.clone(), Some(at)));
                         self.items_chunks.push(ItemRow {
                             linked_chunk_id: linked_chunk_id.to_owned(),
                             position: at,
                             item: Either::Item(item_id),
                         });
+
+                        // Ensure item is updated if it exists anywhere else in the store
+                        for items in &mut self.items.values_mut() {
+                            items.entry(item.id()).and_modify(|e| e.0 = item.clone());
+                        }
+
                         at.increment_index();
                     }
                 }
@@ -258,7 +282,21 @@ where
                     }
 
                     self.items_chunks.remove(entry_to_remove.expect("Remove an unknown item"));
+
                     // We deliberately keep the item in the items collection.
+                    self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                        for (_, opt) in items.values_mut() {
+                            if let Some(position) = opt
+                                && position.chunk_identifier() == at.chunk_identifier()
+                            {
+                                if position.index() == at.index() {
+                                    opt.take();
+                                } else if position.index() > at.index() {
+                                    position.decrement_index();
+                                }
+                            }
+                        }
+                    });
                 }
 
                 Update::DetachLastItems { at } => {
@@ -285,6 +323,11 @@ where
 
                     for index_to_remove in indices_to_remove.into_iter().rev() {
                         self.items_chunks.remove(index_to_remove);
+                        self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                            for (_, pos) in items.values_mut() {
+                                pos.take();
+                            }
+                        });
                     }
                 }
 
@@ -293,7 +336,12 @@ where
                 Update::Clear => {
                     self.chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
                     self.items_chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
-                    // We deliberately leave the items intact.
+                    // We deliberately leave the items in the items collection.
+                    self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                        for (_, pos) in items.values_mut() {
+                            pos.take();
+                        }
+                    });
                 }
             }
         }
@@ -575,7 +623,7 @@ where
 
 impl<ItemId, Item, Gap> Default for RelationalLinkedChunk<ItemId, Item, Gap>
 where
-    Item: IndexableItem<ItemId = ItemId>,
+    Item: IndexableItem<ItemId = ItemId> + Clone,
     ItemId: Hash + PartialEq + Eq + Clone + Ord,
 {
     fn default() -> Self {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -468,6 +468,10 @@ pub mod v7 {
         // and remove the index that used to track position information.
         pub const EVENTS_KEY_PATH: &str = "position";
 
+        // Add a new index that will track the event id of an event
+        pub const EVENTS_EVENT_ID: &str = "events_event_id";
+        pub const EVENTS_EVENT_ID_KEY_PATH: &str = "event_id";
+
         // Add a new index that will track the linked chunk id and event id
         // of an event.
         pub const EVENTS_LINKED_CHUNK_ID: &str = "events_linked_chunk_id";
@@ -493,15 +497,21 @@ pub mod v7 {
     /// Update the events object store, so that the position of an event becomes
     /// the primary key of the object store.
     ///
-    /// Furthermore, turn the previous primary key, `id`, into an index. It
-    /// continues to track the same information that it did previously -
-    /// i.e., linked chunk id and event id of an event.
-    ///
     /// The primary purpose of this modification is to allow a single event to
     /// occupy multiple positions in a linked chunk. Prior to this change,
     /// the primary key was based on the linked chunk id and the event id,
     /// which enforced that an event could only occur once per linked chunk
     /// and, therefore, occupy only a single position.
+    ///
+    /// Furthermore, two new indices have been added.
+    ///
+    /// 1. `event_id` - tracks the event id of an event
+    /// 2. `linked_chunk_id` - tracks the linked chunk id and event id of an
+    ///    event. This is identical to the previous primary key, `id`.
+    ///
+    /// The first index allows finding all instances of an event across all
+    /// linked chunks and the second index allows finding all instances of
+    /// an event in a single linked chunk or room.
     ///
     /// Note that this operation removes the existing events object store and
     /// all of its contents.
@@ -527,6 +537,7 @@ pub mod v7 {
     ///
     /// * Primary Key - `position` - tracks position of an event in linked
     ///   chunks
+    /// * Index - `event_id` - tracks event id of an event
     /// * Index - `linked_chunk_id` - tracks linked chunk id and event id of an
     ///   event
     /// * Index - `room` - tracks whether an event is in a given room
@@ -536,6 +547,9 @@ pub mod v7 {
         let events = db
             .create_object_store(keys::EVENTS)
             .with_key_path(keys::EVENTS_KEY_PATH.into())
+            .build()?;
+        let _ = events
+            .create_index(keys::EVENTS_EVENT_ID, keys::EVENTS_EVENT_ID_KEY_PATH.into())
             .build()?;
         let _ = events
             .create_index(

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v6};
+    use super::{Version, v7};
 
-    pub const VERSION: Version = Version::V6;
-    pub use v6::keys;
+    pub const VERSION: Version = Version::V7;
+    pub use v7::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -64,6 +64,8 @@ pub enum Version {
     V5 = 5,
     /// Version 6 of the database, for details see [`v6`].
     V6 = 6,
+    /// Version 7 of the database, for details see [`v7`].
+    V7 = 7,
 }
 
 impl Version {
@@ -76,7 +78,8 @@ impl Version {
             Self::V3 => v3::upgrade(transaction).map(Some),
             Self::V4 => v4::upgrade(transaction).map(Some),
             Self::V5 => v5::upgrade(transaction).map(Some),
-            Self::V6 => Ok(None),
+            Self::V6 => v6::upgrade(transaction).map(Some),
+            Self::V7 => Ok(None),
         }
     }
 }
@@ -96,6 +99,7 @@ impl TryFrom<u32> for Version {
             3 => Ok(Version::V3),
             4 => Ok(Version::V4),
             5 => Ok(Version::V5),
+            6 => Ok(Version::V6),
             v => Err(UnknownVersionError(v)),
         }
     }
@@ -418,6 +422,132 @@ mod v6 {
         let threads = transaction.object_store(keys::THREADS)?;
         threads.clear()?;
 
+        Ok(())
+    }
+
+    /// Upgrade database from `v6` to `v7`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v7::empty_event_cache(transaction)?;
+        v7::update_events_object_store(transaction)?;
+        Ok(Version::V7)
+    }
+}
+
+pub mod v7 {
+    use indexed_db_futures::Build;
+
+    use super::*;
+
+    #[allow(unused)]
+    pub mod keys {
+        use super::super::v6;
+
+        // Most of the keys are re-used from the previous migrations, with
+        // some exceptions for the events object store.
+        pub const LEASES: &str = v6::keys::LEASES;
+        pub const LEASES_KEY_PATH: &str = v6::keys::LEASES_KEY_PATH;
+        pub const ROOMS: &str = v6::keys::ROOMS;
+        pub const LINKED_CHUNK_IDS: &str = v6::keys::LINKED_CHUNK_IDS;
+        pub const LINKED_CHUNKS: &str = v6::keys::LINKED_CHUNKS;
+        pub const LINKED_CHUNKS_KEY_PATH: &str = v6::keys::LINKED_CHUNKS_KEY_PATH;
+        pub const LINKED_CHUNKS_NEXT: &str = v6::keys::LINKED_CHUNKS_NEXT;
+        pub const LINKED_CHUNKS_NEXT_KEY_PATH: &str = v6::keys::LINKED_CHUNKS_NEXT_KEY_PATH;
+        pub const EVENTS: &str = v6::keys::EVENTS;
+        pub const EVENTS_ROOM: &str = v6::keys::EVENTS_ROOM;
+        pub const EVENTS_ROOM_KEY_PATH: &str = v6::keys::EVENTS_ROOM_KEY_PATH;
+        pub const EVENTS_RELATION: &str = v6::keys::EVENTS_RELATION;
+        pub const EVENTS_RELATION_KEY_PATH: &str = v6::keys::EVENTS_RELATION_KEY_PATH;
+        pub const EVENTS_RELATION_RELATED_EVENTS: &str = v6::keys::EVENTS_RELATION_RELATED_EVENTS;
+        pub const EVENTS_RELATION_RELATION_TYPES: &str = v6::keys::EVENTS_RELATION_RELATION_TYPES;
+        pub const GAPS: &str = v6::keys::GAPS;
+        pub const GAPS_KEY_PATH: &str = v6::keys::GAPS_KEY_PATH;
+        pub const THREADS: &str = v6::keys::THREADS;
+        pub const THREADS_KEY_PATH: &str = v6::keys::THREADS_KEY_PATH;
+
+        // Make the position field the primary key for the events object store
+        // and remove the index that used to track position information.
+        pub const EVENTS_KEY_PATH: &str = "position";
+
+        // Add a new index that will track the linked chunk id and event id
+        // of an event.
+        pub const EVENTS_LINKED_CHUNK_ID: &str = "events_linked_chunk_id";
+        pub const EVENTS_LINKED_CHUNK_ID_KEY_PATH: &str = "linked_chunk_id";
+    }
+
+    pub fn empty_event_cache(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let linked_chunks = transaction.object_store(keys::LINKED_CHUNKS)?;
+        linked_chunks.clear()?;
+
+        let gaps = transaction.object_store(keys::GAPS)?;
+        gaps.clear()?;
+
+        let events = transaction.object_store(keys::EVENTS)?;
+        events.clear()?;
+
+        let threads = transaction.object_store(keys::THREADS)?;
+        threads.clear()?;
+
+        Ok(())
+    }
+
+    /// Update the events object store, so that the position of an event becomes
+    /// the primary key of the object store.
+    ///
+    /// Furthermore, turn the previous primary key, `id`, into an index. It
+    /// continues to track the same information that it did previously -
+    /// i.e., linked chunk id and event id of an event.
+    ///
+    /// The primary purpose of this modification is to allow a single event to
+    /// occupy multiple positions in a linked chunk. Prior to this change,
+    /// the primary key was based on the linked chunk id and the event id,
+    /// which enforced that an event could only occur once per linked chunk
+    /// and, therefore, occupy only a single position.
+    ///
+    /// Note that this operation removes the existing events object store and
+    /// all of its contents.
+    pub fn update_events_object_store(transaction: &Transaction<'_>) -> Result<(), Error> {
+        remove_events_object_store(transaction)?;
+        create_events_object_store(transaction.db())?;
+        Ok(())
+    }
+
+    /// Remove events object store
+    pub fn remove_events_object_store(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let object_store = transaction.object_store(keys::EVENTS)?;
+        // It is faster to clear all events first, then delete the object store rather
+        // than immediately deleting.
+        //
+        // For details, see https://www.artificialworlds.net/blog/2024/02/02/deleting-an-indexed-db-store-can-be-incredibly-slow-on-firefox/
+        object_store.clear()?;
+        transaction.db().delete_object_store(keys::EVENTS)?;
+        Ok(())
+    }
+
+    /// Create an object store for tracking information about events.
+    ///
+    /// * Primary Key - `position` - tracks position of an event in linked
+    ///   chunks
+    /// * Index - `linked_chunk_id` - tracks linked chunk id and event id of an
+    ///   event
+    /// * Index - `room` - tracks whether an event is in a given room
+    /// * Index - `relation` - tracks any event to which the given event is
+    ///   related
+    pub fn create_events_object_store(db: &Database) -> Result<(), Error> {
+        let events = db
+            .create_object_store(keys::EVENTS)
+            .with_key_path(keys::EVENTS_KEY_PATH.into())
+            .build()?;
+        let _ = events
+            .create_index(
+                keys::EVENTS_LINKED_CHUNK_ID,
+                keys::EVENTS_LINKED_CHUNK_ID_KEY_PATH.into(),
+            )
+            .build()?;
+        let _ =
+            events.create_index(keys::EVENTS_ROOM, keys::EVENTS_ROOM_KEY_PATH.into()).build()?;
+        let _ = events
+            .create_index(keys::EVENTS_RELATION, keys::EVENTS_RELATION_KEY_PATH.into())
+            .build()?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -502,7 +502,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         let mut duplicated = Vec::new();
         for event_id in events {
             if let Some(types::Event::InBand(event)) =
-                transaction.get_event_by_id(linked_chunk_id, &event_id).await?
+                transaction.get_event_by_linked_chunk_id(linked_chunk_id, &event_id).await?
             {
                 duplicated.push((event_id, event.position.into()));
             }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -317,6 +317,9 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, LinkedChunkId<'a>> for Index
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEvent {
+    /// An indexed key on the object store, which represents the event id of the
+    /// event.
+    pub event_id: IndexedEventEventIdKey,
     /// An indexed key on the object store, which represents the linked chunk id
     /// and event id of the event.
     pub linked_chunk_id: IndexedEventLinkedChunkIdKey,
@@ -371,6 +374,7 @@ impl Indexed for Event {
             )
         });
         Ok(IndexedEvent {
+            event_id: IndexedEventEventIdKey::encode(event_id, serializer),
             linked_chunk_id,
             room,
             position,
@@ -384,6 +388,26 @@ impl Indexed for Event {
         serializer: &SafeEncodeSerializer,
     ) -> Result<Self, Self::Error> {
         serializer.maybe_decrypt_value(indexed.content).map_err(Into::into)
+    }
+}
+
+/// The value associated with the [`event_id`](IndexedEvent::event_id) index of
+/// the [`EVENTS`][1] object store, which is constructed from:
+///
+/// - The (possibly) hashed Event ID.
+///
+/// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedEventEventIdKey(IndexedEventId);
+
+impl IndexedKey<Event> for IndexedEventEventIdKey {
+    const INDEX: Option<&'static str> = Some(keys::EVENTS_EVENT_ID);
+
+    type KeyComponents<'a> = &'a EventId;
+
+    fn encode(event_id: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
+        let event_id = serializer.encode_key_as_string(keys::EVENTS, event_id);
+        Self(event_id)
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -317,14 +317,15 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, LinkedChunkId<'a>> for Index
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedEvent {
-    /// The primary key of the object store.
-    pub id: IndexedEventIdKey,
+    /// An indexed key on the object store, which represents the linked chunk id
+    /// and event id of the event.
+    pub linked_chunk_id: IndexedEventLinkedChunkIdKey,
     /// An indexed key on the object store, which represents the room in which
     /// the event exists
     pub room: IndexedEventRoomKey,
-    /// An indexed key on the object store, which represents the position of the
-    /// event, if it is in a chunk, or the identifier of the event, if it is not
-    /// in a chunk.
+    /// The primary key on the object store, which represents the position of
+    /// the event, if it is in a chunk, or the identifier of the event, if
+    /// it is not in a chunk.
     pub position: IndexedEventPositionKey,
     /// An indexed key on the object store, which represents the relationship
     /// between this event and another event, if one exists.
@@ -352,7 +353,8 @@ impl Indexed for Event {
         serializer: &SafeEncodeSerializer,
     ) -> Result<Self::IndexedType, Self::Error> {
         let event_id = self.event_id().ok_or(Self::Error::NoEventId)?;
-        let id = IndexedEventIdKey::encode((self.linked_chunk_id(), event_id), serializer);
+        let linked_chunk_id =
+            IndexedEventLinkedChunkIdKey::encode((self.linked_chunk_id(), event_id), serializer);
         let room = IndexedEventRoomKey::encode((self.room_id(), event_id), serializer);
         let position = IndexedEventPositionKey::encode(
             self.position()
@@ -369,7 +371,7 @@ impl Indexed for Event {
             )
         });
         Ok(IndexedEvent {
-            id,
+            linked_chunk_id,
             room,
             position,
             relation,
@@ -385,7 +387,8 @@ impl Indexed for Event {
     }
 }
 
-/// The value associated with the [primary key](IndexedEvent::id) of the
+/// The value associated with the
+/// [`linked_chunk_id`](IndexedEvent::linked_chunk_id) index of the
 /// [`EVENTS`][1] object store, which is constructed from:
 ///
 /// - The (possibly) hashed Linked Chunk ID
@@ -393,9 +396,11 @@ impl Indexed for Event {
 ///
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
-pub struct IndexedEventIdKey(IndexedLinkedChunkId, IndexedEventId);
+pub struct IndexedEventLinkedChunkIdKey(IndexedLinkedChunkId, IndexedEventId);
 
-impl IndexedKey<Event> for IndexedEventIdKey {
+impl IndexedKey<Event> for IndexedEventLinkedChunkIdKey {
+    const INDEX: Option<&'static str> = Some(keys::EVENTS_LINKED_CHUNK_ID);
+
     type KeyComponents<'a> = (LinkedChunkId<'a>, &'a EventId);
 
     fn encode(
@@ -409,7 +414,7 @@ impl IndexedKey<Event> for IndexedEventIdKey {
     }
 }
 
-impl IndexedPrefixKeyBounds<Event, LinkedChunkId<'_>> for IndexedEventIdKey {
+impl IndexedPrefixKeyBounds<Event, LinkedChunkId<'_>> for IndexedEventLinkedChunkIdKey {
     fn lower_key_with_prefix(
         linked_chunk_id: LinkedChunkId<'_>,
         serializer: &SafeEncodeSerializer,
@@ -466,7 +471,7 @@ impl IndexedPrefixKeyBounds<Event, &RoomId> for IndexedEventRoomKey {
     }
 }
 
-/// The value associated with the [`position`](IndexedEvent::position) index of
+/// The value associated with the [primary key](IndexedEvent::position) of
 /// the [`EVENTS`][1] object store, which is constructed from the following
 /// components if the event exists within a linked chunk - i.e., in-band.
 ///
@@ -504,8 +509,6 @@ pub enum IndexedEventPositionKeyComponents<'a> {
 }
 
 impl IndexedKey<Event> for IndexedEventPositionKey {
-    const INDEX: Option<&'static str> = Some(keys::EVENTS_POSITION);
-
     type KeyComponents<'a> = IndexedEventPositionKeyComponents<'a>;
 
     fn encode(components: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -323,8 +323,9 @@ pub struct IndexedEvent {
     /// the event exists
     pub room: IndexedEventRoomKey,
     /// An indexed key on the object store, which represents the position of the
-    /// event, if it is in a chunk.
-    pub position: Option<IndexedEventPositionKey>,
+    /// event, if it is in a chunk, or the identifier of the event, if it is not
+    /// in a chunk.
+    pub position: IndexedEventPositionKey,
     /// An indexed key on the object store, which represents the relationship
     /// between this event and another event, if one exists.
     pub relation: Option<IndexedEventRelationKey>,
@@ -353,9 +354,14 @@ impl Indexed for Event {
         let event_id = self.event_id().ok_or(Self::Error::NoEventId)?;
         let id = IndexedEventIdKey::encode((self.linked_chunk_id(), event_id), serializer);
         let room = IndexedEventRoomKey::encode((self.room_id(), event_id), serializer);
-        let position = self.position().map(|position| {
-            IndexedEventPositionKey::encode((self.linked_chunk_id(), position), serializer)
-        });
+        let position = IndexedEventPositionKey::encode(
+            self.position()
+                .map(|position| {
+                    IndexedEventPositionKeyComponents::InBand(self.linked_chunk_id(), position)
+                })
+                .unwrap_or(IndexedEventPositionKeyComponents::OutOfBand(event_id)),
+            serializer,
+        );
         let relation = self.relation().map(|(related_event, relation_type)| {
             IndexedEventRelationKey::encode(
                 (self.room_id(), &related_event, &RelationType::from(relation_type)),
@@ -461,28 +467,59 @@ impl IndexedPrefixKeyBounds<Event, &RoomId> for IndexedEventRoomKey {
 }
 
 /// The value associated with the [`position`](IndexedEvent::position) index of
-/// the [`EVENTS`][1] object store, which is constructed from:
+/// the [`EVENTS`][1] object store, which is constructed from the following
+/// components if the event exists within a linked chunk - i.e., in-band.
 ///
 /// - The (possibly) hashed Linked Chunk ID
 /// - The Chunk ID
 /// - The index of the event in the chunk.
 ///
+/// Or it is constructed from the following components if the event does NOT
+/// exist within a linked chunk - i.e., out-of-band.
+///
+/// - The (possibly) hashed Event ID
+///
 /// [1]: crate::event_cache_store::migrations::v1::create_events_object_store
 #[derive(Debug, Serialize, Deserialize)]
-pub struct IndexedEventPositionKey(IndexedLinkedChunkId, IndexedChunkId, IndexedEventPositionIndex);
+#[serde(untagged)]
+pub enum IndexedEventPositionKey {
+    /// The [`Event`] indexed by this key exists within a linked chunk
+    InBand(IndexedLinkedChunkId, IndexedChunkId, IndexedEventPositionIndex),
+    /// The [`Event`] indexed by this key does NOT exist within a linked chunk
+    OutOfBand(IndexedEventId),
+}
+
+/// This type is used to construct the [`IndexedEventPositionKey`] for an
+/// [`Event`].
+#[derive(Debug, Copy, Clone)]
+pub enum IndexedEventPositionKeyComponents<'a> {
+    /// The component elements of the [`IndexedEventPositionKey`] for an
+    /// [in-band](Event::InBand) [`Event`] - i.e., an [`Event`] that has a
+    /// [`Position`] within in a [`Chunk`].
+    InBand(LinkedChunkId<'a>, Position),
+    /// The component elements of the [`IndexedEventPositionKey`] for an
+    /// [out-of-band](Event::OutOfBand) [`Event`] - i.e., an [`Event`] that does
+    /// NOT have a [`Position`] within in a [`Chunk`].
+    OutOfBand(&'a EventId),
+}
 
 impl IndexedKey<Event> for IndexedEventPositionKey {
     const INDEX: Option<&'static str> = Some(keys::EVENTS_POSITION);
 
-    type KeyComponents<'a> = (LinkedChunkId<'a>, Position);
+    type KeyComponents<'a> = IndexedEventPositionKeyComponents<'a>;
 
-    fn encode(
-        (linked_chunk_id, position): Self::KeyComponents<'_>,
-        serializer: &SafeEncodeSerializer,
-    ) -> Self {
-        let linked_chunk_id =
-            serializer.hash_key(keys::LINKED_CHUNK_IDS, linked_chunk_id.storage_key());
-        Self(linked_chunk_id, position.chunk_identifier, position.index)
+    fn encode(components: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
+        match components {
+            Self::KeyComponents::InBand(linked_chunk_id, position) => {
+                let linked_chunk_id =
+                    serializer.hash_key(keys::LINKED_CHUNK_IDS, linked_chunk_id.storage_key());
+                Self::InBand(linked_chunk_id, position.chunk_identifier, position.index)
+            }
+            Self::KeyComponents::OutOfBand(event_id) => {
+                let event_id = serializer.encode_key_as_string(keys::EVENTS, event_id);
+                Self::OutOfBand(event_id)
+            }
+        }
     }
 }
 
@@ -490,13 +527,19 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Event, LinkedChunkId<'a>> for Index
     fn lower_key_components_with_prefix(
         linked_chunk_id: LinkedChunkId<'a>,
     ) -> Self::KeyComponents<'a> {
-        (linked_chunk_id, *INDEXED_KEY_LOWER_EVENT_POSITION)
+        IndexedEventPositionKeyComponents::InBand(
+            linked_chunk_id,
+            *INDEXED_KEY_LOWER_EVENT_POSITION,
+        )
     }
 
     fn upper_key_components_with_prefix(
         linked_chunk_id: LinkedChunkId<'a>,
     ) -> Self::KeyComponents<'a> {
-        (linked_chunk_id, *INDEXED_KEY_UPPER_EVENT_POSITION)
+        IndexedEventPositionKeyComponents::InBand(
+            linked_chunk_id,
+            *INDEXED_KEY_UPPER_EVENT_POSITION,
+        )
     }
 }
 
@@ -506,7 +549,7 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Event, (LinkedChunkId<'a>, ChunkIde
     fn lower_key_components_with_prefix(
         (linked_chunk_id, chunk_id): (LinkedChunkId<'a>, ChunkIdentifier),
     ) -> Self::KeyComponents<'a> {
-        (
+        IndexedEventPositionKeyComponents::InBand(
             linked_chunk_id,
             Position { chunk_identifier: chunk_id.index(), index: INDEXED_KEY_LOWER_EVENT_INDEX },
         )
@@ -515,7 +558,7 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Event, (LinkedChunkId<'a>, ChunkIde
     fn upper_key_components_with_prefix(
         (linked_chunk_id, chunk_id): (LinkedChunkId<'a>, ChunkIdentifier),
     ) -> Self::KeyComponents<'a> {
-        (
+        IndexedEventPositionKeyComponents::InBand(
             linked_chunk_id,
             Position { chunk_identifier: chunk_id.index(), index: INDEXED_KEY_UPPER_EVENT_INDEX },
         )

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -27,9 +27,9 @@ use crate::{
     event_cache_store::{
         serializer::indexed_types::{
             IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
-            IndexedEventPositionKey, IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey,
-            IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
-            IndexedThreadIdKey,
+            IndexedEventPositionKey, IndexedEventPositionKeyComponents, IndexedEventRelationKey,
+            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
+            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -468,7 +468,9 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         f: F,
     ) -> Result<(), TransactionError> {
         self.update_items_by_key_components::<Event, IndexedEventPositionKey, F>(
-            range.into().map(|position| (linked_chunk_id, position)),
+            range.into().map(|position| {
+                IndexedEventPositionKeyComponents::InBand(linked_chunk_id, position)
+            }),
             f,
         )
         .await
@@ -485,25 +487,28 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         linked_chunk_id: LinkedChunkId<'_>,
         position: Position,
     ) -> Result<(), TransactionError> {
-        self.delete_item_by_key::<Event, IndexedEventPositionKey>((linked_chunk_id, position))
-            .await?;
+        self.delete_item_by_key::<Event, IndexedEventPositionKey>(
+            IndexedEventPositionKeyComponents::InBand(linked_chunk_id, position),
+        )
+        .await?;
 
         // After deleting an event, every subsequent event in the chunk
         // must shift it's recorded index down one position.
-        let lower = (linked_chunk_id, position);
         let upper = IndexedEventPositionKey::upper_key_components_with_prefix((
             linked_chunk_id,
             ChunkIdentifier::new(position.chunk_identifier),
         ));
-        let range = IndexedKeyRange::Bound(lower, upper).map(|(_, position)| position);
-
-        self.update_events_by_position(linked_chunk_id, range, |mut event| {
-            if let Event::InBand(i) = &mut event {
-                i.position.index -= 1;
-            }
-            event
-        })
-        .await
+        if let IndexedEventPositionKeyComponents::InBand(_, upper_position) = upper {
+            let range = IndexedKeyRange::Bound(position, upper_position);
+            self.update_events_by_position(linked_chunk_id, range, |mut event| {
+                if let Event::InBand(i) = &mut event {
+                    i.position.index -= 1;
+                }
+                event
+            })
+            .await?;
+        }
+        Ok(())
     }
 
     /// Delete events in the given chunk matching the given linked chunk id
@@ -526,15 +531,13 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         linked_chunk_id: LinkedChunkId<'_>,
         position: Position,
     ) -> Result<(), TransactionError> {
-        let lower = (linked_chunk_id, position);
+        let lower = IndexedEventPositionKeyComponents::InBand(linked_chunk_id, position);
         let upper = IndexedEventPositionKey::upper_key_components_with_prefix((
             linked_chunk_id,
             ChunkIdentifier::new(position.chunk_identifier),
         ));
-        let range = IndexedKeyRange::Bound(lower, upper).map(|(_, position)| position);
-
         self.delete_items_by_key_components::<Event, IndexedEventPositionKey>(
-            range.map(|position| (linked_chunk_id, position)),
+            IndexedKeyRange::Bound(lower, upper),
         )
         .await
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,10 +26,11 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventLinkedChunkIdKey,
-            IndexedEventPositionKey, IndexedEventPositionKeyComponents, IndexedEventRelationKey,
-            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
-            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventEventIdKey,
+            IndexedEventLinkedChunkIdKey, IndexedEventPositionKey,
+            IndexedEventPositionKeyComponents, IndexedEventRelationKey, IndexedEventRoomKey,
+            IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
+            IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -329,6 +330,28 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.delete_items_by_linked_chunk_id::<Chunk, IndexedChunkIdKey>(linked_chunk_id).await
     }
 
+    /// Query IndexedDB for the event at the given position in the given
+    /// linked chunk. If more than one item is found, an error is returned.
+    pub async fn get_event_by_position(
+        &self,
+        linked_chunk_id: LinkedChunkId<'_>,
+        position: Position,
+    ) -> Result<Option<Event>, TransactionError> {
+        let key = self
+            .serializer()
+            .encode_key(IndexedEventPositionKeyComponents::InBand(linked_chunk_id, position));
+        self.get_item_by_key::<Event, IndexedEventPositionKey>(key).await
+    }
+
+    /// Query IndexedDB for events that match the given event id.
+    pub async fn get_events_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Vec<Event>, TransactionError> {
+        let key = self.serializer().encode_key::<_, IndexedEventEventIdKey>(event_id);
+        self.get_items_by_key::<Event, IndexedEventEventIdKey>(key).await
+    }
+
     /// Query IndexedDB for events that match the given event id and the given
     /// linked chunk id. If more than one item is found, an error is returned.
     pub async fn get_event_by_linked_chunk_id(
@@ -426,26 +449,35 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
 
     /// Adds an event to IndexedDB.
     ///
-    /// If an event with the same key already exists, actions are
-    /// taken based on the following conditions. If the provided
-    /// event is an [`Event::InBand`] and the existing event is an
-    /// [`Event::OutOfBand`], the provided event will replace the
-    /// existing event. Otherwise, the provided event will be rejected.
-    /// This functionality allows events to be promoted from
-    /// out-of-band events to in-band events, but not vice versa.
+    /// If an event already occupies the given event's position in the given
+    /// linked chunk, the call fails with [`TransactionError::ItemIsNotUnique`].
+    /// Otherwise, the event is added at the given position.
+    ///
+    /// If an event with the same ID already exists, the provided
+    /// content replaces the existing content everywhere the event exists, i.e.,
+    /// across all linked chunks.
     ///
     /// When the event is successfully added, the function returns
     /// the intermediary type [`IndexedEvent`] in case inspection
     /// is needed.
     pub async fn add_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
-        let existing = self
-            .get_event_by_linked_chunk_id(event.linked_chunk_id(), event.event_id().unwrap())
-            .await?;
-        if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
-            self.put_event(event).await
-        } else {
-            self.add_item(event).await
+        let linked_chunk_id = event.linked_chunk_id();
+        let event_id = event.event_id().unwrap();
+
+        if let Some(position) = event.position()
+            && self.get_event_by_position(linked_chunk_id, position).await?.is_some()
+        {
+            return Err(TransactionError::ItemIsNotUnique);
         }
+
+        let content = match event {
+            Event::InBand(e) => &e.content,
+            Event::OutOfBand(e) => &e.content,
+        };
+        for existing in self.get_events_by_event_id(event_id).await? {
+            self.put_event(&existing.with_content(content.clone())).await?;
+        }
+        self.put_event(event).await
     }
 
     /// Puts an event in IndexedDB. If an event with the same key already

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,10 +26,11 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
-            IndexedEventPositionKey, IndexedEventPositionKeyComponents, IndexedEventRelationKey,
-            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
-            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedEvent,
+            IndexedEventLinkedChunkIdKey, IndexedEventPositionKey,
+            IndexedEventPositionKeyComponents, IndexedEventRelationKey, IndexedEventRoomKey,
+            IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
+            IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -331,13 +332,13 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
 
     /// Query IndexedDB for events that match the given event id and the given
     /// linked chunk id. If more than one item is found, an error is returned.
-    pub async fn get_event_by_id(
+    pub async fn get_event_by_linked_chunk_id(
         &self,
         linked_chunk_id: LinkedChunkId<'_>,
         event_id: &EventId,
     ) -> Result<Option<Event>, TransactionError> {
         let key = self.serializer().encode_key((linked_chunk_id, event_id));
-        self.get_item_by_key::<Event, IndexedEventIdKey>(key).await
+        self.get_item_by_key::<Event, IndexedEventLinkedChunkIdKey>(key).await
     }
 
     /// Query IndexedDB for events that match the given event id in the given
@@ -439,7 +440,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// is needed.
     pub async fn add_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
         let existing =
-            self.get_event_by_id(event.linked_chunk_id(), event.event_id().unwrap()).await?;
+            self.get_event_by_linked_chunk_id(event.linked_chunk_id(), event.event_id().unwrap()).await?;
         if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
             self.put_event(event).await
         } else {
@@ -547,7 +548,8 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         &self,
         linked_chunk_id: LinkedChunkId<'_>,
     ) -> Result<(), TransactionError> {
-        self.delete_items_by_linked_chunk_id::<Event, IndexedEventIdKey>(linked_chunk_id).await
+        self.delete_items_by_linked_chunk_id::<Event, IndexedEventLinkedChunkIdKey>(linked_chunk_id)
+            .await
     }
 
     /// Query IndexedDB for the gap in the given chunk matching the given linked

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,11 +26,10 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent,
-            IndexedEventLinkedChunkIdKey, IndexedEventPositionKey,
-            IndexedEventPositionKeyComponents, IndexedEventRelationKey, IndexedEventRoomKey,
-            IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
-            IndexedThreadIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventLinkedChunkIdKey,
+            IndexedEventPositionKey, IndexedEventPositionKeyComponents, IndexedEventRelationKey,
+            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
+            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -439,8 +438,9 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// the intermediary type [`IndexedEvent`] in case inspection
     /// is needed.
     pub async fn add_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
-        let existing =
-            self.get_event_by_linked_chunk_id(event.linked_chunk_id(), event.event_id().unwrap()).await?;
+        let existing = self
+            .get_event_by_linked_chunk_id(event.linked_chunk_id(), event.event_id().unwrap())
+            .await?;
         if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
             self.put_event(event).await
         } else {

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -434,7 +434,7 @@ impl<'a> Transaction<'a> {
     /// does not provide modification utilities.
     pub async fn update_items_by_key_components<'b, T, K, F>(
         &self,
-        range: impl Into<IndexedKeyRange<K::KeyComponents<'b>>>,
+        range: impl Into<IndexedKeyRange<K::KeyComponents<'b>>> + Clone,
         f: F,
     ) -> Result<(), TransactionError>
     where
@@ -444,7 +444,17 @@ impl<'a> Transaction<'a> {
         K: IndexedKey<T> + Serialize + 'b,
         F: Fn(T) -> T,
     {
-        for item in self.get_items_by_key_components::<T, K>(range).await? {
+        let items = self.get_items_by_key_components::<T, K>(range.clone()).await?;
+
+        // In the case where the provided function may be modifying the primary
+        // key of an item, then putting the item back into the store will add
+        // a new object to the store and leave the old one intact.
+        //
+        // This is behavior is somewhat counter-intuitive, so we will make sure
+        // that an update will always remove the old object from the store.
+        self.delete_items_by_key_components::<T, K>(range).await?;
+
+        for item in items {
             self.put_item(&f(item)).await?;
         }
         Ok(())


### PR DESCRIPTION
_Description coming soon..._

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>
