### PR TITLE
feat(sync): add a pre-processing response hook for classic sync

### DIFF
--- a/crates/matrix-sdk/changelog.d/6847.added.md
+++ b/crates/matrix-sdk/changelog.d/6847.added.md
@@ -1,0 +1,2 @@
+Add an optional `SyncResponseHook` for processing typed classic `/sync`
+responses before the SDK persists their state or advances the sync token.

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -74,6 +74,7 @@ use crate::{
     media::{DefaultMediaFetcher, MediaFetcher},
     send_queue::SendQueueData,
     sliding_sync::VersionBuilder as SlidingSyncVersionBuilder,
+    sync::SyncResponseHook,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -144,6 +145,7 @@ pub struct ClientBuilder {
     x509_verifier: Option<Arc<dyn RawX509Verifier>>,
     dm_room_definition: DmRoomDefinition,
     media_fetcher: Arc<dyn MediaFetcher>,
+    sync_response_hook: Option<Arc<dyn SyncResponseHook>>,
 }
 
 impl ClientBuilder {
@@ -186,6 +188,7 @@ impl ClientBuilder {
             x509_verifier: None,
             dm_room_definition: DmRoomDefinition::MatrixSpec,
             media_fetcher: Arc::new(DefaultMediaFetcher),
+            sync_response_hook: None,
         }
     }
 
@@ -193,6 +196,15 @@ impl ClientBuilder {
     /// server.
     pub fn media_fetcher(mut self, media_fetcher: Arc<dyn MediaFetcher>) -> Self {
         self.media_fetcher = media_fetcher.clone();
+        self
+    }
+
+    /// Sets a hook that runs before each decoded classic `/sync` response is
+    /// processed.
+    ///
+    /// See [`SyncResponseHook`] for ordering, retry, and scope guarantees.
+    pub fn sync_response_hook(mut self, hook: Arc<dyn SyncResponseHook>) -> Self {
+        self.sync_response_hook = Some(hook);
         self
     }
 
@@ -702,6 +714,7 @@ impl ClientBuilder {
             search_index,
             thread_subscriptions_catchup,
             self.media_fetcher.clone(),
+            self.sync_response_hook,
         )
         .await;
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -115,7 +115,7 @@ use crate::{
     room_preview::RoomPreview,
     send_queue::{SendQueue, SendQueueData},
     sliding_sync::Version as SlidingSyncVersion,
-    sync::{RoomUpdate, SyncResponse},
+    sync::{RoomUpdate, SyncResponse, SyncResponseHook},
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::{
@@ -420,6 +420,9 @@ pub(crate) struct ClientInner {
 
     pub(crate) media_fetcher: RwLock<Arc<dyn MediaFetcher>>,
 
+    /// Hook invoked before processing classic sync responses.
+    pub(crate) sync_response_hook: Option<Arc<dyn SyncResponseHook>>,
+
     /// When `Some`, `m.call` auto-sync is enabled and the held
     /// [`AutomaticCallStatus`] owns the event handler registration.
     /// Dropping the `Option` (via
@@ -460,6 +463,7 @@ impl ClientInner {
         #[cfg(feature = "experimental-search")] search_index_handler: SearchIndex,
         thread_subscription_catchup: OnceCell<Arc<ThreadSubscriptionCatchup>>,
         media_fetcher: Arc<dyn MediaFetcher>,
+        sync_response_hook: Option<Arc<dyn SyncResponseHook>>,
     ) -> Arc<Self> {
         let caches = ClientCaches {
             supported_versions: Cache::with_value(supported_versions),
@@ -506,6 +510,7 @@ impl ClientInner {
             #[cfg(feature = "e2e-encryption")]
             duplicate_key_upload_error_sender: broadcast::channel(1).0,
             media_fetcher: RwLock::new(media_fetcher),
+            sync_response_hook,
             #[cfg(feature = "unstable-msc4426")]
             automatic_call_status: StdMutex::new(None),
         };
@@ -3537,6 +3542,7 @@ impl Client {
                 self.inner.search_index.clone(),
                 self.inner.thread_subscription_catchup.clone(),
                 (*self.inner.media_fetcher.read().await).clone(),
+                self.inner.sync_response_hook.clone(),
             )
             .await,
         };

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -47,7 +47,7 @@ use url::ParseError as UrlParseError;
 use crate::{
     authentication::oauth::OAuthError, cross_process_lock::CrossProcessLockError,
     event_cache::EventCacheError, media::MediaError, room::reply::ReplyError,
-    sliding_sync::Error as SlidingSyncError,
+    sliding_sync::Error as SlidingSyncError, sync::SyncResponseHookError,
 };
 
 /// Result type of the matrix-sdk.
@@ -391,6 +391,10 @@ pub enum Error {
     /// An error happened during handling of a media subrequest.
     #[error(transparent)]
     Media(#[from] MediaError),
+
+    /// The classic sync response hook rejected a response.
+    #[error(transparent)]
+    SyncResponseHook(#[from] SyncResponseHookError),
 
     /// An error happened while attempting to reply to an event.
     #[error(transparent)]

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -16,6 +16,7 @@
 
 use std::{
     collections::{BTreeMap, btree_map},
+    error::Error as StdError,
     fmt,
     time::Duration,
 };
@@ -30,7 +31,9 @@ use matrix_sdk_base::{
     sync::SyncResponse as BaseSyncResponse,
     timer,
 };
-use matrix_sdk_common::deserialized_responses::ProcessedToDeviceEvent;
+use matrix_sdk_common::{
+    BoxFuture, SendOutsideWasm, SyncOutsideWasm, deserialized_responses::ProcessedToDeviceEvent,
+};
 use ruma::{
     OwnedRoomId, RoomId,
     api::client::sync::sync_events::{
@@ -44,6 +47,48 @@ use ruma::{
 use tracing::{debug, error, instrument, warn};
 
 use crate::{Client, Result, Room, event_handler::HandlerKind};
+
+#[cfg(not(target_family = "wasm"))]
+type SyncResponseHookErrorSource = Box<dyn StdError + Send + Sync>;
+#[cfg(target_family = "wasm")]
+type SyncResponseHookErrorSource = Box<dyn StdError>;
+
+/// An error returned by a [`SyncResponseHook`].
+#[derive(Debug, thiserror::Error)]
+#[error("classic sync response hook failed: {0}")]
+pub struct SyncResponseHookError(#[source] SyncResponseHookErrorSource);
+
+impl SyncResponseHookError {
+    /// Create an error wrapping the given source error.
+    pub fn new(
+        error: impl StdError + SendOutsideWasm + SyncOutsideWasm + 'static,
+    ) -> SyncResponseHookError {
+        Self(Box::new(error))
+    }
+}
+
+/// A callback invoked before a classic `/sync` response is processed.
+///
+/// This hook can be used to durably persist the typed response before the SDK
+/// advances its sync token or applies any of the response's state. It is only
+/// used by classic sync APIs such as [`Client::sync_once`]; sliding sync and
+/// the sync service do not invoke it.
+///
+/// The hook may receive the same response more than once if the application
+/// retries a failed sync, so implementations must be idempotent. If the future
+/// is cancelled or returns an error, the SDK does not persist the response,
+/// advance its sync token, or invoke event, notification, or room update
+/// handlers.
+///
+/// The response has already been decoded into Ruma's typed representation. It
+/// does not provide byte-identical access to the HTTP response body.
+pub trait SyncResponseHook: SendOutsideWasm + SyncOutsideWasm + fmt::Debug {
+    /// Process a decoded classic `/sync` response before the SDK does.
+    fn on_sync_response<'a>(
+        &'a self,
+        response: &'a sync_events::v3::Response,
+    ) -> BoxFuture<'a, std::result::Result<(), SyncResponseHookError>>;
+}
 
 /// The processed response of a `/sync` request.
 #[derive(Clone, Default)]
@@ -151,6 +196,10 @@ impl Client {
         &self,
         response: sync_events::v3::Response,
     ) -> Result<BaseSyncResponse> {
+        if let Some(hook) = &self.inner.sync_response_hook {
+            hook.on_sync_response(&response).await?;
+        }
+
         subscribe_to_room_latest_events(
             self,
             response.rooms.join.keys().chain(response.rooms.leave.keys()),

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -1,17 +1,32 @@
-use std::collections::BTreeSet;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error as _,
+    io,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
 
 use assert_matches2::assert_matches;
 use matrix_sdk::{
+    BoxFuture, Error, MemoryStore, StateStore,
+    config::{RequestConfig, StoreConfig, SyncSettings, SyncToken},
     deserialized_responses::RawSyncOrStrippedState,
+    store::{StateStoreDataKey, StateStoreDataValue},
+    sync::{SyncResponseHook, SyncResponseHookError},
     test_utils::mocks::{AnyRoomBuilder, MatrixMockServer},
 };
-use matrix_sdk_base::RoomMemberships;
+use matrix_sdk_base::{RoomMemberships, sync::RoomUpdates};
+use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
 use matrix_sdk_test::{
-    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, async_test,
-    event_factory::EventFactory,
+    InvitedRoomBuilder, JoinedRoomBuilder, KnockedRoomBuilder, SyncResponseBuilder, async_test,
+    event_factory::EventFactory, stripped_state_event,
 };
 use ruma::{
-    EventEncryptionAlgorithm, MilliSecondsSinceUnixEpoch, RoomVersionId, event_id,
+    EventEncryptionAlgorithm, Int, MilliSecondsSinceUnixEpoch, RoomVersionId,
+    api::client::sync::sync_events,
+    event_id,
     events::{
         AnyStrippedStateEvent, AnySyncStateEvent, SyncStateEvent,
         room::{
@@ -23,7 +38,7 @@ use ruma::{
             history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
             join_rules::RoomJoinRulesEventContent,
             member::RoomMemberEvent,
-            name::RoomNameEventContent,
+            name::{RoomNameEventContent, StrippedRoomNameEvent},
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::RoomPowerLevelsEventContent,
             tombstone::RoomTombstoneEventContent,
@@ -38,6 +53,249 @@ use ruma::{
 };
 use serde_json::json;
 use stream_assert::{assert_pending, assert_ready};
+use wiremock::{
+    Mock, ResponseTemplate,
+    matchers::{method, path_regex},
+};
+
+#[derive(Debug)]
+struct RecordingSyncResponseHook {
+    store: Arc<MemoryStore>,
+    calls: AtomicUsize,
+    fail_next: AtomicBool,
+    journal: Mutex<BTreeSet<String>>,
+    observed_tokens: Mutex<Vec<Option<String>>>,
+}
+
+impl RecordingSyncResponseHook {
+    fn new(store: Arc<MemoryStore>, fail_next: bool) -> Self {
+        Self {
+            store,
+            calls: AtomicUsize::new(0),
+            fail_next: AtomicBool::new(fail_next),
+            journal: Mutex::new(BTreeSet::new()),
+            observed_tokens: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl SyncResponseHook for RecordingSyncResponseHook {
+    fn on_sync_response<'a>(
+        &'a self,
+        response: &'a sync_events::v3::Response,
+    ) -> BoxFuture<'a, Result<(), SyncResponseHookError>> {
+        Box::pin(async move {
+            let token = self
+                .store
+                .get_kv_data(StateStoreDataKey::SyncToken)
+                .await
+                .map_err(SyncResponseHookError::new)?
+                .and_then(StateStoreDataValue::into_sync_token);
+            self.observed_tokens.lock().unwrap().push(token);
+            self.journal.lock().unwrap().insert(response.next_batch.clone());
+            self.calls.fetch_add(1, Ordering::SeqCst);
+
+            if self.fail_next.swap(false, Ordering::SeqCst) {
+                Err(SyncResponseHookError::new(io::Error::other("journal unavailable")))
+            } else {
+                Ok(())
+            }
+        })
+    }
+}
+
+fn invite_sync_response() -> (serde_json::Value, String) {
+    let room_id = room_id!("!hook:localhost");
+    let mut users = BTreeMap::new();
+    users.insert(owned_user_id!("@example:localhost"), Int::new(100).unwrap());
+    users.insert(owned_user_id!("@bob:localhost"), Int::new(0).unwrap());
+
+    let f = EventFactory::new().room(room_id).sender(user_id!("@bob:localhost"));
+    let power_levels_event: Raw<AnyStrippedStateEvent> = f.power_levels(&mut users).into();
+    let invited_room = InvitedRoomBuilder::new(room_id).add_state_bulk([
+        power_levels_event,
+        stripped_state_event!({
+            "content": {
+                "membership": "join"
+            },
+            "sender": "@bob:localhost",
+            "state_key": "@bob:localhost",
+            "type": "m.room.member",
+        }),
+        stripped_state_event!({
+            "content": {
+                "displayname": "example",
+                "membership": "invite"
+            },
+            "sender": "@bob:localhost",
+            "state_key": "@example:localhost",
+            "type": "m.room.member",
+        }),
+        stripped_state_event!({
+            "content": {
+                "name": "Hook test"
+            },
+            "sender": "@bob:localhost",
+            "state_key": "",
+            "type": "m.room.name",
+        }),
+    ]);
+
+    let mut builder = SyncResponseBuilder::new();
+    builder.add_invited_room(invited_room);
+    let response = builder.build_json_sync_response();
+    let next_batch = response["next_batch"].as_str().unwrap().to_owned();
+    (response, next_batch)
+}
+
+async fn stored_sync_token(store: &MemoryStore) -> Option<String> {
+    store
+        .get_kv_data(StateStoreDataKey::SyncToken)
+        .await
+        .unwrap()
+        .and_then(StateStoreDataValue::into_sync_token)
+}
+
+#[async_test]
+async fn test_classic_sync_without_hook_preserves_normal_processing() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let room_id = room_id!("!no-hook:localhost");
+
+    server
+        .mock_sync()
+        .ok(|builder| {
+            builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+        })
+        .mock_once()
+        .mount()
+        .await;
+
+    let response = client.sync_once(SyncSettings::default()).await.unwrap();
+
+    assert!(client.get_room(room_id).is_some());
+    assert!(!response.next_batch.is_empty());
+}
+
+#[async_test]
+async fn test_classic_sync_hook_failure_is_atomic_and_response_can_be_replayed() {
+    let server = MatrixMockServer::new().await;
+    let store = Arc::new(MemoryStore::default());
+    let hook = Arc::new(RecordingSyncResponseHook::new(store.clone(), true));
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder
+                .store_config(
+                    StoreConfig::new(CrossProcessLockConfig::SingleProcess)
+                        .state_store(store.clone()),
+                )
+                .sync_response_hook(hook.clone())
+        })
+        .build()
+        .await;
+
+    let room_id = room_id!("!hook:localhost");
+    let event_handler_calls = Arc::new(AtomicUsize::new(0));
+    client.add_event_handler({
+        let calls = event_handler_calls.clone();
+        move |_event: StrippedRoomNameEvent| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
+
+    let notification_handler_calls = Arc::new(AtomicUsize::new(0));
+    client
+        .register_notification_handler({
+            let calls = notification_handler_calls.clone();
+            move |_notification, _room, _client| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        })
+        .await;
+
+    let mut room_updates = client.subscribe_to_room_updates(room_id);
+    let mut all_room_updates = client.subscribe_to_all_room_updates();
+    let (response, next_batch) = invite_sync_response();
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/(r0|v3)/sync$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(server.server())
+        .await;
+
+    let error =
+        client.sync_once(SyncSettings::default().token(SyncToken::NoToken)).await.unwrap_err();
+    let Error::SyncResponseHook(hook_error) = &error else {
+        panic!("unexpected error: {error}");
+    };
+    assert_eq!(error.to_string(), "classic sync response hook failed: journal unavailable");
+    assert_eq!(hook_error.source().unwrap().to_string(), "journal unavailable");
+    assert_eq!(stored_sync_token(&store).await, None);
+    assert!(client.get_room(room_id).is_none());
+    assert_eq!(event_handler_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(notification_handler_calls.load(Ordering::SeqCst), 0);
+    assert!(room_updates.try_recv().is_err());
+    assert!(all_room_updates.try_recv().is_err());
+
+    client.sync_once(SyncSettings::default().token(SyncToken::NoToken)).await.unwrap();
+
+    assert_eq!(stored_sync_token(&store).await.as_deref(), Some(next_batch.as_str()));
+    assert!(client.get_room(room_id).is_some());
+    assert_eq!(event_handler_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(notification_handler_calls.load(Ordering::SeqCst), 1);
+    assert!(room_updates.try_recv().is_ok());
+    let RoomUpdates { invited, .. } = all_room_updates.try_recv().unwrap();
+    assert!(invited.contains_key(room_id));
+    assert_eq!(hook.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(hook.journal.lock().unwrap().len(), 1);
+    assert_eq!(&*hook.observed_tokens.lock().unwrap(), &[None, None]);
+}
+
+#[async_test]
+async fn test_classic_sync_http_retry_invokes_hook_only_for_decoded_response() {
+    let server = MatrixMockServer::new().await;
+    let store = Arc::new(MemoryStore::default());
+    let hook = Arc::new(RecordingSyncResponseHook::new(store, false));
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder
+                .request_config(RequestConfig::new().retry_limit(2))
+                .sync_response_hook(hook.clone())
+        })
+        .build()
+        .await;
+
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let response = SyncResponseBuilder::new().build_json_sync_response();
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/(r0|v3)/sync$"))
+        .respond_with({
+            let attempts = attempts.clone();
+            move |_request: &wiremock::Request| {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(500)
+                        .set_body_json(json!({"errcode": "M_UNKNOWN", "error": "temporary"}))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(&response)
+                }
+            }
+        })
+        .expect(2)
+        .mount(server.server())
+        .await;
+
+    client.sync_once(SyncSettings::default().token(SyncToken::NoToken)).await.unwrap();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(hook.calls.load(Ordering::SeqCst), 1);
+}
 
 #[async_test]
 async fn test_receive_room_encryption_event_via_sync() {


### PR DESCRIPTION
## Why

Classic `/sync` gives back a response, the SDK persists rooms and advances `next_batch`, and my public event handlers run afterwards. If the process crashes between "SDK advanced the token" and "my external durable journal wrote the events", incremental sync will not resend those events on restart, so the journal has a gap.

I hit this building and now running a durable Matrix gateway for two real bot controllers. Existing hooks (event handlers, room-update streams, callbacks off `sync_with_callback`) all run after SDK persistence, which is too late for this ordering.

## Change

Add an optional `SyncResponseHook` on `ClientBuilder`. It runs inside `Client::process_sync`, on the decoded typed `sync_events::v3::Response`, before `base_client().receive_sync_response(...)` persists anything and before public handlers fire.

Semantics:

- Typed classic response only (no raw HTTP bytes, no sliding-sync response).
- If the hook returns an error or the future is cancelled, the SDK does not persist state, does not advance `next_batch`, and does not run event / notification / room-update handlers. The next sync retries against the same `since` token.
- Because a retry can redeliver the same decoded response, hook work must be idempotent.
- Errors surface through a dedicated `matrix_sdk::Error::SyncResponseHook` variant.
- No hook installed = no behavior change; there is just one `Option` branch in the sync path.

## Scope

- Classic sync only. Sliding sync and the sync service intentionally do not call the hook.
- No raw HTTP bytes are exposed. The hook sees Ruma's typed decoded response.
- Not an exactly-once guarantee. It is a "durably record before we advance" ordering primitive; correctness still depends on the caller's journal and idempotency.

## Tests

Integration tests in `crates/matrix-sdk/tests/integration/sync.rs` cover:

- hook observes the old persisted sync token
- hook failure blocks token, room/state, handler, notification, and room-update advancement
- success path preserves normal sync behavior
- idempotent replay recovers after "journal commit, then hook error"
- transient HTTP retries invoke the hook only for the successful decoded response
- clients without a hook keep existing behavior

Local validation: `cargo fmt` on touched files, `cargo check -p matrix-sdk --tests`, `cargo clippy -p matrix-sdk --tests --all-features` (no new lints on touched files), `cargo test -p matrix-sdk --test integration --features testing -- sync::` (26 passed), `cargo doc -p matrix-sdk --no-deps --lib` clean.