### PR TITLE
feat(timeline): allow attaching custom fields to outgoing reactions

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6848.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6848.added.md
@@ -1,0 +1,6 @@
+`Timeline` gained a `toggle_reaction_with_extra_content()` method (leaving
+`toggle_reaction()` unchanged), allowing additional top-level fields (a
+serialized JSON object) to be included in a reaction's content, e.g.
+vendor-prefixed keys matched by server-side push rules. Fields of the event
+itself take precedence, and the extra fields only apply when a reaction is
+added, since removing one is a redaction.

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -658,6 +658,26 @@ impl Timeline {
         Ok(self.inner.toggle_reaction(&item_id.try_into()?, &key).await?)
     }
 
+    /// Like [`Self::toggle_reaction`], but merges the given additional
+    /// top-level fields (a JSON object, encoded as a string) into the
+    /// reaction's content when one is added.
+    ///
+    /// Removing a reaction is a redaction, which carries no content, so the
+    /// extra fields are only used when adding one.
+    pub async fn toggle_reaction_with_extra_content(
+        &self,
+        item_id: EventOrTransactionId,
+        key: String,
+        extra_content_json: Option<String>,
+    ) -> Result<bool, ClientError> {
+        let extra_content: Option<serde_json::Map<String, serde_json::Value>> =
+            extra_content_json.map(|json| serde_json::from_str(&json)).transpose()?;
+        Ok(self
+            .inner
+            .toggle_reaction_with_extra_content(&item_id.try_into()?, &key, extra_content)
+            .await?)
+    }
+
     pub async fn fetch_details_for_event(&self, event_id: String) -> Result<(), ClientError> {
         let event_id = <&EventId>::try_from(event_id.as_str())?;
         self.inner

--- a/crates/matrix-sdk-ui/changelog.d/6848.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6848.added.md
@@ -1,0 +1,3 @@
+The timeline gained a `toggle_reaction_with_extra_content()` method, forwarding
+extra top-level content fields to the underlying send queue when a reaction is
+added. Extra fields never override the fields of the event itself.

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -566,6 +566,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
         &self,
         item_id: &TimelineEventItemId,
         key: &str,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> Result<bool, Error> {
         let mut state = self.state.write().await;
 
@@ -605,7 +606,7 @@ impl<P: RoomDataProvider> TimelineController<P> {
                     trace!("adding a reaction to a remote echo");
                     let annotation = Annotation::new(event_id.to_owned(), key.to_owned());
                     self.room_data_provider
-                        .send(ReactionEventContent::from(annotation).into())
+                        .send(ReactionEventContent::from(annotation).into(), extra_content)
                         .await?;
                     return Ok(true);
                 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -574,7 +574,23 @@ impl Timeline {
         item_id: &TimelineEventItemId,
         reaction_key: &str,
     ) -> Result<bool, Error> {
-        self.controller.toggle_reaction_local(item_id, reaction_key).await
+        self.controller.toggle_reaction_local(item_id, reaction_key, None).await
+    }
+
+    /// Same as [`Timeline::toggle_reaction`], merging `extra_content`'s fields
+    /// into the reaction's content when one is added.
+    ///
+    /// The reaction's own fields take precedence on conflicts. Removing a
+    /// reaction is a redaction, which carries no content, so `extra_content` is
+    /// only used when adding one — and only for reactions to remote events,
+    /// since a local echo is the user's own not-yet-sent event.
+    pub async fn toggle_reaction_with_extra_content(
+        &self,
+        item_id: &TimelineEventItemId,
+        reaction_key: &str,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<bool, Error> {
+        self.controller.toggle_reaction_local(item_id, reaction_key, extra_content).await
     }
 
     /// Sends an attachment to the room.

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -225,7 +225,16 @@ impl TestTimeline {
         item_id: &TimelineEventItemId,
         key: &str,
     ) -> Result<(), super::Error> {
-        if self.controller.toggle_reaction_local(item_id, key).await? {
+        self.toggle_reaction_local_with_extra_content(item_id, key, None).await
+    }
+
+    async fn toggle_reaction_local_with_extra_content(
+        &self,
+        item_id: &TimelineEventItemId,
+        key: &str,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<(), super::Error> {
+        if self.controller.toggle_reaction_local(item_id, key, extra_content).await? {
             let items = self.controller.items().await;
             if let Some(event_id) = rfind_event_by_item_id(&items, item_id)
                 .and_then(|(_pos, item)| item.event_id().map(ToOwned::to_owned))
@@ -256,6 +265,8 @@ impl TestTimeline {
 type ReadReceiptMap =
     HashMap<ReceiptType, HashMap<ReceiptThread, HashMap<OwnedUserId, (OwnedEventId, Receipt)>>>;
 
+type ExtraContent = serde_json::Map<String, serde_json::Value>;
+
 #[derive(Clone, Debug, Default)]
 struct TestRoomDataProvider {
     /// The room ID.
@@ -276,6 +287,9 @@ struct TestRoomDataProvider {
 
     /// Events sent with that room data provider.
     pub sent_events: Arc<RwLock<Vec<AnyMessageLikeEventContent>>>,
+
+    /// Extra content sent alongside each event in [`Self::sent_events`].
+    pub sent_extra_content: Arc<RwLock<Vec<Option<ExtraContent>>>>,
 
     /// Events redacted with that room data providier.
     pub redacted: Arc<RwLock<Vec<OwnedEventId>>>,
@@ -389,8 +403,13 @@ impl RoomDataProvider for TestRoomDataProvider {
         self.fully_read_marker.clone()
     }
 
-    async fn send(&self, content: AnyMessageLikeEventContent) -> Result<(), super::Error> {
+    async fn send(
+        &self,
+        content: AnyMessageLikeEventContent,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<(), super::Error> {
         self.sent_events.write().await.push(content);
+        self.sent_extra_content.write().await.push(extra_content);
         Ok(())
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -125,6 +125,27 @@ async fn test_add_reaction_success() {
 }
 
 #[async_test]
+async fn test_add_reaction_with_extra_content() {
+    let timeline = TestTimeline::new().await;
+    let mut stream = timeline.subscribe().await;
+    let (item_id, _event_id, _item_pos) = send_first_message(&timeline, &mut stream).await;
+
+    let mut extra_content = serde_json::Map::new();
+    extra_content.insert("com.example.key".to_owned(), "value".into());
+
+    timeline
+        .toggle_reaction_local_with_extra_content(&item_id, REACTION_KEY, Some(extra_content))
+        .await
+        .unwrap();
+
+    // The extra content is forwarded along with the reaction.
+    let sent_extra_content = &timeline.data().sent_extra_content.read().await;
+    assert_eq!(sent_extra_content.len(), 1);
+    assert_let!(Some(extra_content) = &sent_extra_content[0]);
+    assert_eq!(extra_content.get("com.example.key").unwrap(), "value");
+}
+
+#[async_test]
 async fn test_redact_reaction_success() {
     let timeline = TestTimeline::new().await;
     let f = &timeline.factory;

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -128,10 +128,12 @@ pub(super) trait RoomDataProvider:
     /// Load the current fully-read event id, from storage.
     fn load_fully_read_marker(&self) -> impl Future<Output = Option<OwnedEventId>> + '_;
 
-    /// Send an event to that room.
+    /// Send an event to that room, merging `extra_content`'s fields into the
+    /// outgoing event's content, if provided.
     fn send(
         &self,
         content: AnyMessageLikeEventContent,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> impl Future<Output = Result<(), super::Error>> + SendOutsideWasm + '_;
 
     /// Redact an event from that room.
@@ -223,8 +225,18 @@ impl RoomDataProvider for Room {
         }
     }
 
-    async fn send(&self, content: AnyMessageLikeEventContent) -> Result<(), super::Error> {
-        let _ = self.send_queue().send(content).await?;
+    async fn send(
+        &self,
+        content: AnyMessageLikeEventContent,
+        extra_content: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<(), super::Error> {
+        let queue = self.send_queue();
+        let send = queue.send(content);
+        let send = match extra_content {
+            Some(extra_content) => send.with_extra_content(extra_content),
+            None => send,
+        };
+        let _ = send.await?;
         Ok(())
     }
 


### PR DESCRIPTION
Follow-up to #6812, which added this for messages and media but left reactions out. Clients that need vendor-prefixed keys on reactions (e.g. matched by server-side push rules to notify the reacted-to user) currently have to fall back to Room::send_raw, losing the send queue and local echo handling.

This adds Timeline::toggle_reaction_with_extra_content, forwarding the extra fields to the send queue's existing with_extra_content. The FFI gets toggleReactionWithExtraContent, leaving toggleReaction unchanged.

The extra fields only apply when a reaction is added (removing one is a redaction, which carries no content), and only for reactions to remote events, a local echo is the user's own unsent event, so there's nothing to annotate on its behalf.