### PR TITLE
chore(sdk): Be explicit about the `LatestEventValue`

### DIFF
--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -219,9 +219,12 @@ impl LatestEvent {
                 // If at least one is `None`, yes.
                 (_, LatestEventValue::None) | (LatestEventValue::None, _) => true,
 
-                // The new value has no event ID if it's a local echo. Let's always
-                // update so the newer ones move to the top.
-                (_, new) if new.event_id().is_none() => true,
+                // A new local latest event is created, or the local event
+                // cannot be sent, yes.
+                (
+                    _,
+                    LatestEventValue::LocalIsSending(_) | LatestEventValue::LocalCannotBeSent(_),
+                ) => true,
 
                 // If the event IDs are identical, no.
                 (previous, new) if previous.event_id() == new.event_id() => false,


### PR DESCRIPTION
This patch updates the code to use `LatestEventValue` variants instead of using `event_id().is_none()`:

1. It makes the code more explicit,
2. The generated assembly is shorter (because it's one less `match`),
3. When a new variant will be added, the compiler might raise a warning here, which will reduce the possibility of a introducing a bug.

---

* Sequel of https://github.com/matrix-org/matrix-rust-sdk/pull/6836, which is great! cc @stefanceriu in case you're curious.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
