### PR TITLE
Media download progress indicators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,6 +3821,7 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "extension-trait",
+ "eyeball",
  "eyeball-im",
  "futures-executor",
  "futures-util",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -52,6 +52,7 @@ rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs", "matrix-sdk-ui/rustls-aws-lc-
 anyhow.workspace = true
 chrono.workspace = true
 extension-trait = "1.0.2"
+eyeball.workspace = true
 eyeball-im.workspace = true
 futures-util.workspace = true
 language-tags = "0.3.2"

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3665,4 +3665,59 @@ mod tests {
         assert!(client.content_scanner().await.is_none());
         assert_eq!(format!("{:?}", client.inner.get_media_fetcher().await), "DefaultMediaFetcher");
     }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_media_content_reports_download_progress() {
+        use std::sync::mpsc;
+
+        use matrix_sdk::test_utils::mocks::MatrixMockServer;
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+
+        use crate::{
+            client::{ProgressWatcher, TransmissionProgress},
+            ruma::MediaSource,
+        };
+
+        struct TestProgressWatcher {
+            sender: mpsc::Sender<TransmissionProgress>,
+        }
+
+        impl ProgressWatcher for TestProgressWatcher {
+            fn transmission_progress(&self, progress: TransmissionProgress) {
+                let _ = self.sender.send(progress);
+            }
+        }
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .on_builder(|builder| {
+                builder.cross_process_store_config(CrossProcessLockConfig::SingleProcess)
+            })
+            .build()
+            .await;
+        let ffi_client = super::Client::new(sdk_client, None, None).await.unwrap();
+
+        let body = b"some-fake-ffi-media-bytes".to_vec();
+        server.mock_authed_media_download().ok_bytes(body.clone()).mock_once().mount().await;
+
+        let media_source = MediaSource::from_url("mxc://server.local/abcdef".to_owned()).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let watcher: Box<dyn ProgressWatcher> = Box::new(TestProgressWatcher { sender: tx });
+
+        let content = ffi_client.get_media_content(media_source, Some(watcher)).await.unwrap();
+        assert_eq!(content, body);
+
+        let mut last = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("expected at least one progress update");
+        while let Ok(progress) = rx.try_recv() {
+            last = progress;
+        }
+
+        assert_eq!(last.current, body.len() as u64);
+        assert_eq!(last.total, body.len() as u64);
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use anyhow::{Context as _, anyhow};
+use eyeball::SharedObservable;
 use futures_util::pin_mut;
 #[cfg(feature = "sqlite")]
 use matrix_sdk::STATE_STORE_DATABASE_NAME;
@@ -1484,14 +1485,29 @@ impl Client {
     pub async fn get_media_content(
         &self,
         media_source: Arc<MediaSource>,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone().media_source;
+        let progress = SharedObservable::new(matrix_sdk::TransmissionProgress::default());
+
+        if let Some(progress_watcher) = progress_watcher {
+            let mut subscriber = progress.subscribe();
+            get_runtime_handle().spawn(async move {
+                while let Some(progress) = subscriber.next().await {
+                    progress_watcher.transmission_progress(progress.into());
+                }
+            });
+        }
 
         debug!(?source, "requesting media file");
         Ok(self
             .inner
             .media()
-            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
+            .get_media_content_with_progress(
+                &MediaRequestParameters { source, format: MediaFormat::File },
+                true,
+                progress,
+            )
             .await?)
     }
 
@@ -1500,14 +1516,25 @@ impl Client {
         media_source: Arc<MediaSource>,
         width: u64,
         height: u64,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone().media_source;
+        let progress = SharedObservable::new(matrix_sdk::TransmissionProgress::default());
+
+        if let Some(progress_watcher) = progress_watcher {
+            let mut subscriber = progress.subscribe();
+            get_runtime_handle().spawn(async move {
+                while let Some(progress) = subscriber.next().await {
+                    progress_watcher.transmission_progress(progress.into());
+                }
+            });
+        }
 
         debug!(?source, width, height, "requesting media thumbnail");
         Ok(self
             .inner
             .media()
-            .get_media_content(
+            .get_media_content_with_progress(
                 &MediaRequestParameters {
                     source,
                     format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
@@ -1516,6 +1543,7 @@ impl Client {
                     )),
                 },
                 true,
+                progress,
             )
             .await?)
     }

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -530,7 +530,8 @@ impl MatrixAuth {
         };
 
         let request = refresh_token::v3::Request::new(refresh_token);
-        let res = self.client.send_inner(request, None, Default::default()).await;
+        let res =
+            self.client.send_inner(request, None, Default::default(), Default::default()).await;
 
         match res {
             Ok(res) => {

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
@@ -126,6 +126,7 @@ impl Channel {
                     features: Default::default(),
                 }),
                 Default::default(),
+                Default::default(),
             )
             .await?;
 

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -184,6 +184,7 @@ async fn discover_homeserver(
             None,
             (),
             Default::default(),
+            Default::default(),
         )
         .await
         .map_err(|e| match e {
@@ -207,6 +208,7 @@ pub(super) async fn get_supported_versions(
             homeserver_url.to_string(),
             None,
             (),
+            Default::default(),
             Default::default(),
         )
         .await

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -45,6 +45,7 @@ pub struct SendRequest<R> {
     pub(crate) request: R,
     pub(crate) config: Option<RequestConfig>,
     pub(crate) send_progress: SharedObservable<TransmissionProgress>,
+    pub(crate) recv_progress: SharedObservable<TransmissionProgress>,
 }
 
 impl<R> SendRequest<R> {
@@ -62,6 +63,16 @@ impl<R> SendRequest<R> {
         self
     }
 
+    /// Replace the default `SharedObservable` used for tracking download
+    /// progress.
+    pub fn with_recv_progress_observable(
+        mut self,
+        recv_progress: SharedObservable<TransmissionProgress>,
+    ) -> Self {
+        self.recv_progress = recv_progress;
+        self
+    }
+
     /// Use the given [`RequestConfig`] for this send request, instead of the
     /// one provided by default.
     pub fn with_request_config(mut self, request_config: impl Into<Option<RequestConfig>>) -> Self {
@@ -73,6 +84,12 @@ impl<R> SendRequest<R> {
     /// body.
     pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
         self.send_progress.subscribe()
+    }
+
+    /// Get a subscriber to observe the progress of receiving the response
+    /// body.
+    pub fn subscribe_to_recv_progress(&self) -> Subscriber<TransmissionProgress> {
+        self.recv_progress.subscribe()
     }
 }
 
@@ -162,16 +179,22 @@ where
             }
         }
 
-        let Self { client, request, config, send_progress } = self;
+        let Self { client, request, config, send_progress, recv_progress } = self;
 
         Box::pin(async move {
-            let res =
-                Box::pin(client.send_inner(request.clone(), config, send_progress.clone())).await;
+            let res = Box::pin(client.send_inner(
+                request.clone(),
+                config,
+                send_progress.clone(),
+                recv_progress.clone(),
+            ))
+            .await;
 
             if let Err(e) = &res
                 && let RetryRequest::Yes = handle_unknown_token_error(e, &client).await?
             {
-                return Box::pin(client.send_inner(request, config, send_progress)).await;
+                return Box::pin(client.send_inner(request, config, send_progress, recv_progress))
+                    .await;
             }
 
             res

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -650,7 +650,12 @@ impl Client {
         use ruma::api::federation::discovery::get_server_version;
 
         let res = self
-            .send_inner(get_server_version::v1::Request::new(), request_config, Default::default())
+            .send_inner(
+                get_server_version::v1::Request::new(),
+                request_config,
+                Default::default(),
+                Default::default(),
+            )
             .await?;
 
         // Extract server info, using defaults if fields are missing.
@@ -2080,6 +2085,7 @@ impl Client {
             request,
             config: None,
             send_progress: Default::default(),
+            recv_progress: Default::default(),
         }
     }
 
@@ -2088,6 +2094,7 @@ impl Client {
         request: Request,
         config: Option<RequestConfig>,
         send_progress: SharedObservable<TransmissionProgress>,
+        recv_progress: SharedObservable<TransmissionProgress>,
     ) -> HttpResult<Request::IncomingResponse>
     where
         Request: OutgoingRequest + Debug,
@@ -2113,6 +2120,7 @@ impl Client {
                 access_token.as_deref(),
                 path_builder_input,
                 send_progress,
+                recv_progress,
             )
             .await;
 
@@ -2180,6 +2188,7 @@ impl Client {
                     Some(&access_token),
                     (),
                     Default::default(),
+                    Default::default(),
                 )
                 .await;
 
@@ -2204,6 +2213,7 @@ impl Client {
                 homeserver.clone(),
                 None,
                 (),
+                Default::default(),
                 Default::default(),
             )
             .await
@@ -2267,6 +2277,7 @@ impl Client {
                 url,
                 None,
                 (),
+                Default::default(),
                 Default::default(),
             )
             .await;
@@ -5264,6 +5275,7 @@ pub(crate) mod tests {
             request: upload_request,
             config: None,
             send_progress: SharedObservable::new(TransmissionProgress::default()),
+            recv_progress: SharedObservable::new(TransmissionProgress::default()),
         };
         let media_request = SendMediaUploadRequest::new(request);
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -2225,7 +2225,12 @@ impl Encryption {
 
             let send_result = self
                 .client
-                .send_inner(ruma_request, Some(RequestConfig::short_retry()), Default::default())
+                .send_inner(
+                    ruma_request,
+                    Some(RequestConfig::short_retry()),
+                    Default::default(),
+                    Default::default(),
+                )
                 .await;
 
             // If the sending failed we need to collect the failures to report them

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -134,6 +134,7 @@ impl HttpClient {
         Ok(request)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send<R>(
         &self,
         request: R,
@@ -142,6 +143,7 @@ impl HttpClient {
         access_token: Option<&str>,
         path_builder_input: <R::PathBuilder as path_builder::PathBuilder>::Input<'_>,
         send_progress: SharedObservable<TransmissionProgress>,
+        recv_progress: SharedObservable<TransmissionProgress>,
     ) -> impl Future<Output = Result<R::IncomingResponse, HttpError>>
     where
         R: OutgoingRequest + Debug,
@@ -216,7 +218,9 @@ impl HttpClient {
 
             // There's a bunch of state in send_request, factor out a pinned inner
             // future to reduce the size of futures that await this function.
-            match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
+            match Box::pin(self.send_request::<R>(request, config, send_progress, recv_progress))
+                .await
+            {
                 Ok(response) => {
                     log_got_response();
                     Ok(response)

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -23,6 +23,7 @@ use backon::{ExponentialBuilder, Retryable};
 use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
+use futures_util::{Stream, TryStreamExt};
 use http::header::CONTENT_LENGTH;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::Certificate;
@@ -256,12 +257,10 @@ pub(super) async fn execute_request(
             tokio::task::yield_now().await;
 
             let mut req = reqwest::Request::try_from(request.map(|body| {
-                let chunks = stream::iter(BytesChunks::new(body, 8192).map(
-                    move |chunk| -> Result<_, Infallible> {
-                        send_progress.update(|p| p.current += chunk.len());
-                        Ok(chunk)
-                    },
-                ));
+                let chunks = track_chunk_progress(
+                    stream::iter(BytesChunks::new(body, 8192).map(Ok::<_, Infallible>)),
+                    send_progress,
+                );
                 reqwest::Body::wrap_stream(chunks)
             }))?;
 
@@ -281,6 +280,16 @@ pub(super) async fn execute_request(
 
     let response = client.execute(request).await?;
     Ok(response_to_http_response(response).await?)
+}
+
+fn track_chunk_progress<S, E>(
+    stream: S,
+    progress: SharedObservable<TransmissionProgress>,
+) -> impl Stream<Item = Result<Bytes, E>>
+where
+    S: Stream<Item = Result<Bytes, E>>,
+{
+    stream.inspect_ok(move |chunk| progress.update(|p| p.current += chunk.len()))
 }
 
 struct BytesChunks {

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -20,10 +20,10 @@ use std::{
 };
 
 use backon::{ExponentialBuilder, Retryable};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
-use futures_util::{Stream, TryStreamExt};
+use futures_util::{Stream, StreamExt, TryStreamExt};
 use http::header::CONTENT_LENGTH;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::Certificate;
@@ -44,6 +44,7 @@ impl HttpClient {
         request: http::Request<Bytes>,
         config: RequestConfig,
         send_progress: SharedObservable<TransmissionProgress>,
+        recv_progress: SharedObservable<TransmissionProgress>,
     ) -> HttpResult<R::IncomingResponse>
     where
         R: OutgoingRequest + Debug,
@@ -79,12 +80,15 @@ impl HttpClient {
             timeout: Option<Duration>,
             retry_count: &AtomicU64,
             send_progress: SharedObservable<TransmissionProgress>,
+            recv_progress: SharedObservable<TransmissionProgress>,
         ) -> HttpResult<http::Response<Bytes>> {
             let num_attempt = retry_count.fetch_add(1, Ordering::SeqCst);
             debug!(num_attempt, "Sending request");
             let before = ruma::time::Instant::now();
 
-            let response = execute_request(http_client, request, timeout, send_progress).await?;
+            let response =
+                execute_request(http_client, request, timeout, send_progress, recv_progress)
+                    .await?;
 
             let request_duration = ruma::time::Instant::now().saturating_duration_since(before);
 
@@ -144,6 +148,7 @@ impl HttpClient {
 
         let send_request = || {
             let send_progress = send_progress.clone();
+            let recv_progress = recv_progress.clone();
             async {
                 let response = send_request_inner(
                     &self.inner,
@@ -151,6 +156,7 @@ impl HttpClient {
                     config.timeout,
                     &retry_count,
                     send_progress,
+                    recv_progress,
                 )
                 .await?;
                 R::IncomingResponse::try_from_http_response(response).map_err(HttpError::from)
@@ -240,6 +246,7 @@ pub(super) async fn execute_request(
     request: &http::Request<Bytes>,
     timeout: Option<Duration>,
     send_progress: SharedObservable<TransmissionProgress>,
+    recv_progress: SharedObservable<TransmissionProgress>,
 ) -> Result<http::Response<Bytes>, HttpError> {
     use std::convert::Infallible;
 
@@ -278,8 +285,29 @@ pub(super) async fn execute_request(
         request
     };
 
-    let response = client.execute(request).await?;
-    Ok(response_to_http_response(response).await?)
+    let mut response = client.execute(request).await?;
+
+    if recv_progress.subscriber_count() == 0 {
+        return Ok(response_to_http_response(response).await?);
+    }
+
+    let mut http_builder = http::Response::builder().status(response.status());
+    let headers = http_builder.headers_mut().expect("Can't get the response builder headers");
+    for (k, v) in response.headers_mut().drain() {
+        if let Some(key) = k {
+            headers.insert(key, v);
+        }
+    }
+
+    recv_progress.update(|p| p.total += response.content_length().unwrap_or(0) as usize);
+
+    let mut body = BytesMut::new();
+    let mut stream = track_chunk_progress(response.bytes_stream(), recv_progress);
+    while let Some(chunk) = stream.next().await {
+        body.extend_from_slice(&chunk?);
+    }
+
+    Ok(http_builder.body(body.freeze()).expect("Can't construct a response using the given body"))
 }
 
 fn track_chunk_progress<S, E>(

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -28,6 +28,7 @@ impl HttpClient {
         request: http::Request<Bytes>,
         _config: RequestConfig,
         _send_progress: SharedObservable<TransmissionProgress>,
+        _recv_progress: SharedObservable<TransmissionProgress>,
     ) -> Result<R::IncomingResponse, HttpError>
     where
         R: OutgoingRequest + Debug,

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -171,6 +171,17 @@ pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm + fmt::Debug {
         client: &'a Client,
         request: &'a MediaRequestParameters,
     ) -> BoxFuture<'a, Result<Vec<u8>, Error>>;
+
+    /// Like [`Self::fetch_media_content`], but reports download progress.
+    fn fetch_media_content_with_progress<'a>(
+        &'a self,
+        client: &'a Client,
+        request: &'a MediaRequestParameters,
+        progress: SharedObservable<TransmissionProgress>,
+    ) -> BoxFuture<'a, Result<Vec<u8>, Error>> {
+        let _ = progress;
+        self.fetch_media_content(client, request)
+    }
 }
 
 impl Media {
@@ -432,6 +443,21 @@ impl Media {
         request: &MediaRequestParameters,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
+        self.get_media_content_with_progress(
+            request,
+            use_cache,
+            SharedObservable::new(Default::default()),
+        )
+        .await
+    }
+
+    /// Like [`Self::get_media_content`], but reports download progress.
+    pub async fn get_media_content_with_progress(
+        &self,
+        request: &MediaRequestParameters,
+        use_cache: bool,
+        progress: SharedObservable<TransmissionProgress>,
+    ) -> Result<Vec<u8>> {
         // Ignore request parameters for local medias, notably those pending in the send
         // queue.
         if let Some(uri) = Self::as_local_uri(&request.source) {
@@ -443,6 +469,9 @@ impl Media {
             && let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
         {
+            if progress.subscriber_count() != 0 {
+                progress.set(TransmissionProgress { current: content.len(), total: content.len() });
+            }
             return Ok(content);
         }
 
@@ -452,7 +481,7 @@ impl Media {
             .media_fetcher
             .read()
             .await
-            .fetch_media_content(&self.client, request)
+            .fetch_media_content_with_progress(&self.client, request, progress)
             .await?;
 
         if use_cache {
@@ -737,6 +766,19 @@ impl MediaFetcher for DefaultMediaFetcher {
         client: &'a Client,
         request: &'a MediaRequestParameters,
     ) -> BoxFuture<'a, Result<Vec<u8>, Error>> {
+        self.fetch_media_content_with_progress(
+            client,
+            request,
+            SharedObservable::new(Default::default()),
+        )
+    }
+
+    fn fetch_media_content_with_progress<'a>(
+        &'a self,
+        client: &'a Client,
+        request: &'a MediaRequestParameters,
+        progress: SharedObservable<TransmissionProgress>,
+    ) -> BoxFuture<'a, Result<Vec<u8>, Error>> {
         Box::pin(async move {
             let request_config = client
                 .request_config()
@@ -755,11 +797,21 @@ impl MediaFetcher for DefaultMediaFetcher {
                     let content = if use_auth {
                         let request =
                             authenticated_media::get_content::v1::Request::from_uri(&file.url)?;
-                        client.send(request).with_request_config(request_config).await?.file
+                        client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_recv_progress_observable(progress.clone())
+                            .await?
+                            .file
                     } else {
                         #[allow(deprecated)]
                         let request = media::get_content::v3::Request::from_url(&file.url)?;
-                        client.send(request).with_request_config(request_config).await?.file
+                        client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_recv_progress_observable(progress.clone())
+                            .await?
+                            .file
                     };
 
                     #[cfg(feature = "e2e-encryption")]
@@ -795,7 +847,12 @@ impl MediaFetcher for DefaultMediaFetcher {
                             request.method = Some(settings.method.clone());
                             request.animated = Some(settings.animated);
 
-                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                            Ok(client
+                                .send(request)
+                                .with_request_config(request_config)
+                                .with_recv_progress_observable(progress.clone())
+                                .await?
+                                .file)
                         } else {
                             #[allow(deprecated)]
                             let request = {
@@ -810,15 +867,30 @@ impl MediaFetcher for DefaultMediaFetcher {
                                 request
                             };
 
-                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                            Ok(client
+                                .send(request)
+                                .with_request_config(request_config)
+                                .with_recv_progress_observable(progress.clone())
+                                .await?
+                                .file)
                         }
                     } else if use_auth {
                         let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
-                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                        Ok(client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_recv_progress_observable(progress.clone())
+                            .await?
+                            .file)
                     } else {
                         #[allow(deprecated)]
                         let request = media::get_content::v3::Request::from_url(uri)?;
-                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                        Ok(client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_recv_progress_observable(progress.clone())
+                            .await?
+                            .file)
                     }
                 }
             }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -901,6 +901,8 @@ impl MediaFetcher for DefaultMediaFetcher {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
+    use eyeball::SharedObservable;
+    use matrix_sdk_test::async_test;
     use ruma::{
         MxcUri,
         events::room::{EncryptedFile, MediaSource},
@@ -908,7 +910,8 @@ mod tests {
     };
     use serde_json::json;
 
-    use super::Media;
+    use super::{Media, MediaFormat, MediaRequestParameters};
+    use crate::{TransmissionProgress, test_utils::mocks::MatrixMockServer};
 
     /// Create an `EncryptedFile` with the given MXC URI.
     fn encrypted_file(mxc_uri: &MxcUri) -> Box<EncryptedFile> {
@@ -962,5 +965,71 @@ mod tests {
         // Test invalid MXC URI.
         let source = MediaSource::Plain("https://server.local/nbvcxw".into());
         assert_matches!(Media::as_local_uri(&source), None);
+    }
+
+    #[async_test]
+    async fn test_get_media_content_with_progress_reports_download_progress() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let body = b"some-fake-media-bytes-for-progress-test".to_vec();
+        server.mock_authed_media_download().ok_bytes(body.clone()).mock_once().mount().await;
+
+        let request = MediaRequestParameters {
+            source: MediaSource::Plain(owned_mxc_uri!("mxc://server.local/abcdef")),
+            format: MediaFormat::File,
+        };
+
+        let progress = SharedObservable::new(TransmissionProgress::default());
+        let _subscriber = progress.subscribe();
+
+        let content = client
+            .media()
+            .get_media_content_with_progress(&request, false, progress.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(content, body);
+        let final_progress = progress.get();
+        assert_eq!(final_progress.current, body.len());
+        assert_eq!(final_progress.total, body.len());
+    }
+
+    #[async_test]
+    async fn test_get_media_content_with_progress_cache_hit_reports_full_progress() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let body = b"some-other-fake-media-bytes".to_vec();
+        server.mock_authed_media_download().ok_bytes(body.clone()).mock_once().mount().await;
+
+        let request = MediaRequestParameters {
+            source: MediaSource::Plain(owned_mxc_uri!("mxc://server.local/ghijkl")),
+            format: MediaFormat::File,
+        };
+
+        client
+            .media()
+            .get_media_content_with_progress(
+                &request,
+                true,
+                SharedObservable::new(Default::default()),
+            )
+            .await
+            .unwrap();
+
+        let progress = SharedObservable::new(TransmissionProgress::default());
+        let _subscriber = progress.subscribe();
+
+        let content = client
+            .media()
+            .get_media_content_with_progress(&request, true, progress.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(content, body);
+        let final_progress = progress.get();
+        assert_eq!(final_progress.current, body.len());
+        assert_eq!(final_progress.total, body.len());
     }
 }


### PR DESCRIPTION
## Motivation
Parity with the existing Media upload progress indicators so that clients can show that progress is being made in a long download. Currently it is only possible to show that a download is in progress, done, or failed this PR allows clients to report back to the user how far along a download is.

## Summary
Exposes TransmissionProgress on media downloads, and consolidates upload and download chunk counting logic.

## Testing
### New
- Added two new tests in `crates/matrix-sdk/src/media.rs` `test_get_media_content_with_progress_reports_download_progress` and `test_get_media_content_with_progress_cache_hit_reports_full_progress`. The first tests a mocked download with a subscribed progress observable that asserts the `TransmissionProgress` properly reports the download as finished. The other asserts that upon a cache hit for a download it fires an already complete progress event without any follow up network calls.
- Added `test_get_media_content_reports_download_progress` to `bindings/matrix-sdk-ffi/src/client.rs` showing that spawned tasks forward the progress callbacks to FFI consumers.

### Modifications to existing
- Updated `test_uploading_a_too_large_media_file` in `crates/matrix-sdk/src/client/mod.rs` to use the new `recv_progress` field in `SendRequest`. 

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Cody Finn <cody.finn@powerhrg.com>
