### PR TITLE
fix(ui): keep joined child spaces visible after leaving parents

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6858.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6858.fixed.md
@@ -1,0 +1,1 @@
+Joined child spaces whose parent space the user has left now appear at the top level if they have no other joined parent spaces.

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -27,7 +27,11 @@
 //! - `SpaceRoomList`: A component for retrieving a space's children rooms and
 //!   their details.
 
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use eyeball_im::{ObservableVector, VectorSubscriberBatchedStream};
 use futures_util::{future::join_all, pin_mut};
@@ -499,6 +503,8 @@ impl SpaceService {
 
     async fn build_space_state(client: &Client) -> (Vec<SpaceRoom>, Vec<SpaceFilter>, SpaceGraph) {
         let joined_spaces = client.joined_space_rooms();
+        let joined_space_ids =
+            joined_spaces.iter().map(|space| space.room_id()).collect::<HashSet<_>>();
 
         // Build a graph to hold the parent-child relations
         let mut graph = SpaceGraph::new();
@@ -523,7 +529,9 @@ impl SpaceService {
                         trace!(room_id = ?space.room_id(), "Could not deserialize m.space.parent: {e}");
                         None
                     }
-                }).for_each(|parent| graph.add_edge(parent, space.room_id().to_owned()));
+                })
+                .filter(|parent| joined_space_ids.contains(&**parent))
+                .for_each(|parent| graph.add_edge(parent, space.room_id().to_owned()));
             } else {
                 error!(room_id = ?space.room_id(), "Could not get m.space.parent events");
             }
@@ -945,6 +953,60 @@ mod tests {
             space_service.top_level_joined_spaces().await,
             vec![SpaceRoom::new_from_known(&client.get_room(first_space_id).unwrap(), 0).await]
         );
+    }
+
+    #[async_test]
+    async fn test_joined_child_space_becomes_top_level_after_leaving_parent() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        server.mock_room_state_encryption().plain().mount().await;
+
+        let parent_space_id = room_id!("!parent_space:example.org");
+        let child_space_id = room_id!("!child_space:example.org");
+        let child_room_id = room_id!("!child_room:example.org");
+
+        add_space_rooms(
+            vec![
+                MockSpaceRoomParameters {
+                    room_id: child_space_id,
+                    order: None,
+                    parents: vec![parent_space_id],
+                    children: vec![child_room_id],
+                    power_level: None,
+                },
+                MockSpaceRoomParameters {
+                    room_id: parent_space_id,
+                    order: None,
+                    parents: vec![],
+                    children: vec![child_space_id],
+                    power_level: None,
+                },
+            ],
+            &client,
+            &server,
+            &EventFactory::new(),
+            client.user_id().unwrap(),
+        )
+        .await;
+
+        let space_service = SpaceService::new(client.clone()).await;
+
+        let top_level_spaces = space_service.top_level_joined_spaces().await;
+        assert_eq!(top_level_spaces.len(), 1);
+        assert_eq!(top_level_spaces[0].room_id, parent_space_id);
+
+        server.sync_room(&client, LeftRoomBuilder::new(parent_space_id)).await;
+
+        let top_level_spaces = space_service.top_level_joined_spaces().await;
+        assert_eq!(top_level_spaces.len(), 1);
+        assert_eq!(top_level_spaces[0].room_id, child_space_id);
+        assert_eq!(top_level_spaces[0].children_count, 1);
+
+        let filters = space_service.space_filters().await;
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].space_room.room_id, child_space_id);
+        assert_eq!(filters[0].descendants, vec![child_room_id]);
     }
 
     #[async_test]


### PR DESCRIPTION
A child space retains its `m.space.parent` event after the user leaves its parent space. `build_space_state()` then unintentionally omits them from the top-level result because it doesn't take into consideration whether parents are still joined. 

This commit fixes that by not adding those edges if the parent space is not joined, so that the affected child spaces become top-level if they have no other joined parent. I have also added a small regression test.

As discussed with @stefanceriu in the [Matrix-Rust-SDK](https://matrix.to/#/%23matrix-rust-sdk:matrix.org) room.  :) 

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries