### PR TITLE
fix(oauth): fetch server metadata before capturing the refresh token

### DIFF
--- a/crates/matrix-sdk/changelog.d/6860.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6860.fixed.md
@@ -1,3 +1,5 @@
-Apps are no longer signed out when another process rotates the OAuth 2.0 refresh
-token while they are suspended mid-refresh. The refresh now notices the rotation
-and adopts the stored token instead of sending the one it captured earlier.
+The window in which an app can be signed out by another process rotating the
+OAuth 2.0 refresh token has been narrowed. The refresh now fetches the
+authorization server metadata before it reads the token, so a rotation during
+that request no longer makes the app send a stale token. Being suspended during
+the token exchange can still produce a sign-out.

--- a/crates/matrix-sdk/changelog.d/6860.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6860.fixed.md
@@ -1,0 +1,3 @@
+Apps are no longer signed out when another process rotates the OAuth 2.0 refresh
+token while they are suspended mid-refresh. The refresh now notices the rotation
+and adopts the stored token instead of sending the one it captured earlier.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -616,4 +616,158 @@ mod tests {
         let hash = SessionHash(vec![0x13, 0x37, 0x42, 0xde, 0xad, 0xca, 0xfe]);
         assert_eq!(hash.to_hex(), "0x133742deadcafe");
     }
+
+    /// The refresh token can be rotated by another process while the app is
+    /// suspended in the middle of its own refresh. The race, in order:
+    ///
+    /// 1. the app starts a refresh and takes the cross-process lock,
+    /// 2. the OS suspends it while it waits for `server_metadata()`,
+    /// 3. the 500ms lock lease lapses, as the task renewing it is frozen too,
+    /// 4. the NSE takes the lock, refreshes, and rotates the refresh token,
+    /// 5. the app resumes, still holding the token it captured in step 1.
+    ///
+    /// The app must notice the rotation, adopt the token the NSE stored, and
+    /// stay signed in.
+    #[async_test]
+    #[should_panic(expected = "the app was signed out after the NSE rotated the refresh token")]
+    async fn test_refresh_interrupted_by_suspension_does_not_sign_out() {
+        use std::{thread, time::Duration};
+
+        use wiremock::{
+            Mock, ResponseTemplate,
+            matchers::{body_string_contains, method, path_regex},
+        };
+
+        let server = MatrixMockServer::new().await;
+
+        // The token endpoint behaves like a rotating MAS: the first exchange of the
+        // prev refresh token succeeds (that is the NSE's refresh, rotating it to the
+        // next token); any later exchange of the now-consumed token is rejected with
+        // `invalid_grant` (that would be the app spending its stale copy).
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/oauth2/token"))
+            .and(body_string_contains("prev-refresh-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "1234", // == mock_session_tokens_with_refresh()
+                "expires_in": 300,
+                "refresh_token": "ZYXWV",
+                "token_type": "Bearer",
+            })))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(server.server())
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"^/oauth2/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_grant",
+            })))
+            .with_priority(2)
+            .mount(server.server())
+            .await;
+
+        // Server metadata: the app's (first) request is delayed long enough to keep
+        // its refresh parked until after the NSE has rotated the token; the NSE's
+        // own request is answered immediately.
+        let metadata = serde_json::to_value(server.oauth().server_metadata()).unwrap();
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(metadata.clone())
+                    .set_delay(Duration::from_secs(3)),
+            )
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(server.server())
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+            .with_priority(2)
+            .mount(server.server())
+            .await;
+
+        // The app and the NSE are two clients over one shared sqlite store, both
+        // restored with the same (prev) session.
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        let app = server
+            .client_builder()
+            .on_builder(|b| b.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
+        app.oauth().enable_cross_process_refresh_lock("app".to_owned()).await.unwrap();
+        app.oauth()
+            .restore_session(
+                mock_session(mock_prev_session_tokens_with_refresh()),
+                RoomLoadSettings::default(),
+            )
+            .await
+            .unwrap();
+        app.set_session_callbacks(
+            Box::new(|_| Ok(mock_session_tokens_with_refresh())),
+            Box::new(|_| Ok(())),
+        )
+        .unwrap();
+
+        let nse = server
+            .client_builder()
+            .on_builder(|b| b.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
+        nse.oauth().enable_cross_process_refresh_lock("nse".to_owned()).await.unwrap();
+        nse.oauth()
+            .restore_session(
+                mock_session(mock_prev_session_tokens_with_refresh()),
+                RoomLoadSettings::default(),
+            )
+            .await
+            .unwrap();
+        nse.set_session_callbacks(
+            Box::new(|_| Ok(mock_session_tokens_with_refresh())),
+            Box::new(|_| Ok(())),
+        )
+        .unwrap();
+
+        // Start the app's refresh; it takes the lock and then parks in the delayed
+        // `server_metadata()` request.
+        let app_oauth = app.oauth();
+        let app_refresh = tokio::spawn(async move { app_oauth.refresh_access_token().await });
+
+        // Wait until the app has actually issued that request — by then it holds the
+        // lock and, in the buggy ordering, has already captured the refresh token.
+        let mut waited = Duration::ZERO;
+        while !server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|request| request.url.path().contains("auth_metadata"))
+        {
+            assert!(waited < Duration::from_secs(5), "the app never asked for the metadata");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            waited += Duration::from_millis(10);
+        }
+
+        // "Suspend" the app: blocking the current-thread runtime freezes every task,
+        // including the one renewing the lease, so the 500ms lock lease lapses.
+        thread::sleep(Duration::from_millis(700));
+
+        // The NSE steals the lapsed lock and refreshes, rotating prev -> next and
+        // consuming the prev token at the server.
+        nse.oauth().refresh_access_token().await.unwrap();
+        assert_eq!(nse.session_tokens(), Some(mock_session_tokens_with_refresh()));
+
+        // The app resumes when its metadata delay elapses. It must notice the
+        // rotation and recover, rather than exchange the token it captured earlier.
+        let app_refresh = app_refresh.await.expect("the app refresh task shouldn't panic");
+
+        assert!(
+            app_refresh.is_ok(),
+            "the app was signed out after the NSE rotated the refresh token: {app_refresh:?}"
+        );
+    }
 }

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -632,60 +632,34 @@ mod tests {
     async fn test_refresh_interrupted_by_suspension_does_not_sign_out() {
         use std::{thread, time::Duration};
 
-        use wiremock::{
-            Mock, ResponseTemplate,
-            matchers::{body_string_contains, method, path_regex},
-        };
-
         let server = MatrixMockServer::new().await;
+        let oauth_server = server.oauth();
 
-        // The token endpoint behaves like a rotating MAS: the first exchange of the
-        // prev refresh token succeeds (that is the NSE's refresh, rotating it to the
-        // next token); any later exchange of the now-consumed token is rejected with
-        // `invalid_grant` (that would be the app spending its stale copy).
-        Mock::given(method("POST"))
-            .and(path_regex(r"^/oauth2/token"))
-            .and(body_string_contains("prev-refresh-token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "access_token": "1234", // == mock_session_tokens_with_refresh()
-                "expires_in": 300,
-                "refresh_token": "ZYXWV",
-                "token_type": "Bearer",
-            })))
+        // The token endpoint behaves like a rotating MAS. Only the first exchange
+        // succeeds and rotates the token: that one is the NSE's refresh, which the
+        // app is suspended through. Any later exchange presents the token that
+        // rotation consumed, and is rejected with `invalid_grant`.
+        oauth_server
+            .mock_token()
+            .ok_with_tokens("1234", "ZYXWV") // == mock_session_tokens_with_refresh()
             .up_to_n_times(1)
             .with_priority(1)
-            .mount(server.server())
+            .mount()
             .await;
-        Mock::given(method("POST"))
-            .and(path_regex(r"^/oauth2/token"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
-                "error": "invalid_grant",
-            })))
-            .with_priority(2)
-            .mount(server.server())
-            .await;
+        oauth_server.mock_token().invalid_grant().with_priority(2).mount().await;
 
-        // Server metadata: the app's (first) request is delayed long enough to keep
-        // its refresh parked until after the NSE has rotated the token; the NSE's
-        // own request is answered immediately.
-        let metadata = serde_json::to_value(server.oauth().server_metadata()).unwrap();
-        Mock::given(method("GET"))
-            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(metadata.clone())
-                    .set_delay(Duration::from_secs(3)),
-            )
+        // The app's (first) metadata request is delayed, to keep its refresh parked
+        // until after the NSE has rotated the token. The NSE's own request is
+        // answered immediately.
+        oauth_server
+            .mock_server_metadata()
+            .with_delay(Duration::from_secs(1))
+            .ok()
             .up_to_n_times(1)
             .with_priority(1)
-            .mount(server.server())
+            .mount()
             .await;
-        Mock::given(method("GET"))
-            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
-            .with_priority(2)
-            .mount(server.server())
-            .await;
+        oauth_server.mock_server_metadata().ok().with_priority(2).mount().await;
 
         // The app and the NSE are two clients over one shared sqlite store, both
         // restored with the same (prev) session.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -629,7 +629,6 @@ mod tests {
     /// The app must notice the rotation, adopt the token the NSE stored, and
     /// stay signed in.
     #[async_test]
-    #[should_panic(expected = "the app was signed out after the NSE rotated the refresh token")]
     async fn test_refresh_interrupted_by_suspension_does_not_sign_out() {
         use std::{thread, time::Duration};
 

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -642,7 +642,7 @@ mod tests {
         oauth_server
             .mock_token()
             .ok_with_tokens("1234", "ZYXWV") // == mock_session_tokens_with_refresh()
-            .up_to_n_times(1)
+            .mock_once()
             .with_priority(1)
             .mount()
             .await;
@@ -655,7 +655,7 @@ mod tests {
             .mock_server_metadata()
             .with_delay(Duration::from_secs(1))
             .ok()
-            .up_to_n_times(1)
+            .mock_once()
             .with_priority(1)
             .mount()
             .await;

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -1225,6 +1225,30 @@ impl OAuth {
 
         debug!("no other refresh happening in background, starting.");
 
+        // Fetch the authorization server metadata *before* taking the cross-process
+        // lock, checking the session hash, or reading the refresh token. This request
+        // can stall for a long time when the OS suspends the process (e.g. iOS
+        // background suspension), and while suspended the lock lease lapses, which
+        // lets another process refresh and rotate the token. Doing it first means the
+        // lock and the hash check happen after the stall, so such a rotation is caught
+        // below as a hash mismatch instead of being exchanged while stale, which the
+        // server rejects with `invalid_grant` and signs the user out.
+        let server_metadata = match self.server_metadata().await {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                warn!("couldn't get authorization server metadata: {err:?}");
+                fail!(refresh_status_guard, RefreshTokenError::OAuth(Arc::new(err.into())));
+            }
+        };
+
+        let Some(client_id) = self.client_id().cloned() else {
+            warn!("invalid state: missing client ID");
+            fail!(
+                refresh_status_guard,
+                RefreshTokenError::OAuth(Arc::new(OAuthError::NotAuthenticated))
+            );
+        };
+
         #[cfg(feature = "e2e-encryption")]
         let cross_process_guard =
             if let Some(manager) = self.ctx().cross_process_token_refresh_manager.get() {
@@ -1256,6 +1280,9 @@ impl OAuth {
                 None
             };
 
+        // Read the refresh token only now, after the hash check above, so we always
+        // exchange the token that is current in the store, never one that another
+        // process rotated out from under us while we were suspended.
         let Some(session_tokens) = self.client.session_tokens() else {
             warn!("invalid state: missing session tokens");
             fail!(refresh_status_guard, RefreshTokenError::RefreshTokenRequired);
@@ -1264,22 +1291,6 @@ impl OAuth {
         let Some(refresh_token) = session_tokens.refresh_token else {
             warn!("invalid state: missing session tokens");
             fail!(refresh_status_guard, RefreshTokenError::RefreshTokenRequired);
-        };
-
-        let server_metadata = match self.server_metadata().await {
-            Ok(metadata) => metadata,
-            Err(err) => {
-                warn!("couldn't get authorization server metadata: {err:?}");
-                fail!(refresh_status_guard, RefreshTokenError::OAuth(Arc::new(err.into())));
-            }
-        };
-
-        let Some(client_id) = self.client_id().cloned() else {
-            warn!("invalid state: missing client ID");
-            fail!(
-                refresh_status_guard,
-                RefreshTokenError::OAuth(Arc::new(OAuthError::NotAuthenticated))
-            );
         };
 
         // Do not interrupt refresh access token requests and processing, by detaching

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1893,6 +1893,17 @@ impl MatrixMock<'_> {
         Self { mock: self.mock.up_to_n_times(num), ..self }
     }
 
+    /// Set the priority of this [`MatrixMock`].
+    ///
+    /// When several mocks match the same request, the one with the highest
+    /// priority (i.e. the lowest value, 1 being the highest and 255 the
+    /// lowest) responds to it. This is useful to mock the same endpoint
+    /// differently for the first and the subsequent requests, by combining it
+    /// with [`Self::up_to_n_times`].
+    pub fn with_priority(self, priority: u8) -> Self {
+        Self { mock: self.mock.with_priority(priority), ..self }
+    }
+
     /// Mount a [`MatrixMock`] on the attached server.
     ///
     /// The [`MatrixMock`] will remain active until the [`MatrixMockServer`] is

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -14,6 +14,8 @@
 
 //! Helpers to mock an OAuth 2.0 server for the purpose of integration tests.
 
+use std::time::Duration;
+
 use ruma::{
     api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
     serde::Raw,
@@ -90,7 +92,7 @@ impl OAuthMockServer<'_> {
     pub fn mock_server_metadata(&self) -> MockEndpoint<'_, ServerMetadataEndpoint> {
         let mock = Mock::given(method("GET"))
             .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc2965/auth_metadata"));
-        self.mock_endpoint(mock, ServerMetadataEndpoint)
+        self.mock_endpoint(mock, ServerMetadataEndpoint::default())
     }
 
     /// Creates a prebuilt mock for the OAuth 2.0 endpoint used to register a
@@ -123,13 +125,35 @@ impl OAuthMockServer<'_> {
 }
 
 /// A prebuilt mock for a `GET /auth_metadata` request.
-pub struct ServerMetadataEndpoint;
+#[derive(Default)]
+pub struct ServerMetadataEndpoint {
+    /// Optional delay to respond to the query.
+    delay: Option<Duration>,
+}
 
 impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
+    /// Respond with a given delay to the query.
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.endpoint.delay = Some(delay);
+        self
+    }
+
+    /// Returns a successful response with the given metadata, honouring the
+    /// delay set with [`Self::with_delay`].
+    fn ok_with_metadata(self, metadata: Raw<AuthorizationServerMetadata>) -> MatrixMock<'a> {
+        let mut template = ResponseTemplate::new(200).set_body_json(metadata);
+
+        if let Some(delay) = self.endpoint.delay {
+            template = template.set_delay(delay);
+        }
+
+        self.respond_with(template)
+    }
+
     /// Returns a successful metadata response with all the supported endpoints.
     pub fn ok(self) -> MatrixMock<'a> {
         let metadata = MockServerMetadataBuilder::new(&self.server.uri()).build();
-        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+        self.ok_with_metadata(metadata)
     }
 
     /// Returns a successful metadata response with all the supported endpoints
@@ -142,7 +166,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
         let issuer = self.server.uri().replace("http://", "https://");
 
         let metadata = MockServerMetadataBuilder::new(&issuer).build();
-        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+        self.ok_with_metadata(metadata)
     }
 
     /// Returns a successful metadata response without the device authorization
@@ -151,7 +175,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
         let metadata = MockServerMetadataBuilder::new(&self.server.uri())
             .without_device_authorization()
             .build();
-        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+        self.ok_with_metadata(metadata)
     }
 
     /// Returns a successful metadata response without the registration
@@ -159,7 +183,7 @@ impl<'a> MockEndpoint<'a, ServerMetadataEndpoint> {
     pub fn ok_without_registration(self) -> MatrixMock<'a> {
         let metadata =
             MockServerMetadataBuilder::new(&self.server.uri()).without_registration().build();
-        self.respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+        self.ok_with_metadata(metadata)
     }
 }
 


### PR DESCRIPTION
Fixes one case for https://github.com/matrix-org/matrix-rust-sdk/issues/6794.

The regression test is bit long but it mimics the behavior that was observed. The patch avoids the main app to make a hard logout after it started to refresh the token but got paused in the middle.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
