### PR TITLE
chore(base): Short-circuiting `Room::heroes` if there is no heroes

### DIFF
--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -497,6 +497,11 @@ impl Room {
             }
         };
 
+        // Short-circuiting if there is no heroes: we can't do anything.
+        if heroes.is_empty() {
+            return Vec::new();
+        }
+
         // Return with empty profile fields when the user status feature is disabled.
         #[cfg(not(feature = "unstable-msc4426"))]
         {


### PR DESCRIPTION
This patch early returns in `Room::heroes` if there is no heroes to map. It saves one call to the store if `unstable-msc4426` is enabled.

Inspired by https://github.com/matrix-org/matrix-rust-sdk/commit/4966f5403#diff-40ec73160d057ed5bbe28cf81af28f56e27394369779ead9676055b6206cc860R509 and fixed to be placed in the correct place. Thanks @ara4n.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
