### PR TITLE
feat(ffi): add is_profiles_sliding_sync_extension_supported to Client

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6863.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6863.added.md
@@ -1,0 +1,3 @@
+Added `Client::is_profiles_sliding_sync_extension_supported()` on the FFI,
+exposing a standalone check for server support of the Profiles sliding sync
+extension ([MSC4262]), separately from `is_user_status_supported()`.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2159,13 +2159,15 @@ impl Client {
         Ok(transports.iter().any(|focus| matches!(focus, RtcTransport::LiveKit(_))))
     }
 
+    /// Checks if the server supports the Profiles sliding sync extension.
+    pub async fn is_profiles_sliding_sync_extension_supported(&self) -> Result<bool, ClientError> {
+        Ok(self.inner.unstable_features().await?.contains(&FeatureFlag::from("org.matrix.msc4262")))
+    }
+
     /// Checks if the server supports user status.
     pub async fn is_user_status_supported(&self) -> Result<bool, ClientError> {
-        let supports_profiles_sync_extension = self
-            .inner
-            .unstable_features()
-            .await?
-            .contains(&FeatureFlag::from("org.matrix.msc4262"));
+        let supports_profiles_sync_extension =
+            self.is_profiles_sliding_sync_extension_supported().await?;
 
         let can_set_status_field = self
             .inner


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
