### PR TITLE
Media download progress indicators

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6864.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6864.added.md
@@ -1,0 +1,18 @@
+`Client::get_media_content` and `Client::get_media_thumbnail` now accept an
+optional `ProgressWatcher`. When provided, it receives `TransmissionProgress`
+updates as the media is downloaded, mirroring the download-progress reporting
+already available for `upload_media`. This lets clients display how far along
+a media download is, instead of only showing that one is in progress.
+
+```swift
+final class DownloadProgressWatcher: ProgressWatcher {
+    func transmissionProgress(progress: TransmissionProgress) {
+        print("downloaded \(progress.current) of \(progress.total) bytes")
+    }
+}
+
+let content = try await client.getMediaContent(
+    mediaSource: mediaSource,
+    progressWatcher: DownloadProgressWatcher()
+)
+```

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1482,7 +1482,7 @@ impl Client {
         progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<String, ClientError> {
         let mime_type: mime::Mime = mime_type.parse().context("Parsing mime type")?;
-        let request = self.inner.media().upload(&mime_type, data, None);
+        let mut request = self.inner.media().upload(&mime_type, data, None);
 
         if let Some(progress_watcher) = progress_watcher {
             let mut subscriber = request.subscribe_to_send_progress();
@@ -1512,7 +1512,7 @@ impl Client {
             .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true);
 
         if let Some(progress_watcher) = progress_watcher {
-            let mut subscriber = request.subscribe_to_recv_progress();
+            let mut subscriber = request.subscribe_to_receive_progress();
             get_runtime_handle().spawn(async move {
                 while let Some(progress) = subscriber.next().await {
                     progress_watcher.transmission_progress(progress.into());
@@ -1545,7 +1545,7 @@ impl Client {
         );
 
         if let Some(progress_watcher) = progress_watcher {
-            let mut subscriber = request.subscribe_to_recv_progress();
+            let mut subscriber = request.subscribe_to_receive_progress();
             get_runtime_handle().spawn(async move {
                 while let Some(progress) = subscriber.next().await {
                     progress_watcher.transmission_progress(progress.into());
@@ -3723,5 +3723,62 @@ mod tests {
         assert!(converted.avatar_url.is_none());
         assert!(converted.status.is_none());
         assert!(converted.call.is_none());
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_media_content_reports_download_progress() {
+        use std::sync::Arc;
+
+        use matrix_sdk::{
+            ruma::{
+                api::MatrixVersion, events::room::MediaSource as RumaMediaSource, owned_mxc_uri,
+            },
+            test_utils::mocks::MatrixMockServer,
+        };
+        use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+        use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+
+        use crate::client::{ProgressWatcher, TransmissionProgress};
+
+        struct ChannelProgressWatcher(UnboundedSender<TransmissionProgress>);
+
+        impl ProgressWatcher for ChannelProgressWatcher {
+            fn transmission_progress(&self, progress: TransmissionProgress) {
+                let _ = self.0.send(progress);
+            }
+        }
+
+        let server = MatrixMockServer::new().await;
+        let sdk_client = server
+            .client_builder()
+            .server_versions(vec![MatrixVersion::V1_1])
+            .on_builder(|b| b.cross_process_store_config(CrossProcessLockConfig::SingleProcess))
+            .build()
+            .await;
+
+        server.mock_media_download().ok_plain_text().expect(1).mount().await;
+
+        let client = super::Client::new(sdk_client, None, None).await.expect("build ffi client");
+
+        let media_source = Arc::new(crate::ruma::MediaSource {
+            media_source: RumaMediaSource::Plain(owned_mxc_uri!("mxc://localhost/textfile")),
+        });
+
+        let (tx, mut rx) = unbounded_channel();
+        let watcher: Box<dyn ProgressWatcher> = Box::new(ChannelProgressWatcher(tx));
+
+        let content =
+            client.get_media_content(media_source, Some(watcher)).await.expect("get media content");
+
+        assert_eq!(content, b"Hello, World!");
+
+        let mut last = None;
+        while let Some(progress) = rx.recv().await {
+            last = Some(progress);
+        }
+        let last = last.expect("expected at least one progress update");
+        assert_eq!(last.current, content.len() as u64);
+        assert_eq!(last.total, content.len() as u64);
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1501,15 +1501,26 @@ impl Client {
     pub async fn get_media_content(
         &self,
         media_source: Arc<MediaSource>,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone().media_source;
 
         debug!(?source, "requesting media file");
-        Ok(self
+        let mut request = self
             .inner
             .media()
-            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true)
-            .await?)
+            .get_media_content(&MediaRequestParameters { source, format: MediaFormat::File }, true);
+
+        if let Some(progress_watcher) = progress_watcher {
+            let mut subscriber = request.subscribe_to_recv_progress();
+            get_runtime_handle().spawn(async move {
+                while let Some(progress) = subscriber.next().await {
+                    progress_watcher.transmission_progress(progress.into());
+                }
+            });
+        }
+
+        Ok(request.await?)
     }
 
     pub async fn get_media_thumbnail(
@@ -1517,24 +1528,32 @@ impl Client {
         media_source: Arc<MediaSource>,
         width: u64,
         height: u64,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
     ) -> Result<Vec<u8>, ClientError> {
         let source = (*media_source).clone().media_source;
 
         debug!(?source, width, height, "requesting media thumbnail");
-        Ok(self
-            .inner
-            .media()
-            .get_media_content(
-                &MediaRequestParameters {
-                    source,
-                    format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                        UInt::new(width).unwrap(),
-                        UInt::new(height).unwrap(),
-                    )),
-                },
-                true,
-            )
-            .await?)
+        let mut request = self.inner.media().get_media_content(
+            &MediaRequestParameters {
+                source,
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    UInt::new(width).unwrap(),
+                    UInt::new(height).unwrap(),
+                )),
+            },
+            true,
+        );
+
+        if let Some(progress_watcher) = progress_watcher {
+            let mut subscriber = request.subscribe_to_recv_progress();
+            get_runtime_handle().spawn(async move {
+                while let Some(progress) = subscriber.next().await {
+                    progress_watcher.transmission_progress(progress.into());
+                }
+            });
+        }
+
+        Ok(request.await?)
     }
 
     /// Get the homeserver-generated preview for a URL, as OpenGraph JSON.

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -26,8 +26,9 @@ use api::{
     public_server_key::PublicServerKeyRequest,
 };
 use matrix_sdk::{
-    BoxFuture, Client, Error, IdParseError,
+    BoxFuture, Client, Error, IdParseError, SharedObservable, TransmissionProgress,
     encryption::vodozemac::pk_encryption::Message,
+    futures::RequestProgress,
     locks::Mutex,
     media::{MediaFetcher, MediaRequestParameters},
     ruma::events::room::MediaSource,
@@ -96,6 +97,7 @@ impl ContentScanner {
         &self,
         client: &Client,
         media_source: &MediaSource,
+        progress: SharedObservable<TransmissionProgress>,
     ) -> Result<DownloadAndScanMediaResponse, Error> {
         match &media_source {
             MediaSource::Encrypted(encrypted) => {
@@ -108,6 +110,10 @@ impl ContentScanner {
                         public_server_key,
                         *encrypted.clone(),
                     ))
+                    .with_progress_observable(RequestProgress {
+                        receive: progress,
+                        ..Default::default()
+                    })
                     .await?)
             }
             MediaSource::Plain(mxc) => {
@@ -119,6 +125,10 @@ impl ContentScanner {
                         server_name.as_str(),
                         media_id,
                     ))
+                    .with_progress_observable(RequestProgress {
+                        receive: progress,
+                        ..Default::default()
+                    })
                     .await?)
             }
         }
@@ -215,9 +225,11 @@ impl MediaFetcher for ContentScannerMediaFetcher {
         &'a self,
         client: &'a Client,
         request: &'a MediaRequestParameters,
+        progress: SharedObservable<TransmissionProgress>,
     ) -> BoxFuture<'a, matrix_sdk::Result<Vec<u8>, Error>> {
         Box::pin(async move {
-            let content = self.content_scanner.get_media(client, &request.source).await?.content;
+            let content =
+                self.content_scanner.get_media(client, &request.source, progress).await?.content;
             #[cfg(feature = "e2e-encryption")]
             let content = {
                 match &request.source {
@@ -355,7 +367,10 @@ mod tests {
         let content_scanner = ContentScanner::new(content_scanner_server.uri());
         let media_source =
             MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
-        content_scanner.get_media(&client, &media_source).await.expect("Get media");
+        content_scanner
+            .get_media(&client, &media_source, Default::default())
+            .await
+            .expect("Get media");
     }
 
     #[async_test]
@@ -378,8 +393,10 @@ mod tests {
         let content_scanner = ContentScanner::new(content_scanner_server.uri());
         let media_source =
             MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/ckTaStcNnFXLzKApkBmgRDoC"));
-        let err =
-            content_scanner.get_media(&client, &media_source).await.expect_err("Get media error");
+        let err = content_scanner
+            .get_media(&client, &media_source, Default::default())
+            .await
+            .expect_err("Get media error");
         let client_error = err.as_client_api_error().expect("Get client error");
         assert_eq!(client_error.status_code, StatusCode::FORBIDDEN);
         assert_eq!(
@@ -420,7 +437,10 @@ mod tests {
             file_info,
             hashes,
         )));
-        content_scanner.get_media(&client, &media_source).await.expect("Get media");
+        content_scanner
+            .get_media(&client, &media_source, Default::default())
+            .await
+            .expect("Get media");
     }
 
     #[async_test]
@@ -456,7 +476,7 @@ mod tests {
             hashes,
         )));
         let err = content_scanner
-            .get_media(&client, &media_source)
+            .get_media(&client, &media_source, Default::default())
             .await
             .expect_err("Invalid type error");
         let client_error = err.as_client_api_error().expect("Invalid error");

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -97,7 +97,7 @@ impl ContentScanner {
         &self,
         client: &Client,
         media_source: &MediaSource,
-        progress: SharedObservable<TransmissionProgress>,
+        progress: Option<SharedObservable<TransmissionProgress>>,
     ) -> Result<DownloadAndScanMediaResponse, Error> {
         match &media_source {
             MediaSource::Encrypted(encrypted) => {
@@ -225,7 +225,7 @@ impl MediaFetcher for ContentScannerMediaFetcher {
         &'a self,
         client: &'a Client,
         request: &'a MediaRequestParameters,
-        progress: SharedObservable<TransmissionProgress>,
+        progress: Option<SharedObservable<TransmissionProgress>>,
     ) -> BoxFuture<'a, matrix_sdk::Result<Vec<u8>, Error>> {
         Box::pin(async move {
             let content =
@@ -304,7 +304,10 @@ mod tests {
     use assert_matches2::assert_matches;
     #[cfg(feature = "e2e-encryption")]
     use matrix_sdk::media::{MediaFormat, MediaRequestParameters};
-    use matrix_sdk::{HttpError, RumaApiError, test_utils::mocks::MatrixMockServer};
+    use matrix_sdk::{
+        HttpError, RumaApiError, SharedObservable, TransmissionProgress,
+        test_utils::mocks::MatrixMockServer,
+    };
     use matrix_sdk_test::async_test;
     use ruma::{
         api::{
@@ -371,6 +374,39 @@ mod tests {
             .get_media(&client, &media_source, Default::default())
             .await
             .expect("Get media");
+    }
+
+    #[async_test]
+    async fn test_get_media_reports_download_progress() {
+        let server = MatrixMockServer::new().await;
+        let client =
+            server.client_builder().server_versions(vec![MatrixVersion::V1_11]).build().await;
+
+        let content_scanner_server = MockServer::start().await;
+        let body = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        Mock::given(method("GET"))
+            .and(path_regex(r"/_matrix/media_proxy/unstable/download/.+/.+"))
+            .and(header_exists("Authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&content_scanner_server)
+            .await;
+
+        let content_scanner = ContentScanner::new(content_scanner_server.uri());
+        let media_source =
+            MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/RhfpOXOzAwzkuqcmbgMwQUrJ"));
+
+        let progress = SharedObservable::new(TransmissionProgress::default());
+        let subscriber = progress.subscribe();
+        let response = content_scanner
+            .get_media(&client, &media_source, Some(progress))
+            .await
+            .expect("Get media");
+
+        assert_eq!(response.content, body);
+
+        let progress = subscriber.get();
+        assert_eq!(progress.current, body.len());
+        assert_eq!(progress.total, body.len());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/changelog.d/6864.added.md
+++ b/crates/matrix-sdk/changelog.d/6864.added.md
@@ -1,0 +1,21 @@
+`Media::get_media_content` now returns the `GetMediaContentRequest` future
+instead of an anonymous future. It implements `IntoFuture`, so existing
+`.await` call sites continue to work unchanged, and it additionally exposes the
+progress of the download through `subscribe_to_receive_progress()` and
+`with_recv_progress_observable()`. This mirrors the existing upload-side
+`send_progress` API and lets clients report how far along a media download is,
+rather than only whether it is in progress, done, or failed.
+
+```rust
+let mut request = client.media().get_media_content(&request_parameters, true);
+
+// Observe the download progress before awaiting the request.
+let mut progress = request.subscribe_to_receive_progress();
+matrix_sdk_common::executor::spawn(async move {
+    while let Some(progress) = progress.next().await {
+        println!("downloaded {} of {} bytes", progress.current, progress.total);
+    }
+});
+
+let content = request.await?;
+```

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -38,27 +38,36 @@ use crate::{
     media::MediaError,
 };
 
+/// The upload and download progress of a request, tracked as a pair since a
+/// single HTTP exchange can have both a request body being sent and a
+/// response body being received.
+#[derive(Debug, Clone, Default)]
+pub struct RequestProgress {
+    /// Progress of sending the request body.
+    pub send: Option<SharedObservable<TransmissionProgress>>,
+    /// Progress of receiving the response body.
+    pub receive: Option<SharedObservable<TransmissionProgress>>,
+}
+
 /// `IntoFuture` returned by [`Client::send`].
 #[allow(missing_debug_implementations)]
 pub struct SendRequest<R> {
     pub(crate) client: Client,
     pub(crate) request: R,
     pub(crate) config: Option<RequestConfig>,
-    pub(crate) send_progress: SharedObservable<TransmissionProgress>,
+    pub(crate) progress: RequestProgress,
 }
 
 impl<R> SendRequest<R> {
-    /// Replace the default `SharedObservable` used for tracking upload
-    /// progress.
+    /// Replace the default [`RequestProgress`] used for tracking upload and
+    /// download progress.
     ///
     /// Note that any subscribers obtained from
-    /// [`subscribe_to_send_progress`][Self::subscribe_to_send_progress]
-    /// will be invalidated by this.
-    pub fn with_send_progress_observable(
-        mut self,
-        send_progress: SharedObservable<TransmissionProgress>,
-    ) -> Self {
-        self.send_progress = send_progress;
+    /// [`subscribe_to_send_progress`][Self::subscribe_to_send_progress] or
+    /// [`subscribe_to_recv_progress`][Self::subscribe_to_recv_progress] will
+    /// be invalidated by this.
+    pub fn with_progress_observable(mut self, progress: RequestProgress) -> Self {
+        self.progress = progress;
         self
     }
 
@@ -71,8 +80,14 @@ impl<R> SendRequest<R> {
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
-        self.send_progress.subscribe()
+    pub fn subscribe_to_send_progress(&mut self) -> Subscriber<TransmissionProgress> {
+        self.progress.send.get_or_insert_with(SharedObservable::default).subscribe()
+    }
+
+    /// Get a subscriber to observe the progress of receiving the response
+    /// body.
+    pub fn subscribe_to_recv_progress(&mut self) -> Subscriber<TransmissionProgress> {
+        self.progress.receive.get_or_insert_with(SharedObservable::default).subscribe()
     }
 }
 
@@ -162,16 +177,15 @@ where
             }
         }
 
-        let Self { client, request, config, send_progress } = self;
+        let Self { client, request, config, progress } = self;
 
         Box::pin(async move {
-            let res =
-                Box::pin(client.send_inner(request.clone(), config, send_progress.clone())).await;
+            let res = Box::pin(client.send_inner(request.clone(), config, progress.clone())).await;
 
             if let Err(e) = &res
                 && let RetryRequest::Yes = handle_unknown_token_error(e, &client).await?
             {
-                return Box::pin(client.send_inner(request, config, send_progress)).await;
+                return Box::pin(client.send_inner(request, config, progress)).await;
             }
 
             res
@@ -202,14 +216,14 @@ impl SendMediaUploadRequest {
         mut self,
         send_progress: SharedObservable<TransmissionProgress>,
     ) -> Self {
-        self.send_request = self.send_request.with_send_progress_observable(send_progress);
+        self.send_request.progress.send = Some(send_progress);
         self
     }
 
     /// Get a subscriber to observe the progress of sending the request
     /// body.
-    pub fn subscribe_to_send_progress(&self) -> Subscriber<TransmissionProgress> {
-        self.send_request.send_progress.subscribe()
+    pub fn subscribe_to_send_progress(&mut self) -> Subscriber<TransmissionProgress> {
+        self.send_request.progress.send.get_or_insert_with(SharedObservable::default).subscribe()
     }
 }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -86,11 +86,11 @@ use url::Url;
 
 use self::{
     caches::{Cache, CachedValue, ClientCaches},
-    futures::SendRequest,
+    futures::{RequestProgress, SendRequest},
 };
 use crate::{
     Account, AuthApi, AuthSession, Error, HttpError, Media, Pusher, RefreshTokenError, Result,
-    Room, SessionTokens, TransmissionProgress,
+    Room, SessionTokens,
     authentication::{
         AuthCtx, AuthData, ReloadSessionCallback, SaveSessionCallback, matrix::MatrixAuth,
         oauth::OAuth,
@@ -663,7 +663,11 @@ impl Client {
         use ruma::api::federation::discovery::get_server_version;
 
         let res = self
-            .send_inner(get_server_version::v1::Request::new(), request_config, Default::default())
+            .send_inner(
+                get_server_version::v1::Request::new(),
+                request_config,
+                RequestProgress::default(),
+            )
             .await?;
 
         // Extract server info, using defaults if fields are missing.
@@ -2092,7 +2096,7 @@ impl Client {
             client: self.clone(),
             request,
             config: None,
-            send_progress: Default::default(),
+            progress: RequestProgress::default(),
         }
     }
 
@@ -2100,7 +2104,7 @@ impl Client {
         &self,
         request: Request,
         config: Option<RequestConfig>,
-        send_progress: SharedObservable<TransmissionProgress>,
+        progress: RequestProgress,
     ) -> HttpResult<Request::IncomingResponse>
     where
         Request: OutgoingRequest + Debug,
@@ -2125,7 +2129,7 @@ impl Client {
                 homeserver,
                 access_token.as_deref(),
                 path_builder_input,
-                send_progress,
+                progress,
             )
             .await;
 
@@ -4006,7 +4010,6 @@ pub(crate) mod tests {
 
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use eyeball::SharedObservable;
     use futures_util::{FutureExt, StreamExt, pin_mut};
     use js_int::{UInt, uint};
     use matrix_sdk_base::{
@@ -4047,10 +4050,10 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
-        Error, Result, TransmissionProgress,
+        Error, Result,
         client::{WeakClient, caches::CachedValue, futures::SendMediaUploadRequest},
         config::{RequestConfig, SyncSettings},
-        futures::SendRequest,
+        futures::{RequestProgress, SendRequest},
         media::MediaError,
         test_utils::{client::MockClientBuilder, mocks::MatrixMockServer},
     };
@@ -5475,7 +5478,7 @@ pub(crate) mod tests {
             client: client.clone(),
             request: upload_request,
             config: None,
-            send_progress: SharedObservable::new(TransmissionProgress::default()),
+            progress: RequestProgress::default(),
         };
         let media_request = SendMediaUploadRequest::new(request);
 

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -26,7 +26,6 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use bytesize::ByteSize;
-use eyeball::SharedObservable;
 use http::Method;
 use matrix_sdk_base::SendOutsideWasm;
 use ruma::api::{
@@ -38,7 +37,9 @@ use ruma::api::{
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tracing::{Instrument, debug, error, field::debug, trace};
 
-use crate::{HttpResult, config::RequestConfig, error::HttpError};
+use crate::{
+    HttpResult, client::futures::RequestProgress, config::RequestConfig, error::HttpError,
+};
 
 #[cfg(not(target_family = "wasm"))]
 mod native;
@@ -134,6 +135,7 @@ impl HttpClient {
         Ok(request)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send<R>(
         &self,
         request: R,
@@ -141,7 +143,7 @@ impl HttpClient {
         homeserver: String,
         access_token: Option<&str>,
         path_builder_input: <R::PathBuilder as path_builder::PathBuilder>::Input<'_>,
-        send_progress: SharedObservable<TransmissionProgress>,
+        progress: RequestProgress,
     ) -> impl Future<Output = Result<R::IncomingResponse, HttpError>>
     where
         R: OutgoingRequest + Debug,
@@ -216,7 +218,7 @@ impl HttpClient {
 
             // There's a bunch of state in send_request, factor out a pinned inner
             // future to reduce the size of futures that await this function.
-            match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
+            match Box::pin(self.send_request::<R>(request, config, progress)).await {
                 Ok(response) => {
                     log_got_response();
                     Ok(response)

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -20,9 +20,8 @@ use std::{
 };
 
 use backon::{ExponentialBuilder, Retryable};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use bytesize::ByteSize;
-use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::Certificate;
@@ -30,9 +29,10 @@ use reqwest::tls;
 use ruma::api::{IncomingResponseExt as _, OutgoingRequest, error::FromHttpResponseError};
 use tracing::{debug, info, warn};
 
-use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
+use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, response_to_http_response};
 use crate::{
     HttpResult,
+    client::futures::RequestProgress,
     config::RequestConfig,
     error::{HttpError, RetryKind},
 };
@@ -42,7 +42,7 @@ impl HttpClient {
         &self,
         request: http::Request<Bytes>,
         config: RequestConfig,
-        send_progress: SharedObservable<TransmissionProgress>,
+        progress: RequestProgress,
     ) -> HttpResult<R::IncomingResponse>
     where
         R: OutgoingRequest + Debug,
@@ -77,13 +77,13 @@ impl HttpClient {
             request: &http::Request<Bytes>,
             timeout: Option<Duration>,
             retry_count: &AtomicU64,
-            send_progress: SharedObservable<TransmissionProgress>,
+            progress: RequestProgress,
         ) -> HttpResult<http::Response<Bytes>> {
             let num_attempt = retry_count.fetch_add(1, Ordering::SeqCst);
             debug!(num_attempt, "Sending request");
             let before = ruma::time::Instant::now();
 
-            let response = execute_request(http_client, request, timeout, send_progress).await?;
+            let response = execute_request(http_client, request, timeout, progress).await?;
 
             let request_duration = ruma::time::Instant::now().saturating_duration_since(before);
 
@@ -142,14 +142,14 @@ impl HttpClient {
         let retry_count = AtomicU64::new(1);
 
         let send_request = || {
-            let send_progress = send_progress.clone();
+            let progress = progress.clone();
             async {
                 let response = send_request_inner(
                     &self.inner,
                     &request,
                     config.timeout,
                     &retry_count,
-                    send_progress,
+                    progress,
                 )
                 .await?;
                 let (parts, body) = response.into_parts();
@@ -240,7 +240,7 @@ pub(super) async fn execute_request(
     client: &reqwest::Client,
     request: &http::Request<Bytes>,
     timeout: Option<Duration>,
-    send_progress: SharedObservable<TransmissionProgress>,
+    RequestProgress { send: send_progress, receive: receive_progress }: RequestProgress,
 ) -> Result<http::Response<Bytes>, HttpError> {
     use std::convert::Infallible;
 
@@ -248,7 +248,7 @@ pub(super) async fn execute_request(
 
     let request = request.clone();
     let request = {
-        let mut request = if send_progress.subscriber_count() != 0 {
+        let mut request = if let Some(send_progress) = send_progress {
             let content_length = request.body().len();
             send_progress.update(|p| p.total += content_length);
 
@@ -281,8 +281,33 @@ pub(super) async fn execute_request(
         request
     };
 
-    let response = client.execute(request).await?;
-    Ok(response_to_http_response(response).await?)
+    let mut response = client.execute(request).await?;
+
+    let Some(receive_progress) = receive_progress else {
+        return Ok(response_to_http_response(response).await?);
+    };
+
+    // Read the content length before draining the headers below.
+    let content_length = response.content_length().unwrap_or(0) as usize;
+
+    let status = response.status();
+    let mut http_builder = http::Response::builder().status(status);
+    let headers = http_builder.headers_mut().expect("Can't get the response builder headers");
+    for (k, v) in response.headers_mut().drain() {
+        if let Some(key) = k {
+            headers.insert(key, v);
+        }
+    }
+
+    receive_progress.update(|p| p.total += content_length);
+
+    let mut body = BytesMut::new();
+    while let Some(chunk) = response.chunk().await? {
+        receive_progress.update(|p| p.current += chunk.len());
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(http_builder.body(body.freeze()).expect("Can't construct a response using the given body"))
 }
 
 struct BytesChunks {

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -16,18 +16,17 @@ use std::fmt::Debug;
 
 use bytes::Bytes;
 use bytesize::ByteSize;
-use eyeball::SharedObservable;
 use ruma::api::{IncomingResponseExt as _, OutgoingRequest, error::FromHttpResponseError};
 
-use super::{HttpClient, TransmissionProgress, response_to_http_response};
-use crate::{config::RequestConfig, error::HttpError};
+use super::{HttpClient, response_to_http_response};
+use crate::{client::futures::RequestProgress, config::RequestConfig, error::HttpError};
 
 impl HttpClient {
     pub(super) async fn send_request<R>(
         &self,
         request: http::Request<Bytes>,
         _config: RequestConfig,
-        _send_progress: SharedObservable<TransmissionProgress>,
+        _progress: RequestProgress,
     ) -> Result<R::IncomingResponse, HttpError>
     where
         R: OutgoingRequest + Debug,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -80,6 +80,7 @@ pub use error::{
     BeaconError, Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError,
     Result, RumaApiError,
 };
+pub use eyeball::SharedObservable;
 pub use http_client::{SupportedAuthScheme, SupportedPathBuilder, TransmissionProgress};
 #[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
 pub use matrix_sdk_sqlite::SqliteCryptoStore;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -57,7 +57,7 @@ pub mod utils;
 pub mod futures {
     //! Named futures returned from methods on types in [the crate root][crate].
 
-    pub use super::client::futures::SendRequest;
+    pub use super::client::futures::{RequestProgress, SendRequest};
 }
 pub mod sliding_sync;
 pub mod sync;

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -17,15 +17,15 @@
 
 #[cfg(feature = "e2e-encryption")]
 use std::io::Read;
-use std::{fmt, time::Duration};
+use std::{fmt, future::IntoFuture, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use std::{fs::File, path::Path};
 
-use eyeball::SharedObservable;
+use eyeball::{SharedObservable, Subscriber};
 use futures_util::future::try_join;
 use matrix_sdk_base::media::store::IgnoreMediaRetentionPolicy;
 pub use matrix_sdk_base::media::{store::MediaRetentionPolicy, *};
-use matrix_sdk_common::{BoxFuture, SendOutsideWasm, SyncOutsideWasm};
+use matrix_sdk_common::{BoxFuture, SendOutsideWasm, SyncOutsideWasm, boxed_into_future};
 use mime::Mime;
 use ruma::{
     MilliSecondsSinceUnixEpoch, MxcUri, OwnedMxcUri, TransactionId, UInt,
@@ -44,8 +44,10 @@ use tempfile::{Builder as TempFileBuilder, NamedTempFile, TempDir};
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
-    Client, Error, Result, TransmissionProgress, attachment::Thumbnail,
-    client::futures::SendMediaUploadRequest, config::RequestConfig,
+    Client, Error, Result, TransmissionProgress,
+    attachment::Thumbnail,
+    client::futures::{RequestProgress, SendMediaUploadRequest},
+    config::RequestConfig,
 };
 
 /// A conservative upload speed of 1Mbps
@@ -165,12 +167,14 @@ pub enum MediaError {
 
 /// A generic trait for fetching media content.
 pub trait MediaFetcher: SendOutsideWasm + SyncOutsideWasm + fmt::Debug {
-    /// Fetches the media content for the given [`MediaRequestParameters`].
+    /// Fetches the media content for the given [`MediaRequestParameters`],
+    /// reporting download progress through `progress`.
     /// Returns either a byte array or an [`crate::Error`].
     fn fetch_media_content<'a>(
         &'a self,
         client: &'a Client,
         request: &'a MediaRequestParameters,
+        receive_progress: Option<SharedObservable<TransmissionProgress>>,
     ) -> BoxFuture<'a, Result<Vec<u8>, Error>>;
 }
 
@@ -428,61 +432,20 @@ impl Media {
     /// * `request` - The `MediaRequest` of the content.
     ///
     /// * `use_cache` - If we should use the media cache for this request.
-    pub async fn get_media_content(
+    ///
+    /// Download progress can be observed through
+    /// [`GetMediaContentRequest::subscribe_to_receive_progress`].
+    pub fn get_media_content(
         &self,
         request: &MediaRequestParameters,
         use_cache: bool,
-    ) -> Result<Vec<u8>> {
-        // This is a local media. Force to read the media's content from the store: it
-        // cannot exist somewhere else!
-        if Self::is_local_uri(&request.source) {
-            // Local medias are always cached with `MediaFormat::File`, be it the file
-            // itself or its thumbnail (see `RoomSendQueue::cache_media`), so ignore the
-            // requested format.
-            let request = &MediaRequestParameters {
-                source: request.source.clone(),
-                format: MediaFormat::File,
-            };
-
-            if let Some(content) =
-                self.client.media_store().lock().await?.get_media_content(request).await?
-            {
-                return Ok(content);
-            } else {
-                return Err(Error::MediaStore(Box::new(store::MediaStoreError::InvalidData {
-                    details: format!("Media does not exist: `{request:?}`"),
-                })));
-            }
+    ) -> GetMediaContentRequest {
+        GetMediaContentRequest {
+            media: self.clone(),
+            request: request.clone(),
+            use_cache,
+            recv_progress: None,
         }
-
-        // Read from the cache: if it doesn't exist, the execution continues by reading
-        // the media from the network.
-        if use_cache
-            && let Some(content) =
-                self.client.media_store().lock().await?.get_media_content(request).await?
-        {
-            return Ok(content);
-        }
-
-        let content = self
-            .client
-            .inner
-            .media_fetcher
-            .read()
-            .await
-            .fetch_media_content(&self.client, request)
-            .await?;
-
-        if use_cache {
-            self.client
-                .media_store()
-                .lock()
-                .await?
-                .add_media_content(request, content.clone(), IgnoreMediaRetentionPolicy::No)
-                .await?;
-        }
-
-        Ok(content)
     }
 
     /// Remove a media file's content from the store.
@@ -799,6 +762,110 @@ impl Media {
     }
 }
 
+/// Builder for the future returned when polling [`Media::get_media_content`]'s
+/// result, allowing progress to be observed before awaiting it.
+#[derive(Debug)]
+#[must_use]
+pub struct GetMediaContentRequest {
+    media: Media,
+    request: MediaRequestParameters,
+    use_cache: bool,
+    recv_progress: Option<SharedObservable<TransmissionProgress>>,
+}
+
+impl GetMediaContentRequest {
+    /// Replace the default `SharedObservable` used for tracking download
+    /// progress.
+    ///
+    /// Note that any subscribers obtained from
+    /// [`subscribe_to_receive_progress`][Self::subscribe_to_receive_progress]
+    /// will be invalidated by this.
+    pub fn with_recv_progress_observable(
+        mut self,
+        recv_progress: SharedObservable<TransmissionProgress>,
+    ) -> Self {
+        self.recv_progress = Some(recv_progress);
+        self
+    }
+
+    /// Get a subscriber to observe the progress of receiving the media
+    /// content.
+    pub fn subscribe_to_receive_progress(&mut self) -> Subscriber<TransmissionProgress> {
+        self.recv_progress.get_or_insert_with(SharedObservable::default).subscribe()
+    }
+}
+
+impl IntoFuture for GetMediaContentRequest {
+    type Output = Result<Vec<u8>>;
+    boxed_into_future!();
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { media, request, use_cache, recv_progress } = self;
+
+        Box::pin(async move {
+            // This is a local media. Force to read the media's content from the store: it
+            // cannot exist somewhere else!
+            if Media::is_local_uri(&request.source) {
+                // Local medias are always cached with `MediaFormat::File`, be it the file
+                // itself or its thumbnail (see `RoomSendQueue::cache_media`), so ignore the
+                // requested format.
+                let request = &MediaRequestParameters {
+                    source: request.source.clone(),
+                    format: MediaFormat::File,
+                };
+
+                return if let Some(content) =
+                    media.client.media_store().lock().await?.get_media_content(request).await?
+                {
+                    if let Some(rp) = &recv_progress {
+                        rp.set(TransmissionProgress {
+                            current: content.len(),
+                            total: content.len(),
+                        });
+                    }
+                    Ok(content)
+                } else {
+                    Err(Error::MediaStore(Box::new(store::MediaStoreError::InvalidData {
+                        details: format!("Media does not exist: `{request:?}`"),
+                    })))
+                };
+            }
+
+            // Read from the cache.
+            if use_cache
+                && let Some(content) =
+                    media.client.media_store().lock().await?.get_media_content(&request).await?
+            {
+                if let Some(rp) = &recv_progress {
+                    rp.set(TransmissionProgress { current: content.len(), total: content.len() });
+                }
+                return Ok(content);
+            }
+
+            let content = media
+                .client
+                .inner
+                .media_fetcher
+                .read()
+                .await
+                .fetch_media_content(&media.client, &request, recv_progress)
+                .await?;
+
+            if use_cache {
+                media
+                    .client
+                    .media_store()
+                    .lock()
+                    .await?
+                    .add_media_content(&request, content.clone(), IgnoreMediaRetentionPolicy::No)
+                    .await?;
+            }
+
+            Ok(content)
+        })
+    }
+}
+
 /// A [`MediaFetcher`] that uses the default media/authenticated media endpoints
 /// to fetch new media.
 #[derive(Debug, Clone)]
@@ -809,6 +876,7 @@ impl MediaFetcher for DefaultMediaFetcher {
         &'a self,
         client: &'a Client,
         request: &'a MediaRequestParameters,
+        progress: Option<SharedObservable<TransmissionProgress>>,
     ) -> BoxFuture<'a, Result<Vec<u8>, Error>> {
         Box::pin(async move {
             let request_config = client
@@ -828,11 +896,27 @@ impl MediaFetcher for DefaultMediaFetcher {
                     let content = if use_auth {
                         let request =
                             authenticated_media::get_content::v1::Request::from_uri(&file.url)?;
-                        client.send(request).with_request_config(request_config).await?.file
+                        client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_progress_observable(RequestProgress {
+                                receive: progress.clone(),
+                                ..Default::default()
+                            })
+                            .await?
+                            .file
                     } else {
                         #[allow(deprecated)]
                         let request = media::get_content::v3::Request::from_url(&file.url)?;
-                        client.send(request).with_request_config(request_config).await?.file
+                        client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_progress_observable(RequestProgress {
+                                receive: progress.clone(),
+                                ..Default::default()
+                            })
+                            .await?
+                            .file
                     };
 
                     #[cfg(feature = "e2e-encryption")]
@@ -868,7 +952,15 @@ impl MediaFetcher for DefaultMediaFetcher {
                             request.method = Some(settings.method.clone());
                             request.animated = Some(settings.animated);
 
-                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                            Ok(client
+                                .send(request)
+                                .with_request_config(request_config)
+                                .with_progress_observable(RequestProgress {
+                                    receive: progress.clone(),
+                                    ..Default::default()
+                                })
+                                .await?
+                                .file)
                         } else {
                             #[allow(deprecated)]
                             let request = {
@@ -883,15 +975,39 @@ impl MediaFetcher for DefaultMediaFetcher {
                                 request
                             };
 
-                            Ok(client.send(request).with_request_config(request_config).await?.file)
+                            Ok(client
+                                .send(request)
+                                .with_request_config(request_config)
+                                .with_progress_observable(RequestProgress {
+                                    receive: progress.clone(),
+                                    ..Default::default()
+                                })
+                                .await?
+                                .file)
                         }
                     } else if use_auth {
                         let request = authenticated_media::get_content::v1::Request::from_uri(uri)?;
-                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                        Ok(client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_progress_observable(RequestProgress {
+                                receive: progress.clone(),
+                                ..Default::default()
+                            })
+                            .await?
+                            .file)
                     } else {
                         #[allow(deprecated)]
                         let request = media::get_content::v3::Request::from_url(uri)?;
-                        Ok(client.send(request).with_request_config(request_config).await?.file)
+                        Ok(client
+                            .send(request)
+                            .with_request_config(request_config)
+                            .with_progress_observable(RequestProgress {
+                                receive: progress.clone(),
+                                ..Default::default()
+                            })
+                            .await?
+                            .file)
                     }
                 }
             }

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -89,6 +89,101 @@ async fn test_get_media_content_no_auth() {
 }
 
 #[async_test]
+async fn test_get_media_content_reports_download_progress() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().no_server_versions().build().await;
+
+    server
+        .mock_versions()
+        .with_versions(vec!["v1.1"])
+        .ok()
+        .named("versions")
+        .expect(1)
+        .mount()
+        .await;
+
+    let media = client.media();
+
+    let request = MediaRequestParameters {
+        source: MediaSource::Plain(owned_mxc_uri!("mxc://localhost/textfile")),
+        format: MediaFormat::File,
+    };
+
+    let _mock_guard = server
+        .mock_media_download()
+        .ok_plain_text()
+        .named("get_media_content_progress")
+        .expect(1)
+        .mount_as_scoped()
+        .await;
+
+    let mut request_builder = media.get_media_content(&request, false);
+    let subscriber = request_builder.subscribe_to_receive_progress();
+    let content = request_builder.await.unwrap();
+
+    assert_eq!(content, b"Hello, World!");
+
+    let progress = subscriber.get();
+    assert_eq!(progress.current, content.len());
+    assert_eq!(progress.total, content.len());
+}
+
+#[async_test]
+async fn test_get_media_content_cache_hit_reports_full_progress() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().no_server_versions().build().await;
+
+    server
+        .mock_versions()
+        .with_versions(vec!["v1.1"])
+        .ok()
+        .named("versions")
+        .expect(1)
+        .mount()
+        .await;
+
+    let media = client.media();
+
+    let request = MediaRequestParameters {
+        source: MediaSource::Plain(owned_mxc_uri!("mxc://localhost/textfile")),
+        format: MediaFormat::File,
+    };
+
+    // Populate the cache.
+    {
+        let _mock_guard = server
+            .mock_media_download()
+            .ok_plain_text()
+            .named("get_media_content_cache_populate")
+            .expect(1)
+            .mount_as_scoped()
+            .await;
+
+        media.get_media_content(&request, true).await.unwrap();
+    }
+
+    // Cache hit: no HTTP request is made, but progress still reports full
+    // completion.
+    let _mock_guard = server
+        .mock_media_download()
+        .error500()
+        .named("get_media_content_cache_hit")
+        .expect(0)
+        .mount_as_scoped()
+        .await;
+
+    let mut request_builder = media.get_media_content(&request, true);
+    let subscriber = request_builder.subscribe_to_receive_progress();
+    let content = request_builder.await.unwrap();
+
+    assert_eq!(content, b"Hello, World!");
+
+    let progress = subscriber.get();
+    assert_eq!(progress.current, content.len());
+    assert_eq!(progress.total, content.len());
+}
+
+#[async_test]
 async fn test_get_media_file_no_auth() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().no_server_versions().build().await;


### PR DESCRIPTION
## Motivation
Parity with the existing Media upload progress indicators so that clients can show that progress is being made in a long download. Currently it is only possible to show that a download is in progress, done, or failed. This PR allows clients to report back to the user how far along a download is.

## Summary
Exposes TransmissionProgress on media downloads, and consolidates upload and download chunk counting logic.

## Testing

**New tests:**
- `test_get_media_content_reports_download_progress` and `test_get_media_content_cache_hit_reports_full_progress`, added to `crates/matrix-sdk/tests/integration/media.rs`. The first ensures that the download progress is reported correctly. The second asserts zero further HTTP calls for cache hits, and checks the cache-hit path still reports full progress.
- `test_get_media_reports_download_progress`, added to `crates/matrix-sdk-contentscanner/src/lib.rs` ensures the content-scanner-backed fetcher reports progress
- `test_get_media_content_reports_download_progress`, added to `bindings/matrix-sdk-ffi/src/client.rs` ensures the progress is reported across the FFI boundary.

**Modifications to existing:**
- `test_uploading_a_too_large_media_file` in `crates/matrix-sdk/src/client/mod.rs` updated `SendRequest` to add the new `recv_progress` no behavioral change to the test itself.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
