### PR TITLE
feat(sdk): Add discovery_cache_timeout to ClientBuilder

### DIFF
--- a/crates/matrix-sdk-common/src/ttl.rs
+++ b/crates/matrix-sdk-common/src/ttl.rs
@@ -15,8 +15,28 @@
 //! Types to implement TTL caches which can be used to persist data for a fixed
 //! duration.
 
+use std::{sync::Arc, time::Duration};
+
 use ruma::time::SystemTime;
 use serde::{Deserialize, Serialize};
+
+/// A source of the current time, used so that tests can control what "now" is.
+pub trait Clock: std::fmt::Debug + Send + Sync {
+    /// Get the current time as a Duration since the Unix epoch.
+    fn now(&self) -> Duration;
+}
+
+/// A [`Clock`] that returns the real, current system time.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Duration {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("System clock was before 1970.")
+    }
+}
 
 /// A value that expires after some time.
 ///
@@ -39,14 +59,9 @@ pub struct TtlValue<T> {
 }
 
 impl<T> TtlValue<T> {
-    /// The number of milliseconds after which the data is considered stale.
-    ///
-    /// This matches 1 day.
-    pub const STALE_THRESHOLD: f64 = (1000 * 60 * 60 * 24) as _;
-
     /// Construct a new `TtlValue` with the given data.
     pub fn new(data: T) -> Self {
-        Self { data, last_fetch_ts: Some(now_timestamp_ms()) }
+        Self { data, last_fetch_ts: Some(SystemClock.now().as_secs_f64() * 1000.0) }
     }
 
     /// Construct a new `TtlValue` with the given data that never expires.
@@ -67,9 +82,13 @@ impl<T> TtlValue<T> {
         TtlValue { data: f(self.data), last_fetch_ts: self.last_fetch_ts }
     }
 
-    /// Whether this value has expired.
-    pub fn has_expired(&self) -> bool {
-        self.last_fetch_ts.is_some_and(|ts| now_timestamp_ms() - ts >= Self::STALE_THRESHOLD)
+    /// Whether this value has expired, given a custom stale threshold.
+    pub fn has_expired(&self, max_age: Duration, clock: Arc<dyn Clock>) -> bool {
+        self.last_fetch_ts.is_some_and(|ts_ms| {
+            // Convert the clock's Duration to milliseconds to match our storage format
+            let now_ms = clock.now().as_secs_f64() * 1000.0;
+            now_ms - ts_ms >= max_age.as_secs_f64() * 1000.0
+        })
     }
 
     /// Mark this value has expired.
@@ -88,19 +107,15 @@ impl<T> TtlValue<T> {
     pub fn into_data(self) -> T {
         self.data
     }
-}
 
-/// Get the current timestamp as the number of milliseconds since Unix Epoch.
-fn now_timestamp_ms() -> f64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("System clock was before 1970.")
-        .as_secs_f64()
-        * 1000.0
+    /// Construct a new `TtlValue` with a specific timestamp (for testing).
+    #[cfg(test)]
+    pub fn new_with_timestamp(data: T, timestamp: Duration) -> Self {
+        Self { data, last_fetch_ts: Some(timestamp.as_secs_f64() * 1000.0) }
+    }
 }
 
 /// The default timestamp if it is missing during deserialization.
-///
 /// We expect that a value that was serialized always has an expiry time, so the
 /// default is `Some(0.0)`.
 fn default_timestamp() -> Option<f64> {
@@ -109,27 +124,33 @@ fn default_timestamp() -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use super::{TtlValue, now_timestamp_ms};
+    use super::{SystemClock, TtlValue, *};
 
     #[test]
     fn test_ttl_value_expiry() {
-        // Definitely stale.
+        let one_day = Duration::from_secs(60 * 60 * 24);
+
+        // Definitely stale (older than 1 day).
         let ttl_value = TtlValue {
             data: (),
-            last_fetch_ts: Some(now_timestamp_ms() - TtlValue::<()>::STALE_THRESHOLD - 1.0),
+            last_fetch_ts: Some(
+                SystemClock.now().as_secs_f64() * 1000.0 - (one_day.as_secs_f64() * 1000.0) - 1.0,
+            ),
         };
-        assert!(ttl_value.has_expired());
+        assert!(ttl_value.has_expired(one_day, Arc::new(SystemClock)));
 
         // Definitely not stale.
         let ttl_value = TtlValue::new(());
-        assert!(!ttl_value.has_expired());
+        assert!(!ttl_value.has_expired(one_day, Arc::new(SystemClock)));
 
         // Cannot be stale.
         let ttl_value = TtlValue::without_expiry(());
-        assert!(!ttl_value.has_expired());
+        assert!(!ttl_value.has_expired(one_day, Arc::new(SystemClock)));
     }
 
     #[test]

--- a/crates/matrix-sdk/changelog.d/6865.added.md
+++ b/crates/matrix-sdk/changelog.d/6865.added.md
@@ -1,0 +1,1 @@
+Add `ClientBuilder::discovery_cache_timeout()` to support configurable caching of homeserver discovery data.

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -452,7 +452,7 @@ impl OAuth {
         let server_metadata_cache = &self.client.inner.caches.server_metadata;
 
         if let CachedValue::Cached(metadata) = server_metadata_cache.value() {
-            if metadata.has_expired() {
+            if metadata.has_expired(self.client.discovery_cache_timeout(), self.client.clock()) {
                 debug!("spawning task to refresh OAuth 2.0 server metadata cache");
 
                 let oauth = self.clone();

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -711,9 +711,19 @@ async fn test_server_metadata_cache() {
     // Call the method to trigger a cache refresh background task.
     oauth.cached_server_metadata().await.expect("We should be able to fetch the server metadata");
 
-    // We wait for the task to finish, the endpoint should have been called again.
-    sleep(Duration::from_secs(1)).await;
-    assert_matches!(client.inner.caches.server_metadata.value(), CachedValue::Cached(value) if !value.has_expired());
+    // Poll for the background task to finish and update the cache.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let CachedValue::Cached(value) = client.inner.caches.server_metadata.value()
+                && !value.has_expired(client.discovery_cache_timeout(), client.clock())
+            {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("Timed out waiting for OAuth metadata cache to refresh");
 }
 
 #[async_test]

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -25,6 +25,7 @@ use std::{
     collections::BTreeSet,
     fmt,
     sync::{Arc, RwLock as StdRwLock},
+    time::Duration,
 };
 
 #[cfg(feature = "sqlite")]
@@ -39,7 +40,10 @@ use matrix_sdk_base::crypto::{CollectStrategy, TrustRequirement};
 use matrix_sdk_base::{
     BaseClient, DmRoomDefinition, ThreadingSupport, store::StoreConfig, ttl::TtlValue,
 };
-use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
+use matrix_sdk_common::{
+    cross_process_lock::CrossProcessLockConfig,
+    ttl::{Clock, SystemClock},
+};
 #[cfg(feature = "sqlite")]
 use matrix_sdk_sqlite::SqliteStoreConfig;
 #[cfg(not(target_family = "wasm"))]
@@ -114,6 +118,23 @@ use crate::{
 ///     Client::builder().http_client(reqwest_builder.build()?);
 /// # anyhow::Ok(())
 /// ```
+/// The default duration after which cached discovery data is considered stale.
+///
+/// This matches 1 day.
+const DEFAULT_DISCOVERY_CACHE_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// A builder for the [`Client`].
+///
+/// # Examples
+///
+/// ```no_run
+/// # use matrix_sdk::Client;
+/// # use url::Url;
+/// # async {
+/// let homeserver = Url::parse("https://example.com")?;
+/// let client = Client::builder().homeserver_url(homeserver).build().await?;
+/// # anyhow::Ok(()) };
+/// ```
 #[must_use]
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
@@ -144,6 +165,8 @@ pub struct ClientBuilder {
     x509_verifier: Option<Arc<dyn RawX509Verifier>>,
     dm_room_definition: DmRoomDefinition,
     media_fetcher: Arc<dyn MediaFetcher>,
+    discovery_cache_timeout: Duration,
+    clock: Arc<dyn Clock>,
 }
 
 impl ClientBuilder {
@@ -186,6 +209,8 @@ impl ClientBuilder {
             x509_verifier: None,
             dm_room_definition: DmRoomDefinition::MatrixSpec,
             media_fetcher: Arc::new(DefaultMediaFetcher),
+            discovery_cache_timeout: DEFAULT_DISCOVERY_CACHE_TIMEOUT,
+            clock: Arc::new(SystemClock),
         }
     }
 
@@ -702,12 +727,30 @@ impl ClientBuilder {
             search_index,
             thread_subscriptions_catchup,
             self.media_fetcher.clone(),
+            self.discovery_cache_timeout,
+            self.clock.clone(),
         )
         .await;
 
         debug!("Done building the Client");
 
         Ok(Client { inner })
+    }
+
+    /// Set the duration after which cached discovery data (e.g. supported
+    /// versions, well-known info) is considered stale and needs to be
+    /// refreshed.
+    ///
+    /// By default, this is 24 hours
+    pub fn discovery_cache_timeout(mut self, stale_timeout: Duration) -> Self {
+        self.discovery_cache_timeout = stale_timeout;
+        self
+    }
+
+    /// Set a custom [`Clock`] implementation, useful for testing.
+    pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
     }
 }
 

--- a/crates/matrix-sdk/src/client/caches.rs
+++ b/crates/matrix-sdk/src/client/caches.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use matrix_sdk_base::store::WellKnownResponse;
-use matrix_sdk_common::{locks::Mutex, ttl::TtlValue};
+use matrix_sdk_common::{
+    locks::Mutex,
+    ttl::{Clock, TtlValue},
+};
 use ruma::api::{
     SupportedVersions,
     client::{
@@ -46,6 +49,10 @@ pub(crate) struct ClientCaches {
     pub(crate) server_metadata: Cache<AuthorizationServerMetadata, ()>,
     /// Homeserver capabilities.
     pub(crate) homeserver_capabilities: Cache<Capabilities, Arc<HttpError>>,
+    /// The duration after which cached discovery data is considered stale.
+    pub(crate) discovery_cache_timeout: Duration,
+    /// The clock used to determine the current time when checking staleness.
+    pub(crate) clock: Arc<dyn Clock>,
     /// RTC transports advertised by the homeserver
     /// ([MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143)).
     ///

--- a/crates/matrix-sdk/src/client/homeserver_capabilities.rs
+++ b/crates/matrix-sdk/src/client/homeserver_capabilities.rs
@@ -159,7 +159,7 @@ impl HomeserverCapabilities {
         };
 
         // Spawn a task to refresh the cache if it has expired.
-        if value.has_expired() {
+        if value.has_expired(self.client.discovery_cache_timeout(), self.client.clock()) {
             debug!("spawning task to refresh homeserver capabilities cache");
 
             let homeserver_capabilities = self.clone();
@@ -218,7 +218,8 @@ impl HomeserverCapabilities {
 
                 // Reuse the data if it was cached and it hasn't expired.
                 if let CachedValue::Cached(value) = capabilities_cache.value()
-                    && !value.has_expired()
+                    && !value
+                        .has_expired(self.client.discovery_cache_timeout(), self.client.clock())
                 {
                     return Ok(value.into_data());
                 }
@@ -313,7 +314,6 @@ struct ProfileCapabilities {
 mod tests {
     use std::time::Duration;
 
-    use assert_matches::assert_matches;
     use matrix_sdk_base::sleep::sleep;
     use matrix_sdk_test::async_test;
     #[allow(deprecated)]
@@ -420,9 +420,20 @@ mod tests {
         // Call a method to trigger a cache refresh background task.
         capabilities.homeserver_capabilities_cached().await.unwrap().unwrap();
 
-        // We wait for the task to finish, the endpoint should have been called again.
-        sleep(Duration::from_secs(1)).await;
-        assert_matches!(client.inner.caches.homeserver_capabilities.value(), CachedValue::Cached(value) if !value.has_expired());
+        // Poll for the background task to finish and update the cache.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let CachedValue::Cached(value) =
+                    client.inner.caches.homeserver_capabilities.value()
+                    && !value.has_expired(client.discovery_cache_timeout(), client.clock())
+                {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Timed out waiting for homeserver capabilities cache to refresh");
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -41,7 +41,10 @@ use matrix_sdk_base::{
     sync::{Notification, RoomUpdates},
     task_monitor::TaskMonitor,
 };
-use matrix_sdk_common::{cross_process_lock::CrossProcessLockConfig, ttl::TtlValue};
+use matrix_sdk_common::{
+    cross_process_lock::CrossProcessLockConfig,
+    ttl::{Clock, TtlValue},
+};
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{InitialStateEvent, room::encryption::RoomEncryptionEventContent};
 use ruma::{
@@ -460,6 +463,8 @@ impl ClientInner {
         #[cfg(feature = "experimental-search")] search_index_handler: SearchIndex,
         thread_subscription_catchup: OnceCell<Arc<ThreadSubscriptionCatchup>>,
         media_fetcher: Arc<dyn MediaFetcher>,
+        discovery_cache_timeout: Duration,
+        clock: Arc<dyn Clock>,
     ) -> Arc<Self> {
         let caches = ClientCaches {
             supported_versions: Cache::with_value(supported_versions),
@@ -467,6 +472,8 @@ impl ClientInner {
             server_metadata: Cache::new(),
             homeserver_capabilities: Cache::new(),
             rtc_transports: Cache::new(),
+            discovery_cache_timeout,
+            clock,
         };
 
         let client = Self {
@@ -573,6 +580,13 @@ impl Client {
 
     pub(crate) fn auth_ctx(&self) -> &AuthCtx {
         &self.inner.auth_ctx
+    }
+
+    pub(crate) fn discovery_cache_timeout(&self) -> Duration {
+        self.inner.caches.discovery_cache_timeout
+    }
+    pub(crate) fn clock(&self) -> Arc<dyn Clock> {
+        self.inner.caches.clock.clone()
     }
 
     /// The cross-process store lock configuration used by this [`Client`].
@@ -2374,7 +2388,7 @@ impl Client {
 
                 // Reuse the data if it was cached and it hasn't expired.
                 if let CachedValue::Cached(value) = cached_supported_versions.value()
-                    && !value.has_expired()
+                    && !value.has_expired(self.discovery_cache_timeout(), self.clock())
                 {
                     return Ok(value.into_data());
                 }
@@ -2483,7 +2497,7 @@ impl Client {
 
         // Spawn a task to refresh the cache if it has expired and we have a valid
         // access token.
-        if value.has_expired() && self.auth_ctx().has_valid_access_token() {
+        if self.discovery_has_expired(&value) && self.auth_ctx().has_valid_access_token() {
             debug!("spawning task to refresh supported versions cache");
 
             let client = self.clone();
@@ -2581,7 +2595,7 @@ impl Client {
         };
 
         // Spawn a task to refresh the cache if it has expired.
-        if value.has_expired() {
+        if value.has_expired(self.discovery_cache_timeout(), self.clock()) {
             debug!("spawning task to refresh well-known cache");
 
             let client = self.clone();
@@ -2608,7 +2622,7 @@ impl Client {
 
                 // Reuse the data if it was cached and it hasn't expired.
                 if let CachedValue::Cached(value) = well_known_cache.value()
-                    && !value.has_expired()
+                    && !value.has_expired(self.discovery_cache_timeout(), self.clock())
                 {
                     return value.into_data();
                 }
@@ -2756,7 +2770,7 @@ impl Client {
 
         // Spawn a task to refresh the cache if it has expired and we have a valid
         // access token.
-        if value.has_expired() && self.auth_ctx().has_valid_access_token() {
+        if self.discovery_has_expired(&value) && self.auth_ctx().has_valid_access_token() {
             debug!("spawning task to refresh RTC transports cache");
 
             let client = self.clone();
@@ -2787,7 +2801,7 @@ impl Client {
 
                 // Reuse the data if it was cached and it hasn't expired.
                 if let CachedValue::Cached(value) = cache.value()
-                    && !value.has_expired()
+                    && !self.discovery_has_expired(&value)
                 {
                     return Ok(value.into_data());
                 }
@@ -3531,6 +3545,8 @@ impl Client {
                 self.inner.search_index.clone(),
                 self.inner.thread_subscription_catchup.clone(),
                 (*self.inner.media_fetcher.read().await).clone(),
+                self.inner.caches.discovery_cache_timeout,
+                self.inner.caches.clock.clone(),
             )
             .await,
         };
@@ -3671,6 +3687,12 @@ impl Client {
             .contains(&FeatureFlag::from("org.matrix.msc4306"));
 
         Ok(server_enabled)
+    }
+
+    /// Check if a cached discovery value has expired based on the client's
+    /// configured timeout.
+    fn discovery_has_expired<T>(&self, value: &TtlValue<T>) -> bool {
+        value.has_expired(self.discovery_cache_timeout(), self.clock())
     }
 
     /// Fetch thread subscriptions changes between `from` and up to `to`.
@@ -3931,6 +3953,8 @@ pub(crate) mod tests {
         DEFAULT_TEST_ROOM_ID, JoinedRoomBuilder, SyncResponseBuilder, async_test,
         event_factory::EventFactory,
     };
+
+    use super::*;
     #[cfg(target_family = "wasm")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
@@ -4180,6 +4204,79 @@ pub(crate) mod tests {
                 .is_err(),
             "Creating a client from a user ID should fail when the .well-known request fails."
         );
+    }
+
+    #[async_test]
+    async fn test_discovery_cache_respects_timeout() {
+        // Start at time zero for a deterministic test.
+        let clock = Arc::new(FakeClock::new(matrix_sdk_common::ttl::SystemClock.now()));
+        let server = MatrixMockServer::new().await;
+
+        let client = server
+            .client_builder()
+            .no_server_versions()
+            .clock(clock.clone())
+            .discovery_cache_timeout(Duration::from_secs(1))
+            .build()
+            .await;
+
+        // Mock v1.11 for the initial fetch.
+        server.mock_versions().with_versions(vec!["v1.11"]).ok().mock_once().mount().await;
+
+        // First fetch: hits the server.
+        // First fetch: hits the server for v1.11
+        let versions = client.supported_versions().await.unwrap();
+        assert!(versions.versions.contains(&MatrixVersion::V1_11));
+
+        // Set up the mock for the background refresh BEFORE advancing time
+        server.mock_versions().with_versions(vec!["v1.10"]).ok().mount().await;
+
+        // Now advance the clock past the 1-second timeout
+        clock.advance(Duration::from_secs(2));
+
+        // Third fetch: triggers the background task
+        let versions = client.supported_versions().await.unwrap();
+        assert!(versions.versions.contains(&MatrixVersion::V1_11));
+
+        // Poll for the background task to finish and update the cache to v1.10.
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if let CachedValue::Cached(value) = client.inner.caches.supported_versions.value()
+                    && value.data().versions.contains(&MatrixVersion::V1_10)
+                {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Timed out waiting for discovery cache to refresh");
+
+        // Final check: ensure the cache is now fresh with v1.10.
+        let versions = client.supported_versions().await.unwrap();
+        assert!(versions.versions.contains(&MatrixVersion::V1_10));
+    }
+
+    #[derive(Debug)]
+    struct FakeClock {
+        current: std::sync::Mutex<Duration>,
+    }
+
+    impl FakeClock {
+        fn new(start: Duration) -> Self {
+            Self { current: std::sync::Mutex::new(start) }
+        }
+
+        fn advance(&self, duration: Duration) {
+            let mut current = self.current.lock().unwrap();
+            *current += duration;
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn now(&self) -> Duration {
+            *self.current.lock().unwrap()
+        }
     }
 
     #[async_test]
@@ -4501,7 +4598,7 @@ pub(crate) mod tests {
         assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
         // Hits in-memory cache again.
         assert!(client.server_versions().await.unwrap().contains(&MatrixVersion::V1_0));
-        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired());
+        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
 
         // Force an expiry of the data.
         let supported_versions = client.supported_versions_cached().await.unwrap().unwrap();
@@ -4514,7 +4611,7 @@ pub(crate) mod tests {
 
         // We wait for the task to finish, the endpoint should have been called again.
         sleep(Duration::from_secs(1)).await;
-        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired());
+        assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
     }
 
     #[async_test]
@@ -4594,7 +4691,7 @@ pub(crate) mod tests {
         // We need to wait a bit because the first requests using the server name of the
         // user will fail, only the requests using the homeserver URL will succeed.
         sleep(Duration::from_secs(5)).await;
-        assert_matches!(client.inner.caches.well_known.value(), CachedValue::Cached(value) if !value.has_expired());
+        assert_matches!(client.inner.caches.well_known.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
     }
 
     #[async_test]
@@ -4625,8 +4722,7 @@ pub(crate) mod tests {
         assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
         // Subsequent call hits the in-memory cache.
         assert_eq!(client.rtc_transports().await.unwrap(), Some(transports.clone()));
-        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
-
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
         drop(transports_mock);
 
         // Reset the cache, and observe the endpoint being called again once.
@@ -4659,7 +4755,7 @@ pub(crate) mod tests {
 
         // We wait for the task to finish, the endpoint should have been called again.
         sleep(Duration::from_secs(1)).await;
-        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
     }
 
     #[async_test]
@@ -4693,7 +4789,7 @@ pub(crate) mod tests {
         assert_eq!(client.rtc_transports().await.unwrap(), None);
         // Subsequent call hits the in-memory cache, without re-hitting the endpoint.
         assert_eq!(client.rtc_transports().await.unwrap(), None);
-        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
+        assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired(client.discovery_cache_timeout(), client.clock()));
     }
 
     #[async_test]
@@ -5220,8 +5316,7 @@ pub(crate) mod tests {
         assert_eq!(*client.inner.server_max_upload_size.lock().await.get().unwrap(), uint!(1));
 
         let data = vec![1, 2];
-        let upload_request =
-            ruma::api::client::media::create_content::v3::Request::new(data.clone());
+        let upload_request = media::create_content::v3::Request::new(data.clone());
         let request = SendRequest {
             client: client.clone(),
             request: upload_request,

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -14,7 +14,10 @@
 
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
+use std::{sync::Arc, time::Duration};
+
 use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
+use matrix_sdk_common::ttl::Clock;
 use ruma::{OwnedDeviceId, OwnedUserId, api::MatrixVersion, owned_device_id, owned_user_id};
 
 use crate::{
@@ -137,6 +140,19 @@ impl MockClientBuilder {
         self.auth_state.maybe_restore_client(&client).await;
 
         client
+    }
+
+    /// Set a custom [`Clock`] implementation, useful for testing time-dependent
+    /// behavior like cache expiry.
+    pub fn clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.builder = self.builder.clock(clock);
+        self
+    }
+
+    /// Set the duration after which cached discovery data is considered stale.
+    pub fn discovery_cache_timeout(mut self, timeout: Duration) -> Self {
+        self.builder = self.builder.discovery_cache_timeout(timeout);
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

This PR is a split of the original #6712, specifically focusing on the `discovery_cache_timeout` logic to make the review process easier. 
The `rediscover()` feature is intentionally excluded from this branch to keep the PR focused.

## What this PR adds

- `ClientBuilder::discovery_cache_timeout(Duration)` to configure how long discovery data is considered fresh (default: 24h).
- A `FakeClock` for testing the stale-while-revalidate logic.

Closes #1469.

## Checklist

- I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries](https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries)).
- This PR was made with the help of AI.

## Files touched

- `crates/matrix-sdk-common/src/ttl.rs`
  - Added the `Clock` trait and `SystemClock`.

- `crates/matrix-sdk/src/client/builder/mod.rs`
  - Added `discovery_cache_timeout()` and `clock()` to `ClientBuilder`.

- `crates/matrix-sdk/src/client/caches.rs`
  - Added fields to `ClientCaches`.

- `crates/matrix-sdk/src/client/mod.rs`
  - Integrated the timeout into discovery methods.
  - Added `FakeClock`.

- `crates/matrix-sdk/src/client/homeserver_capabilities.rs`
  - Updated `has_expired()` calls.

- `crates/matrix-sdk/src/authentication/oauth/mod.rs`
  - Updated `has_expired()` calls.

- `crates/matrix-sdk/src/test_utils/client.rs`
 - Added `clock()` and `discovery_cache_timeout()` to `MockClientBuilder`.

## Sign-off

Signed-off-by: Sidharth <sidharth.120504@gmail.com>
