### PR TITLE
 fix(oauth): recover when the refresh token was rotated during the exchange

### DIFF
--- a/crates/matrix-sdk/changelog.d/6866.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6866.fixed.md
@@ -1,0 +1,5 @@
+The window in which an app can be signed out by another process rotating the
+OAuth 2.0 refresh token has been closed. When the token exchange fails, the app
+now checks whether another process rotated the token while the request was in
+flight, and adopts the token it stored rather than signing out. A genuinely
+revoked session still signs the app out.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -262,7 +262,7 @@ mod tests {
 
     use super::compute_session_hash;
     use crate::{
-        Error,
+        Client, Error, RefreshTokenError,
         authentication::oauth::cross_process::SessionHash,
         test_utils::{
             client::{
@@ -629,9 +629,16 @@ mod tests {
     ///
     /// The app must notice the rotation, adopt the token the NSE stored, and
     /// stay signed in.
-    #[async_test]
-    #[should_panic(expected = "the app was signed out after the NSE rotated the refresh token")]
-    async fn test_refresh_interrupted_during_token_exchange_does_not_sign_out() {
+    ///
+    /// `app_can_reload` tells whether the app's reload callback manages to read
+    /// the session the NSE stored.
+    ///
+    /// Returns the app, the result of its refresh, and the store directory the
+    /// two clients share — keep that last one alive, dropping it wipes the
+    /// databases.
+    async fn run_refresh_interrupted_during_token_exchange(
+        app_can_reload: bool,
+    ) -> (Client, Result<(), RefreshTokenError>, tempfile::TempDir) {
         use std::{thread, time::Duration};
 
         let server = MatrixMockServer::new().await;
@@ -671,7 +678,13 @@ mod tests {
             .await
             .unwrap();
         app.set_session_callbacks(
-            Box::new(|_| Ok(mock_session_tokens_with_refresh())),
+            Box::new(move |_| {
+                if app_can_reload {
+                    Ok(mock_session_tokens_with_refresh())
+                } else {
+                    Err("the app can't read the session back".into())
+                }
+            }),
             Box::new(|_| Ok(())),
         )
         .unwrap();
@@ -725,9 +738,33 @@ mod tests {
 
         let app_refresh = app_refresh.await.expect("the app refresh task shouldn't panic");
 
+        (app, app_refresh, tmp_dir)
+    }
+
+    #[async_test]
+    async fn test_refresh_interrupted_during_token_exchange_does_not_sign_out() {
+        let (app, app_refresh, _store_dir) =
+            run_refresh_interrupted_during_token_exchange(true).await;
+
         assert!(
             app_refresh.is_ok(),
             "the app was signed out after the NSE rotated the refresh token: {app_refresh:?}"
         );
+        // Reporting success is only correct because the app now holds the token the
+        // NSE stored; the next request must not reuse the consumed one.
+        assert_eq!(app.session_tokens(), Some(mock_session_tokens_with_refresh()));
+    }
+
+    /// Recovering hinges on the reload callback handing us the session the
+    /// other process stored. When it can't, the app is still stuck with the
+    /// consumed refresh token, and reporting success would leave it
+    /// retrying forever with a token that can no longer work.
+    #[async_test]
+    async fn test_refresh_interrupted_during_token_exchange_fails_if_reload_fails() {
+        let (app, app_refresh, _store_dir) =
+            run_refresh_interrupted_during_token_exchange(false).await;
+
+        assert!(app_refresh.is_err(), "the failed exchange was reported as a success");
+        assert_eq!(app.session_tokens(), Some(mock_prev_session_tokens_with_refresh()));
     }
 }

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -653,7 +653,7 @@ mod tests {
             .mock_token()
             .with_delay(Duration::from_secs(1))
             .invalid_grant()
-            .up_to_n_times(1)
+            .mock_once()
             .mount()
             .await;
         // The NSE's exchange arrives second, and rotates the token.

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -616,4 +616,118 @@ mod tests {
         let hash = SessionHash(vec![0x13, 0x37, 0x42, 0xde, 0xad, 0xca, 0xfe]);
         assert_eq!(hash.to_hex(), "0x133742deadcafe");
     }
+
+    /// The refresh token can be rotated by another process while the app is
+    /// suspended during the token exchange of its own refresh. The race, in
+    /// order:
+    ///
+    /// 1. the app starts a refresh and sends the token exchange request,
+    /// 2. the OS suspends it while that request is in flight,
+    /// 3. the 500ms lock lease lapses, as the task renewing it is frozen too,
+    /// 4. the NSE takes the lock, refreshes, and rotates the refresh token,
+    /// 5. the app resumes, and the server rejects the token it sent in step 1.
+    ///
+    /// The app must notice the rotation, adopt the token the NSE stored, and
+    /// stay signed in.
+    #[async_test]
+    #[should_panic(expected = "the app was signed out after the NSE rotated the refresh token")]
+    async fn test_refresh_interrupted_during_token_exchange_does_not_sign_out() {
+        use std::{thread, time::Duration};
+
+        let server = MatrixMockServer::new().await;
+        let oauth_server = server.oauth();
+
+        oauth_server.mock_server_metadata().ok().mount().await;
+
+        // The app's exchange is the first to reach the token endpoint, and is left
+        // in flight. By the time the app sees the response the NSE has rotated the
+        // token, so the one the app sent has been consumed: it is rejected.
+        oauth_server
+            .mock_token()
+            .with_delay(Duration::from_secs(1))
+            .invalid_grant()
+            .up_to_n_times(1)
+            .mount()
+            .await;
+        // The NSE's exchange arrives second, and rotates the token.
+        oauth_server.mock_token().ok_with_tokens("1234", "ZYXWV").mount().await;
+
+        // The app and the NSE are two clients over one shared sqlite store, both
+        // restored with the same (prev) session.
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        let app = server
+            .client_builder()
+            .on_builder(|b| b.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
+        app.oauth().enable_cross_process_refresh_lock("app".to_owned()).await.unwrap();
+        app.oauth()
+            .restore_session(
+                mock_session(mock_prev_session_tokens_with_refresh()),
+                RoomLoadSettings::default(),
+            )
+            .await
+            .unwrap();
+        app.set_session_callbacks(
+            Box::new(|_| Ok(mock_session_tokens_with_refresh())),
+            Box::new(|_| Ok(())),
+        )
+        .unwrap();
+
+        let nse = server
+            .client_builder()
+            .on_builder(|b| b.sqlite_store(&tmp_dir, None))
+            .unlogged()
+            .build()
+            .await;
+        nse.oauth().enable_cross_process_refresh_lock("nse".to_owned()).await.unwrap();
+        nse.oauth()
+            .restore_session(
+                mock_session(mock_prev_session_tokens_with_refresh()),
+                RoomLoadSettings::default(),
+            )
+            .await
+            .unwrap();
+        nse.set_session_callbacks(
+            Box::new(|_| Ok(mock_session_tokens_with_refresh())),
+            Box::new(|_| Ok(())),
+        )
+        .unwrap();
+
+        let app_oauth = app.oauth();
+        let app_refresh = tokio::spawn(async move { app_oauth.refresh_access_token().await });
+
+        // Wait until the app has actually sent its token exchange before suspending
+        // it, so we know it is parked in that request.
+        let mut waited = Duration::ZERO;
+        while !server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|request| request.url.path().contains("/oauth2/token"))
+        {
+            assert!(waited < Duration::from_secs(5), "the app never sent its token exchange");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            waited += Duration::from_millis(10);
+        }
+
+        // "Suspend" the app: blocking the current-thread runtime freezes every task,
+        // including the one renewing the lease, so the 500ms lock lease lapses.
+        thread::sleep(Duration::from_millis(700));
+
+        // The NSE steals the lapsed lock and refreshes, rotating the token that the
+        // app's in-flight exchange is about to present.
+        nse.oauth().refresh_access_token().await.unwrap();
+        assert_eq!(nse.session_tokens(), Some(mock_session_tokens_with_refresh()));
+
+        let app_refresh = app_refresh.await.expect("the app refresh task shouldn't panic");
+
+        assert!(
+            app_refresh.is_ok(),
+            "the app was signed out after the NSE rotated the refresh token: {app_refresh:?}"
+        );
+    }
 }

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -1142,12 +1142,63 @@ impl OAuth {
         let token = RefreshToken::new(refresh_token.clone());
         let token_uri = TokenUrl::from_url(token_endpoint);
 
-        let response = OAuthClient::new(client_id)
+        let response = match OAuthClient::new(client_id)
             .set_token_uri(token_uri)
             .exchange_refresh_token(&token)
             .request_async(self.http_client())
             .await
-            .map_err(OAuthError::RefreshToken)?;
+        {
+            Ok(response) => response,
+            Err(err) => {
+                // The exchange failed. If another process (e.g. the NSE) rotated the
+                // refresh token while this request was in flight — or while we were
+                // suspended in the small window between reading the token and sending
+                // it — then the token we sent is legitimately stale and this failure
+                // is spurious; signing the user out here would be wrong. Release our
+                // now-stale guard, re-take the cross-process lock, and if the persisted
+                // session changed under us, reload it and report success (the next
+                // sync uses the fresh token).
+                #[cfg(feature = "e2e-encryption")]
+                {
+                    drop(cross_process_lock);
+                    if let Some(manager) = self.ctx().cross_process_token_refresh_manager.get() {
+                        // Recovering is best-effort: neither failing to take the lock nor
+                        // failing to reload the session must mask `err`, so both only warn
+                        // and let the original error be reported.
+                        match manager.spin_lock().await {
+                            Err(lock_err) => {
+                                warn!("couldn't take the cross-process lock back: {lock_err}");
+                            }
+
+                            Ok(mut guard) if guard.hash_mismatch => {
+                                if let Err(reload_err) =
+                                    Box::pin(self.handle_session_hash_mismatch(&mut guard)).await
+                                {
+                                    warn!("couldn't reload the session: {reload_err}");
+                                } else if self
+                                    .client
+                                    .session_tokens()
+                                    .and_then(|tokens| tokens.refresh_token)
+                                    .is_some_and(|reloaded| reloaded != refresh_token)
+                                {
+                                    // `handle_session_hash_mismatch` leaves the tokens
+                                    // untouched when its callback fails, so only a token
+                                    // that actually changed proves the failure was spurious.
+                                    tracing::info!(
+                                        "refresh token was rotated by another process during \
+                                         the exchange; recovering instead of failing"
+                                    );
+                                    return Ok(());
+                                }
+                            }
+
+                            Ok(_) => {}
+                        }
+                    }
+                }
+                return Err(OAuthError::RefreshToken(err));
+            }
+        };
 
         let new_access_token = response.access_token().secret().clone();
         let new_refresh_token = response.refresh_token().map(RefreshToken::secret).cloned();

--- a/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/oauth.rs
@@ -14,6 +14,8 @@
 
 //! Helpers to mock an OAuth 2.0 server for the purpose of integration tests.
 
+use std::time::Duration;
+
 use ruma::{
     api::client::discovery::get_authorization_server_metadata::v1::AuthorizationServerMetadata,
     serde::Raw,
@@ -111,7 +113,7 @@ impl OAuthMockServer<'_> {
     /// access token.
     pub fn mock_token(&self) -> MockEndpoint<'_, TokenEndpoint> {
         let mock = Mock::given(method("POST")).and(path_regex(r"^/oauth2/token"));
-        self.mock_endpoint(mock, TokenEndpoint)
+        self.mock_endpoint(mock, TokenEndpoint::default())
     }
 
     /// Creates a prebuilt mock for the OAuth 2.0 endpoint used to revoke a
@@ -300,9 +302,29 @@ impl<'a> MockEndpoint<'a, DeviceAuthorizationEndpoint> {
 }
 
 /// A prebuilt mock for a `POST /oauth/token` request.
-pub struct TokenEndpoint;
+#[derive(Default)]
+pub struct TokenEndpoint {
+    /// Optional delay to respond to the query.
+    delay: Option<Duration>,
+}
 
 impl<'a> MockEndpoint<'a, TokenEndpoint> {
+    /// Respond with a given delay to the query.
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.endpoint.delay = Some(delay);
+        self
+    }
+
+    /// Returns the given response, honouring the delay set with
+    /// [`Self::with_delay`].
+    fn respond_with_delay(self, mut template: ResponseTemplate) -> MatrixMock<'a> {
+        if let Some(delay) = self.endpoint.delay {
+            template = template.set_delay(delay);
+        }
+
+        self.respond_with(template)
+    }
+
     /// Returns a successful token response with the default tokens.
     pub fn ok(self) -> MatrixMock<'a> {
         self.ok_with_tokens("1234", "ZYXWV")
@@ -310,7 +332,7 @@ impl<'a> MockEndpoint<'a, TokenEndpoint> {
 
     /// Returns a successful token response with custom tokens.
     pub fn ok_with_tokens(self, access_token: &str, refresh_token: &str) -> MatrixMock<'a> {
-        self.respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        self.respond_with_delay(ResponseTemplate::new(200).set_body_json(json!({
             "access_token": access_token,
             "expires_in": 300,
             "refresh_token":  refresh_token,
@@ -320,21 +342,21 @@ impl<'a> MockEndpoint<'a, TokenEndpoint> {
 
     /// Returns an error response when the request was invalid.
     pub fn access_denied(self) -> MatrixMock<'a> {
-        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with_delay(ResponseTemplate::new(400).set_body_json(json!({
             "error": "access_denied",
         })))
     }
 
     /// Returns an error response when the token in the request has expired.
     pub fn expired_token(self) -> MatrixMock<'a> {
-        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with_delay(ResponseTemplate::new(400).set_body_json(json!({
             "error": "expired_token",
         })))
     }
 
     /// Returns an error response when the token in the request is invalid.
     pub fn invalid_grant(self) -> MatrixMock<'a> {
-        self.respond_with(ResponseTemplate::new(400).set_body_json(json!({
+        self.respond_with_delay(ResponseTemplate::new(400).set_body_json(json!({
             "error": "invalid_grant",
         })))
     }


### PR DESCRIPTION
This PR covers another scenario of https://github.com/matrix-org/matrix-rust-sdk/issues/6794.

Associated with https://github.com/matrix-org/matrix-rust-sdk/pull/6860, we should be much more robust against unexpected logouts.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
