### PR TITLE
Make X.509 signing an async operation

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -333,7 +333,8 @@ pub trait SyncNotificationListener: SyncOutsideWasm + SendOutsideWasm {
 pub trait RawX509Signer: SyncOutsideWasm + SendOutsideWasm + Debug {
     /// Create a signature for the given message using our private key
     ///
-    /// Returns (key ID, signature)
+    /// Note: the matrix-rust-sdk implementation supports asynchronous signing,
+    /// but (for now) in this FFI we only support synchronous.
     fn sign(&self, message: Vec<u8>) -> Result<RawX509Signature, ClientError>;
 
     /// Return the "not after" time for the certificate's validity period as a

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -611,19 +611,28 @@ impl ClientBuilder {
 
         #[cfg(feature = "experimental-x509-identity-verification")]
         if let Some(x509_sign) = builder.raw_x509_signer {
+            use std::{future::ready, pin::Pin};
+
+            use matrix_sdk_base::crypto::x509::X509SignatureSigningError;
+
             // Wrap the provided RawX509Signer impl in a shim which converts the arguments
             // and results.
             #[derive(Debug)]
             struct X509SignImpl(Arc<dyn RawX509Signer>);
-            impl matrix_sdk_base::crypto::x509::RawX509Signer for X509SignImpl {
-                fn sign(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError> {
-                    use matrix_sdk_base::crypto::x509::X509SignatureSigningError;
 
-                    self.0.sign(message.to_vec()).map_err(|e| {
+            impl matrix_sdk_base::crypto::x509::RawX509Signer for X509SignImpl {
+                fn sign(
+                    &self,
+                    message: Vec<u8>,
+                ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>> + Send>>
+                {
+                    let result = self.0.sign(message.to_vec()).map_err(|e| {
                         SignatureError::X509SigningError(X509SignatureSigningError::Custom(
                             e.into(),
                         ))
-                    })
+                    });
+
+                    Box::pin(ready(result))
                 }
 
                 fn validity_not_after(&self) -> Result<DateTime, ValidityError> {

--- a/crates/matrix-sdk-crypto/changelog.d/6867.changed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6867.changed.md
@@ -1,0 +1,1 @@
+Make X.509 signing an async operation, meaning that the experimental `RawX509Signer::sign` now returns a Future.

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -487,7 +487,7 @@ impl IdentityManager {
             {
                 // Check if we need to re-sign our identity with the X.509 signer.
                 *self.x509_signature_upload_request.lock().await =
-                    identity.refresh_x509_signature(&self.store).unwrap_or(None).into();
+                    identity.refresh_x509_signature(&self.store).await.unwrap_or(None).into();
             }
 
             None
@@ -888,7 +888,7 @@ impl IdentityManager {
                 .and_then(UserIdentityData::into_own)
             {
                 *upload_request =
-                    identity.refresh_x509_signature(&self.store).unwrap_or(None).into();
+                    identity.refresh_x509_signature(&self.store).await.unwrap_or(None).into();
             }
         }
         match &*upload_request {
@@ -2640,6 +2640,7 @@ pub(crate) mod tests {
             let account = Account::with_device_id(&user_id, device_id);
             let identity =
                 PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current))
+                    .await
                     .unwrap();
             manager_with_private_identity_and_x509(identity, account, x509_signer_current.clone())
                 .await
@@ -2659,9 +2660,9 @@ pub(crate) mod tests {
 
         // Make a `/keys/query` response where the master key is signed by the
         // given X.509 signer.
-        let make_response = |x509_signer: &crate::x509::X509Signer| {
+        let make_response = async move |x509_signer: &crate::x509::X509Signer| {
             let mut master_key = master_key.clone();
-            x509_signer.sign_cross_signing_key(user_id, &mut master_key).unwrap();
+            x509_signer.sign_cross_signing_key(user_id, &mut master_key).await.unwrap();
 
             let response = json!({
                 "device_keys": {
@@ -2685,19 +2686,19 @@ pub(crate) mod tests {
 
         // We receive a master key signed by the old signer.  In this case, we
         // should re-sign the key, since our signer has a newer validity period.
-        let response = make_response(&x509_signer_old);
+        let response = make_response(&x509_signer_old).await;
         manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
         assert!(manager.get_x509_signature_upload_request().await.is_some());
 
         // We receive a master key signed by the same signer, so we don't need
         // to re-sign.
-        let response = make_response(&x509_signer_current);
+        let response = make_response(&x509_signer_current).await;
         manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
         assert!(manager.get_x509_signature_upload_request().await.is_none());
 
         // We receive a master key signed by a newer signer, so we don't need to
         // re-sign.
-        let response = make_response(&x509_signer_new);
+        let response = make_response(&x509_signer_new).await;
         manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
         assert!(manager.get_x509_signature_upload_request().await.is_none());
     }
@@ -2718,7 +2719,9 @@ pub(crate) mod tests {
         // We create a cross-signing identity signed with the current signer.
         let account = Account::with_device_id(&user_id, device_id);
         let identity =
-            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current)).unwrap();
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current))
+                .await
+                .unwrap();
 
         // If we have an identity manager with an old signer, then it won't try
         // to re-sign the master key.

--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -1114,6 +1114,7 @@ mod tests {
                 #[cfg(feature = "experimental-x509-identity-verification")]
                 None,
             )
+            .await
             .unwrap(),
         ));
 
@@ -1162,6 +1163,7 @@ mod tests {
                 #[cfg(feature = "experimental-x509-identity-verification")]
                 None,
             )
+            .await
             .unwrap(),
         ));
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -263,7 +263,7 @@ impl OwnUserIdentity {
 
         #[cfg(feature = "experimental-x509-identity-verification")]
         if let Some(x509_signer) = x509_signer {
-            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key)?;
+            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key).await?;
         }
 
         let mut user_signed_keys = SignedKeys::new();
@@ -1196,7 +1196,7 @@ impl OwnUserIdentityData {
     /// notify us of the changed key, we will re-fetch it, and then store the
     /// new result at that point.
     #[cfg(feature = "experimental-x509-identity-verification")]
-    pub(crate) fn refresh_x509_signature(
+    pub(crate) async fn refresh_x509_signature(
         &self,
         store: &Store,
     ) -> Result<Option<SignatureUploadRequest>, SignatureError> {
@@ -1214,7 +1214,7 @@ impl OwnUserIdentityData {
         {
             let mut cross_signing_key = cross_signing_key.clone();
             cross_signing_key.signatures.clear();
-            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key)?;
+            x509_signer.sign_cross_signing_key(&self.user_id, &mut cross_signing_key).await?;
 
             let public_key = self
                 .master_key
@@ -1708,8 +1708,8 @@ pub(crate) mod tests {
         assert_eq!(*id.verified.read(), OwnUserIdentityVerifiedState::VerificationViolation);
     }
 
-    #[test]
-    fn own_identity_check_signatures() {
+    #[async_test]
+    async fn test_own_identity_check_signatures() {
         let response = own_key_query();
         let identity = get_own_identity();
         let (first, second) = device(&response);
@@ -1718,7 +1718,7 @@ pub(crate) mod tests {
         assert!(identity.is_device_signed(&second));
 
         let account = Account::with_device_id(second.user_id(), second.device_id());
-        let verification_machine = get_verification_machine(&account);
+        let verification_machine = get_verification_machine(&account).await;
 
         let first = Device {
             inner: first,
@@ -1751,7 +1751,7 @@ pub(crate) mod tests {
         let (_, device) = device(&response);
 
         let account = Account::with_device_id(device.user_id(), device.device_id());
-        let verification_machine = get_verification_machine(&account);
+        let verification_machine = get_verification_machine(&account).await;
         let public_identity = verification_machine.get_own_user_identity_data().await.unwrap();
 
         let mut device = Device {
@@ -2163,7 +2163,7 @@ pub(crate) mod tests {
 
         // (And Bob exists)
         let bob_account = Account::with_device_id(user_id!("@bob:hs.co"), device_id!("DEV123"));
-        let bob_verification_machine = get_verification_machine(&bob_account);
+        let bob_verification_machine = get_verification_machine(&bob_account).await;
 
         let bob_identity_data =
             bob_verification_machine.get_own_user_identity_data().await.unwrap();
@@ -2201,7 +2201,9 @@ pub(crate) mod tests {
 
         // We sign our identity with the current signer.
         let private_identity =
-            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current)).unwrap();
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer_current))
+                .await
+                .unwrap();
 
         // If we create a store with the old signer, it should not try to
         // re-sign our identity.
@@ -2214,7 +2216,7 @@ pub(crate) mod tests {
         .await;
 
         let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
-        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+        assert!(own_identity.refresh_x509_signature(&store).await.unwrap().is_none());
 
         // If we create a store with the same signer, it should not try to
         // re-sign our identity.
@@ -2227,7 +2229,7 @@ pub(crate) mod tests {
         .await;
 
         let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
-        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_none());
+        assert!(own_identity.refresh_x509_signature(&store).await.unwrap().is_none());
 
         // If we create a store with the newer signer, it should re-sign our
         // identity.
@@ -2240,7 +2242,7 @@ pub(crate) mod tests {
         .await;
 
         let own_identity = store.get_identity(user_id).await.unwrap().unwrap().own().unwrap();
-        assert!(own_identity.refresh_x509_signature(&store).unwrap().is_some());
+        assert!(own_identity.refresh_x509_signature(&store).await.unwrap().is_some());
     }
 
     /// Generate a key pair and cert, signed by the supplied certificate
@@ -2262,7 +2264,7 @@ pub(crate) mod tests {
         let account = Account::with_device_id(user_id!("@alice:hs.co"), device_id!("DEV123"));
 
         let private_identity =
-            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer)).unwrap();
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer)).await.unwrap();
 
         let public_identity = private_identity.to_public_identity().await.unwrap();
 
@@ -2280,7 +2282,7 @@ pub(crate) mod tests {
         let account =
             Account::with_device_id(user_id!("@own_user:localhost"), device_id!("DEV123"));
 
-        let verification_machine = get_verification_machine(&account);
+        let verification_machine = get_verification_machine(&account).await;
         let own_identity_data = verification_machine.get_own_user_identity_data().await.unwrap();
 
         OtherUserIdentity {
@@ -2298,12 +2300,13 @@ pub(crate) mod tests {
      *
      * Creates a new private user identity for the account.
      */
-    fn get_verification_machine(account: &Account) -> VerificationMachine {
+    async fn get_verification_machine(account: &Account) -> VerificationMachine {
         let private_identity = PrivateCrossSigningIdentity::for_account(
             account,
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
         VerificationMachine::new(
             account.static_data().clone(),
@@ -2327,7 +2330,8 @@ pub(crate) mod tests {
         x509_verifier: X509Verifier,
         x509_signer: X509Signer,
     ) -> Store {
-        let private_identity = PrivateCrossSigningIdentity::for_account(&account, None).unwrap();
+        let private_identity =
+            PrivateCrossSigningIdentity::for_account(&account, None).await.unwrap();
 
         create_store_with_private_identity_and_x509(
             account,

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -858,7 +858,8 @@ impl Account {
             self,
             #[cfg(feature = "experimental-x509-identity-verification")]
             x509_signer.as_ref(),
-        )?;
+        )
+        .await?;
 
         let signature_request = identity.sign_account(self.static_data()).await?;
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -801,6 +801,7 @@ mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
 
         let bob_identity = PrivateCrossSigningIdentity::new(owned_user_id!("@bob:example.com"));

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -919,6 +919,7 @@ mod tests {
                     #[cfg(feature = "experimental-x509-identity-verification")]
                     None,
                 )
+                .await
                 .unwrap(),
             ));
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -566,7 +566,8 @@ impl PrivateCrossSigningIdentity {
      *
      * * `account` - The Olm account that is creating the new identity.
      */
-    pub(crate) fn for_account(
+    #[allow(clippy::unused_async, reason = "async is needed for x509")]
+    pub(crate) async fn for_account(
         account: &Account,
         #[cfg(feature = "experimental-x509-identity-verification")] x509_signer: Option<
             &X509Signer,
@@ -583,7 +584,7 @@ impl PrivateCrossSigningIdentity {
 
         #[cfg(feature = "experimental-x509-identity-verification")]
         if let Some(x509_signer) = x509_signer {
-            x509_signer.sign_cross_signing_key(&account.user_id, cross_signing_key)?;
+            x509_signer.sign_cross_signing_key(&account.user_id, cross_signing_key).await?;
         }
 
         Ok(Self::new_helper(account.user_id(), master))
@@ -769,6 +770,7 @@ mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
         let master = identity.master_key.lock().await;
         let master = master.as_ref().unwrap();
@@ -804,7 +806,7 @@ mod tests {
 
         // When we pass in an X509Signer to for_account, ...
         let identity =
-            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer)).unwrap();
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer)).await.unwrap();
         let master = identity.master_key.lock().await;
         let master = master.as_ref().unwrap();
 
@@ -822,6 +824,7 @@ mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
 
         let mut device = DeviceData::from_account(&account);
@@ -844,6 +847,7 @@ mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
 
         let bob_account =
@@ -853,6 +857,7 @@ mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
         let mut bob_public = OtherUserIdentityData::from_private(&bob_private).await;
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -835,6 +835,7 @@ pub(crate) mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
         let alice_private_identity = Mutex::new(alice_private_identity);
 
@@ -845,6 +846,7 @@ pub(crate) mod tests {
             #[cfg(feature = "experimental-x509-identity-verification")]
             None,
         )
+        .await
         .unwrap();
         let bob_private_identity = Mutex::new(bob_private_identity);
 

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -117,7 +117,7 @@ pub use cms::cert::x509::der::DateTime;
 pub use errors::{
     IntoX509SignatureError, X509SignatureSigningError, X509SignatureVerificationError,
 };
-pub use raw_x509_signature::RawX509Signature;
+pub use raw_x509_signature::{RawX509Signature, X509SignatureScheme};
 pub(crate) use x509_signer::X509Signer;
 pub use x509_signer::{RawX509Signer, ValidityError};
 pub use x509_verify::RawX509Verifier;

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{future::ready, pin::Pin, sync::Arc};
 
 use cms::cert::x509::{Certificate, der};
 use rustls::{
@@ -103,13 +103,8 @@ impl RustRawX509Signer {
             validity_not_after,
         })
     }
-}
 
-impl RawX509Signer for RustRawX509Signer {
-    /// Create a signature for the given message using our private key
-    ///
-    /// Returns (key ID, signature)
-    fn sign(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError> {
+    fn sign_impl(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError> {
         let signer = self
             .signing_key
             .choose_scheme(&[SignatureScheme::RSA_PSS_SHA512])
@@ -124,6 +119,33 @@ impl RawX509Signer for RustRawX509Signer {
             certificate_chain: self.certificate_chain.clone(),
             signature_scheme: X509SignatureScheme::RsaPssSha512,
         })
+    }
+}
+
+impl RawX509Signer for RustRawX509Signer {
+    /// Create a signature for the given message using our private key
+    ///
+    /// Returns (key ID, signature)
+    #[cfg(not(target_family = "wasm"))]
+    fn sign(
+        &self,
+        message: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>> + Send>> {
+        let ret = self.sign_impl(&message);
+        Box::pin(ready(ret))
+    }
+
+    // (On WASM this is identical except the return value is not Send)
+    /// Create a signature for the given message using our private key
+    ///
+    /// Returns (key ID, signature)
+    #[cfg(target_family = "wasm")]
+    fn sign(
+        &self,
+        message: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>>>> {
+        let ret = self.sign_impl(&message);
+        Box::pin(ready(ret))
     }
 
     fn validity_not_after(&self) -> Result<der::DateTime, ValidityError> {
@@ -143,18 +165,19 @@ impl std::fmt::Debug for RustRawX509Signer {
 #[cfg(test)]
 mod tests {
     use cms::cert::x509::der;
+    use matrix_sdk_test::async_test;
 
     use crate::x509::{
         RawX509Signer, raw_x509_signature::X509SignatureScheme,
         rust_raw_x509_signer::RustRawX509Signer,
     };
 
-    #[test]
-    fn test_can_sign() {
+    #[async_test]
+    async fn test_can_sign() {
         let x509_sign =
             RustRawX509Signer::new_from_pem_data(TEST_CERT_CHAIN, TEST_CERT_KEY).unwrap();
 
-        let sig = x509_sign.sign(b"hello world").unwrap();
+        let sig = x509_sign.sign(b"hello world".to_vec()).await.unwrap();
 
         assert_eq!(sig.certificate_chain, TEST_CERT_CHAIN);
         assert_eq!(sig.signature_scheme, X509SignatureScheme::RsaPssSha512);

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_verifier.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_verifier.rs
@@ -138,6 +138,7 @@ impl RawX509Verifier for RustRawX509Verifier {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
+    use matrix_sdk_test::async_test;
 
     use crate::x509::{
         RawX509Signer, RawX509Verifier, X509SignatureVerificationError,
@@ -145,8 +146,8 @@ mod tests {
         tests::cert_and_key_with_email_in_subject_distinguished_name,
     };
 
-    #[test]
-    fn test_can_verify() {
+    #[async_test]
+    async fn test_can_verify() {
         let (cert, signing_key) =
             cert_and_key_with_email_in_subject_distinguished_name("alice@localhost");
 
@@ -156,7 +157,7 @@ mod tests {
         let x509_sign = RustRawX509Signer::new_from_pem_data(&cert_pem, &key_pem).unwrap();
 
         // After we sign a text
-        let sig = x509_sign.sign(b"hello world").unwrap();
+        let sig = x509_sign.sign(b"hello world".to_vec()).await.unwrap();
 
         let x509_verify = RustRawX509Verifier::new_from_pem_data(&cert_pem).unwrap();
 

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{pin::Pin, sync::Arc};
 
 use cms::cert::x509::der;
 use ruma::{DeviceKeyId, UserId, canonical_json::to_canonical_value};
@@ -50,16 +50,16 @@ impl X509Signer {
 
     /// Add a signature to the given cross-signing key using our private X.509
     /// key.
-    pub(crate) fn sign_cross_signing_key(
+    pub(crate) async fn sign_cross_signing_key(
         &self,
         signing_user_id: &UserId,
         cross_signing_key: &mut CrossSigningKey,
     ) -> Result<(), SignatureError> {
         let json = to_signable_json(to_canonical_value(&cross_signing_key)?)?;
 
-        let (authority_key_identifier, signature) = self
-            .x509_sign
-            .sign(json.as_bytes())?
+        let signing_result = self.x509_sign.sign(json.into_bytes()).await;
+
+        let (authority_key_identifier, signature) = signing_result?
             .into_x509_signature()
             .map_err(|e| SignatureError::X509SigningError(e.into()))?;
 
@@ -145,9 +145,19 @@ impl X509Signer {
 /// and platform-specific implementations.
 pub trait RawX509Signer: std::fmt::Debug + Send + Sync {
     /// Create a signature for the given message using our private key
-    ///
-    /// Returns (key ID, signature)
-    fn sign(&self, message: &[u8]) -> Result<RawX509Signature, SignatureError>;
+    #[cfg(not(target_family = "wasm"))]
+    fn sign(
+        &self,
+        message: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>> + Send>>;
+
+    // (On WASM this is identical except the return value is not Send)
+    /// Create a signature for the given message using our private key
+    #[cfg(target_family = "wasm")]
+    fn sign(
+        &self,
+        message: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>>>>;
 
     /// Return the "not after" time for the certificate's validity period.
     fn validity_not_after(&self) -> Result<der::DateTime, ValidityError>;
@@ -163,6 +173,7 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
+    use matrix_sdk_test::async_test;
     use rcgen::{CertificateParams, KeyPair};
     use ruma::{DeviceKeyAlgorithm, DeviceKeyId, encryption::KeyUsage, user_id};
     use vodozemac::Ed25519SecretKey;
@@ -175,8 +186,8 @@ mod tests {
         },
     };
 
-    #[test]
-    fn test_can_sign() {
+    #[async_test]
+    async fn test_can_sign() {
         let x509_signer = {
             let rust_raw_x509_signer =
                 RustRawX509Signer::new_from_pem_data(TEST_CERT_CHAIN, TEST_CERT_KEY).unwrap();
@@ -199,7 +210,7 @@ mod tests {
             CrossSigningKey::new(user_id.clone(), vec![KeyUsage::Master], keys, Default::default())
         };
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         let self_sigs = cross_signing_key.signatures.get(&user_id).unwrap();
 
@@ -216,8 +227,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_can_compare_validity() {
+    #[async_test]
+    async fn test_can_compare_validity() {
         let signing_key = KeyPair::from_pem(TEST_CERT_KEY).unwrap();
 
         let mut cert_params = CertificateParams::default();
@@ -251,7 +262,10 @@ mod tests {
                 )
             };
 
-            x509_signer_current.sign_cross_signing_key(user_id, &mut cross_signing_key).unwrap();
+            x509_signer_current
+                .sign_cross_signing_key(user_id, &mut cross_signing_key)
+                .await
+                .unwrap();
 
             cross_signing_key.signatures
         };

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -57,14 +57,14 @@ impl X509Signer {
     ) -> Result<(), SignatureError> {
         let json = to_signable_json(to_canonical_value(&cross_signing_key)?)?;
 
-        // We use the authority key identifier as a device ID because it yields
-        // a unique signature per CA, which is what we want.
         let (authority_key_identifier, signature) = self
             .x509_sign
             .sign(json.as_bytes())?
             .into_x509_signature()
             .map_err(|e| SignatureError::X509SigningError(e.into()))?;
 
+        // We use the authority key identifier as a device ID because it yields
+        // a unique signature per CA, which is what we want.
         cross_signing_key.signatures.add_signature(
             signing_user_id.to_owned(),
             DeviceKeyId::from_parts(X509_SIGNATURE_ALGORITHM.into(), &authority_key_identifier),

--- a/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
@@ -245,6 +245,7 @@ fn get_attribute_value_as_string(value: &AttributeValue) -> Option<&str> {
 pub(crate) mod tests {
 
     use cms::cert::x509::der::Decode;
+    use matrix_sdk_test::async_test;
     use rcgen::generate_simple_self_signed;
     use ruma::{DeviceKeyAlgorithm, DeviceKeyId, encryption::KeyUsage, user_id};
     use vodozemac::Ed25519SecretKey;
@@ -329,8 +330,8 @@ pub(crate) mod tests {
         assert!(user_id.is_none());
     }
 
-    #[test]
-    fn test_can_verify_cert_containing_email_in_dn() {
+    #[async_test]
+    async fn test_can_verify_cert_containing_email_in_dn() {
         // Given a cert containing the email address in the Subject Distinguished Name
         let (cert, signing_key) =
             cert_and_key_with_email_in_subject_distinguished_name("alice@localhost");
@@ -345,14 +346,14 @@ pub(crate) mod tests {
         assert!(!x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
 
         // But when we sign it
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it verifies correctly
         assert!(x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_can_verify_cert_containing_email_in_san() {
+    #[async_test]
+    async fn test_can_verify_cert_containing_email_in_san() {
         // Given a cert containing the email address in the Subject Alternative
         // Name
         let (cert, signing_key) =
@@ -364,14 +365,14 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it verifies correctly.
         assert!(x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_can_verify_cert_containing_username_in_san() {
+    #[async_test]
+    async fn test_can_verify_cert_containing_username_in_san() {
         // Given a cert containing the Matrix user ID in the Subject Alternative
         // Name
         let (cert, signing_key) =
@@ -383,14 +384,14 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it verifies correctly.
         assert!(x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_verification_fails_if_dn_email_is_wrong() {
+    #[async_test]
+    async fn test_verification_fails_if_dn_email_is_wrong() {
         // Given a cert containing an incorrect email address in the Subject
         // Distinguished Name
         let (cert, signing_key) =
@@ -402,15 +403,15 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it fails to verify because the supplied email address translates
         // to a different user ID.
         assert!(!x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_verification_fails_if_san_email_is_wrong() {
+    #[async_test]
+    async fn test_verification_fails_if_san_email_is_wrong() {
         // Given a cert containing an incorrect email address in the Subject
         // Alternative Name
         let (cert, signing_key) =
@@ -422,15 +423,15 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it fails to verify because the supplied email address translates
         // to a different user ID.
         assert!(!x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_verification_fails_if_cert_user_id_is_wrong() {
+    #[async_test]
+    async fn test_verification_fails_if_cert_user_id_is_wrong() {
         // Given a cert containing an incorrect email address in the Subject
         // Alternative Name
         let (cert, signing_key) =
@@ -442,15 +443,15 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it fails to verify because the supplied user ID does not match
         // the signing user.
         assert!(!x509_verifier.verify_signed_object(&user_id, &cross_signing_key));
     }
 
-    #[test]
-    fn test_verification_fails_if_cert_user_id_is_missing() {
+    #[async_test]
+    async fn test_verification_fails_if_cert_user_id_is_missing() {
         // Given a cert with no email or user ID at all
         let (cert, signing_key) = cert_and_key_with_no_user_id();
 
@@ -460,7 +461,7 @@ pub(crate) mod tests {
         let user_id = user_id!("@alice:localhost").to_owned();
         let mut cross_signing_key = create_cross_signing_key(&user_id);
 
-        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).unwrap();
+        x509_signer.sign_cross_signing_key(&user_id, &mut cross_signing_key).await.unwrap();
 
         // Then it fails to verify because there is no user ID to check against
         // the user's ID.


### PR DESCRIPTION
This is to support signing from a Web environment which may require asynchronous operations, whether it's using [Web Crypto](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign) or some external tool like a physical key.

Most of the changes are because `PrivateCrossSigningIdentity::for_account` has become async, which is fine but touches a lot of tests.

- [x] I've documented the public API changes in the appropriate changelog files
- No AI was used

Part of https://github.com/element-hq/crypto-internal/issues/458
