### PR TITLE
fix(sdk): Fix a possible deadlock in `caches::aggregate_timeline_for_threads`

### DIFF
--- a/crates/matrix-sdk/changelog.d/6869.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6869.fixed.md
@@ -1,0 +1,28 @@
+A rare deadlock has been fixed in
+`event_cache::caches::aggregator::aggregate_timeline_for_threads`.
+
+When aggregating the timeline for each thread, we are doing look ups in the room
+cache, and in the thread caches. Every time we do a look up with `find_event`,
+we are acquiring a read lock over the state. Because look up in the room cache
+can happen frequently, we were acquiring a read lock over the state for the room
+cache for the entire lifetime of the `aggregate_timeline_for_threads` function.
+However, in some situations, it could lead to a deadlock.
+
+Imagine task T1 is running `handle_joined_room_update` (which runs
+`aggregate_timeline_for_threads`): a read lock over the room state is acquired
+(L1), and the read lock over a thread state must be acquired for another look
+up (L2). Before L2 is acquired, task T2 is running a different part of the code,
+like a pagination, and waits to acquire a write lock (L3). It waits because L1
+is still alive and L3 needs an exclusive access. Now, L2 enters the game and
+cannot be acquired because L3 is waiting. So we have:
+
+- L1 is acquired but not released,
+- L1 is waiting on L3 to release itself,
+- L2 is waiting on L1,
+- L3 is waiting on L2.
+
+This is a deadlock.
+
+The fix consists of acquiring a read lock over (all) the states once, to then
+project the read lock guard to the room and to each thread. This way, L1 is now
+a combination of L1 and L3. L2 will always wait on L1 to be released.

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -116,14 +116,15 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                         None => false,
                     }
                 {
-                    // The redacted event exists (in the room, because it contains _all_ the
-                    // events) **but** the event has been redacted (in
-                    // the room). It's no more possible to extract its
-                    // thread root (because this information has been removed).
+                    // The redacted event exists (in the room, because it
+                    // contains _all_ the events) **but** the event has been
+                    // redacted (in the room). It's no more possible to extract
+                    // its thread root (because this information has been
+                    // removed).
                     //
-                    // But we need to know if the event is part of a thread to apply the
-                    // redaction in the thread too. No other choice than
-                    // doing a full search…
+                    // But we need to know if the event is part of a thread to
+                    // apply the redaction in the thread too. No other choice
+                    // than doing a full search…
 
                     let mut associated_thread_root = None;
 

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -23,18 +23,18 @@ use ruma::{OwnedEventId, events::relation::RelationType, room_version_rules::Red
 use super::{
     super::{Result, states::StateLockReadGuard},
     room::RoomEventCacheState,
-    thread::ThreadEventCache,
+    thread::ThreadEventCacheState,
 };
 
 pub fn aggregate_timeline_for_room(timeline: Timeline) -> Timeline {
     timeline
 }
 
-pub async fn aggregate_timeline_for_threads(
-    timeline: &Timeline,
-    existing_threads: &HashMap<OwnedEventId, ThreadEventCache>,
-    room_event_cache: StateLockReadGuard<'_, RoomEventCacheState>,
-    redaction_rules: &RedactionRules,
+pub async fn aggregate_timeline_for_threads<'sync, 'state>(
+    timeline: &'sync Timeline,
+    existing_threads: StateLockReadGuard<'state, HashMap<OwnedEventId, ThreadEventCacheState>>,
+    maybe_room: Option<StateLockReadGuard<'state, RoomEventCacheState>>,
+    redaction_rules: &'sync RedactionRules,
 ) -> Result<HashMap<OwnedEventId, Timeline>> {
     let mut new_events_by_thread = HashMap::new();
 
@@ -77,9 +77,14 @@ pub async fn aggregate_timeline_for_threads(
 
                         // Not in `timeline`, okay, look for the related event in the `room` as it
                         // knows about all the events, and then extract its thread root.
-                        None => room_event_cache.find_event(&related_event_id).await?.and_then(
-                            |(_location, related_event)| extract_thread_root(related_event.raw()),
-                        ),
+                        None => match &maybe_room {
+                            Some(room) => room.find_event(&related_event_id).await?.and_then(
+                                |(_location, related_event)| {
+                                    extract_thread_root(related_event.raw())
+                                },
+                            ),
+                            None => None,
+                        },
                     } {
                         new_events_by_thread
                             .entry(thread_root)
@@ -106,7 +111,10 @@ pub async fn aggregate_timeline_for_threads(
                 // Otherwise, this event might be a redaction that applies to a thread.
                 else if let Some(redaction_target) =
                     extract_redaction_target(event.raw(), redaction_rules)
-                    && room_event_cache.find_event(&redaction_target).await?.is_some()
+                    && match &maybe_room {
+                        Some(room) => room.find_event(&redaction_target).await?.is_some(),
+                        None => false,
+                    }
                 {
                     // The redacted event exists (in the room, because it contains _all_ the
                     // events) **but** the event has been redacted (in
@@ -119,9 +127,9 @@ pub async fn aggregate_timeline_for_threads(
 
                     let mut associated_thread_root = None;
 
-                    for (thread_root, thread) in existing_threads {
+                    for thread in existing_threads.values() {
                         if thread.find_event(&redaction_target).await?.is_some() {
-                            associated_thread_root = Some(thread_root.clone());
+                            associated_thread_root = Some(thread.thread_id.clone());
                             break;
                         }
                     }

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
@@ -289,7 +289,7 @@ impl Caches {
 
     /// Update all the event caches with a [`JoinedRoomUpdate`].
     pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        let Self { room, threads, pinned_events, event_focused, internals } = &self;
+        let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
         // Room.
         {
@@ -305,13 +305,24 @@ impl Caches {
             updates.account_data.clear();
             updates.ambiguity_changes.clear();
 
-            let timeline_for_threads = aggregator::aggregate_timeline_for_threads(
-                &updates.timeline,
-                threads.read().await.deref(),
-                room.state().read().await?,
-                &internals.room_version_rules.redaction,
-            )
-            .await?;
+            let timeline_for_threads = {
+                // To aggregate the timelines for threads, we need to lookup in the room cache
+                // and the thread caches. We acquire a read lock over all the caches, and select
+                // the room cache and thread cache' states.
+                let all_states_lock = states::CacheStateLock::new(
+                    states::selectors::AllStatesSelector::new(room.room_id().to_owned()),
+                    self.internals.state.clone(),
+                );
+                let all_states = all_states_lock.read().await?;
+
+                aggregator::aggregate_timeline_for_threads(
+                    &updates.timeline,
+                    all_states.threads(),
+                    all_states.room(),
+                    &internals.room_version_rules.redaction,
+                )
+                .await?
+            };
 
             for (thread_id, timeline) in timeline_for_threads {
                 let mut updates = updates.clone();
@@ -351,7 +362,7 @@ impl Caches {
 
     /// Update all the event caches with a [`LeftRoomUpdate`].
     pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        let Self { room, threads, pinned_events, event_focused, internals } = &self;
+        let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
         // Room.
         {
@@ -367,13 +378,24 @@ impl Caches {
             updates.account_data.clear();
             updates.ambiguity_changes.clear();
 
-            let timeline_for_threads = aggregator::aggregate_timeline_for_threads(
-                &updates.timeline,
-                threads.read().await.deref(),
-                room.state().read().await?,
-                &internals.room_version_rules.redaction,
-            )
-            .await?;
+            let timeline_for_threads = {
+                // To aggregate the timelines for threads, we need to lookup in the room cache
+                // and the thread caches. We acquire a read lock over all the caches, and select
+                // the room cache and thread cache' states.
+                let all_caches_states_lock = states::CacheStateLock::new(
+                    states::selectors::AllStatesSelector::new(room.room_id().to_owned()),
+                    self.internals.state.clone(),
+                );
+                let all_caches_states = all_caches_states_lock.read().await?;
+
+                aggregator::aggregate_timeline_for_threads(
+                    &updates.timeline,
+                    all_caches_states.threads(),
+                    all_caches_states.room(),
+                    &internals.room_version_rules.redaction,
+                )
+                .await?
+            };
 
             for (thread_id, timeline) in timeline_for_threads {
                 let mut updates = updates.clone();

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -245,7 +245,8 @@ impl ThreadEventCache {
     ///
     /// It starts by looking into loaded events in `EventLinkedChunk` before
     /// looking inside the storage.
-    pub(super) async fn find_event(
+    #[cfg(test)]
+    async fn find_event(
         &self,
         event_id: &EventId,
     ) -> Result<Option<(super::EventLocation, Event)>> {

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -358,7 +358,7 @@ impl<'a> StateLockReadGuard<'a, ThreadEventCacheState> {
     }
 
     /// See documentation of [`find_event`].
-    pub(super) async fn find_event(
+    pub(in super::super) async fn find_event(
         &self,
         event_id: &EventId,
     ) -> Result<Option<(EventLocation, Event)>> {

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -377,6 +377,20 @@ impl<'state> StateLockReadGuard<'state, StateForRoom> {
     }
 }
 
+impl<'state> StateLockReadGuard<'state, HashMap<OwnedEventId, ThreadEventCacheState>> {
+    /// Project the current read lock guard onto all thread cache states via an
+    /// iterator.
+    pub(super) fn values(
+        &'state self,
+    ) -> impl Iterator<Item = StateLockReadGuard<'state, ThreadEventCacheState>> {
+        self.state.values().map(|item| StateLockReadGuard {
+            state: StateLockReadGuardKind::Reference(item),
+            store: self.store.clone(),
+            tracing_timer: None,
+        })
+    }
+}
+
 impl<'state, S> Deref for StateLockReadGuard<'state, S> {
     type Target = S;
 

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -50,7 +50,7 @@ pub struct State {
 }
 
 #[derive(Default)]
-struct StateForRoom {
+pub(super) struct StateForRoom {
     room: Option<RoomEventCacheState>,
     threads: HashMap<OwnedEventId, ThreadEventCacheState>,
     pinned_events: Option<PinnedEventsCacheState>,

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -299,7 +299,7 @@ impl StateLock {
 
         cache_state_selector
             .insert_once(&mut state.state, cache_state)
-            .then(|| CacheStateLock { cache_state_selector, state_lock: self.clone() })
+            .then(|| CacheStateLock::new(cache_state_selector, self.clone()))
             .ok_or_else(|| EventCacheError::CacheStateAlreadyExists)
     }
 }
@@ -590,14 +590,21 @@ impl<'state, S> DerefMut for StateLockWriteGuardKind<'state, S> {
 
 /// A wrapper around [`State`] with a [`CacheStateSelector`], facilitating the
 /// embedding of these API in a single type.
-pub struct CacheStateLock<Selector>
-where
-    Selector: selectors::CacheState,
-{
+pub struct CacheStateLock<Selector> {
     cache_state_selector: Selector,
     state_lock: StateLock,
 }
 
+impl<Selector> CacheStateLock<Selector>
+where
+    Selector: selectors::CacheState,
+{
+    pub(super) fn new(cache_state_selector: Selector, state_lock: StateLock) -> Self {
+        Self { cache_state_selector, state_lock }
+    }
+}
+
+// Fallible methods.
 impl<Selector> CacheStateLock<Selector>
 where
     Selector: selectors::CacheState,

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -160,7 +160,11 @@ impl StateLock {
             EventCacheStoreLockState::Clean(store_guard) => {
                 trace!("Lock acquired (from clean)");
 
-                StateLockReadGuard { state: state_guard, store: store_guard, tracing_timer }
+                StateLockReadGuard {
+                    state: StateLockReadGuardKind::Owned(state_guard),
+                    store: store_guard,
+                    tracing_timer: Some(tracing_timer),
+                }
             }
             EventCacheStoreLockState::Dirty(store_guard) => {
                 // Drop the read lock, and take a write lock to modify the state.
@@ -309,13 +313,13 @@ impl fmt::Debug for StateLock {
 /// The read lock guard returned by [`StateLock::read`].
 pub struct StateLockReadGuard<'state, S> {
     /// The per-thread read lock guard over the state `S`.
-    pub state: RwLockReadGuard<'state, S>,
+    pub state: StateLockReadGuardKind<'state, S>,
 
     /// The cross-process lock guard over the store.
     pub store: EventCacheStoreLockGuard,
 
     /// The [`timer!`] value, used to compute the time the lock is live.
-    tracing_timer: TracingTimer,
+    tracing_timer: Option<TracingTimer>,
 }
 
 impl<'state> StateLockReadGuard<'state, State> {
@@ -333,8 +337,18 @@ impl<'state> StateLockReadGuard<'state, State> {
         EventCacheError: From<&'selector Selector>,
     {
         Ok(StateLockReadGuard {
-            state: RwLockReadGuard::try_map(self.state, |state| cache_state_selector.select(state))
-                .map_err(|_| EventCacheError::from(cache_state_selector))?,
+            state: match self.state {
+                StateLockReadGuardKind::Reference(state) => StateLockReadGuardKind::Reference(
+                    cache_state_selector
+                        .select(state)
+                        .ok_or_else(|| EventCacheError::from(cache_state_selector))?,
+                ),
+
+                StateLockReadGuardKind::Owned(state) => StateLockReadGuardKind::Owned(
+                    RwLockReadGuard::try_map(state, |state| cache_state_selector.select(state))
+                        .map_err(|_| EventCacheError::from(cache_state_selector))?,
+                ),
+            },
             store: self.store,
             tracing_timer: self.tracing_timer,
         })
@@ -346,6 +360,32 @@ impl<'state, S> Deref for StateLockReadGuard<'state, S> {
 
     fn deref(&self) -> &Self::Target {
         &self.state
+    }
+}
+
+/// The kind of guard [`StateLockReadGuard`] owns.
+pub enum StateLockReadGuardKind<'state, S> {
+    /// A read lock over the state is acquired, and this is a reference to a
+    /// cache (sub-)state.
+    ///
+    /// This is useful if one needs to run operations over multiple cache
+    /// (sub-)states without mapping the read lock guard over the state
+    /// (because it would consume it).
+    Reference(&'state S),
+
+    /// The read lock over the state `S` is acquired, and this is a mapped
+    /// guard to a cache (sub-)state.
+    Owned(RwLockReadGuard<'state, S>),
+}
+
+impl<'state, S> Deref for StateLockReadGuardKind<'state, S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Reference(state) => state,
+            Self::Owned(state) => state.deref(),
+        }
     }
 }
 
@@ -403,9 +443,9 @@ impl<'state> ReloadableStateLockWriteGuard<'state> {
     /// state and to the store when dropped.
     fn downgrade(self) -> StateLockReadGuard<'state, State> {
         StateLockReadGuard {
-            state: self.state.downgrade(),
+            state: StateLockReadGuardKind::Owned(self.state.downgrade()),
             store: self.store,
-            tracing_timer: self.tracing_timer,
+            tracing_timer: Some(self.tracing_timer),
         }
     }
 

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -355,6 +355,28 @@ impl<'state> StateLockReadGuard<'state, State> {
     }
 }
 
+impl<'state> StateLockReadGuard<'state, StateForRoom> {
+    /// Project the current read lock guard onto the room cache state.
+    pub(super) fn room(&'state self) -> Option<StateLockReadGuard<'state, RoomEventCacheState>> {
+        self.state.room.as_ref().map(|room| StateLockReadGuard {
+            state: StateLockReadGuardKind::Reference(room),
+            store: self.store.clone(),
+            tracing_timer: None,
+        })
+    }
+
+    /// Project the current read lock guard onto all thread cache states.
+    pub(super) fn threads(
+        &'state self,
+    ) -> StateLockReadGuard<'state, HashMap<OwnedEventId, ThreadEventCacheState>> {
+        StateLockReadGuard {
+            state: StateLockReadGuardKind::Reference(&self.state.threads),
+            store: self.store.clone(),
+            tracing_timer: None,
+        }
+    }
+}
+
 impl<'state, S> Deref for StateLockReadGuard<'state, S> {
     type Target = S;
 

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -423,7 +423,7 @@ impl<'state> ReloadableStateLockWriteGuard<'state> {
         EventCacheError: From<&'selector Selector>,
     {
         Ok(StateLockWriteGuard {
-            state: StateLockWriteGuardKind::MappedGuard(
+            state: StateLockWriteGuardKind::Owned(
                 RwLockWriteGuard::try_map(self.state, |state| {
                     cache_state_selector.select_mut(state)
                 })
@@ -565,7 +565,7 @@ pub enum StateLockWriteGuardKind<'state, S> {
 
     /// The write lock over the state `S` is acquired, and this is a mapped
     /// guard to a cache (sub-)state.
-    MappedGuard(RwLockMappedWriteGuard<'state, S>),
+    Owned(RwLockMappedWriteGuard<'state, S>),
 }
 
 impl<'state, S> Deref for StateLockWriteGuardKind<'state, S> {
@@ -574,7 +574,7 @@ impl<'state, S> Deref for StateLockWriteGuardKind<'state, S> {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Reference(state) => state,
-            Self::MappedGuard(state) => state.deref(),
+            Self::Owned(state) => state.deref(),
         }
     }
 }
@@ -583,7 +583,7 @@ impl<'state, S> DerefMut for StateLockWriteGuardKind<'state, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Reference(state) => state,
-            Self::MappedGuard(state) => state.deref_mut(),
+            Self::Owned(state) => state.deref_mut(),
         }
     }
 }

--- a/crates/matrix-sdk/src/event_cache/states/selectors.rs
+++ b/crates/matrix-sdk/src/event_cache/states/selectors.rs
@@ -21,7 +21,7 @@ use ruma::{OwnedEventId, OwnedRoomId};
 
 use super::{
     super::EventCacheError, EventFocusedCacheKey, EventFocusedCacheState, PinnedEventsCacheState,
-    RoomEventCacheState, State, ThreadEventCacheState,
+    RoomEventCacheState, State, StateForRoom, ThreadEventCacheState,
 };
 
 /// Trait to select a specific state of a cache inside a [`State`].
@@ -40,6 +40,40 @@ pub trait CacheState {
     /// It returns `true` if it's been inserted, `false` otherwise, i.e. if the
     /// place is occupied.
     fn insert_once(&self, state: &mut State, cache_state: Self::Item) -> bool;
+}
+
+/// Select all states ([`RoomEventCacheState`], [`ThreadEventCacheState`],
+/// [`PinnedEventsCacheState`] and [`EventFocusedCacheState`]) for a particular
+/// room in [`State`].
+#[derive(Debug)]
+pub(in super::super) struct AllStatesSelector(OwnedRoomId);
+
+impl AllStatesSelector {
+    pub fn new(room_id: OwnedRoomId) -> Self {
+        Self(room_id)
+    }
+}
+
+impl CacheState for AllStatesSelector {
+    type Item = StateForRoom;
+
+    fn select<'state>(&self, state: &'state State) -> Option<&'state Self::Item> {
+        state.by_room.get(&self.0)
+    }
+
+    fn select_mut<'state>(&self, state: &'state mut State) -> Option<&'state mut Self::Item> {
+        state.by_room.get_mut(&self.0)
+    }
+
+    fn insert_once(&self, _state: &mut State, _cache_state: Self::Item) -> bool {
+        false
+    }
+}
+
+impl From<&AllStatesSelector> for EventCacheError {
+    fn from(value: &AllStatesSelector) -> Self {
+        Self::RoomNotFound { room_id: value.0.clone() }
+    }
 }
 
 /// Select a [`RoomEventCacheState`] in [`State`].


### PR DESCRIPTION
This patch fixes a possible deadlock in `event_cache::caches::aggregate_timeline_for_threads`.

When aggregating the timeline for each thread, we are doing look ups in the room cache, and in the thread caches. Every time we do a look up with `find_event`, we are acquiring a read lock over the state. Because look up in the room cache can happen frequently, we were acquiring a read lock over the state for the room cache for the entire lifetime of the `aggregate_timeline_for_threads` method. However, in some situations, it could lead to a deadlock.

Imagine task T1 is running `handle_joined_room_update` (which runs `aggregate_timeline_for_threads`): a read lock over the room state is acquired (L1), and the read lock over a thread state must be acquired for another look up (L2). Before L2 is acquired, task T2 is running a different part of the code, like a pagination, and waits to acquire a write lock (L3). It waits because L1 is still alive and L3 needs an exclusive access. Now, L2 enters the game and cannot be acquired because L3 is waiting. So we have:

- L1 is acquired but not released,
- L1 is waiting on L3 to release itself,
- L2 is waiting on L1,
- L3 is waiting on L2.

This is a deadlock.

That's the semantics behind `tokio::sync::RwLock`, it is _write-preferring_. Quoting [the documentation][`RwLock`]:

> The priority policy of Tokio's read-write lock is _fair_ (or [_write-preferring_](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies)), in order to ensure that readers cannot starve writers. Fairness is ensured using a first-in, first-out queue for the tasks awaiting the lock; a read lock will not be given out until all write lock requests that were queued before it have been acquired and released. This is in contrast to the Rust standard library’s `std::sync::RwLock`, where the priority policy is dependent on the operating system’s implementation.

I personally find this not extremely clear, but [the `read` method][`RwLock::read`] provides more information:

> Note that under the priority policy of `RwLock`, read locks are not granted until prior write locks, to prevent starvation. Therefore deadlock may occur if a read lock is held by the current task, a write lock attempt is made, and then a subsequent read lock attempt is made by the current task.

This problem is delicate as each cache has its own API but over the same lock. It's sadly not so robust against misuses.

This patch fixes the problem by acquiring a read lock over (all) the states once, to then project the read lock guard to the room and to each thread. This way, L1 is now a combination of L1 and L3. L2 will always wait on L1 to be released.

### Bonus

As an extra, the new `AllStatesSelector` selector reduces the number of lock acquisition in `aggregate_timeline_for_threads` (before, it happened for every `thread.find_event`). Now it happens once before `aggregate_timeline_for_threads` is called and that's it. We could expect a performance improvement if we had a micro-benchmark.

[`RwLock`]: https://docs.rs/tokio/1.53.1/tokio/sync/struct.RwLock.html
[`RwLock::read`]: https://docs.rs/tokio/1.53.1/tokio/sync/struct.RwLock.html#method.read

---

* Close https://github.com/matrix-org/matrix-rust-sdk/pull/6839

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
