### PR TITLE
feat(qr-login): Add a method to check if the server supports MSC4388 style QR login

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "db24422e03aea7c7974230098f
     "unstable-msc4306",
     "unstable-msc4308",
     "unstable-msc4310",
+    "unstable-msc4388",
 ] }
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }

--- a/crates/matrix-sdk/changelog.d/6871.added.md
+++ b/crates/matrix-sdk/changelog.d/6871.added.md
@@ -1,0 +1,2 @@
+Added the `msc_4388_rendezvous_server_supported()` method to check if the
+homeserver supports MSC4388 for the QR code login.

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -370,6 +370,33 @@ impl OAuth {
         as_variant!(data, AuthData::OAuth)
     }
 
+    /// Check if the homeserver supports the [MSC4388] variant of the rendezvous
+    /// server.
+    ///
+    /// Returns `Ok(true)` if the rendezvous discovery endpoint returns a 200 OK
+    /// HTTP response, `Ok(false)` if the endpoint returns a 404 NOT_FOUND or
+    /// 403 FORBIDDEN HTTP response, otherwise an error is returned.
+    ///
+    /// [MSC4388]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
+    #[cfg(feature = "e2e-encryption")]
+    pub async fn msc_4388_rendezvous_server_supported(&self) -> Result<bool, crate::HttpError> {
+        use http::StatusCode;
+        use ruma::api::client::rendezvous::discover_rendezvous;
+
+        match self.client.send(discover_rendezvous::unstable::Request::new()).await {
+            Ok(response) => Ok(response.create_available),
+            Err(e) => {
+                if e.as_client_api_error().is_some_and(|err| {
+                    matches!(err.status_code, StatusCode::NOT_FOUND | StatusCode::FORBIDDEN)
+                }) {
+                    Ok(false)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
     /// Log in this device using a QR code.
     ///
     /// # Arguments

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/mod.rs
@@ -414,3 +414,134 @@ pub enum SenderError {
     #[error("message cannot be sent.")]
     CannotSend,
 }
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use matrix_sdk_test::async_test;
+    use serde_json::json;
+    use wiremock::{
+        Mock, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use crate::test_utils::mocks::MatrixMockServer;
+
+    #[async_test]
+    async fn test_msc_4388_rendezvous_server_supported() {
+        const URL: &str = "/_matrix/client/unstable/io.element.msc4388/rendezvous";
+
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().logged_in_with_oauth().build().await;
+
+        {
+            let _discover_guard = server
+                .server()
+                .register_as_scoped(
+                    Mock::given(method("GET"))
+                        .and(path(URL))
+                        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                            "create_available": true,
+                        })))
+                        .expect(1),
+                )
+                .await;
+
+            let supported = client
+                .oauth()
+                .msc_4388_rendezvous_server_supported()
+                .await
+                .expect("We should be able to check if the rendezvous server is supported");
+
+            assert!(supported, "The rendezvous server should be supported");
+        }
+
+        {
+            let _discover_guard = server
+                .server()
+                .register_as_scoped(
+                    Mock::given(method("GET"))
+                        .and(path(URL))
+                        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                            "create_available": false,
+                        })))
+                        .expect(1),
+                )
+                .await;
+
+            let supported = client
+                .oauth()
+                .msc_4388_rendezvous_server_supported()
+                .await
+                .expect("We should be able to check if the rendezvous server is supported");
+
+            assert!(
+                !supported,
+                "The rendezvous server should not be supported, because create_available is false"
+            );
+        }
+
+        {
+            let _discover_guard = server
+                .server()
+                .register_as_scoped(
+                    Mock::given(method("GET"))
+                        .and(path(URL))
+                        .respond_with(ResponseTemplate::new(404))
+                        .expect(1),
+                )
+                .await;
+
+            let supported = client
+                .oauth()
+                .msc_4388_rendezvous_server_supported()
+                .await
+                .expect("We should be able to check if the rendezvous server is supported");
+
+            assert!(
+                !supported,
+                "The rendezvous server should not be supported if we receive a 404 response"
+            );
+        }
+
+        {
+            let _discover_guard = server
+                .server()
+                .register_as_scoped(
+                    Mock::given(method("GET"))
+                        .and(path(URL))
+                        .respond_with(ResponseTemplate::new(403))
+                        .expect(1),
+                )
+                .await;
+
+            let supported = client
+                .oauth()
+                .msc_4388_rendezvous_server_supported()
+                .await
+                .expect("We should be able to check if the rendezvous server is supported");
+
+            assert!(
+                !supported,
+                "The rendezvous server should not be supported if we receive a 403 response"
+            );
+        }
+
+        {
+            let _discover_guard = server
+                .server()
+                .register_as_scoped(
+                    Mock::given(method("GET"))
+                        .and(path(URL))
+                        .respond_with(ResponseTemplate::new(500))
+                        .expect(1),
+                )
+                .await;
+
+            client
+                .oauth()
+                .msc_4388_rendezvous_server_supported()
+                .await
+                .expect_err("We should return an error if the homeserver can't tell us if the endpoint is supported or not");
+        }
+    }
+}


### PR DESCRIPTION
Split out from #6173.