### PR TITLE
fix: Disable `sha3` target-feature for Android ARM64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,7 +10,7 @@ rustdoc-map = true
 
 [target.aarch64-linux-android]
 # These rust flags improve the performance on Android on arm64
-rustflags = ["-C", "target-feature=+neon,+aes,+sha2,+sha3,+pmuv3"]
+rustflags = ["-C", "target-feature=+neon,+aes,+sha2,+pmuv3"]
 
 [env]
 IPHONEOS_DEPLOYMENT_TARGET = "16.0"


### PR DESCRIPTION
This flag recently started causing crashes that end with:

```
sha2::sha512::aarch64_sha3::compress::h986393a1305f8918+808)
ed25519_dalek::signing::_$LT$impl$u20$core..convert..From$LT$$RF$$u5b$u8$u3b$$u20$32$u5d$$GT$$u20$for$u20$ed25519_dalek..hazmat..ExpandedSecretKey$GT$::from::habd2e8bc398c5bd3+596)
...
```

And disabling this made local builds work fine again.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
