### PR TITLE
chore: Fix patch dependencies, update tracing

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -44,6 +44,8 @@ allow-git = [
     "https://github.com/tokio-rs/tracing.git",
     # Well, it's Ruma.
     "https://github.com/ruma/ruma",
+    # This is our fork of Ruma, needed until the fix for https://github.com/mozilla/uniffi-rs/issues/2939 is merged.
+    "https://github.com/matrix-org/ruma",
     # Vodozemac won't block us as we're doing the releases.
     "https://github.com/matrix-org/vodozemac",
     # A patch override for the bindings: https://github.com/rodrimati1992/const_panic/pull/10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "assign",
  "js_int",
@@ -5442,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "as_variant",
  "assign",
@@ -5464,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5521,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "headers",
  "http",
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5553,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 2.1.1",
@@ -8548,28 +8548,3 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[patch.unused]]
-name = "ruma"
-version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
-
-[[patch.unused]]
-name = "tracing"
-version = "0.1.41"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05"
-
-[[patch.unused]]
-name = "tracing-appender"
-version = "0.2.3"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05"
-
-[[patch.unused]]
-name = "tracing-core"
-version = "0.1.34"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05"
-
-[[patch.unused]]
-name = "tracing-subscriber"
-version = "0.3.20"
-source = "git+https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,10 +108,10 @@ tempfile = { version = "3.27.0", default-features = false }
 thiserror = { version = "2.0.19", default-features = false }
 tokio = { version = "1.53.1", default-features = false, features = ["sync"] }
 tokio-stream = { version = "0.1.19", default-features = false }
-tracing = { version = "0.1.41", default-features = false, features = ["std"] }
-tracing-appender = { version = "0.2.3", default-features = false }
-tracing-core = { version = "0.1.34", default-features = false }
-tracing-subscriber = { version = "0.3.20", default-features = false, features = ["std", "smallvec", "fmt"] }
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
+tracing-appender = { version = "0.2.5", default-features = false }
+tracing-core = { version = "0.1.36", default-features = false }
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["std", "smallvec", "fmt"] }
 unicode-normalization = { version = "0.1.25", default-features = false }
 unicode-segmentation = { version = "1.13.3", default-features = false }
 uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410bea19e71984ea5e06a7bc8b11ed9e5", version = "0.31.0", default-features = false, features = ["cargo-metadata"] }
@@ -250,11 +250,8 @@ lto = false
 [patch.crates-io]
 async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27c8b290f1f1dcfc0c4ec22c464e38528aa591" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
+
+[patch."https://github.com/ruma/ruma"]
 # Needed to disable checksums since they're incorrect in 32bit devices.
 # Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
 ruma = { git = "https://github.com/matrix-org/ruma", rev = "2a1d714314f6f711d5bca755c73cf2ce3053c3d1" }
-# Needed to fix rotation log issue on Android (https://github.com/tokio-rs/tracing/issues/2937)
-tracing = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
-tracing-core = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }
-tracing-appender = { git = "https://github.com/tokio-rs/tracing.git", rev = "20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05" }

--- a/crates/matrix-sdk/changelog.d/6874.changed.md
+++ b/crates/matrix-sdk/changelog.d/6874.changed.md
@@ -1,0 +1,2 @@
+Fix the `[patch]` declaration of the Ruma forked repo, which was not working. Also remove not working patches 
+for `tracing` crates, and bump them to their latest versions. 


### PR DESCRIPTION
Changes:

- `ruma` wasn't using the proper patch header, so it wasn't getting overridden.
- `tracing` and sub-crates had the same issue and were using patch versions that weren't being applied, they've been bumped to their latest versions instead.

```
warning: patch `tracing v0.1.41 (https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8)` was not used in the crate graph
warning: patch `tracing-appender v0.2.3 (https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8)` was not used in the crate graph
warning: patch `tracing-core v0.1.34 (https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8)` was not used in the crate graph
warning: patch `tracing-subscriber v0.3.20 (https://github.com/tokio-rs/tracing.git?rev=20f5b3d8ba057ca9c4ae00ad30dda3dce8a71c05#20f5b3d8)` was not used in the crate graph
```

This means we've been used unpatched versions for a while, so we might as well just use the upstream ones. It seems like they did include a [more thorough fix](https://github.com/tokio-rs/tracing/pull/3000) than [the workaround we added](https://github.com/matrix-org/matrix-rust-sdk/pull/4038).

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
