### PR TITLE
FFI: expose load_or_fetch_event_with_relations on Room

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6875.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6875.added.md
@@ -1,0 +1,3 @@
+Add `Room::load_or_fetch_event_with_relations`, exposing the existing Rust-side
+API over FFI. Returns the event together with its related events (optionally
+filtered by `RelationType`).

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -21,6 +21,7 @@ use matrix_sdk::{
     DraftAttachment as SdkDraftAttachment, DraftAttachmentContent, DraftThumbnail, EncryptionState,
     PredecessorRoom as SdkPredecessorRoom, RoomHeroWithProfile as SdkRoomHeroWithProfile,
     RoomMemberships, RoomState, SuccessorRoom as SdkSuccessorRoom,
+    deserialized_responses::TimelineEvent as SdkTimelineEvent,
     encryption::LocalTrust,
     room::{
         Room as SdkRoom, RoomMemberRole, edit::EditedContent, power_levels::RoomPowerLevelChanges,
@@ -39,6 +40,7 @@ use ruma::{
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         receipt::ReceiptThread as RumaReceiptThread,
+        relation::RelationType as RumaRelationType,
         room::{
             MediaSource as RumaMediaSource, avatar::ImageInfo as RumaAvatarImageInfo,
             history_visibility::HistoryVisibility as RumaHistoryVisibility,
@@ -1315,6 +1317,79 @@ impl Room {
             .into_full_event(self.inner.room_id().to_owned())
             .into())
     }
+
+    /// Either loads the event associated with the `event_id` from the event
+    /// cache or fetches it from the homeserver, along with the events related
+    /// to it (e.g. reactions and edits), fetched recursively.
+    ///
+    /// An optional filter restricts the relation types fetched; no filter
+    /// fetches relations of all types.
+    pub async fn load_or_fetch_event_with_relations(
+        &self,
+        event_id: String,
+        relation_filter: Option<Vec<RelationType>>,
+    ) -> Result<EventWithRelations, ClientError> {
+        let event_id = EventId::parse(event_id)?;
+        let filter = relation_filter.map(|filter| filter.into_iter().map(Into::into).collect());
+
+        let (event, related_events) =
+            self.inner.load_or_fetch_event_with_relations(&event_id, filter, None).await?;
+
+        let as_ffi_event = |event: SdkTimelineEvent| -> Result<Arc<TimelineEvent>, ClientError> {
+            Ok(Arc::new(
+                event
+                    .kind
+                    .into_raw()
+                    .deserialize()?
+                    .into_full_event(self.inner.room_id().to_owned())
+                    .into(),
+            ))
+        };
+
+        Ok(EventWithRelations {
+            event: as_ffi_event(event)?,
+            related_events: related_events
+                .into_iter()
+                .map(as_ffi_event)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+/// The relation types that can be used to filter related events when calling
+/// [`Room::load_or_fetch_event_with_relations`].
+#[derive(uniffi::Enum)]
+pub enum RelationType {
+    /// An annotation to an event (e.g. a reaction), `m.annotation`.
+    Annotation,
+    /// A reference to another event, `m.reference`.
+    Reference,
+    /// An event that replaces another event (e.g. an edit), `m.replace`.
+    Replacement,
+    /// An event that belongs to a thread, `m.thread`.
+    Thread,
+}
+
+impl From<RelationType> for RumaRelationType {
+    fn from(value: RelationType) -> Self {
+        match value {
+            RelationType::Annotation => Self::Annotation,
+            RelationType::Reference => Self::Reference,
+            RelationType::Replacement => Self::Replacement,
+            RelationType::Thread => Self::Thread,
+        }
+    }
+}
+
+/// An event and the events related to it, as returned by
+/// [`Room::load_or_fetch_event_with_relations`].
+#[derive(uniffi::Record)]
+pub struct EventWithRelations {
+    /// The event itself.
+    pub event: Arc<TimelineEvent>,
+    /// The events related to it, directly or (recursively) through other
+    /// related events.
+    pub related_events: Vec<Arc<TimelineEvent>>,
 }
 
 /// A listener for receiving call decline events in a room.


### PR DESCRIPTION
`Room::load_or_fetch_event_with_relations` exists on the Rust side (the pinned-events cache uses it to load events together with their reactions and edits), but it isn't reachable over FFI.
Clients that want an event outside their timeline window, with its aggregation-relevant relations, currently have no direct way to get them.

This exposes it next to the existing `load_or_fetch_event` binding. Since uniffi can't return tuples, the result is a small `EventWithRelations` record, and the relation filter comes in as a new RelationType enum mapped onto ruma's.

Use case: a feed that surfaces thread roots which fell outside the client's timeline window, fetching the root plus its Annotation/Replacement relations in one call, the same way the pinned-events loader does internally.