### PR TITLE
event_cache: add SpecificEventsCache for caller-supplied event IDs

### DIFF
--- a/crates/matrix-sdk/changelog.d/6877.added.md
+++ b/crates/matrix-sdk/changelog.d/6877.added.md
@@ -1,0 +1,1 @@
+Add `EventCache::specific_events()`, an in-memory cache for a caller-supplied set of event IDs, loaded together with their reactions and edits and kept up to date from sync.

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -40,6 +40,7 @@ pub mod pagination;
 pub mod pinned_events;
 mod read_receipts;
 pub mod room;
+pub mod specific_events;
 pub mod subscriber;
 pub mod thread;
 

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -70,6 +70,15 @@ pub(super) struct Caches {
     pub event_focused:
         Arc<RwLock<HashMap<event_focused::EventFocusedCacheKey, event_focused::EventFocusedCache>>>,
 
+    /// All the [`SpecificEventsCache`], created on demand.
+    ///
+    /// [`SpecificEventsCache`]: specific_events::SpecificEventsCache
+    //
+    // TODO: caches are kept alive for the lifetime of the room's caches;
+    // an eviction strategy (e.g. dropping caches nobody subscribes to
+    // anymore) is to be discussed.
+    pub specific_events: Arc<RwLock<Vec<specific_events::SpecificEventsCache>>>,
+
     /// Internals data, used to lazily create caches.
     internals: CachesInternals,
 }
@@ -161,6 +170,7 @@ impl Caches {
             threads: Arc::new(RwLock::new(HashMap::new())),
             pinned_events: OnceCell::new(),
             event_focused: Arc::new(RwLock::new(HashMap::new())),
+            specific_events: Arc::new(RwLock::new(Vec::new())),
             internals: CachesInternals {
                 state: state.clone(),
                 auto_shrink_sender,
@@ -288,9 +298,30 @@ impl Caches {
         )
     }
 
+    /// Create a [`SpecificEventsCache`] for the given set of event IDs. It
+    /// isn't loaded yet.
+    ///
+    /// [`SpecificEventsCache`]: specific_events::SpecificEventsCache
+    pub async fn specific_events(
+        &self,
+        event_ids: Vec<OwnedEventId>,
+    ) -> Result<specific_events::SpecificEventsCache> {
+        let cache = specific_events::SpecificEventsCache::new(
+            self.room.weak_room().clone(),
+            event_ids,
+            &self.internals.state,
+        )
+        .await?;
+
+        self.specific_events.write().await.push(cache.clone());
+
+        Ok(cache)
+    }
+
     /// Update all the event caches with a [`JoinedRoomUpdate`].
     pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
+        let Self { room, threads: _, pinned_events, event_focused, specific_events, internals } =
+            &self;
 
         // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
         // avoid cloning useless data or to clone as few data as possible. That's a fun
@@ -393,12 +424,31 @@ impl Caches {
             let _ = event_focused;
         }
 
+        // Specific-events.
+        {
+            let specific_events = specific_events.read().await;
+
+            for specific_events in specific_events.iter() {
+                let updates = JoinedRoomUpdate {
+                    timeline: aggregator::aggregate_timeline_for_pinned_events(
+                        &original_timeline,
+                        &specific_events.state().read().await?.current_event_ids(),
+                        &internals.room_version_rules.redaction,
+                    ),
+                    ..Default::default()
+                };
+
+                specific_events.handle_joined_room_update(updates).await?;
+            }
+        }
+
         Ok(())
     }
 
     /// Update all the event caches with a [`LeftRoomUpdate`].
     pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
+        let Self { room, threads: _, pinned_events, event_focused, specific_events, internals } =
+            &self;
 
         // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
         // avoid cloning useless data or to clone as few data as possible. That's a fun
@@ -470,6 +520,24 @@ impl Caches {
             let _ = event_focused;
         }
 
+        // Specific-events.
+        {
+            let specific_events = specific_events.read().await;
+
+            for specific_events in specific_events.iter() {
+                let updates = LeftRoomUpdate {
+                    timeline: aggregator::aggregate_timeline_for_pinned_events(
+                        &original_timeline,
+                        &specific_events.state().read().await?.current_event_ids(),
+                        &internals.room_version_rules.redaction,
+                    ),
+                    ..Default::default()
+                };
+
+                specific_events.handle_left_room_update(updates).await?;
+            }
+        }
+
         Ok(())
     }
 
@@ -491,6 +559,15 @@ impl Caches {
 
             for event_focused in event_focused.values() {
                 events.extend(event_focused.events().await?);
+            }
+        }
+
+        // The specific-events caches also only live in memory.
+        {
+            let specific_events = self.specific_events.read().await;
+
+            for specific_events in specific_events.iter() {
+                events.extend(specific_events.events().await?);
             }
         }
 
@@ -519,7 +596,7 @@ impl Caches {
             state.store.get_room_events(self.room.room_id(), event_type, session_id).await?
         };
 
-        // The only cache to not store its events is the event-focused cache. Its events
+        // The event-focused and specific-events caches don't store their events; they
         // only live in memory.
         {
             let event_focused = self.event_focused.read().await;
@@ -527,6 +604,21 @@ impl Caches {
             for event_focused in event_focused.values() {
                 events.extend(
                     event_focused
+                        .events()
+                        .await?
+                        .into_iter()
+                        .filter(|event| event_type == event.kind.event_type().as_deref())
+                        .filter(|event| session_id == event.kind.session_id()),
+                );
+            }
+        }
+
+        {
+            let specific_events = self.specific_events.read().await;
+
+            for specific_events in specific_events.iter() {
+                events.extend(
+                    specific_events
                         .events()
                         .await?
                         .into_iter()

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -680,63 +680,74 @@ impl PinnedEventsCache {
             return Ok(Some(Vec::new()));
         }
 
-        let mut num_successful_loads = 0;
-
-        let mut loaded_events: Vec<Event> =
-            stream::iter(pinned_event_ids.clone().into_iter().map(|event_id| {
-                let room = room.clone();
-                let filter = vec![RelationType::Annotation, RelationType::Replacement];
-                let request_config = RequestConfig::default().retry_limit(3);
-
-                async move {
-                    let (target, mut relations) = room
-                        .load_or_fetch_event_with_relations(
-                            &event_id,
-                            Some(filter),
-                            Some(request_config),
-                        )
-                        .await?;
-
-                    relations.insert(0, target);
-                    Ok::<_, crate::Error>(relations)
-                }
-            }))
-            .buffer_unordered(max_concurrent_requests)
-            // Count successful queries.
-            .inspect(|result| {
-                if result.is_ok() {
-                    num_successful_loads += 1;
-                }
-            })
-            // Get rid of error results.
-            .flat_map(stream::iter)
-            // Flatten the list of `Vec<Event>` into a list of `Event`.
-            .flat_map(stream::iter)
-            .collect()
-            .await;
-
-        if num_successful_loads != pinned_event_ids.len() {
-            warn!(
-                "only successfully loaded {} out of {} pinned events",
-                num_successful_loads,
-                pinned_event_ids.len()
-            );
-        }
-
-        if loaded_events.is_empty() {
-            // If the list of loaded events is empty, we ran into an error to load *all* the
-            // pinned events, which needs to be reported to the caller.
-            return Err(EventCacheError::UnableToLoadPinnedEvents);
-        }
-
-        // Since we have all the events and their related events, we can't nicely sort
-        // them, since we've lost all ordering information from using /event or
-        // /relations. Resort to sorting using chronological ordering (oldest ->
-        // newest).
-        loaded_events.sort_by(compare_pinned_items);
-
-        Ok(Some(loaded_events))
+        // If nothing could be loaded, we ran into an error to load *all* the pinned
+        // events, which needs to be reported to the caller.
+        load_events_with_relations(&room, pinned_event_ids, max_concurrent_requests)
+            .await
+            .map(Some)
+            .ok_or(EventCacheError::UnableToLoadPinnedEvents)
     }
+}
+
+/// Load the given events, using the cache first and then requesting them from
+/// the homeserver, along with their reactions and edits, performing at most
+/// `max_concurrent_requests` requests at once.
+///
+/// Events that can't be loaded are skipped with a warning; `None` is returned
+/// when none of them could be. Since ordering information is lost when going
+/// through `/event` and `/relations`, the result is sorted chronologically
+/// (oldest to newest).
+pub(super) async fn load_events_with_relations(
+    room: &Room,
+    event_ids: Vec<OwnedEventId>,
+    max_concurrent_requests: usize,
+) -> Option<Vec<Event>> {
+    let num_requested = event_ids.len();
+    let mut num_successful_loads = 0;
+
+    let mut loaded_events: Vec<Event> = stream::iter(event_ids.into_iter().map(|event_id| {
+        let room = room.clone();
+        let filter = vec![RelationType::Annotation, RelationType::Replacement];
+        let request_config = RequestConfig::default().retry_limit(3);
+
+        async move {
+            let (target, mut relations) = room
+                .load_or_fetch_event_with_relations(&event_id, Some(filter), Some(request_config))
+                .await?;
+
+            relations.insert(0, target);
+            Ok::<_, crate::Error>(relations)
+        }
+    }))
+    .buffer_unordered(max_concurrent_requests)
+    // Count successful queries.
+    .inspect(|result| {
+        if result.is_ok() {
+            num_successful_loads += 1;
+        }
+    })
+    // Get rid of error results.
+    .flat_map(stream::iter)
+    // Flatten the list of `Vec<Event>` into a list of `Event`.
+    .flat_map(stream::iter)
+    .collect()
+    .await;
+
+    if num_successful_loads != num_requested {
+        warn!("only successfully loaded {num_successful_loads} out of {num_requested} events");
+    }
+
+    if num_requested > 0 && num_successful_loads == 0 {
+        return None;
+    }
+
+    // An event may be both requested and a relation of another one.
+    let mut seen = BTreeSet::new();
+    loaded_events.retain(|event| event.event_id().is_none_or(|id| seen.insert(id.to_owned())));
+
+    loaded_events.sort_by(compare_pinned_items);
+
+    Some(loaded_events)
 }
 
 impl fmt::Debug for PinnedEventsCache {

--- a/crates/matrix-sdk/src/event_cache/caches/specific_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/specific_events/mod.rs
@@ -1,0 +1,228 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An event cache for a caller-supplied set of event IDs.
+//!
+//! This is a generalisation of the pinned-events cache: instead of the event
+//! IDs coming from the room's `m.room.pinned_events` state, they are supplied
+//! (and updated) by the caller. Each event is loaded together with its
+//! reactions and edits, and the cache receives the sync events related to what
+//! it holds (any relation type, redactions included), so the events are kept
+//! up to date over time.
+//!
+//! Unlike the pinned-events cache, this cache is **in-memory only** (like the
+//! event-focused cache): caller-supplied sets have no natural persistent
+//! identity, so nothing is written to the store.
+
+use std::{collections::BTreeSet, fmt};
+
+use matrix_sdk_base::{
+    apply_redaction, event_cache::Event, linked_chunk::Position,
+    serde_helpers::extract_redaction_target, sync::Timeline,
+};
+use ruma::{
+    EventId, OwnedEventId, events::room::redaction::SyncRoomRedactionEvent,
+    room_version_rules::RoomVersionRules,
+};
+use tokio::sync::broadcast::Sender;
+use tracing::trace;
+
+use super::{
+    super::{EventsOrigin, Result, states::StateLockWriteGuard},
+    TimelineVectorDiffs,
+    event_linked_chunk::EventLinkedChunk,
+};
+use crate::room::WeakRoom;
+
+/// State of a [`SpecificEventsCache`].
+pub struct SpecificEventsCacheState {
+    /// The room owning the events, used to (re)load them.
+    room: WeakRoom,
+
+    /// The rules for the version of this room.
+    room_version_rules: RoomVersionRules,
+
+    /// The caller-supplied set of event IDs this cache is about.
+    event_ids: Vec<OwnedEventId>,
+
+    /// The linked chunk holding the events and their related events, sorted
+    /// chronologically (oldest to newest), as ordering information is lost
+    /// when loading events through `/event` and `/relations`.
+    chunk: EventLinkedChunk,
+
+    /// Update sender for this cache.
+    pub update_sender: Sender<TimelineVectorDiffs>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for SpecificEventsCacheState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SpecificEventsCacheState")
+            .field("room_id", &self.room.room_id())
+            .field("event_ids", &self.event_ids)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SpecificEventsCacheState {
+    /// Return a list of the current event IDs in this linked chunk (the
+    /// caller-supplied events and their loaded relations).
+    pub(super) fn current_event_ids(&self) -> Vec<OwnedEventId> {
+        self.chunk
+            .events()
+            .filter_map(|(_position, event)| event.event_id().map(ToOwned::to_owned))
+            .collect()
+    }
+
+    fn has_event_ids(&self, event_ids: &[OwnedEventId]) -> bool {
+        self.event_ids.iter().collect::<BTreeSet<_>>() == event_ids.iter().collect::<BTreeSet<_>>()
+    }
+}
+
+impl<'a> StateLockWriteGuard<'a, SpecificEventsCacheState> {
+    /// Handle new events from sync: events already loaded (e.g. through
+    /// `/relations`) keep their position, the rest are appended, then any
+    /// redaction is applied.
+    fn handle_sync(&mut self, timeline: Timeline) -> Result<()> {
+        let mut new_events = Vec::new();
+
+        for event in &timeline.events {
+            let known_position = event.event_id().and_then(|event_id| {
+                self.state.chunk.events().find_map(|(position, known)| {
+                    (known.event_id() == Some(event_id)).then_some(position)
+                })
+            });
+
+            match known_position {
+                Some(position) => {
+                    self.state
+                        .chunk
+                        .replace_event_at(position, event.clone())
+                        .expect("should have been a valid position of an item");
+                }
+                None => new_events.push(event.clone()),
+            }
+        }
+
+        if !new_events.is_empty() {
+            self.state.chunk.push_live_events(None, &new_events);
+        }
+
+        self.drain_store_updates();
+        self.notify_subscribers(EventsOrigin::Sync);
+
+        for event in &timeline.events {
+            self.maybe_apply_new_redaction(event)?;
+        }
+
+        Ok(())
+    }
+
+    /// If the given event is a redaction, try to retrieve the to-be-redacted
+    /// event in the chunk, and replace it by the redacted form.
+    fn maybe_apply_new_redaction(&mut self, event: &Event) -> Result<()> {
+        let Some(event_id) =
+            extract_redaction_target(event.raw(), &self.state.room_version_rules.redaction)
+        else {
+            return Ok(());
+        };
+
+        let Some((position, mut target_event)) = self.find_event_in_memory(&event_id) else {
+            trace!("redacted event is missing from the linked chunk");
+            return Ok(());
+        };
+
+        // Don't redact already redacted events.
+        if let Ok(deserialized) = target_event.raw().deserialize()
+            && deserialized.is_redacted()
+        {
+            return Ok(());
+        }
+
+        if let Some(redacted_event) = apply_redaction(
+            target_event.raw(),
+            event.raw().cast_ref_unchecked::<SyncRoomRedactionEvent>(),
+            &self.state.room_version_rules.redaction,
+        ) {
+            // It's safe to cast `redacted_event` here:
+            // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
+            //   when calling .raw(), so it's still one under the hood.
+            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
+            target_event.replace_raw(redacted_event.cast_unchecked());
+
+            self.state
+                .chunk
+                .replace_event_at(position, target_event)
+                .expect("should have been a valid position of an item");
+
+            self.drain_store_updates();
+            self.notify_subscribers(EventsOrigin::Sync);
+        }
+
+        Ok(())
+    }
+
+    /// Find an event in the linked chunk, by ID.
+    fn find_event_in_memory(&self, event_id: &EventId) -> Option<(Position, Event)> {
+        self.state
+            .chunk
+            .events()
+            .find(|(_position, event)| event.event_id() == Some(event_id))
+            .map(|(position, event)| (position, event.clone()))
+    }
+
+    /// Replace the entire content of the linked chunk with the given events,
+    /// unless nothing changed, and notify subscribers.
+    fn replace_all_events(&mut self, new_events: Vec<Event>) {
+        let previous_event_ids = self.state.current_event_ids();
+
+        if new_events
+            .iter()
+            .filter_map(|event| event.event_id())
+            .map(ToOwned::to_owned)
+            .collect::<BTreeSet<OwnedEventId>>()
+            == previous_event_ids.into_iter().collect::<BTreeSet<OwnedEventId>>()
+        {
+            return;
+        }
+
+        if self.state.chunk.events().next().is_some() {
+            self.state.chunk.reset();
+        }
+
+        self.state.chunk.push_live_events(None, &new_events);
+
+        self.drain_store_updates();
+        self.notify_subscribers(EventsOrigin::Sync);
+    }
+
+    /// This cache is in-memory only: drain the accumulated store updates so
+    /// they don't grow unbounded.
+    //
+    // TODO: decide whether these updates should be broadcast on the
+    // `linked_chunk_update_sender` too, which would require a non-persisted
+    // `LinkedChunkId` variant for caller-supplied sets.
+    fn drain_store_updates(&mut self) {
+        let _ = self.state.chunk.store_updates().take();
+    }
+
+    /// Notify subscribers of timeline updates.
+    fn notify_subscribers(&mut self, origin: EventsOrigin) {
+        let diffs = self.state.chunk.updates_as_vector_diffs();
+
+        if !diffs.is_empty() {
+            let _ = self.state.update_sender.send(TimelineVectorDiffs { diffs, origin });
+        }
+    }
+}

--- a/crates/matrix-sdk/src/event_cache/caches/specific_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/specific_events/mod.rs
@@ -25,25 +25,47 @@
 //! event-focused cache): caller-supplied sets have no natural persistent
 //! identity, so nothing is written to the store.
 
-use std::{collections::BTreeSet, fmt};
+use std::{
+    collections::BTreeSet,
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+    },
+};
 
 use matrix_sdk_base::{
-    apply_redaction, event_cache::Event, linked_chunk::Position,
-    serde_helpers::extract_redaction_target, sync::Timeline,
+    apply_redaction,
+    event_cache::Event,
+    linked_chunk::Position,
+    serde_helpers::extract_redaction_target,
+    sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
     EventId, OwnedEventId, events::room::redaction::SyncRoomRedactionEvent,
     room_version_rules::RoomVersionRules,
 };
-use tokio::sync::broadcast::Sender;
+use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::trace;
 
+#[cfg(feature = "e2e-encryption")]
+use super::super::redecryptor::{MaybeResolvedEvent, TryResolveEvents};
 use super::{
-    super::{EventsOrigin, Result, states::StateLockWriteGuard},
+    super::{
+        EventCacheError, EventsOrigin, Result,
+        states::{
+            CacheStateLock, StateLock, StateLockWriteGuard, selectors::SpecificEventsStateSelector,
+        },
+    },
     TimelineVectorDiffs,
     event_linked_chunk::EventLinkedChunk,
+    pinned_events::load_events_with_relations,
 };
 use crate::room::WeakRoom;
+
+/// Monotonic source of instance IDs, so several caches can coexist for the
+/// same room, each with its own state.
+static NEXT_INSTANCE_ID: AtomicU64 = AtomicU64::new(0);
 
 /// State of a [`SpecificEventsCache`].
 pub struct SpecificEventsCacheState {
@@ -225,4 +247,204 @@ impl<'a> StateLockWriteGuard<'a, SpecificEventsCacheState> {
             let _ = self.state.update_sender.send(TimelineVectorDiffs { diffs, origin });
         }
     }
+}
+
+/// An event cache for a caller-supplied set of event IDs.
+///
+/// Cloning is shallow, and thus is cheap to do.
+#[derive(Clone)]
+pub struct SpecificEventsCache {
+    inner: Arc<SpecificEventsCacheInner>,
+}
+
+/// The (non-cloneable) details of the `SpecificEventsCache`.
+struct SpecificEventsCacheInner {
+    /// State of this `SpecificEventsCache`.
+    state: CacheStateLock<SpecificEventsStateSelector>,
+}
+
+impl SpecificEventsCache {
+    /// Creates a new, empty [`SpecificEventsCache`] for the given room and
+    /// event IDs; call [`Self::reload`] to load the events.
+    pub(in super::super) async fn new(
+        weak_room: WeakRoom,
+        mut event_ids: Vec<OwnedEventId>,
+        state: &StateLock,
+    ) -> Result<Self> {
+        let room = weak_room.get().ok_or(EventCacheError::ClientDropped)?;
+        let room_id = room.room_id().to_owned();
+        let room_version_rules = room.clone_info().room_version_rules_or_default();
+        let instance_id = NEXT_INSTANCE_ID.fetch_add(1, AtomicOrdering::Relaxed);
+
+        dedup_event_ids(&mut event_ids);
+
+        let cache_state = state
+            .try_insert_once_with(
+                SpecificEventsStateSelector::new(room_id, instance_id),
+                |_store_guard| async {
+                    Ok(SpecificEventsCacheState {
+                        room: weak_room.clone(),
+                        room_version_rules,
+                        event_ids: event_ids.clone(),
+                        chunk: EventLinkedChunk::new(),
+                        update_sender: Sender::new(32),
+                    })
+                },
+            )
+            .await?;
+
+        Ok(Self { inner: Arc::new(SpecificEventsCacheInner { state: cache_state }) })
+    }
+
+    /// Load the events for the current set of IDs, notifying subscribers of
+    /// the changes.
+    ///
+    /// The events are fetched with no lock held: loading goes through the
+    /// event cache, which needs the state lock too.
+    pub(in super::super) async fn reload(&self) -> Result<()> {
+        let (room, event_ids) = {
+            let guard = self.inner.state.read().await?;
+            (guard.state.room.get(), guard.state.event_ids.clone())
+        };
+
+        let Some(room) = room else {
+            // The client is shutting down; there's nothing sensible to reload.
+            return Ok(());
+        };
+
+        let max_concurrent_requests =
+            room.client().event_cache().config().max_pinned_events_concurrent_requests;
+
+        let events = load_events_with_relations(&room, event_ids.clone(), max_concurrent_requests)
+            .await
+            .ok_or(EventCacheError::UnableToLoadSpecificEvents)?;
+
+        let mut guard = self.inner.state.write().await?;
+
+        // A newer set is being loaded by someone else: let it win.
+        if !guard.state.has_event_ids(&event_ids) {
+            return Ok(());
+        }
+
+        guard.replace_all_events(events);
+
+        Ok(())
+    }
+
+    /// Return a reference to the state.
+    pub(super) fn state(&self) -> &CacheStateLock<SpecificEventsStateSelector> {
+        &self.inner.state
+    }
+
+    /// Read all current events (the caller-supplied events and their loaded
+    /// relations).
+    pub async fn events(&self) -> Result<Vec<Event>> {
+        let guard = self.inner.state.read().await?;
+
+        Ok(guard.state.chunk.events().map(|(_position, event)| event.clone()).collect())
+    }
+
+    /// Subscribe to live updates from this cache.
+    pub async fn subscribe(&self) -> Result<(Vec<Event>, Receiver<TimelineVectorDiffs>)> {
+        let guard = self.inner.state.read().await?;
+        let events = guard.state.chunk.events().map(|(_position, event)| event.clone()).collect();
+        let recv = guard.state.update_sender.subscribe();
+
+        Ok((events, recv))
+    }
+
+    /// Replace the set of event IDs this cache is about, reloading the events
+    /// if the set changed.
+    ///
+    /// There is no state event to observe for caller-supplied sets, so this is
+    /// the caller's way of keeping the set up to date. If the events can't be
+    /// loaded, the previous set is kept.
+    pub async fn set_event_ids(&self, mut event_ids: Vec<OwnedEventId>) -> Result<()> {
+        dedup_event_ids(&mut event_ids);
+
+        let previous_event_ids = {
+            let mut guard = self.inner.state.write().await?;
+
+            if guard.state.has_event_ids(&event_ids) {
+                return Ok(());
+            }
+
+            std::mem::replace(&mut guard.state.event_ids, event_ids.clone())
+        };
+
+        if let Err(err) = self.reload().await {
+            let mut guard = self.inner.state.write().await?;
+
+            if guard.state.has_event_ids(&event_ids) {
+                guard.state.event_ids = previous_event_ids;
+            }
+
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    /// Handle a joined-room update from sync.
+    ///
+    /// The caller is expected to have filtered the timeline down to events
+    /// related to this cache's events already (see
+    /// [`super::aggregator::aggregate_timeline_for_pinned_events`]).
+    pub(in super::super) async fn handle_joined_room_update(
+        &self,
+        updates: JoinedRoomUpdate,
+    ) -> Result<()> {
+        if updates.timeline.events.is_empty() {
+            return Ok(());
+        }
+
+        self.inner.state.write().await?.handle_sync(updates.timeline)
+    }
+
+    /// Handle a left-room update from sync.
+    pub(in super::super) async fn handle_left_room_update(
+        &self,
+        updates: LeftRoomUpdate,
+    ) -> Result<()> {
+        if updates.timeline.events.is_empty() {
+            return Ok(());
+        }
+
+        self.inner.state.write().await?.handle_sync(updates.timeline)
+    }
+
+    /// Try to locate the events in the linked chunk corresponding to the given
+    /// list of resolved events, and replace them, while alerting observers
+    /// about the update.
+    #[cfg(feature = "e2e-encryption")]
+    pub(in super::super) async fn replace_in_memory_utds(
+        &self,
+        resolved_events: &[MaybeResolvedEvent],
+    ) -> Result<()> {
+        let mut guard = self.inner.state.write().await?;
+
+        // This cache doesn't persist anything in the store, so try to resolve
+        // events against the in-memory linked chunk.
+        let resolved_events = resolved_events.try_resolve_events(&guard.state.chunk);
+
+        if guard.state.chunk.replace_utds(&resolved_events) {
+            guard.drain_store_updates();
+            guard.notify_subscribers(EventsOrigin::Cache);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for SpecificEventsCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SpecificEventsCache").finish_non_exhaustive()
+    }
+}
+
+/// Remove duplicate IDs, keeping the first occurrence.
+fn dedup_event_ids(event_ids: &mut Vec<OwnedEventId>) {
+    let mut seen = BTreeSet::new();
+    event_ids.retain(|event_id| seen.insert(event_id.clone()));
 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -115,6 +115,16 @@ pub enum EventCacheError {
         thread_id: OwnedEventId,
     },
 
+    /// Specific-events cache is not found.
+    #[error("Specific-events cache `{instance_id}` of room `{room_id}` is not found.")]
+    SpecificEventsNotFound {
+        /// The room ID of the specific-events cache.
+        room_id: OwnedRoomId,
+
+        /// The instance ID of the specific-events cache.
+        instance_id: u64,
+    },
+
     /// Pinned-events cache are not found.
     #[error("Pinned-events cache for room `{room_id}` are not found.")]
     PinnedEventsNotFound {
@@ -171,6 +181,10 @@ pub enum EventCacheError {
     /// list, incorrectly.
     #[error("Unable to load any of the pinned events.")]
     UnableToLoadPinnedEvents,
+
+    /// None of the events of a specific-events cache could be loaded.
+    #[error("Unable to load any of the specific events.")]
+    UnableToLoadSpecificEvents,
 
     /// An error happened when reading the metadata of a linked chunk, upon
     /// reload.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -79,6 +79,7 @@ pub use self::{
             RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheUpdate,
             pagination::RoomPagination,
         },
+        specific_events::SpecificEventsCache,
         subscriber::Subscriber,
         thread::{ThreadEventCache, ThreadEventCacheUpdate, pagination::ThreadPagination},
     },
@@ -115,16 +116,6 @@ pub enum EventCacheError {
         thread_id: OwnedEventId,
     },
 
-    /// Specific-events cache is not found.
-    #[error("Specific-events cache `{instance_id}` of room `{room_id}` is not found.")]
-    SpecificEventsNotFound {
-        /// The room ID of the specific-events cache.
-        room_id: OwnedRoomId,
-
-        /// The instance ID of the specific-events cache.
-        instance_id: u64,
-    },
-
     /// Pinned-events cache are not found.
     #[error("Pinned-events cache for room `{room_id}` are not found.")]
     PinnedEventsNotFound {
@@ -140,6 +131,16 @@ pub enum EventCacheError {
 
         /// The thread root event ID.
         event_focused_id: EventFocusedCacheKey,
+    },
+
+    /// Specific-events cache is not found.
+    #[error("Specific-events cache `{instance_id}` of room `{room_id}` is not found.")]
+    SpecificEventsNotFound {
+        /// The room ID of the specific-events cache.
+        room_id: OwnedRoomId,
+
+        /// The instance ID of the specific-events cache.
+        instance_id: u64,
     },
 
     /// A new cache was inserted at an occupied place, i.e. where an existing
@@ -461,6 +462,32 @@ impl EventCache {
         let caches_for_room = self.inner.all_caches_for_room(room_id).await?;
 
         Ok((caches_for_room.pinned_events().await?.clone(), drop_handles))
+    }
+
+    /// Create a view over the [`EventCache`] for a caller-supplied set of
+    /// event IDs, loaded together with their reactions and edits and kept up
+    /// to date from sync.
+    ///
+    /// Each call creates a new cache. It lives in memory only, as long as the
+    /// room's caches do: after [`Self::forget_room`], existing handles stop
+    /// receiving updates.
+    pub async fn specific_events(
+        &self,
+        room_id: &RoomId,
+        event_ids: Vec<OwnedEventId>,
+    ) -> Result<(SpecificEventsCache, Arc<EventCacheDropHandles>)> {
+        let Some(drop_handles) = self.inner.drop_handles.get().cloned() else {
+            return Err(EventCacheError::NotSubscribedYet);
+        };
+
+        let cache =
+            self.inner.all_caches_for_room(room_id).await?.specific_events(event_ids).await?;
+
+        // Load with no lock on the room's caches held: loading goes through the event
+        // cache, which takes it too.
+        cache.reload().await?;
+
+        Ok((cache, drop_handles))
     }
 
     /// Return an event-focused view over the [`EventCache`].

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -585,6 +585,16 @@ impl EventCache {
             .await?;
         }
 
+        // Resolve in-memory UTDs on the specific-events caches.
+        {
+            try_join_all(all_caches.specific_events.read().await.iter().map(
+                |specific_events_cache| {
+                    specific_events_cache.replace_in_memory_utds(&maybe_resolved_events)
+                },
+            ))
+            .await?;
+        }
+
         let report =
             RedecryptorReport::ResolvedUtds { room_id: room_id.to_owned(), events: event_ids };
         let _ = self.inner.redecryption_channels.utd_reporter.send(report);

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -37,6 +37,7 @@ use super::{
         event_focused::{EventFocusedCacheKey, EventFocusedCacheState},
         pinned_events::PinnedEventsCacheState,
         room::{self, RoomEventCacheState},
+        specific_events::SpecificEventsCacheState,
         thread::{self, ThreadEventCacheState},
     },
 };
@@ -55,6 +56,7 @@ pub(super) struct StateForRoom {
     threads: HashMap<OwnedEventId, ThreadEventCacheState>,
     pinned_events: Option<PinnedEventsCacheState>,
     event_focused: HashMap<EventFocusedCacheKey, EventFocusedCacheState>,
+    specific_events: HashMap<u64, SpecificEventsCacheState>,
 }
 
 /// State for the entire Event Cache.
@@ -489,8 +491,10 @@ impl<'state> ReloadableStateLockWriteGuard<'state> {
         trace!("Reloading the state");
 
         // Iterate over all states and reload them.
-        for (room_id, StateForRoom { room, threads, pinned_events, event_focused }) in
-            self.state.by_room.iter_mut()
+        for (
+            room_id,
+            StateForRoom { room, threads, pinned_events, event_focused, specific_events },
+        ) in self.state.by_room.iter_mut()
         {
             // Room.
             if let Some(room_state) = room {
@@ -557,6 +561,10 @@ impl<'state> ReloadableStateLockWriteGuard<'state> {
                     origin: EventsOrigin::Cache,
                 });
             }
+
+            // Specific-events caches load through the event cache, which would need this
+            // very lock; their in-memory content stays valid, so they aren't reloaded here.
+            let _ = specific_events;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/states/selectors.rs
+++ b/crates/matrix-sdk/src/event_cache/states/selectors.rs
@@ -21,7 +21,7 @@ use ruma::{OwnedEventId, OwnedRoomId};
 
 use super::{
     super::EventCacheError, EventFocusedCacheKey, EventFocusedCacheState, PinnedEventsCacheState,
-    RoomEventCacheState, State, StateForRoom, ThreadEventCacheState,
+    RoomEventCacheState, SpecificEventsCacheState, State, StateForRoom, ThreadEventCacheState,
 };
 
 /// Trait to select a specific state of a cache inside a [`State`].
@@ -249,5 +249,52 @@ impl CacheState for EventFocusedStateSelector {
 impl From<&EventFocusedStateSelector> for EventCacheError {
     fn from(value: &EventFocusedStateSelector) -> Self {
         Self::EventFocusedNotFound { room_id: value.0.clone(), event_focused_id: value.1.clone() }
+    }
+}
+
+/// Select a [`SpecificEventsCacheState`] in [`State`].
+#[derive(Debug)]
+pub struct SpecificEventsStateSelector(OwnedRoomId, u64);
+
+impl SpecificEventsStateSelector {
+    pub fn new(room_id: OwnedRoomId, instance_id: u64) -> Self {
+        Self(room_id, instance_id)
+    }
+}
+
+impl CacheState for SpecificEventsStateSelector {
+    type Item = SpecificEventsCacheState;
+
+    fn select<'state>(&self, state: &'state State) -> Option<&'state Self::Item> {
+        state
+            .by_room
+            .get(&self.0)
+            .and_then(|state_for_room| state_for_room.specific_events.get(&self.1))
+    }
+
+    fn select_mut<'state>(&self, state: &'state mut State) -> Option<&'state mut Self::Item> {
+        state
+            .by_room
+            .get_mut(&self.0)
+            .and_then(|state_for_room| state_for_room.specific_events.get_mut(&self.1))
+    }
+
+    fn insert_once(&self, state: &mut State, cache_state: Self::Item) -> bool {
+        let specific_events = &mut state.by_room.entry(self.0.clone()).or_default().specific_events;
+
+        match specific_events.entry(self.1) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
+                entry.insert(cache_state);
+
+                true
+            }
+        }
+    }
+}
+
+impl From<&SpecificEventsStateSelector> for EventCacheError {
+    fn from(value: &SpecificEventsStateSelector) -> Self {
+        Self::SpecificEventsNotFound { room_id: value.0.clone(), instance_id: value.1 }
     }
 }

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -38,6 +38,7 @@ use ruma::{
 use tokio::{spawn, sync::broadcast, task::yield_now, time::sleep};
 
 mod read_receipts;
+mod specific_events;
 mod threads;
 
 macro_rules! assert_event_id {

--- a/crates/matrix-sdk/tests/integration/event_cache/specific_events.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/specific_events.rs
@@ -1,0 +1,304 @@
+use std::time::Duration;
+
+use imbl::Vector;
+use matrix_sdk::{
+    event_cache::{EventCacheError, TimelineVectorDiffs},
+    test_utils::mocks::{MatrixMockServer, RoomRelationsResponseTemplate},
+    timeout::timeout,
+};
+use matrix_sdk_base::event_cache::Event;
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use ruma::{
+    EventId, OwnedEventId, event_id, events::room::message::RoomMessageEventContentWithoutRelation,
+    room_id,
+};
+use tokio::sync::broadcast::Receiver;
+
+fn room_id() -> &'static ruma::RoomId {
+    room_id!("!galette:saucisse.bzh")
+}
+
+/// Wait for the next update, apply it and whatever follows it closely
+/// (one sync can produce several) to `events`.
+async fn apply_next_updates(
+    subscriber: &mut Receiver<TimelineVectorDiffs>,
+    events: &mut Vector<Event>,
+) {
+    let mut wait = Duration::from_secs(3);
+
+    while let Ok(update) = timeout(subscriber.recv(), wait).await {
+        for diff in update.expect("the update channel should be open").diffs {
+            diff.apply(events);
+        }
+        wait = Duration::from_millis(300);
+    }
+
+    assert!(wait < Duration::from_secs(3), "an update should arrive");
+}
+
+/// Assert that no update arrives for a while.
+async fn assert_no_update(subscriber: &mut Receiver<TimelineVectorDiffs>) {
+    assert!(timeout(subscriber.recv(), Duration::from_millis(300)).await.is_err());
+}
+
+fn event_ids(events: &Vector<Event>) -> Vec<OwnedEventId> {
+    events.iter().filter_map(|event| event.event_id().map(ToOwned::to_owned)).collect()
+}
+
+fn find<'a>(events: &'a Vector<Event>, event_id: &EventId) -> &'a Event {
+    events.iter().find(|event| event.event_id() == Some(event_id)).expect("event should be present")
+}
+
+async fn subscribed_client(server: &MatrixMockServer) -> matrix_sdk::Client {
+    let client = server.client_builder().build().await;
+    client.event_cache().subscribe().unwrap();
+    server.sync_joined_room(&client, room_id()).await;
+    client
+}
+
+#[async_test]
+async fn test_specific_events_are_loaded_with_their_relations() {
+    let f = EventFactory::new().room(room_id()).sender(*ALICE);
+
+    let first = f.text_msg("first").event_id(event_id!("$first")).server_ts(1).into_event();
+    let second = f.text_msg("second").event_id(event_id!("$second")).server_ts(2).into_event();
+    let reaction = f
+        .reaction(event_id!("$first"), "👍")
+        .event_id(event_id!("$reaction"))
+        .server_ts(3)
+        .into_event();
+    let edit = f
+        .text_msg("* second, edited")
+        .edit(
+            event_id!("$second"),
+            RoomMessageEventContentWithoutRelation::text_plain("second, edited"),
+        )
+        .event_id(event_id!("$edit"))
+        .server_ts(4)
+        .into_event();
+
+    let server = MatrixMockServer::new().await;
+    server.mock_room_event().match_event_id().ok(first).mount().await;
+    server.mock_room_event().match_event_id().ok(second).mount().await;
+    server
+        .mock_room_relations()
+        .match_target_event(event_id!("$first").to_owned())
+        .ok(RoomRelationsResponseTemplate::default()
+            .events(vec![reaction.raw().clone().cast_unchecked()]))
+        .mount()
+        .await;
+    server
+        .mock_room_relations()
+        .match_target_event(event_id!("$second").to_owned())
+        .ok(RoomRelationsResponseTemplate::default()
+            .events(vec![edit.raw().clone().cast_unchecked()]))
+        .mount()
+        .await;
+
+    let client = subscribed_client(&server).await;
+
+    // The IDs are given in any order, with a duplicate; the cache loads each
+    // once, with its relations, sorted chronologically.
+    let (cache, _drop_handles) = client
+        .event_cache()
+        .specific_events(
+            room_id(),
+            vec![
+                event_id!("$second").to_owned(),
+                event_id!("$first").to_owned(),
+                event_id!("$first").to_owned(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let (events, _subscriber) = cache.subscribe().await.unwrap();
+    assert_eq!(
+        event_ids(&events.into()),
+        [event_id!("$first"), event_id!("$second"), event_id!("$reaction"), event_id!("$edit")]
+    );
+    assert_eq!(cache.events().await.unwrap().len(), 4);
+}
+
+#[async_test]
+async fn test_specific_events_skip_events_that_cannot_be_loaded() {
+    let f = EventFactory::new().room(room_id()).sender(*ALICE);
+
+    let server = MatrixMockServer::new().await;
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(f.text_msg("first").event_id(event_id!("$first")).into_event())
+        .mount()
+        .await;
+
+    let client = subscribed_client(&server).await;
+
+    // `$missing` isn't mocked: its request fails, the rest is loaded.
+    let (cache, _drop_handles) = client
+        .event_cache()
+        .specific_events(
+            room_id(),
+            vec![event_id!("$first").to_owned(), event_id!("$missing").to_owned()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(event_ids(&cache.events().await.unwrap().into()), [event_id!("$first")]);
+
+    // When nothing can be loaded, that's an error.
+    let result = client
+        .event_cache()
+        .specific_events(room_id(), vec![event_id!("$missing").to_owned()])
+        .await;
+    assert!(matches!(result, Err(EventCacheError::UnableToLoadSpecificEvents)));
+}
+
+#[async_test]
+async fn test_specific_events_follow_sync_updates() {
+    let f = EventFactory::new().room(room_id()).sender(*ALICE);
+
+    let server = MatrixMockServer::new().await;
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(f.text_msg("target").event_id(event_id!("$target")).server_ts(1).into_event())
+        .mount()
+        .await;
+
+    let client = subscribed_client(&server).await;
+
+    let (cache, _drop_handles) = client
+        .event_cache()
+        .specific_events(room_id(), vec![event_id!("$target").to_owned()])
+        .await
+        .unwrap();
+    let (events, mut subscriber) = cache.subscribe().await.unwrap();
+    let mut events: Vector<Event> = events.into();
+    assert_eq!(event_ids(&events), [event_id!("$target")]);
+
+    // A reaction and an edit of the target arrive from sync.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id())
+                .add_timeline_event(
+                    f.reaction(event_id!("$target"), "👍").event_id(event_id!("$reaction")),
+                )
+                .add_timeline_event(
+                    f.text_msg("* edited")
+                        .edit(
+                            event_id!("$target"),
+                            RoomMessageEventContentWithoutRelation::text_plain("edited"),
+                        )
+                        .event_id(event_id!("$edit")),
+                ),
+        )
+        .await;
+    apply_next_updates(&mut subscriber, &mut events).await;
+    assert_eq!(
+        event_ids(&events),
+        [event_id!("$target"), event_id!("$reaction"), event_id!("$edit")]
+    );
+
+    // An unrelated message doesn't reach the cache.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id())
+                .add_timeline_event(f.text_msg("noise").event_id(event_id!("$noise"))),
+        )
+        .await;
+    assert_no_update(&mut subscriber).await;
+
+    // Redacting the reaction replaces it with its redacted form.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id()).add_timeline_event(
+                f.redaction(event_id!("$reaction")).event_id(event_id!("$redaction_of_reaction")),
+            ),
+        )
+        .await;
+    apply_next_updates(&mut subscriber, &mut events).await;
+    assert!(find(&events, event_id!("$reaction")).raw().deserialize().unwrap().is_redacted());
+    assert!(!find(&events, event_id!("$target")).raw().deserialize().unwrap().is_redacted());
+
+    // So does redacting the target itself.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id()).add_timeline_event(
+                f.redaction(event_id!("$target")).event_id(event_id!("$redaction_of_target")),
+            ),
+        )
+        .await;
+    apply_next_updates(&mut subscriber, &mut events).await;
+    assert!(find(&events, event_id!("$target")).raw().deserialize().unwrap().is_redacted());
+
+    assert!(!event_ids(&events).contains(&event_id!("$noise").to_owned()));
+}
+
+#[async_test]
+async fn test_specific_events_set_event_ids_reloads_when_the_set_changes() {
+    let f = EventFactory::new().room(room_id()).sender(*ALICE);
+
+    let server = MatrixMockServer::new().await;
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(f.text_msg("first").event_id(event_id!("$first")).server_ts(1).into_event())
+        .mount()
+        .await;
+    server
+        .mock_room_event()
+        .match_event_id()
+        .ok(f.text_msg("second").event_id(event_id!("$second")).server_ts(2).into_event())
+        .mount()
+        .await;
+
+    let client = subscribed_client(&server).await;
+
+    let (cache, _drop_handles) = client
+        .event_cache()
+        .specific_events(room_id(), vec![event_id!("$first").to_owned()])
+        .await
+        .unwrap();
+    let (events, mut subscriber) = cache.subscribe().await.unwrap();
+    let mut events: Vector<Event> = events.into();
+    assert_eq!(event_ids(&events), [event_id!("$first")]);
+
+    // The same set, in any order, is a no-op.
+    cache.set_event_ids(vec![event_id!("$first").to_owned()]).await.unwrap();
+    assert_no_update(&mut subscriber).await;
+
+    // Growing the set loads the new event.
+    cache
+        .set_event_ids(vec![event_id!("$second").to_owned(), event_id!("$first").to_owned()])
+        .await
+        .unwrap();
+    apply_next_updates(&mut subscriber, &mut events).await;
+    assert_eq!(event_ids(&events), [event_id!("$first"), event_id!("$second")]);
+
+    // Shrinking it drops the removed event.
+    cache.set_event_ids(vec![event_id!("$second").to_owned()]).await.unwrap();
+    apply_next_updates(&mut subscriber, &mut events).await;
+    assert_eq!(event_ids(&events), [event_id!("$second")]);
+
+    // A set that can't be loaded at all is an error, and the previous set is kept.
+    let result = cache.set_event_ids(vec![event_id!("$missing").to_owned()]).await;
+    assert!(matches!(result, Err(EventCacheError::UnableToLoadSpecificEvents)));
+    assert_no_update(&mut subscriber).await;
+    assert_eq!(event_ids(&cache.events().await.unwrap().into()), [event_id!("$second")]);
+    cache.set_event_ids(vec![event_id!("$second").to_owned()]).await.unwrap();
+    assert_no_update(&mut subscriber).await;
+}
+
+#[async_test]
+async fn test_specific_events_require_the_event_cache_to_be_subscribed() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    server.sync_joined_room(&client, room_id()).await;
+
+    let result = client.event_cache().specific_events(room_id(), vec![]).await;
+    assert!(matches!(result, Err(EventCacheError::NotSubscribedYet)));
+}


### PR DESCRIPTION
First event-cache step for #6876. `SpecificEventsCache` is the pinned-events approach with the id list supplied by the caller instead of coming from `m.room.pinned_events`.

- load: each id with its reactions and edits, through the same loader as pinned events (now shared), sorted chronologically
- sync: reuses `aggregate_timeline_for_pinned_events` with the cache's current ids, so reactions, edits and redactions of what it holds reach it
- `set_event_ids()`: diffs the set and reloads if it changed; a set that can't be loaded at all is an error and the previous set is kept
- in-memory only, like the event-focused cache; it doesn't paginate, callers grow the set
- lifetime: the room's caches hold these caches weakly. Once the caller drops its handles, the next sync forgets the cache and its state

Six commits: the loader refactor, the state and how it follows sync, the cache handle, the wiring into the room caches, the tests, and the weak handles.

A store clear leaves these caches alone on purpose: nothing of theirs lives in the store, and sync keeps them current.

No timeline or FFI yet.
