### PR TITLE
chore(sdk): Clean up around `ReadReceipts`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -733,7 +733,7 @@ impl Room {
 
         Ok(self
             .inner
-            .load_user_receipt(receipt_type.try_into()?, thread.try_into()?, &user_id)
+            .load_user_receipt(receipt_type.try_into()?, &thread.try_into()?, &user_id)
             .await?
             .map(|(event_id, receipt)| UserReceipt {
                 event_id: event_id.to_string(),

--- a/crates/matrix-sdk-base/changelog.d/6879.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/6879.changed.md
@@ -1,0 +1,7 @@
+The following methods `StateStore::get_user_room_receipt_event`,
+`StateStore::get_event_room_receipt_events`, `Room::load_user_receipt` and
+`Room::load_event_receipts` take a `ReceiptThread` by reference. No
+known implementation needs an owned value.
+
+`RoomReadReceipts` has also been renamed to `ReadReceipts`, reusing it for
+threads as an objective.

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -36,9 +36,6 @@ pub struct LatestReadReceipt {
 }
 
 /// Public data about read receipts collected during processing of that room.
-///
-/// Remember that each time a field of `RoomReadReceipts` is updated in
-/// `compute_unread_counts`, this function must return true!
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RoomReadReceipts {
     /// Does the room have unread messages?

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -37,7 +37,7 @@ pub struct LatestReadReceipt {
 
 /// Public data about read receipts collected during processing of that room.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct RoomReadReceipts {
+pub struct ReadReceipts {
     /// Does the room have unread messages?
     pub num_unread: u64,
 
@@ -64,7 +64,7 @@ pub struct RoomReadReceipts {
     pub pending: RingBuffer<OwnedEventId>,
 }
 
-impl Default for RoomReadReceipts {
+impl Default for ReadReceipts {
     fn default() -> Self {
         Self {
             num_unread: Default::default(),

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -549,10 +549,12 @@ impl Room {
     pub async fn load_user_receipt(
         &self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> StoreResult<Option<(OwnedEventId, Receipt)>> {
-        self.store.get_user_room_receipt_event(self.room_id(), receipt_type, thread, user_id).await
+        self.store
+            .get_user_room_receipt_event(self.room_id(), receipt_type, receipt_thread, user_id)
+            .await
     }
 
     /// Load from storage the receipts as a list of `OwnedUserId` and `Receipt`
@@ -561,11 +563,11 @@ impl Room {
     pub async fn load_event_receipts(
         &self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
         self.store
-            .get_event_room_receipt_events(self.room_id(), receipt_type, thread, event_id)
+            .get_event_room_receipt_events(self.room_id(), receipt_type, receipt_thread, event_id)
             .await
     }
 

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -71,7 +71,7 @@ use crate::{
     DmRoomDefinition, Error, StateStore,
     deserialized_responses::MemberEvent,
     notification_settings::RoomNotificationMode,
-    read_receipts::RoomReadReceipts,
+    read_receipts::ReadReceipts,
     store::{Result as StoreResult, SaveLockedStateStore, StateStoreExt},
     sync::UnreadNotificationsCount,
 };
@@ -207,7 +207,7 @@ impl Room {
     }
 
     /// Get the detailed information about read receipts for the room.
-    pub fn read_receipts(&self) -> RoomReadReceipts {
+    pub fn read_receipts(&self) -> ReadReceipts {
         self.info.read().read_receipts.clone()
     }
 

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -70,7 +70,7 @@ use crate::{
     deserialized_responses::RawSyncOrStrippedState,
     latest_event::LatestEventValue,
     notification_settings::RoomNotificationMode,
-    read_receipts::RoomReadReceipts,
+    read_receipts::ReadReceipts,
     room::call::CallIntentConsensus,
     store::{IncorrectMutexGuardError, SaveLockedStateStore, StateStoreExt},
     sync::UnreadNotificationsCount,
@@ -609,7 +609,7 @@ pub struct RoomInfo {
 
     /// Information about read receipts for this room.
     #[serde(default)]
-    pub(crate) read_receipts: RoomReadReceipts,
+    pub(crate) read_receipts: ReadReceipts,
 
     /// Base room info which holds some basic event contents important for the
     /// room state.
@@ -1265,12 +1265,12 @@ impl RoomInfo {
     }
 
     /// Returns the computed read receipts for this room.
-    pub fn read_receipts(&self) -> &RoomReadReceipts {
+    pub fn read_receipts(&self) -> &ReadReceipts {
         &self.read_receipts
     }
 
     /// Set the computed read receipts for this room.
-    pub fn set_read_receipts(&mut self, read_receipts: RoomReadReceipts) {
+    pub fn set_read_receipts(&mut self, read_receipts: ReadReceipts) {
         self.read_receipts = read_receipts;
     }
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -359,7 +359,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id
             )
             .await?
@@ -369,7 +369,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 first_receipt_event_id()
             )
             .await?
@@ -839,7 +839,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id()
             )
             .await
@@ -850,7 +850,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 first_event_id
             )
             .await
@@ -861,7 +861,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 second_event_id
             )
             .await
@@ -877,7 +877,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id(),
             )
             .await
@@ -889,7 +889,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 first_event_id,
             )
             .await
@@ -905,7 +905,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 second_event_id
             )
             .await
@@ -921,7 +921,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id(),
             )
             .await
@@ -933,7 +933,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 first_event_id
             )
             .await
@@ -944,7 +944,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 second_event_id,
             )
             .await
@@ -961,7 +961,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Main,
+                &ReceiptThread::Main,
                 user_id()
             )
             .await
@@ -972,7 +972,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Main,
+                &ReceiptThread::Main,
                 second_event_id
             )
             .await
@@ -989,7 +989,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id(),
             )
             .await
@@ -1001,7 +1001,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 second_event_id,
             )
             .await
@@ -1015,7 +1015,12 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(second_event_unthreaded_receipts[0].1.ts.unwrap().0, second_receipt_ts);
         // Threaded receipts should have changed
         let (threaded_user_receipt_event_id, threaded_user_receipt) = self
-            .get_user_room_receipt_event(room_id, ReceiptType::Read, ReceiptThread::Main, user_id())
+            .get_user_room_receipt_event(
+                room_id,
+                ReceiptType::Read,
+                &ReceiptThread::Main,
+                user_id(),
+            )
             .await
             .expect("Getting threaded user room receipt after save failed")
             .unwrap();
@@ -1025,7 +1030,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             .get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Main,
+                &ReceiptThread::Main,
                 second_event_id,
             )
             .await
@@ -1167,7 +1172,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_user_room_receipt_event(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 user_id
             )
             .await?
@@ -1177,12 +1182,12 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_event_room_receipt_events(
                 room_id,
                 ReceiptType::Read,
-                ReceiptThread::Unthreaded,
+                &ReceiptThread::Unthreaded,
                 first_receipt_event_id()
             )
             .await?
             .is_empty(),
-            "still event recepts in the store"
+            "still event receipts in the store"
         );
         assert!(self.load_send_queue_requests(room_id).await?.is_empty());
         assert!(self.load_dependent_queued_requests(room_id).await?.is_empty());

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -116,7 +116,7 @@ impl MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Option<(OwnedEventId, Receipt)> {
         self.inner
@@ -124,7 +124,7 @@ impl MemoryStore {
             .unwrap()
             .room_user_receipts
             .get(room_id)?
-            .get(&(receipt_type.to_string(), thread.as_str().map(ToOwned::to_owned)))?
+            .get(&(receipt_type.to_string(), receipt_thread.as_str().map(ToOwned::to_owned)))?
             .get(user_id)
             .cloned()
     }
@@ -133,7 +133,7 @@ impl MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Option<Vec<(OwnedUserId, Receipt)>> {
         Some(
@@ -142,7 +142,7 @@ impl MemoryStore {
                 .unwrap()
                 .room_event_receipts
                 .get(room_id)?
-                .get(&(receipt_type.to_string(), thread.as_str().map(ToOwned::to_owned)))?
+                .get(&(receipt_type.to_string(), receipt_thread.as_str().map(ToOwned::to_owned)))?
                 .get(event_id)?
                 .iter()
                 .map(|(key, value)| (key.clone(), value.clone()))
@@ -792,21 +792,21 @@ impl StateStore for MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
-        Ok(self.get_user_room_receipt_event_impl(room_id, receipt_type, thread, user_id))
+        Ok(self.get_user_room_receipt_event_impl(room_id, receipt_type, receipt_thread, user_id))
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
         Ok(self
-            .get_event_room_receipt_events_impl(room_id, receipt_type, thread, event_id)
+            .get_event_room_receipt_events_impl(room_id, receipt_type, receipt_thread, event_id)
             .unwrap_or_default())
     }
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -274,14 +274,14 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// * `receipt_type` - The type of the receipt.
     ///
-    /// * `thread` - The thread containing this receipt.
+    /// * `receipt_thread` - The thread a receipt applies to.
     ///
     /// * `user_id` - The id of the user for whom the receipt should be fetched.
     async fn get_user_room_receipt_event(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error>;
 
@@ -294,7 +294,7 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// * `receipt_type` - The type of the receipts.
     ///
-    /// * `thread` - The thread containing this receipt.
+    /// * `receipt_thread` - The thread a receipt applies to.
     ///
     /// * `event_id` - The id of the event for which the receipts should be
     ///   fetched.
@@ -302,7 +302,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error>;
 
@@ -698,20 +698,20 @@ impl<T: StateStore> StateStore for &T {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
-        (*self).get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+        (*self).get_user_room_receipt_event(room_id, receipt_type, receipt_thread, user_id).await
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
-        (*self).get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+        (*self).get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id).await
     }
 
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -1020,20 +1020,24 @@ impl<T: StateStore + ?Sized> StateStore for Arc<T> {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
-        self.deref().get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+        self.deref()
+            .get_user_room_receipt_event(room_id, receipt_type, receipt_thread, user_id)
+            .await
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
-        self.deref().get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+        self.deref()
+            .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
+            .await
     }
 
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -1352,11 +1356,11 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
         self.0
-            .get_user_room_receipt_event(room_id, receipt_type, thread, user_id)
+            .get_user_room_receipt_event(room_id, receipt_type, receipt_thread, user_id)
             .await
             .map_err(Into::into)
     }
@@ -1365,11 +1369,11 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
         self.0
-            .get_event_room_receipt_events(room_id, receipt_type, thread, event_id)
+            .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
             .await
             .map_err(Into::into)
     }
@@ -1758,20 +1762,22 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
-        self.store.get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
+        self.store.get_user_room_receipt_event(room_id, receipt_type, receipt_thread, user_id).await
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
-        self.store.get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
+        self.store
+            .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
+            .await
     }
 
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1455,10 +1455,10 @@ impl_state_store!({
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
-        let key = match thread.as_str() {
+        let key = match receipt_thread.as_str() {
             Some(thread_id) => self
                 .encode_key(keys::ROOM_USER_RECEIPTS, (room_id, receipt_type, thread_id, user_id)),
             None => self.encode_key(keys::ROOM_USER_RECEIPTS, (room_id, receipt_type, user_id)),
@@ -1478,10 +1478,10 @@ impl_state_store!({
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
-        let range = match thread.as_str() {
+        let range = match receipt_thread.as_str() {
             Some(thread_id) => self.encode_to_range(
                 keys::ROOM_EVENT_RECEIPTS,
                 (room_id, receipt_type, thread_id, event_id),

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1140,14 +1140,14 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         &self,
         room_id: Key,
         receipt_type: Key,
-        thread: Key,
+        receipt_thread: Key,
         user_id: Key,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
             .query_row(
                 "SELECT data FROM receipt
                  WHERE room_id = ? AND receipt_type = ? AND thread = ? and user_id = ?",
-                (room_id, receipt_type, thread, user_id),
+                (room_id, receipt_type, receipt_thread, user_id),
                 |row| row.get(0),
             )
             .await
@@ -1922,19 +1922,20 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
         let room_id = self.encode_key(keys::RECEIPT, room_id);
         let receipt_type = self.encode_key(keys::RECEIPT, receipt_type.to_string());
         // We cannot have a NULL primary key so we rely on serialization instead of the
         // string representation.
-        let thread = self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(&thread)?);
+        let receipt_thread =
+            self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(receipt_thread)?);
         let user_id = self.encode_key(keys::RECEIPT, user_id);
 
         self.read()
             .await?
-            .get_user_receipt(room_id, receipt_type, thread, user_id)
+            .get_user_receipt(room_id, receipt_type, receipt_thread, user_id)
             .await?
             .map(|value| {
                 self.deserialize_json::<ReceiptData>(&value).map(|d| (d.event_id, d.receipt))
@@ -1946,19 +1947,20 @@ impl StateStore for SqliteStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
         let room_id = self.encode_key(keys::RECEIPT, room_id);
         let receipt_type = self.encode_key(keys::RECEIPT, receipt_type.to_string());
         // We cannot have a NULL primary key so we rely on serialization instead of the
         // string representation.
-        let thread = self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(&thread)?);
+        let receipt_thread =
+            self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(receipt_thread)?);
         let event_id = self.encode_key(keys::RECEIPT, event_id);
 
         self.read()
             .await?
-            .get_event_receipts(room_id, receipt_type, thread, event_id)
+            .get_event_receipts(room_id, receipt_type, receipt_thread, event_id)
             .await?
             .iter()
             .map(|value| {

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/unread.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/unread.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_base::read_receipts::RoomReadReceipts;
+use matrix_sdk_base::read_receipts::ReadReceipts;
 
 use super::{super::RoomListItem, Filter};
 
@@ -20,7 +20,7 @@ type IsMarkedUnread = bool;
 
 fn matches<F>(read_receipts_and_unread: F, room: &RoomListItem) -> bool
 where
-    F: Fn(&RoomListItem) -> (RoomReadReceipts, IsMarkedUnread),
+    F: Fn(&RoomListItem) -> (ReadReceipts, IsMarkedUnread),
 {
     let (read_receipts, is_marked_unread) = read_receipts_and_unread(room);
 
@@ -41,7 +41,7 @@ mod tests {
     use std::ops::Not;
 
     use matrix_sdk::test_utils::mocks::MatrixMockServer;
-    use matrix_sdk_base::read_receipts::RoomReadReceipts;
+    use matrix_sdk_base::read_receipts::ReadReceipts;
     use matrix_sdk_test::async_test;
     use ruma::room_id;
 
@@ -55,11 +55,8 @@ mod tests {
 
         for is_marked_as_unread in [true, false] {
             let read_receipts_and_unread = |_: &RoomListItem| {
-                let read_receipts = RoomReadReceipts {
-                    num_unread: 42,
-                    num_notifications: 42,
-                    ..Default::default()
-                };
+                let read_receipts =
+                    ReadReceipts { num_unread: 42, num_notifications: 42, ..Default::default() };
 
                 (read_receipts, is_marked_as_unread)
             };
@@ -76,7 +73,7 @@ mod tests {
 
         let read_receipts_and_unread = |_: &RoomListItem| {
             let read_receipts =
-                RoomReadReceipts { num_unread: 42, num_notifications: 0, ..Default::default() };
+                ReadReceipts { num_unread: 42, num_notifications: 0, ..Default::default() };
 
             (read_receipts, false)
         };
@@ -92,7 +89,7 @@ mod tests {
 
         let read_receipts_and_unread = |_: &RoomListItem| {
             let read_receipts =
-                RoomReadReceipts { num_unread: 42, num_notifications: 0, ..Default::default() };
+                ReadReceipts { num_unread: 42, num_notifications: 0, ..Default::default() };
 
             (read_receipts, true)
         };
@@ -106,7 +103,7 @@ mod tests {
         let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let read_receipts_and_unread = |_: &RoomListItem| (RoomReadReceipts::default(), false);
+        let read_receipts_and_unread = |_: &RoomListItem| (ReadReceipts::default(), false);
 
         assert!(matches(read_receipts_and_unread, &room).not());
     }
@@ -117,7 +114,7 @@ mod tests {
         let client = server.client_builder().build().await;
         let [room] = new_rooms([room_id!("!a:b.c")], &client, &server).await;
 
-        let read_receipts_and_unread = |_: &RoomListItem| (RoomReadReceipts::default(), true);
+        let read_receipts_and_unread = |_: &RoomListItem| (ReadReceipts::default(), true);
 
         assert!(matches(read_receipts_and_unread, &room));
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -37,7 +37,7 @@ use super::{
     super::{TimelineItem, TimelineItemKind, TimelineUniqueId, subscriber::skip::SkipCount},
     ActiveCallInfo, Aggregation, AggregationKind, Aggregations, AllRemoteEvents,
     ObservableItemsTransaction, PendingEdit, PendingEditKind,
-    read_receipts::ReadReceipts,
+    read_receipts::ReadReceiptsState,
 };
 use crate::{
     timeline::{
@@ -126,7 +126,7 @@ pub(in crate::timeline) struct TimelineMetadata {
     /// Read receipts related state.
     ///
     /// TODO: move this over to the event cache (see also #3058).
-    pub(super) read_receipts: ReadReceipts,
+    pub(super) read_receipts: ReadReceiptsState,
 
     /// The event ID of the active RtcNotification item that should have
     /// active_members populated.

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -660,11 +660,11 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
 
             // First, load the main receipts.
             let mut main_receipts =
-                room_data_provider.load_event_receipts(event_id, ReceiptThread::Main).await;
+                room_data_provider.load_event_receipts(event_id, &ReceiptThread::Main).await;
 
             // Then, load the unthreaded receipts.
             let unthreaded_receipts =
-                room_data_provider.load_event_receipts(event_id, ReceiptThread::Unthreaded).await;
+                room_data_provider.load_event_receipts(event_id, &ReceiptThread::Unthreaded).await;
 
             // We can safely extend both here: if a key is already set, then that means that
             // the user has the unthreaded and main receipt on the main event,
@@ -674,7 +674,7 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
         } else {
             // In all other cases, return what's requested, and only that (threaded
             // receipts).
-            room_data_provider.load_event_receipts(event_id, receipt_thread.clone()).await
+            room_data_provider.load_event_receipts(event_id, &receipt_thread).await
         };
 
         let own_user_id = room_data_provider.own_user_id();
@@ -801,13 +801,13 @@ impl<P: RoomDataProvider> TimelineState<P> {
         let wants_unthreaded_receipts = receipt_thread == ReceiptThread::Unthreaded;
 
         let mut read_receipt = room_data_provider
-            .load_user_receipt(receipt_type.clone(), receipt_thread, &own_user_id)
+            .load_user_receipt(receipt_type.clone(), &receipt_thread, &own_user_id)
             .await;
 
         if wants_unthreaded_receipts && read_receipt.is_none() {
             // Fallback to the one in the main thread.
             read_receipt = room_data_provider
-                .load_user_receipt(receipt_type.clone(), ReceiptThread::Main, &own_user_id)
+                .load_user_receipt(receipt_type.clone(), &ReceiptThread::Main, &own_user_id)
                 .await;
         }
 
@@ -933,11 +933,11 @@ impl TimelineMetadata {
             // Maintain compatibility with clients using either the unthreaded and main read
             // receipts, and try to find the most recent one.
             let unthreaded_read_receipt = room_data_provider
-                .load_user_receipt(receipt_type.clone(), ReceiptThread::Unthreaded, user_id)
+                .load_user_receipt(receipt_type.clone(), &ReceiptThread::Unthreaded, user_id)
                 .await;
 
             let main_thread_read_receipt = room_data_provider
-                .load_user_receipt(receipt_type.clone(), ReceiptThread::Main, user_id)
+                .load_user_receipt(receipt_type.clone(), &ReceiptThread::Main, user_id)
                 .await;
 
             // Let's use the unthreaded read receipt as default, since it's the one we
@@ -956,7 +956,7 @@ impl TimelineMetadata {
             // in particular will use this code path, and not be compatible with
             // an unthreaded read receipt.
             room_data_provider
-                .load_user_receipt(receipt_type.clone(), receipt_thread, user_id)
+                .load_user_receipt(receipt_type.clone(), &receipt_thread, user_id)
                 .await
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -32,7 +32,7 @@ use crate::timeline::{TimelineItem, TimelineItemContent, controller::TimelineSta
 
 /// In-memory caches for read receipts.
 #[derive(Clone, Debug, Default)]
-pub(super) struct ReadReceipts {
+pub(super) struct ReadReceiptsState {
     /// Map of public read receipts on events.
     ///
     /// Event ID => User ID => Read receipt of the user.
@@ -66,7 +66,7 @@ pub(super) enum ImplicitReadReceipts {
     Exclude,
 }
 
-impl ReadReceipts {
+impl ReadReceiptsState {
     /// Empty the caches.
     pub(super) fn clear(&mut self) {
         self.by_event.clear();

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -747,7 +747,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             room_data_provider
                 .load_user_receipt(
                     ReceiptType::Read,
-                    ReceiptThread::Thread(event_id.to_owned()),
+                    &ReceiptThread::Thread(event_id.to_owned()),
                     &self.meta.own_user_id,
                 )
                 .await
@@ -760,7 +760,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             room_data_provider
                 .load_user_receipt(
                     ReceiptType::ReadPrivate,
-                    ReceiptThread::Thread(event_id.to_owned()),
+                    &ReceiptThread::Thread(event_id.to_owned()),
                     &self.meta.own_user_id,
                 )
                 .await

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -371,12 +371,12 @@ impl RoomDataProvider for TestRoomDataProvider {
     async fn load_user_receipt<'a>(
         &'a self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        thread: &'a ReceiptThread,
         user_id: &'a UserId,
     ) -> Option<(OwnedEventId, Receipt)> {
         self.initial_user_receipts
             .get(&receipt_type)
-            .and_then(|thread_map| thread_map.get(&thread))
+            .and_then(|thread_map| thread_map.get(thread))
             .and_then(|user_map| user_map.get(user_id))
             .cloned()
     }
@@ -384,7 +384,7 @@ impl RoomDataProvider for TestRoomDataProvider {
     async fn load_event_receipts<'a>(
         &'a self,
         event_id: &'a EventId,
-        _receipt_thread: ReceiptThread,
+        _receipt_thread: &'a ReceiptThread,
     ) -> IndexMap<OwnedUserId, Receipt> {
         let mut map = IndexMap::new();
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -114,7 +114,7 @@ pub(super) trait RoomDataProvider:
     fn load_user_receipt<'a>(
         &'a self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        thread: &'a ReceiptThread,
         user_id: &'a UserId,
     ) -> impl Future<Output = Option<(OwnedEventId, Receipt)>> + SendOutsideWasm + 'a;
 
@@ -122,7 +122,7 @@ pub(super) trait RoomDataProvider:
     fn load_event_receipts<'a>(
         &'a self,
         event_id: &'a EventId,
-        receipt_thread: ReceiptThread,
+        receipt_thread: &'a ReceiptThread,
     ) -> impl Future<Output = IndexMap<OwnedUserId, Receipt>> + SendOutsideWasm + 'a;
 
     /// Load the current fully-read event id, from storage.
@@ -177,15 +177,15 @@ impl RoomDataProvider for Room {
     async fn load_user_receipt<'a>(
         &'a self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &'a ReceiptThread,
         user_id: &'a UserId,
     ) -> Option<(OwnedEventId, Receipt)> {
-        match self.load_user_receipt(receipt_type.clone(), thread.clone(), user_id).await {
+        match self.load_user_receipt(receipt_type.clone(), receipt_thread, user_id).await {
             Ok(receipt) => receipt,
             Err(e) => {
                 error!(
                     ?receipt_type,
-                    ?thread,
+                    ?receipt_thread,
                     ?user_id,
                     "Failed to get read receipt for user: {e}"
                 );
@@ -197,9 +197,9 @@ impl RoomDataProvider for Room {
     async fn load_event_receipts<'a>(
         &'a self,
         event_id: &'a EventId,
-        receipt_thread: ReceiptThread,
+        receipt_thread: &'a ReceiptThread,
     ) -> IndexMap<OwnedUserId, Receipt> {
-        match self.load_event_receipts(ReceiptType::Read, receipt_thread.clone(), event_id).await {
+        match self.load_event_receipts(ReceiptType::Read, receipt_thread, event_id).await {
             Ok(receipts) => receipts.into_iter().collect(),
             Err(e) => {
                 error!(?event_id, ?receipt_thread, "Failed to get read receipts for event: {e}");

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -355,7 +355,7 @@ async fn try_find_store_receipts(
                 .get_user_room_receipt_event(
                     room_id,
                     receipt_type.clone(),
-                    receipt_thread.clone(),
+                    &receipt_thread,
                     user_id,
                 )
                 .await

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -87,7 +87,7 @@
 //! chunk ordering which does.
 //!
 //! Once we have a new *better active receipt*, we'll save it in the
-//! [`RoomReadReceipts`] data (stored in [`RoomInfo`]), and we'll compute the
+//! [`ReadReceipts`] data (stored in [`RoomInfo`]), and we'll compute the
 //! counts, starting from the event the better active receipt was referring to.
 //!
 //! If we *don't* have a better active receipt, that means that all the events
@@ -100,7 +100,7 @@
 //! [`ThreadEventCache`]: super::thread::ThreadEventCache
 
 use matrix_sdk_base::{
-    read_receipts::{LatestReadReceipt, RoomReadReceipts},
+    read_receipts::{LatestReadReceipt, ReadReceipts},
     serde_helpers::extract_relation,
     store::DynStateStore,
 };
@@ -123,8 +123,8 @@ use super::{
     super::automatic_pagination::AutomaticPagination, event_linked_chunk::EventLinkedChunk,
 };
 
-trait RoomReadReceiptsExt {
-    /// Update the [`RoomReadReceipts`] unread counts according to the new
+trait ReadReceiptsExt {
+    /// Update the [`ReadReceipts`] unread counts according to the new
     /// event.
     ///
     /// Returns whether a new event triggered a new unread/notification/mention.
@@ -148,8 +148,8 @@ trait RoomReadReceiptsExt {
     ) -> bool;
 }
 
-impl RoomReadReceiptsExt for RoomReadReceipts {
-    /// Update the [`RoomReadReceipts`] unread counts according to the new
+impl ReadReceiptsExt for ReadReceipts {
+    /// Update the [`ReadReceipts`] unread counts according to the new
     /// event.
     ///
     /// Returns whether a new event triggered a new unread/notification/mention.
@@ -336,7 +336,7 @@ fn select_best_receipt(
 }
 
 /// Try to find extra read receipts that were in the store but never saved in
-/// the [`RoomReadReceipts`] data structure.
+/// the [`ReadReceipts`] data structure.
 ///
 /// Doesn't return a `Result`, because this is entirely optional; if the store
 /// fails to load these receipts, the worst that can happen is incorrect unread
@@ -345,7 +345,7 @@ async fn try_find_store_receipts(
     store: &DynStateStore,
     user_id: &UserId,
     room_id: &RoomId,
-    read_receipts: &mut RoomReadReceipts,
+    read_receipts: &mut ReadReceipts,
 ) {
     for receipt_type in ALL_RECEIPT_TYPES {
         // Implementation note: we want to prioritize an `Unthreaded` receipt over a
@@ -377,7 +377,7 @@ async fn try_find_store_receipts(
 }
 
 /// Given a set of events coming from sync, for a _timeline_, update the
-/// [`RoomReadReceipts`]'s counts of unread messages, notifications and
+/// [`ReadReceipts`]'s counts of unread messages, notifications and
 /// highlights' in place.
 ///
 /// See this module's documentation for more information.
@@ -388,7 +388,7 @@ pub(crate) async fn compute_unread_counts(
     room_id: &RoomId,
     receipt_event: Option<&ReceiptEventContent>,
     linked_chunk: &EventLinkedChunk,
-    read_receipts: &mut RoomReadReceipts,
+    read_receipts: &mut ReadReceipts,
     with_threading_support: bool,
     automatic_pagination: Option<&AutomaticPagination>,
     state_store: &DynStateStore,
@@ -396,7 +396,7 @@ pub(crate) async fn compute_unread_counts(
     debug!(?read_receipts, "Starting");
 
     // If we don't have a latest active receipt for this timeline, try to reload one
-    // from the state store into the `RoomReadReceipts`.
+    // from the state store into the `ReadReceipts`.
     if read_receipts.latest_active.is_none() {
         try_find_store_receipts(state_store, user_id, room_id, read_receipts).await;
     }
@@ -517,7 +517,7 @@ fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool 
 mod tests {
     use std::{num::NonZeroUsize, ops::Not as _};
 
-    use matrix_sdk_base::read_receipts::RoomReadReceipts;
+    use matrix_sdk_base::read_receipts::ReadReceipts;
     use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
     use matrix_sdk_test::{ALICE, event_factory::EventFactory};
     use ruma::{
@@ -534,7 +534,7 @@ mod tests {
     use super::marks_as_unread;
     use crate::event_cache::caches::{
         event_linked_chunk::EventLinkedChunk,
-        read_receipts::{RoomReadReceiptsExt as _, select_best_receipt},
+        read_receipts::{ReadReceiptsExt as _, select_best_receipt},
     };
 
     #[test]
@@ -636,7 +636,7 @@ mod tests {
 
         // An interesting event from oneself doesn't count as a new unread message.
         let event = make_event(user_id, Vec::new());
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -644,7 +644,7 @@ mod tests {
 
         // An interesting event from someone else does count as a new unread message.
         let event = make_event(user_id!("@bob:example.org"), Vec::new());
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
@@ -652,7 +652,7 @@ mod tests {
 
         // Push actions computed beforehand are respected.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify]);
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
@@ -662,7 +662,7 @@ mod tests {
             user_id!("@bob:example.org"),
             vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
         );
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
@@ -672,7 +672,7 @@ mod tests {
             user_id!("@bob:example.org"),
             vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)), Action::Notify],
         );
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
@@ -681,7 +681,7 @@ mod tests {
         // Technically this `push_actions` set would be a bug somewhere else, but let's
         // make sure to resist against it.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify, Action::Notify]);
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id, threading_support);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
@@ -696,7 +696,7 @@ mod tests {
 
         // When provided with no events, we report not finding the event to which the
         // receipt relates.
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
         assert!(receipts.find_and_process_events(ev0, user_id, &[], thread_support).not());
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
@@ -712,7 +712,7 @@ mod tests {
                 .into()
         }
 
-        let mut receipts = RoomReadReceipts {
+        let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
             num_mentions: 37,
@@ -735,7 +735,7 @@ mod tests {
         // When provided with one event that's the receipt target, we find it, reset the
         // count, and since there's nothing else, we stop there and end up with
         // zero counts.
-        let mut receipts = RoomReadReceipts {
+        let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
             num_mentions: 37,
@@ -748,7 +748,7 @@ mod tests {
 
         // When provided with multiple events and not the receipt event, we do not count
         // anything..
-        let mut receipts = RoomReadReceipts {
+        let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
             num_mentions: 37,
@@ -774,7 +774,7 @@ mod tests {
 
         // When provided with multiple events including one that's the receipt event, we
         // find it and count from it.
-        let mut receipts = RoomReadReceipts {
+        let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
             num_mentions: 37,
@@ -796,7 +796,7 @@ mod tests {
         assert_eq!(receipts.num_mentions, 0);
 
         // Even if duplicates are present in the new events list, the count is correct.
-        let mut receipts = RoomReadReceipts {
+        let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
             num_mentions: 37,
@@ -830,7 +830,7 @@ mod tests {
                 .into_event()
         }
 
-        let mut receipts = RoomReadReceipts::default();
+        let mut receipts = ReadReceipts::default();
 
         let own_alice = user_id!("@alice:example.org");
         let bob = user_id!("@bob:example.org");

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -363,13 +363,12 @@ async fn try_find_store_receipts(
                 trace!(%event_id, ?receipt_type, ?receipt_thread, "Found a dormant receipt in the store");
 
                 if read_receipts.latest_active.is_none() {
-                    read_receipts.latest_active =
-                        Some(LatestReadReceipt { event_id: event_id.clone() });
+                    read_receipts.latest_active = Some(LatestReadReceipt { event_id });
                 } else {
                     // This loop has already flagged a read receipt as the new `latest_active`.
                     // Extra read receipts can go to the pending receipts list, as they're lower
                     // priority, by the implementation notes above.
-                    read_receipts.pending.push(event_id.clone());
+                    read_receipts.pending.push(event_id);
                 }
             }
         }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3547,7 +3547,7 @@ impl Room {
     ///
     /// * `receipt_type` - The type of receipt to get.
     ///
-    /// * `thread` - The thread containing the event of the receipt, if any.
+    /// * `receipt_thread` - The thread a receipt applies to.
     ///
     /// * `user_id` - The ID of the user.
     ///
@@ -3556,10 +3556,13 @@ impl Room {
     pub async fn load_user_receipt(
         &self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
-        self.inner.load_user_receipt(receipt_type, thread, user_id).await.map_err(Into::into)
+        self.inner
+            .load_user_receipt(receipt_type, receipt_thread, user_id)
+            .await
+            .map_err(Into::into)
     }
 
     /// Load the receipts for an event in this room from storage.
@@ -3568,7 +3571,7 @@ impl Room {
     ///
     /// * `receipt_type` - The type of receipt to get.
     ///
-    /// * `thread` - The thread containing the event of the receipt, if any.
+    /// * `receipt_thread` - The thread a receipt applies to.
     ///
     /// * `event_id` - The ID of the event.
     ///
@@ -3577,10 +3580,13 @@ impl Room {
     pub async fn load_event_receipts(
         &self,
         receipt_type: ReceiptType,
-        thread: ReceiptThread,
+        receipt_thread: &ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
-        self.inner.load_event_receipts(receipt_type, thread, event_id).await.map_err(Into::into)
+        self.inner
+            .load_event_receipts(receipt_type, receipt_thread, event_id)
+            .await
+            .map_err(Into::into)
     }
 
     /// Get the push-condition context for this room.

--- a/labs/multiverse/src/widgets/room_view/details/read_receipts.rs
+++ b/labs/multiverse/src/widgets/room_view/details/read_receipts.rs
@@ -1,5 +1,5 @@
 use matrix_sdk::Room;
-use matrix_sdk_base::read_receipts::RoomReadReceipts;
+use matrix_sdk_base::read_receipts::ReadReceipts as RoomReadReceipts;
 use matrix_sdk_ui::timeline::TimelineItem;
 use ratatui::{
     prelude::*,


### PR DESCRIPTION
While implementing read receipts for threads, I've done a little bit of clean up, which I've extracted from the original PR for review easing.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
