### PR TITLE
Heroes: Notify RoomInfo subscribers when a room hero's global profile changes.

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6880.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6880.fixed.md
@@ -1,0 +1,1 @@
+Make sure `Room::subscribe_info` subscribers are notified when a room hero's global profile changes.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -234,12 +234,10 @@ impl BaseClient {
                     .iter()
                     .any(|user_id| extensions.profiles.users.contains_key(user_id))
                 {
-                    let _ = self.state_store.room_info_notable_update_sender.send(
-                        crate::RoomInfoNotableUpdate {
-                            room_id: room.room_id().to_owned(),
-                            reasons: crate::RoomInfoNotableUpdateReasons::HEROES,
-                        },
-                    );
+                    room.update_room_info_with_store_guard(state_store_guard, |room_info| {
+                        (room_info, crate::RoomInfoNotableUpdateReasons::HEROES)
+                    })
+                    .map_err(crate::StoreError::from)?;
                 }
             }
         }
@@ -333,6 +331,8 @@ mod tests {
         uint, user_id,
     };
     use serde_json::json;
+    #[cfg(feature = "unstable-msc4426")]
+    use stream_assert::{assert_pending, assert_ready};
 
     use super::http;
     use crate::{
@@ -1682,7 +1682,11 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
+        let room = client.get_room(room_id).expect("The room should be known");
+        let mut room_info_subscriber = room.subscribe_info();
         let mut room_info_notable_update = client.room_info_notable_update_receiver();
+
+        assert_pending!(room_info_subscriber);
 
         // When a subsequent sync carries only a profiles-extension update for Alice.
         let mut response = http::Response::new("1".to_owned());
@@ -1709,6 +1713,19 @@ mod tests {
             }
         );
         assert!(room_info_notable_update.is_empty());
+
+        // And the `RoomInfo` observable is notified too, so that subscribers of
+        // `Room::subscribe_info` re-read the hero profiles as well.
+        assert_ready!(room_info_subscriber);
+        assert_pending!(room_info_subscriber);
+
+        // Sanity check: Alice's hero carries the new status.
+        let heroes = room.heroes().await;
+        assert_eq!(heroes.len(), 1);
+        assert_eq!(heroes[0].user_id, alice);
+        let status = heroes[0].status.as_ref().expect("Alice's status should be set");
+        assert_eq!(status.text, "Away");
+        assert_eq!(status.emoji, "🌴");
     }
 
     #[async_test]


### PR DESCRIPTION
It turns out that sending notable updates isn't enough, the room info itself needs to be updated with a notable update for the subscribers to be notified.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
