### PR TITLE
feat(ui): Return a `SendHandle` from `Timeline::send_reply`

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6881.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6881.changed.md
@@ -1,0 +1,3 @@
+[**breaking**] `Timeline::send_reply` now returns the `SendHandle` of the
+queued reply, instead of nothing. This matches `Timeline::send` and lets
+consumers abort or retry a reply that has not been sent yet.

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -549,15 +549,15 @@ impl Timeline {
     ///
     /// If the replied to event has a thread relation, it is forwarded on the
     /// reply so that clients that support threads can render the reply
-    /// inside the thread.
+    /// inside the thread. Returns a handle to abort the pending send.
     pub async fn send_reply(
         &self,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
         event_id: String,
-    ) -> Result<(), ClientError> {
+    ) -> Result<Arc<SendHandle>, ClientError> {
         let event_id = EventId::parse(&event_id).map_err(|_| RoomError::InvalidRepliedToEventId)?;
-        self.inner.send_reply((*msg).clone(), event_id).await?;
-        Ok(())
+        let handle = self.inner.send_reply((*msg).clone(), event_id).await?;
+        Ok(Arc::new(SendHandle::new(handle)))
     }
 
     /// Edits an event from the timeline.
@@ -630,11 +630,11 @@ impl Timeline {
         );
 
         if let Some(replied_to_event_id) = replied_to_event_id {
-            self.send_reply(Arc::new(room_message_event_content), replied_to_event_id).await
+            self.send_reply(Arc::new(room_message_event_content), replied_to_event_id).await?;
         } else {
             self.send(Arc::new(room_message_event_content)).await?;
-            Ok(())
         }
+        Ok(())
     }
 
     /// Toggle a reaction on an event.

--- a/crates/matrix-sdk-ui/changelog.d/6881.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6881.changed.md
@@ -1,0 +1,4 @@
+[**breaking**] `Timeline::send_reply` now returns the `SendHandle` of the
+queued reply, instead of `()`. Replies go through the send queue like any other
+message, so callers can now track, abort or retry them, as they already can with
+`Timeline::send`.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -418,14 +418,13 @@ impl Timeline {
         &self,
         content: RoomMessageEventContentWithoutRelation,
         in_reply_to: OwnedEventId,
-    ) -> Result<(), Error> {
+    ) -> Result<SendHandle, Error> {
         let reply = self
             .infer_reply(Some(in_reply_to))
             .await
             .expect("the reply will always be set because we provided a replied-to event id");
         let content = self.room().make_reply_event(content, reply).await?;
-        self.send(content.into()).await?;
-        Ok(())
+        self.send(content.into()).await
     }
 
     /// Given a message or media to send, and an optional `in_reply_to` event,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -746,6 +746,51 @@ async fn test_send_reply() {
 }
 
 #[async_test]
+async fn test_send_reply_can_be_aborted() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    client.send_queue().set_enabled(false).await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    let event_id_from_bob = event_id!("$event_from_bob");
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("Hello from Bob").sender(&BOB).event_id(event_id_from_bob),
+            ),
+        )
+        .await;
+
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
+
+    let handle = timeline
+        .send_reply(
+            RoomMessageEventContentWithoutRelation::text_plain("Replying to Bob"),
+            event_id_from_bob.into(),
+        )
+        .await
+        .unwrap();
+
+    assert_let_timeout!(Some(VectorDiff::PushBack { value: reply_item }) = timeline_stream.next());
+    assert_matches!(reply_item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
+
+    assert!(handle.abort().await.unwrap());
+
+    assert_let_timeout!(Some(VectorDiff::Remove { index: 1 }) = timeline_stream.next());
+}
+
+#[async_test]
 async fn test_send_reply_to_self() {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;


### PR DESCRIPTION
`Timeline::send_reply` queues the reply through `Timeline::send`, which returns a `SendHandle`, and then drops that handle and returns `()`. A reply is queued exactly like any other message, so the machinery to track, abort and retry it already exists, but callers cannot reach it. This PR returns the handle instead of dropping it, in `matrix-sdk-ui` and in the FFI layer.

`Timeline::send_location` in the FFI keeps its current signature and drops the handle explicitly. Returning it there is a separate breaking change that this issue does not ask for, so tell me if you want it in the same PR.

The new integration test `test_send_reply_can_be_aborted` disables the send queue so the reply stays local, sends the reply, aborts it through the returned handle, and waits for the local echo to be removed from the timeline.

Fixes #6528

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>