### PR TITLE
fix(event cache): do not abort the client when a duplicated event cannot be removed

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -33,7 +33,7 @@ use ruma::{
     room_version_rules::RoomVersionRules,
 };
 use tokio::sync::broadcast::{Receiver, Sender};
-use tracing::{debug, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 
 pub(super) use self::updates::PinnedEventsCacheUpdateSender;
 #[cfg(feature = "e2e-encryption")]
@@ -194,12 +194,11 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
         }
 
         // `remove_events_by_position` is responsible of sorting positions.
-        self.state
-            .chunk
-            .remove_events_by_position(
-                in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
-            )
-            .expect("failed to remove an event");
+        if let Err(error) = self.state.chunk.remove_events_by_position(
+            in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
+        ) {
+            error!("failed to remove duplicated events: {error}");
+        }
 
         self.propagate_changes().await
     }

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -461,12 +461,14 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         }
 
         // `remove_events_by_position` is responsible of sorting positions.
-        self.state
-            .room_linked_chunk
-            .remove_events_by_position(
-                in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
-            )
-            .expect("failed to remove an event");
+        //
+        // Positions come from the store, whose copy of a chunk can hold more items
+        // than the in-memory one, so an index may be out of range.
+        if let Err(error) = self.state.room_linked_chunk.remove_events_by_position(
+            in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
+        ) {
+            error!("failed to remove duplicated events: {error}");
+        }
 
         self.propagate_changes().await
     }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -639,12 +639,11 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         }
 
         // `remove_events_by_position` is responsible of sorting positions.
-        self.state
-            .thread_linked_chunk
-            .remove_events_by_position(
-                in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
-            )
-            .expect("failed to remove an event");
+        if let Err(error) = self.state.thread_linked_chunk.remove_events_by_position(
+            in_memory_events.into_iter().map(|(_event_id, position)| position).collect(),
+        ) {
+            error!("failed to remove duplicated events: {error}");
+        }
 
         self.state.propagate_changes(&self.store).await
     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Replace the expect("failed to remove an event") in the event cache's deduplication with a logged error: the positions come from the store, whose copy of a chunk can hold more items than the in-memory one, so an out of-range index aborts the whole client on panic = "abort" targets.
- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Erwan Leboucher <erwanleboucher@gmail.com>
