### PR TITLE
feat(sdk): `ThreadEventCache`'s pagination and in-memory UTD resolution post-process upserted events

### DIFF
--- a/crates/matrix-sdk/changelog.d/6888.added.md
+++ b/crates/matrix-sdk/changelog.d/6888.added.md
@@ -1,0 +1,3 @@
+`ThreadEventCache` now applies new redactions and saves bundled latest thread
+events for events coming from the pagination, or that have been redecrypted (by
+the `Redecryptor`).

--- a/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
@@ -407,6 +407,9 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
             &topo_ordered_events,
         );
 
+        // Update the store.
+        state.propagate_changes().await?;
+
         // A back-pagination can't include new read receipt events, as those are
         // ephemeral events not included in /messages responses, so we can
         // safely set the receipt event to None here.

--- a/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
@@ -420,7 +420,7 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
         let receipt_event = None;
 
         // Post-process newly inserted events.
-        state.post_process_upserted_events(topo_ordered_events, receipt_event).await?;
+        state.post_process_upserted_events(topo_ordered_events.iter(), receipt_event).await?;
 
         let timeline_event_diffs = state.room_linked_chunk_mut().updates_as_vector_diffs();
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
@@ -419,8 +419,8 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
         // receipt.
         let receipt_event = None;
 
-        // Note: this flushes updates to the store.
-        state.post_process_new_events(topo_ordered_events, receipt_event).await?;
+        // Post-process newly inserted events.
+        state.post_process_upserted_events(topo_ordered_events, receipt_event).await?;
 
         let timeline_event_diffs = state.room_linked_chunk_mut().updates_as_vector_diffs();
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -611,7 +611,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     // --------------------------------------------
 
     /// Post-process newly inserted or updated events.
-    pub async fn post_process_upserted_events<'i, I>(
+    pub(super) async fn post_process_upserted_events<'i, I>(
         &mut self,
         events: I,
         receipt_event: Option<ReceiptEventContent>,

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -588,9 +588,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         // Update the store.
         self.propagate_changes().await?;
 
-        // Extract a new read receipt, if available.
-        let new_receipt = extract_read_receipt(ephemeral_events);
-        self.post_process_new_events(events, new_receipt).await?;
+        // Post-process newly inserted events.
+        self.post_process_upserted_events(events, extract_read_receipt(ephemeral_events)).await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -610,9 +609,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     // utility methods
     // --------------------------------------------
 
-    /// Post-process new events, after they have been added to the in-memory
-    /// linked chunk.
-    pub async fn post_process_new_events(
+    /// Post-process newly inserted or updated events.
+    pub async fn post_process_upserted_events(
         &mut self,
         events: Vec<Event>,
         receipt_event: Option<ReceiptEventContent>,

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -471,7 +471,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         self.propagate_changes().await
     }
 
-    async fn propagate_changes(&mut self) -> Result<(), EventCacheError> {
+    pub(super) async fn propagate_changes(&mut self) -> Result<(), EventCacheError> {
         let updates = self.state.room_linked_chunk.store_updates().take();
 
         self.send_updates_to_store(updates).await
@@ -585,6 +585,9 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             &events,
         );
 
+        // Update the store.
+        self.propagate_changes().await?;
+
         // Extract a new read receipt, if available.
         let new_receipt = extract_read_receipt(ephemeral_events);
         self.post_process_new_events(events, new_receipt).await?;
@@ -594,8 +597,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             // so it only contains the last one; otherwise, there might be a
             // valid gap in between, and observers may not render it (yet).
             //
-            // We must do this *after* persisting these events to storage (in
-            // `post_process_new_events`).
+            // We must do this *after* persisting these events to storage.
             self.shrink_to_last_reloaded_chunk().await?;
         }
 
@@ -610,16 +612,11 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
 
     /// Post-process new events, after they have been added to the in-memory
     /// linked chunk.
-    ///
-    /// Flushes updates to disk first.
     pub async fn post_process_new_events(
         &mut self,
         events: Vec<Event>,
         receipt_event: Option<ReceiptEventContent>,
     ) -> Result<(), EventCacheError> {
-        // Update the store before doing the post-processing.
-        self.propagate_changes().await?;
-
         for event in events {
             self.maybe_apply_new_redaction(&event).await?;
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -589,7 +589,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         self.propagate_changes().await?;
 
         // Post-process newly inserted events.
-        self.post_process_upserted_events(events, extract_read_receipt(ephemeral_events)).await?;
+        self.post_process_upserted_events(events.iter(), extract_read_receipt(ephemeral_events))
+            .await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -610,17 +611,20 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     // --------------------------------------------
 
     /// Post-process newly inserted or updated events.
-    pub async fn post_process_upserted_events(
+    pub async fn post_process_upserted_events<'i, I>(
         &mut self,
-        events: Vec<Event>,
+        events: I,
         receipt_event: Option<ReceiptEventContent>,
-    ) -> Result<(), EventCacheError> {
+    ) -> Result<(), EventCacheError>
+    where
+        I: Iterator<Item = &'i Event>,
+    {
         for event in events {
-            self.maybe_apply_new_redaction(&event).await?;
+            self.maybe_apply_new_redaction(event).await?;
 
             // Save a bundled thread event, if there was one.
-            if let Some(bundled_thread) = event.bundled_latest_thread_event {
-                self.save_events([*bundled_thread]).await?;
+            if let Some(bundled_thread) = &event.bundled_latest_thread_event {
+                self.save_events([*bundled_thread.clone()]).await?;
             }
         }
 
@@ -774,7 +778,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     /// about the update.
     #[cfg(feature = "e2e-encryption")]
     #[must_use = "Propagate `VectorDiff` updates via `TimelineVectorDiffs`"]
-    pub(in super::super::super) fn replace_in_memory_utds(
+    pub(in super::super::super) async fn replace_in_memory_utds(
         &mut self,
         resolved_events: &[MaybeResolvedEvent],
     ) -> Result<Option<Vec<VectorDiff<Event>>>, EventCacheError> {
@@ -782,6 +786,19 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             // Drain the updates to the store, events have already been updated with
             // `save_events`!
             let _ = self.room_linked_chunk_mut().store_updates().take();
+
+            self.post_process_upserted_events(
+                resolved_events.iter().filter_map(|resolved_event| resolved_event.as_resolved()),
+                // Read receipt events aren't encrypted, so we can't have decrypted a new
+                // one here. As a result, we don't have any new receipt events to
+                // post-process, so we can just pass `None` here.
+                //
+                // Note: read receipts may be updated anyhow in the post-processing step,
+                // as the redecryption may have decrypted some events that don't count as
+                // unreads.
+                None,
+            )
+            .await?;
 
             Some(self.room_linked_chunk_mut().updates_as_vector_diffs())
         } else {

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -299,23 +299,28 @@ impl ThreadEventCache {
         // calling this method.
         let _ = state.thread_linked_chunk_mut().store_updates().take();
 
-        Ok(
-            if let Some(timeline_event_diffs) = timeline_event_diffs
-                && !timeline_event_diffs.is_empty()
-            {
-                state.update_sender.send(
-                    TimelineVectorDiffs {
-                        diffs: timeline_event_diffs,
-                        origin: EventsOrigin::Cache,
-                    },
-                    Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
-                );
+        state
+            .post_process_upserted_events(
+                resolved_events.iter().filter_map(|resolved_event| resolved_event.as_resolved()),
+            )
+            .await?;
 
-                true
-            } else {
-                false
-            },
-        )
+        let timeline_event_diffs = timeline_event_diffs
+            .into_iter()
+            .flatten()
+            .chain(state.thread_linked_chunk_mut().updates_as_vector_diffs())
+            .collect::<Vec<_>>();
+
+        Ok(if !timeline_event_diffs.is_empty() {
+            state.update_sender.send(
+                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Cache },
+                Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
+            );
+
+            true
+        } else {
+            false
+        })
     }
 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -380,7 +380,7 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         state.state.propagate_changes(&state.store).await?;
 
         // Post-process newly inserted events.
-        state.post_process_upserted_events(topo_ordered_events).await?;
+        state.post_process_upserted_events(topo_ordered_events.iter()).await?;
 
         // Notify observers about the updates.
         let timeline_event_diffs = state.thread_linked_chunk_mut().updates_as_vector_diffs();

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -376,7 +376,11 @@ impl PaginatedCache for ThreadEventCacheWrapper {
             &topo_ordered_events,
         );
 
+        // Update the store.
         state.state.propagate_changes(&state.store).await?;
+
+        // Post-process newly inserted events.
+        state.post_process_upserted_events(topo_ordered_events).await?;
 
         // Notify observers about the updates.
         let timeline_event_diffs = state.thread_linked_chunk_mut().updates_as_vector_diffs();

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -484,7 +484,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         self.state.propagate_changes(&self.store).await?;
 
         // Post-process newly inserted events.
-        self.post_process_upserted_events(events).await?;
+        self.post_process_upserted_events(events.iter()).await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -501,14 +501,17 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     }
 
     /// Post-process newly inserted or updated events.
-    pub async fn post_process_upserted_events(&mut self, events: Vec<Event>) -> Result<()> {
+    pub async fn post_process_upserted_events<'i, I>(&mut self, events: I) -> Result<()>
+    where
+        I: Iterator<Item = &'i Event>,
+    {
         for event in events {
             // Handle redaction.
-            self.maybe_apply_new_redaction(&event).await?;
+            self.maybe_apply_new_redaction(event).await?;
 
             // Save a bundled thread event, if there was one.
-            if let Some(bundled_thread) = event.bundled_latest_thread_event {
-                self.save_events([*bundled_thread]).await?;
+            if let Some(bundled_thread) = &event.bundled_latest_thread_event {
+                self.save_events([*bundled_thread.clone()]).await?;
             }
         }
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -501,7 +501,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     }
 
     /// Post-process newly inserted or updated events.
-    pub async fn post_process_upserted_events<'i, I>(&mut self, events: I) -> Result<()>
+    pub(super) async fn post_process_upserted_events<'i, I>(&mut self, events: I) -> Result<()>
     where
         I: Iterator<Item = &'i Event>,
     {

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -480,7 +480,11 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             &events,
         );
 
+        // Update the store.
         self.state.propagate_changes(&self.store).await?;
+
+        // Post-process newly inserted events.
+        self.post_process_upserted_events(events).await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -491,7 +495,13 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
         }
 
-        // Do stuff for each event.
+        let timeline_event_diffs = self.state.thread_linked_chunk.updates_as_vector_diffs();
+
+        Ok((has_new_gap, timeline_event_diffs))
+    }
+
+    /// Post-process newly inserted or updated events.
+    pub async fn post_process_upserted_events(&mut self, events: Vec<Event>) -> Result<()> {
         for event in events {
             // Handle redaction.
             self.maybe_apply_new_redaction(&event).await?;
@@ -502,9 +512,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             }
         }
 
-        let timeline_event_diffs = self.state.thread_linked_chunk.updates_as_vector_diffs();
-
-        Ok((has_new_gap, timeline_event_diffs))
+        Ok(())
     }
 
     /// If the given event is a redaction, try to retrieve the

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -506,31 +506,21 @@ impl EventCache {
                 }
             }
 
-            let resolved_events = maybe_resolved_events
-                .iter()
-                .filter_map(|resolved_event| resolved_event.as_resolved())
-                .cloned()
-                .collect::<Vec<_>>();
-
             // Replace all resolved events in the store.
-            state.save_events(resolved_events.clone().into_iter()).await?;
+            state
+                .save_events(
+                    maybe_resolved_events
+                        .iter()
+                        .filter_map(|resolved_event| resolved_event.as_resolved())
+                        .cloned(),
+                )
+                .await?;
 
             // Now, replace the in-memory events.
-            let mut timeline_event_diffs =
-                state.replace_in_memory_utds(&maybe_resolved_in_memory_events)?.unwrap_or_default();
-
-            // Read receipt events aren't encrypted, so we can't have decrypted a new
-            // one here. As a result, we don't have any new receipt events to
-            // post-process, so we can just pass `None` here.
-            //
-            // Note: read receipts may be updated anyhow in the post-processing step,
-            // as the redecryption may have decrypted some events that don't count as
-            // unreads.
-            let receipt_event = None;
-
-            state.post_process_upserted_events(resolved_events, receipt_event).await?;
-
-            timeline_event_diffs.extend(state.room_linked_chunk_mut().updates_as_vector_diffs());
+            let timeline_event_diffs = state
+                .replace_in_memory_utds(&maybe_resolved_in_memory_events)
+                .await?
+                .unwrap_or_default();
 
             if !timeline_event_diffs.is_empty() {
                 state.update_sender.send(

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -528,7 +528,7 @@ impl EventCache {
             // unreads.
             let receipt_event = None;
 
-            state.post_process_new_events(resolved_events, receipt_event).await?;
+            state.post_process_upserted_events(resolved_events, receipt_event).await?;
 
             timeline_event_diffs.extend(state.room_linked_chunk_mut().updates_as_vector_diffs());
 


### PR DESCRIPTION
This patch revisits the post-processing of new events.

This post-process exists only in `RoomEventCache`. So, it's introduced in `ThreadEventCache` for several reasons:

- it must run in the Pagination,
- it must run in the Redecryptor.

`ThreadEventCache::post_process_upserted_events` does the following:

- apply new redactions,
- save bundled latest thread event,
- (later read receipt).

The new design saves the allocations of all resolved events (via a clone) in the Redecryptor. It also isolates a bit better when the post-processors are called since it is called by `replace_in_memory_utds` instead of by the Redecryptor directly.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
