### PR TITLE
chore: Update `eyeball-im`, `eyeball-im-utils` and `imbl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4790c03df183c2b46665c1a58118c04fd3e3976ec2fe16a0aa00e00c9eea7754"
+checksum = "3cf0c52231b6a6c3e262e5d69cbb425506abcce15bdd4c235fbb0d2a62ff64a2"
 dependencies = [
  "futures-core",
  "imbl",
@@ -2101,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809fa2e8e59c25a41f5b2440aa937f1e84df6ae48b707e65f69ce259b1c44bda"
+checksum = "bdcd038306bd720751aaf9881dfe952379413f463535ff6ee7c6e7e96067169d"
 dependencies = [
  "arrayvec",
  "eyeball-im",
@@ -3012,17 +3012,19 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "6.1.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
 dependencies = [
  "archery",
  "bitmaps",
+ "equivalent",
  "imbl-sized-chunks",
  "rand_core 0.9.3",
  "rand_xoshiro",
- "serde",
+ "serde_core",
  "version_check",
+ "wide",
 ]
 
 [[package]]
@@ -5747,6 +5749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7802,6 +7813,16 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ clap = { version = "4.6.4", default-features = false, features = ["std", "help",
 chrono = { version = "0.4.45", default-features = false, features = ["clock", "std", "oldtime", "wasmbind"] }
 dirs = { version = "6.0.0", default-features = false }
 eyeball = { version = "0.8.8", default-features = false, features = ["tracing"] }
-eyeball-im = { version = "0.8.0", default-features = false, features = ["tracing"] }
-eyeball-im-util = { version = "0.10.0", default-features = false }
+eyeball-im = { version = "0.9.0", default-features = false, features = ["tracing"] }
+eyeball-im-util = { version = "0.11.0", default-features = false }
 futures-core = { version = "0.3.33", default-features = false, features = ["std"] }
 futures-executor = { version = "0.3.33", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.33", default-features = false, features = ["std"] }
@@ -49,7 +49,7 @@ growable-bloom-filter = { version = "2.1.1", default-features = false }
 hkdf = "0.13.0"
 hmac = "0.13.0"
 http = { version = "1.5.0", default-features = false }
-imbl = { version = "6.1.0", default-features = false }
+imbl = { version = "7.0.1", default-features = false }
 indexed_db_futures = { version = "0.7.0", package = "matrix_indexed_db_futures", default-features = false }
 indexmap = { version = "2.14.0", default-features = false }
 insta = { version = "1.48.0", features = ["json", "redactions"] }


### PR DESCRIPTION
This patch updates `imbl` from 6 to 7, to include
https://github.com/jneem/imbl/pull/164.

This is done by updating `eyeball-im` and `eyeball-im-util`, see https://codeberg.org/jplatte/eyeball/pulls/2.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
