### PR TITLE
feat(ui): Add `Timeline::send_location`, moved from the FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6891.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6891.changed.md
@@ -1,0 +1,1 @@
+`Timeline::send_location` is now a thin wrapper around the new `matrix_sdk_ui::Timeline::send_location`. Its signature is unchanged, but invalid input now returns an error instead of the old silent behavior: an out-of-range `zoom_level` (above 20) and `AssetType::Unknown` are rejected, where before the zoom level was silently dropped and the unknown asset type caused a panic.

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -41,7 +41,7 @@ use ruma::{
     EventId, UInt, assign,
     events::{
         AnyMessageLikeEventContent,
-        location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
+        location::{AssetType as RumaAssetType, ZoomLevel},
         poll::{
             unstable_end::UnstablePollEndEventContent,
             unstable_response::UnstablePollResponseEventContent,
@@ -51,8 +51,7 @@ use ruma::{
             },
         },
         room::message::{
-            LocationMessageEventContent, MessageType, RoomMessageEventContentWithoutRelation,
-            TextMessageEventContent,
+            MessageType, RoomMessageEventContentWithoutRelation, TextMessageEventContent,
         },
     },
 };
@@ -612,28 +611,36 @@ impl Timeline {
         asset_type: Option<AssetType>,
         replied_to_event_id: Option<String>,
     ) -> Result<(), ClientError> {
-        let mut location_event_message_content =
-            LocationMessageEventContent::new(body, geo_uri.clone());
-
-        if let Some(asset_type) = asset_type {
-            location_event_message_content =
-                location_event_message_content.with_asset_type(RumaAssetType::from(asset_type));
+        if matches!(asset_type, Some(AssetType::Unknown)) {
+            return Err(ClientError::Generic {
+                msg: "cannot send a location with an unknown asset type".to_owned(),
+                details: None,
+            });
         }
 
-        let mut location_content = LocationContent::new(geo_uri);
-        location_content.description = description;
-        location_content.zoom_level = zoom_level.and_then(ZoomLevel::new);
-        location_event_message_content.location = Some(location_content);
+        let zoom_level = zoom_level
+            .map(|zoom| {
+                ZoomLevel::new(zoom).ok_or_else(|| ClientError::Generic {
+                    msg: format!("zoom level {zoom} is out of range"),
+                    details: None,
+                })
+            })
+            .transpose()?;
 
-        let room_message_event_content = RoomMessageEventContentWithoutRelation::new(
-            MessageType::Location(location_event_message_content),
-        );
+        let in_reply_to = replied_to_event_id
+            .map(|id| EventId::parse(id).map_err(|_| RoomError::InvalidRepliedToEventId))
+            .transpose()?;
 
-        if let Some(replied_to_event_id) = replied_to_event_id {
-            self.send_reply(Arc::new(room_message_event_content), replied_to_event_id).await?;
-        } else {
-            self.send(Arc::new(room_message_event_content)).await?;
-        }
+        self.inner
+            .send_location(
+                body,
+                geo_uri,
+                description,
+                zoom_level,
+                asset_type.map(RumaAssetType::from),
+                in_reply_to,
+            )
+            .await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-ui/changelog.d/6891.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6891.added.md
@@ -1,0 +1,4 @@
+Add `Timeline::send_location`, moved from the FFI bindings. It builds a
+`m.location` room message, sends it through the send queue, and returns the
+`SendHandle`. It optionally sends the location as a reply, with the same
+semantics as `Timeline::send_reply`.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -44,11 +44,13 @@ use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent, Mentions,
+        location::{AssetType, LocationContent, ZoomLevel},
         poll::unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
         receipt::{Receipt, ReceiptThread},
         relation::Thread,
         room::message::{
-            AddMentions, Relation, RelationWithoutReplacement, ReplyWithinThread,
+            AddMentions, LocationMessageEventContent, MessageType, Relation,
+            RelationWithoutReplacement, ReplyWithinThread, RoomMessageEventContent,
             RoomMessageEventContentWithoutRelation, TextMessageEventContent,
         },
     },
@@ -425,6 +427,41 @@ impl Timeline {
             .expect("the reply will always be set because we provided a replied-to event id");
         let content = self.room().make_reply_event(content, reply).await?;
         self.send(content.into()).await
+    }
+
+    /// Send a location event to the room, with `body` as the plain-text
+    /// fallback and `geo_uri` its RFC 5870 representation. With `in_reply_to`,
+    /// the location is sent as a reply, with [`Self::send_reply`] semantics.
+    #[instrument(skip(self, body, geo_uri, description))]
+    pub async fn send_location(
+        &self,
+        body: String,
+        geo_uri: String,
+        description: Option<String>,
+        zoom_level: Option<ZoomLevel>,
+        asset_type: Option<AssetType>,
+        in_reply_to: Option<OwnedEventId>,
+    ) -> Result<SendHandle, Error> {
+        let mut content = LocationMessageEventContent::new(body, geo_uri.clone());
+
+        if let Some(asset_type) = asset_type {
+            content = content.with_asset_type(asset_type);
+        }
+
+        let mut location = LocationContent::new(geo_uri);
+        location.description = description;
+        location.zoom_level = zoom_level;
+        content.location = Some(location);
+
+        let msgtype = MessageType::Location(content);
+
+        match in_reply_to {
+            Some(event_id) => {
+                self.send_reply(RoomMessageEventContentWithoutRelation::new(msgtype), event_id)
+                    .await
+            }
+            None => self.send(RoomMessageEventContent::new(msgtype).into()).await,
+        }
     }
 
     /// Given a message or media to send, and an optional `in_reply_to` event,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/location.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/location.rs
@@ -1,0 +1,189 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use assert_matches2::assert_let;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
+use matrix_sdk_base::timeout::timeout;
+use matrix_sdk_test::{BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use matrix_sdk_ui::timeline::{EventSendState, RoomExt};
+use ruma::{
+    event_id,
+    events::{
+        location::{AssetType, ZoomLevel},
+        room::message::MessageType,
+    },
+    room_id,
+};
+use serde_json::json;
+use stream_assert::assert_next_matches;
+use tokio::task::yield_now;
+use wiremock::{Request, ResponseTemplate};
+
+#[async_test]
+async fn test_send_location() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    server
+        .mock_room_send()
+        .respond_with(|req: &Request| {
+            let content: serde_json::Value = req.body_json().unwrap();
+
+            assert_eq!(content["msgtype"], "m.location");
+            assert_eq!(content["body"], "Big Ben");
+            assert_eq!(content["geo_uri"], "geo:51.5008,-0.1247");
+            let location = &content["org.matrix.msc3488.location"];
+            assert_eq!(location["uri"], "geo:51.5008,-0.1247");
+            assert_eq!(location["description"], "Elizabeth Tower");
+            assert_eq!(location["zoom_level"], 10);
+            assert_eq!(content["org.matrix.msc3488.asset"]["type"], "m.pin");
+            assert!(content.get("m.relates_to").is_none());
+
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$location_event" }))
+        })
+        .expect(1)
+        .mount()
+        .await;
+
+    timeline
+        .send_location(
+            "Big Ben".to_owned(),
+            "geo:51.5008,-0.1247".to_owned(),
+            Some("Elizabeth Tower".to_owned()),
+            ZoomLevel::new(10),
+            Some(AssetType::Pin),
+            None,
+        )
+        .await
+        .unwrap();
+
+    yield_now().await;
+
+    let item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
+    let message = item.content().as_message().unwrap();
+    assert_let!(MessageType::Location(location) = message.msgtype());
+    assert_eq!(location.geo_uri, "geo:51.5008,-0.1247");
+
+    let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
+    assert_let!(VectorDiff::Set { index: 0, value: remote_echo } = diff);
+    assert_matches!(remote_echo.send_state(), Some(EventSendState::Sent { .. }));
+}
+
+#[async_test]
+async fn test_send_location_as_reply() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    let event_id_from_bob = event_id!("$event_from_bob");
+    let f = EventFactory::new();
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("Where are you?").sender(&BOB).event_id(event_id_from_bob),
+            ),
+        )
+        .await;
+
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { .. });
+
+    server
+        .mock_room_send()
+        .respond_with(move |req: &Request| {
+            let content: serde_json::Value = req.body_json().unwrap();
+
+            assert_eq!(content["msgtype"], "m.location");
+            assert_eq!(
+                content["m.relates_to"]["m.in_reply_to"]["event_id"],
+                event_id_from_bob.as_str()
+            );
+            assert_eq!(content["m.mentions"]["user_ids"], json!([BOB.as_str()]));
+
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$location_event" }))
+        })
+        .expect(1)
+        .mount()
+        .await;
+
+    timeline
+        .send_location(
+            "Here".to_owned(),
+            "geo:51.5008,-0.1247".to_owned(),
+            None,
+            None,
+            None,
+            Some(event_id_from_bob.to_owned()),
+        )
+        .await
+        .unwrap();
+
+    yield_now().await;
+
+    let item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    let msglike = item.content().as_msglike().unwrap();
+    assert_eq!(msglike.in_reply_to.clone().unwrap().event_id, event_id_from_bob);
+    let message = item.content().as_message().unwrap();
+    assert_let!(MessageType::Location(location) = message.msgtype());
+    assert_eq!(location.geo_uri, "geo:51.5008,-0.1247");
+
+    let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
+    assert_let!(VectorDiff::Set { index: 1, value: remote_echo } = diff);
+    assert_matches!(remote_echo.send_state(), Some(EventSendState::Sent { .. }));
+}
+
+#[async_test]
+async fn test_send_location_can_be_aborted() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    client.send_queue().set_enabled(false).await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    let handle = timeline
+        .send_location(
+            "Big Ben".to_owned(),
+            "geo:51.5008,-0.1247".to_owned(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_let_timeout!(Some(VectorDiff::PushBack { value: item }) = timeline_stream.next());
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
+
+    assert!(handle.abort().await.unwrap());
+
+    assert_let_timeout!(Some(VectorDiff::Remove { index: 0 }) = timeline_stream.next());
+}

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -48,6 +48,7 @@ mod decryption;
 mod echo;
 mod edit;
 mod focus_event;
+mod location;
 mod media;
 mod pagination;
 mod pinned_event;


### PR DESCRIPTION
`Timeline::send_location` in the FFI built the `m.location` content and picked between `send` and `send_reply` itself, so it was logic living in a binding. As asked in https://github.com/matrix-org/matrix-rust-sdk/pull/6881#issuecomment-5313756795, this PR moves that logic into `matrix_sdk_ui::Timeline::send_location` and turns the FFI method into a thin wrapper with an unchanged signature.

Two FFI behavior changes:

- `AssetType::Unknown` now returns an error instead of a panic.
- An out-of-range `zoom_level` now returns an error instead of a silent drop.

Three new integration tests:

- `test_send_location` sends a plain location and asserts the JSON that goes over the wire (`msgtype`, `geo_uri`, the `org.matrix.msc3488.location` block with description and zoom level, the asset type, and no relation).
- `test_send_location_as_reply` replies to another user's event and asserts the request carries `m.in_reply_to` pointing at that event and a mention of its sender.
- `test_send_location_can_be_aborted` disables the send queue, aborts the location through the returned handle, and waits for the local echo to be removed from the timeline.

**Note:** took the liberty of fixing the flaky `test_generation_counter_invalidates_olm_machine` and its sibling in `crates/matrix-sdk`. It's unrelated to this PR, so lmk if you prefer this be a separate one.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>
