### PR TITLE
Allow add, put, and delete operations in `matrix-sdk-indexeddb` to defer awaiting until transaction commit

### DIFF
--- a/crates/matrix-sdk-indexeddb/changelog.d/6892.changed.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6892.changed.md
@@ -1,0 +1,3 @@
+Defer `await`s in write operations in `Transaction` until calling `Transaction::commit`.
+Additionally, remove `async` modifier from functions that no longer need to be asynchronous
+as a result of the change.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -150,7 +150,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         };
 
         Ok(if let Some(lease) = lease {
-            transaction.put_lease(&lease).await?;
+            transaction.put_lease(&lease)?;
             transaction.commit().await?;
 
             Some(lease.generation)
@@ -188,13 +188,11 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                 }
                 Update::NewGapChunk { previous, new, next, gap } => {
                     trace!(%linked_chunk_id, "Inserting new gap (prev={previous:?}, new={new:?}, next={next:?})");
-                    transaction
-                        .add_item(&types::Gap {
-                            linked_chunk_id: linked_chunk_id.to_owned(),
-                            chunk_identifier: new.index(),
-                            token: gap.token,
-                        })
-                        .await?;
+                    transaction.add_item(&types::Gap {
+                        linked_chunk_id: linked_chunk_id.to_owned(),
+                        chunk_identifier: new.index(),
+                        token: gap.token,
+                    })?;
                     transaction
                         .add_chunk(&types::Chunk {
                             linked_chunk_id: linked_chunk_id.to_owned(),
@@ -439,7 +437,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
             thread_id: thread_id.to_owned(),
             info: ThreadInfo::new(),
         };
-        transaction.update_thread_info(&thread).await?;
+        transaction.update_thread_info(&thread)?;
         transaction.commit().await?;
 
         Ok(thread.info)
@@ -461,7 +459,7 @@ impl EventCacheStore for IndexeddbEventCacheStore {
             thread_id: thread_id.to_owned(),
             info: thread_info.clone(),
         };
-        transaction.update_thread_info(&thread).await?;
+        transaction.update_thread_info(&thread)?;
         transaction.commit().await?;
 
         Ok(())
@@ -482,9 +480,9 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         match room_id {
             // Clear all events.
             None => {
-                transaction.clear::<types::Chunk>().await?;
-                transaction.clear::<types::Event>().await?;
-                transaction.clear::<types::Gap>().await?;
+                transaction.clear::<types::Chunk>()?;
+                transaction.clear::<types::Event>()?;
+                transaction.clear::<types::Gap>()?;
                 transaction.commit().await?;
             }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -149,8 +149,8 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// exists, it will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`IndexedLease`] in case
     /// inspection is needed.
-    pub async fn put_lease(&self, lease: &Lease) -> Result<IndexedLease, TransactionError> {
-        self.put_item(lease).await
+    pub fn put_lease(&self, lease: &Lease) -> Result<IndexedLease, TransactionError> {
+        self.put_item(lease)
     }
 
     /// Query IndexedDB for chunks that match the given chunk identifier and the
@@ -257,7 +257,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// function returns the intermediary type [`IndexedChunk`] in case
     /// inspection is needed.
     pub async fn add_chunk(&self, chunk: &Chunk) -> Result<IndexedChunk, TransactionError> {
-        let indexed = self.add_item(chunk).await?;
+        let indexed = self.add_item(chunk)?;
         if let Some(previous) = chunk.previous {
             let previous_identifier = ChunkIdentifier::new(previous);
             let mut previous_chunk = self
@@ -265,7 +265,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
                 .await?
                 .ok_or(TransactionError::ItemNotFound)?;
             previous_chunk.next = Some(chunk.identifier);
-            self.put_item(&previous_chunk).await?;
+            self.put_item(&previous_chunk)?;
         }
         if let Some(next) = chunk.next {
             let next_identifier = ChunkIdentifier::new(next);
@@ -274,7 +274,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
                 .await?
                 .ok_or(TransactionError::ItemNotFound)?;
             next_chunk.previous = Some(chunk.identifier);
-            self.put_item(&next_chunk).await?;
+            self.put_item(&next_chunk)?;
         }
         Ok(indexed)
     }
@@ -295,7 +295,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
                     self.get_chunk_by_id(linked_chunk_id, previous_identifier).await?
                 {
                     previous_chunk.next = chunk.next;
-                    self.put_item(&previous_chunk).await?;
+                    self.put_item(&previous_chunk)?;
                 }
             }
             if let Some(next) = chunk.next {
@@ -304,7 +304,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
                     self.get_chunk_by_id(linked_chunk_id, next_identifier).await?
                 {
                     next_chunk.previous = chunk.previous;
-                    self.put_item(&next_chunk).await?;
+                    self.put_item(&next_chunk)?;
                 }
             }
             self.delete_item_by_key::<Chunk, IndexedChunkIdKey>((linked_chunk_id, chunk_id))
@@ -461,9 +461,9 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
 
         let indexed =
             if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
-                self.put_item(event).await?
+                self.put_item(event)?
             } else {
-                self.add_item(event).await?
+                self.add_item(event)?
             };
 
         self.update_events_by_event_id(event_id, |existing| {
@@ -487,7 +487,7 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
             return Err(TransactionError::Serialization(Box::new(IndexedEventError::NoEventId)));
         };
 
-        let indexed = self.put_item(event).await?;
+        let indexed = self.put_item(event)?;
 
         self.update_events_by_event_id(event_id, |existing| {
             existing.with_content(event.content().clone())
@@ -641,11 +641,8 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     }
 
     /// Update a thread info.
-    pub async fn update_thread_info(
-        &self,
-        thread: &Thread,
-    ) -> Result<IndexedThread, TransactionError> {
-        self.put_item(thread).await
+    pub fn update_thread_info(&self, thread: &Thread) -> Result<IndexedThread, TransactionError> {
+        self.put_item(thread)
     }
 
     /// List all threads (remembered with [`Self::update_thread_info`]) for a

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -151,7 +151,7 @@ impl MediaStore for IndexeddbMediaStore {
         };
 
         Ok(if let Some(lease) = lease {
-            transaction.put_lease(&lease).await?;
+            transaction.put_lease(&lease)?;
             transaction.commit().await?;
 
             Some(lease.generation)
@@ -185,7 +185,7 @@ impl MediaStore for IndexeddbMediaStore {
             // delete before adding, in case `from` and `to` generate the same key
             transaction.delete_media_metadata_by_id(from).await?;
             metadata.request_parameters = to.clone();
-            transaction.add_media_metadata(&metadata).await?;
+            transaction.add_media_metadata(&metadata)?;
             transaction.commit().await?;
         }
         Ok(())
@@ -303,7 +303,7 @@ impl MediaStoreInner for IndexeddbMediaStore {
 
         let transaction =
             self.transaction(&[MediaRetentionPolicy::OBJECT_STORE], TransactionMode::Readwrite)?;
-        transaction.put_item(&policy).await?;
+        transaction.put_item(&policy)?;
         transaction.commit().await.map_err(Into::into)
     }
 
@@ -348,7 +348,7 @@ impl MediaStoreInner for IndexeddbMediaStore {
             && metadata.ignore_policy != ignore_policy
         {
             metadata.ignore_policy = ignore_policy;
-            transaction.put_media_metadata(&metadata).await?;
+            transaction.put_media_metadata(&metadata)?;
             transaction.commit().await?;
         }
         Ok(())
@@ -437,7 +437,7 @@ impl MediaStoreInner for IndexeddbMediaStore {
             }
         }
 
-        transaction.put_media_cleanup_time(current_time).await?;
+        transaction.put_media_cleanup_time(current_time)?;
         transaction.commit().await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -79,8 +79,8 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
     /// exists, it will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`IndexedLease`] in case
     /// inspection is needed.
-    pub async fn put_lease(&self, lease: &Lease) -> Result<IndexedLease, TransactionError> {
-        self.transaction.put_item(lease).await
+    pub fn put_lease(&self, lease: &Lease) -> Result<IndexedLease, TransactionError> {
+        self.transaction.put_item(lease)
     }
 
     /// Query IndexedDB for the stored [`MediaRetentionPolicy`]
@@ -103,12 +103,12 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
     /// will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`IndexedMediaCLeanupTime`] in
     /// case inspection is needed.
-    pub async fn put_media_cleanup_time(
+    pub fn put_media_cleanup_time(
         &self,
         time: impl Into<MediaCleanupTime>,
     ) -> Result<IndexedMediaCleanupTime, TransactionError> {
         let time: MediaCleanupTime = time.into();
-        self.transaction.put_item(&time).await
+        self.transaction.put_item(&time)
     }
 
     /// Query IndexedDB for [`MediaMetadata`] and [`MediaContent`] that matches
@@ -174,20 +174,18 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         };
         let content = MediaContent { content_id, data: media.content };
         let option = if media.ignore_policy.is_yes() {
-            self.put_media_content(&content).await.map(Some)?
+            self.put_media_content(&content).map(Some)?
         } else {
-            self.put_media_content_if_policy_compliant(&content, policy).await?
+            self.put_media_content_if_policy_compliant(&content, policy)?
         };
         if let Some(indexed_content) = option {
-            let indexed_metadata = self
-                .put_media_metadata(&MediaMetadata {
-                    request_parameters: media.request_parameters,
-                    last_access: media.last_access,
-                    ignore_policy: media.ignore_policy,
-                    content_id,
-                    content_size: indexed_content.content.len(),
-                })
-                .await?;
+            let indexed_metadata = self.put_media_metadata(&MediaMetadata {
+                request_parameters: media.request_parameters,
+                last_access: media.last_access,
+                ignore_policy: media.ignore_policy,
+                content_id,
+                content_size: indexed_content.content.len(),
+            })?;
             Ok(Some((indexed_metadata, indexed_content)))
         } else {
             Ok(None)
@@ -327,7 +325,7 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         if let Some(mut media_metadata) = self.get_media_metadata_by_id(request_parameters).await? {
             let last_access = media_metadata.last_access;
             media_metadata.last_access = current_time.into();
-            self.put_item(&media_metadata).await?;
+            self.put_item(&media_metadata)?;
             media_metadata.last_access = last_access;
             Ok(Some(media_metadata))
         } else {
@@ -357,7 +355,7 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         for mut media_metadata in self.get_media_metadata_by_uri(uri).await? {
             let last_access = media_metadata.last_access;
             media_metadata.last_access = current_time;
-            self.put_item(&media_metadata).await?;
+            self.put_item(&media_metadata)?;
             media_metadata.last_access = last_access;
             media_metadatas.push(media_metadata);
         }
@@ -456,22 +454,22 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
     /// already exists, it will be rejected. When the item is successfully
     /// added, the function returns the intermediary type
     /// [`IndexedMediaMetadata`] in case inspection is needed.
-    pub async fn add_media_metadata(
+    pub fn add_media_metadata(
         &self,
         media_metadata: &MediaMetadata,
     ) -> Result<IndexedMediaMetadata, TransactionError> {
-        self.add_item(media_metadata).await
+        self.add_item(media_metadata)
     }
 
     /// Puts [`MediaMetadata`] in IndexedDB object. If an item with the same key
     /// already exists, it will be overwritten. When the item is successfully
     /// put, the function returns the intermediary type
     /// [`IndexedMediaMetadata`] in case inspection is needed.
-    pub async fn put_media_metadata(
+    pub fn put_media_metadata(
         &self,
         media_metadata: &MediaMetadata,
     ) -> Result<IndexedMediaMetadata, TransactionError> {
-        self.put_item(media_metadata).await
+        self.put_item(media_metadata)
     }
 
     /// Delete [`MediaMetadata`] that match the given [`MediaRequestParameters`]
@@ -591,22 +589,22 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
     /// exists, it will be rejected. When the item is successfully added, the
     /// function returns the intermediary type [`IndexedMediaContent`] in case
     /// inspection is needed.
-    pub async fn add_media_content(
+    pub fn add_media_content(
         &self,
         content: &MediaContent,
     ) -> Result<IndexedMediaContent, TransactionError> {
-        self.add_item(content).await
+        self.add_item(content)
     }
 
     /// Puts [`MediaContent`] in IndexedDB object. If an item with the same key
     /// already exists, it will be overwritten. When the item is successfully
     /// put, the function returns the intermediary type
     /// [`IndexedMediaContent`] in case inspection is needed.
-    pub async fn put_media_content(
+    pub fn put_media_content(
         &self,
         content: &MediaContent,
     ) -> Result<IndexedMediaContent, TransactionError> {
-        self.put_item(content).await
+        self.put_item(content)
     }
 
     /// Adds [`MediaContent`] to IndexedDB if the size of
@@ -615,7 +613,7 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
     /// already exists, it will be overwritten. When the item is successfully
     /// put, the function returns the intermediary type
     /// [`IndexedMediaContent`] in case inspection is needed.
-    pub async fn put_media_content_if_policy_compliant(
+    pub fn put_media_content_if_policy_compliant(
         &self,
         media: &MediaContent,
         policy: MediaRetentionPolicy,
@@ -623,7 +621,6 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         self.put_item_if(media, |indexed| {
             !policy.exceeds_max_file_size(indexed.content.len() as u64)
         })
-        .await
     }
 
     /// Delete [`MediaContent`] that match the given identifier from IndexedDB

--- a/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/transaction/mod.rs
@@ -20,7 +20,7 @@
 
 use futures_util::TryStreamExt;
 use indexed_db_futures::{
-    BuildSerde, cursor::CursorDirection, internals::SystemRepr, query_source::QuerySource,
+    Build, BuildSerde, cursor::CursorDirection, internals::SystemRepr, query_source::QuerySource,
     transaction as inner,
 };
 use serde::{
@@ -366,7 +366,7 @@ impl<'a> Transaction<'a> {
     /// exists, it will be rejected. When the item is successfully added, the
     /// function returns the intermediary type [`Indexed::IndexedType`] in case
     /// inspection is needed.
-    pub async fn add_item<T>(&self, item: &T) -> Result<T::IndexedType, TransactionError>
+    pub fn add_item<T>(&self, item: &T) -> Result<T::IndexedType, TransactionError>
     where
         T: Indexed + Serialize,
         T::IndexedType: Serialize,
@@ -376,7 +376,7 @@ impl<'a> Transaction<'a> {
             .serializer
             .serialize(item)
             .map_err(|e| TransactionError::Serialization(Box::new(e)))?;
-        self.transaction.object_store(T::OBJECT_STORE)?.add(output.value).await?;
+        self.transaction.object_store(T::OBJECT_STORE)?.add(output.value).build()?;
         Ok(output.indexed)
     }
 
@@ -385,7 +385,7 @@ impl<'a> Transaction<'a> {
     /// exists, it will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`Indexed::IndexedType`] in case
     /// inspection is needed.
-    pub async fn put_item<T>(&self, item: &T) -> Result<T::IndexedType, TransactionError>
+    pub fn put_item<T>(&self, item: &T) -> Result<T::IndexedType, TransactionError>
     where
         T: Indexed + Serialize,
         T::IndexedType: Serialize,
@@ -395,7 +395,7 @@ impl<'a> Transaction<'a> {
             .serializer
             .serialize(item)
             .map_err(|e| TransactionError::Serialization(Box::new(e)))?;
-        self.transaction.object_store(T::OBJECT_STORE)?.put(output.value).await?;
+        self.transaction.object_store(T::OBJECT_STORE)?.put(output.value).build()?;
         Ok(output.indexed)
     }
 
@@ -405,7 +405,7 @@ impl<'a> Transaction<'a> {
     /// exists, it will be overwritten. When the item is successfully put, the
     /// function returns the intermediary type [`Indexed::IndexedType`] in case
     /// inspection is needed.
-    pub async fn put_item_if<T>(
+    pub fn put_item_if<T>(
         &self,
         item: &T,
         f: impl Fn(&T::IndexedType) -> bool,
@@ -420,7 +420,7 @@ impl<'a> Transaction<'a> {
             .serialize_if(item, f)
             .map_err(|e| TransactionError::Serialization(Box::new(e)))?;
         if let Some(output) = option {
-            self.transaction.object_store(T::OBJECT_STORE)?.put(output.value).await?;
+            self.transaction.object_store(T::OBJECT_STORE)?.put(output.value).build()?;
             Ok(Some(output.indexed))
         } else {
             Ok(None)
@@ -445,7 +445,7 @@ impl<'a> Transaction<'a> {
         F: Fn(T) -> T,
     {
         for item in self.get_items_by_key_components::<T, K>(range).await? {
-            self.put_item(&f(item)).await?;
+            self.put_item(&f(item))?;
         }
         Ok(())
     }
@@ -472,7 +472,7 @@ impl<'a> Transaction<'a> {
                 }
             }
         } else {
-            object_store.delete(range).serde()?.await?;
+            object_store.delete(range).serde()?;
         }
         Ok(())
     }
@@ -506,10 +506,11 @@ impl<'a> Transaction<'a> {
 
     /// Clear all items of type `T` from the associated object store
     /// `T::OBJECT_STORE` from IndexedDB
-    pub async fn clear<T>(&self) -> Result<(), TransactionError>
+    pub fn clear<T>(&self) -> Result<(), TransactionError>
     where
         T: Indexed,
     {
-        self.transaction.object_store(T::OBJECT_STORE)?.clear()?.await.map_err(Into::into)
+        self.transaction.object_store(T::OBJECT_STORE)?.clear()?;
+        Ok(())
     }
 }


### PR DESCRIPTION
In the [`indexed_db_futures`](https://docs.rs/indexed_db_futures/latest/indexed_db_futures/index.html) crate which is used in `matrix-sdk-indexeddb`, operations are sent out 

> ...immediately after being built, not after being awaited.[^1]

However, all of the add, put, and delete operations in `matrix-sdk-indexeddb` are being `await`ed at the call site, which means that when adding many operations to a single transaction, each is being `await`ed serially.

This pull request aims to remove `await`s wherever possible, so that they may be deferred until the transaction is committed.

## Example

To illustrate the change, let's consider an example case from the codebase. Below is an excerpt from the IndexedDB implementation of `EventCacheStore::clear_all_events`[^2].

```rust
impl EventCacheStore for IndexeddbEventCacheStore {
    async fn clear_all_events(
        &self,
        room_id: Option<&RoomId>,
    ) -> Result<(), IndexeddbEventCacheStoreError> {
        let _timer = timer!("method");

        let transaction = self.transaction(
            &[keys::LINKED_CHUNKS, keys::EVENTS, keys::GAPS, keys::THREADS],
            IdbTransactionMode::Readwrite,
        )?;

        match room_id {
            None => {
                transaction.clear::<types::Chunk>().await?;
                transaction.clear::<types::Event>().await?;
                transaction.clear::<types::Gap>().await?;
                transaction.commit().await?;
            },
            Some(_) => { // -- snip -- },
        }
        Ok(())
    }
}
```

Notice that each object store is cleared, but these operation are `await`ed individually. Then the transaction is committed and `await`ed once again. The individual `await`s are not necessary, as the operations are attached to the transaction and are all `await`ed when calling `transaction.commit().await`.

Note, however, that in cases where information is being retrieved from the database, `await`ing is necessary in order to receive the desired information.

## Changes

The changes in this pull request largely entail removing unnecessary `await`s in `matrix_sdk_indexeddb::transaction`, and additionally removing `async` from any function signatures that no longer need it. This change is then propagated to any callers of the relevant functions. These changes were ultimately limited to the `event_cache_store` and `media_store` modules.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>


[^1]: https://docs.rs/indexed_db_futures/latest/indexed_db_futures/index.html#builders
[^2]: https://github.com/matrix-org/matrix-rust-sdk/blob/b479a6f09c86dec73d3389c1cc039efa8f62250b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs#L436-L487