### PR TITLE
feat(sdk): Add `ThreadInfo` with its own `ReadReceipts`

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6893.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6893.added.md
@@ -1,0 +1,8 @@
+We welcome the new `ThreadInfo` type! It is similar to `RoomInfo`, but tailored
+to threads!
+
+This type is managed by the Event Cache (`matrix_sdk::event_cache`).
+Consequently, the `EventCacheStore` trait gains 2 new methods:
+
+1. `load_thread_info` to load a `ThreadInfo`,
+2. `update_thread_info` to update a `ThreadInfo`.

--- a/crates/matrix-sdk-base/changelog.d/6893.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/6893.changed.md
@@ -1,0 +1,1 @@
+The `EventCacheStore::remember_thread` method has been removed.

--- a/crates/matrix-sdk-base/src/event_cache/mod.rs
+++ b/crates/matrix-sdk-base/src/event_cache/mod.rs
@@ -17,6 +17,7 @@
 use matrix_sdk_common::deserialized_responses::TimelineEvent;
 
 pub mod store;
+pub mod thread;
 
 /// The kind of event the event storage holds.
 pub type Event = TimelineEvent;

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -41,8 +41,11 @@ use ruma::{
     room_id,
 };
 
-use super::DynEventCacheStore;
-use crate::event_cache::{Gap, store::DEFAULT_CHUNK_CAPACITY};
+use super::{
+    super::{Gap, thread::ThreadInfo},
+    DEFAULT_CHUNK_CAPACITY, DynEventCacheStore,
+};
+use crate::read_receipts::ReadReceipts;
 
 /// Create a test event with all data filled, for testing that linked chunk
 /// correctly stores event data.
@@ -191,8 +194,8 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test that loading a linked chunk's metadata works as intended.
     async fn test_load_all_chunks_metadata(&self);
 
-    /// Test that remembering a thread acts as expected.
-    async fn test_remember_thread(&self);
+    /// Test that loading and updating a `ThreadInfo` acts as expected.
+    async fn test_load_and_update_thread_info(&self);
 
     /// Test that clearing all the rooms' events and linked chunks work.
     async fn test_clear_all_events(&self);
@@ -1268,14 +1271,51 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         });
     }
 
-    async fn test_remember_thread(&self) {
+    async fn test_load_and_update_thread_info(&self) {
         let room_id = room_id!("!r0");
         let thread_id = event_id!("$t0");
 
-        assert!(self.remember_thread(room_id, thread_id).await.is_ok());
+        // Load for the first time.
+        //
+        // We must get an empty `ThreadInfo`.
+        let ThreadInfo { read_receipts } = self.load_thread_info(room_id, thread_id).await.unwrap();
+        let ReadReceipts { num_unread, num_notifications, num_mentions, latest_active, pending } =
+            read_receipts;
+        assert_eq!(num_unread, 0);
+        assert_eq!(num_notifications, 0);
+        assert_eq!(num_mentions, 0);
+        assert!(latest_active.is_none());
+        assert!(pending.is_empty());
 
-        // Remember the same thread does return successfully.
-        assert!(self.remember_thread(room_id, thread_id).await.is_ok());
+        // Load for the second time.
+        //
+        // We must get the same empty `ThreadInfo`.
+        let mut thread_info = self.load_thread_info(room_id, thread_id).await.unwrap();
+        let ThreadInfo { read_receipts } = &thread_info;
+        let ReadReceipts { num_unread, num_notifications, num_mentions, latest_active, pending } =
+            read_receipts;
+        assert_eq!(*num_unread, 0);
+        assert_eq!(*num_notifications, 0);
+        assert_eq!(*num_mentions, 0);
+        assert!(latest_active.is_none());
+        assert!(pending.is_empty());
+
+        // Update the `ThreadInfo`.
+        thread_info.read_receipts.num_unread = 1;
+        thread_info.read_receipts.num_notifications = 2;
+        self.update_thread_info(room_id, thread_id, &thread_info).await.unwrap();
+
+        // Load for the third time.
+        //
+        // We must get the updated `ThreadInfo`.
+        let ThreadInfo { read_receipts } = self.load_thread_info(room_id, thread_id).await.unwrap();
+        let ReadReceipts { num_unread, num_notifications, num_mentions, latest_active, pending } =
+            read_receipts;
+        assert_eq!(num_unread, 1);
+        assert_eq!(num_notifications, 2);
+        assert_eq!(num_mentions, 0);
+        assert!(latest_active.is_none());
+        assert!(pending.is_empty());
     }
 
     async fn test_clear_all_events(&self) {
@@ -1293,7 +1333,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // Assume the thread has been “remembered” correctly (this is done in
             // `ThreadEventCacheState::new`).
             if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
-                self.remember_thread(room_id, thread_id).await.unwrap();
+                self.load_thread_info(room_id, thread_id).await.unwrap();
             }
 
             self.handle_linked_chunk_updates(
@@ -1377,7 +1417,7 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             // Assume the thread has been “remembered” correctly (this is done in
             // `ThreadEventCacheState::new`).
             if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
-                self.remember_thread(room_id, thread_id).await.unwrap();
+                self.load_thread_info(room_id, thread_id).await.unwrap();
             }
 
             self.handle_linked_chunk_updates(
@@ -2490,10 +2530,10 @@ macro_rules! event_cache_store_integration_tests {
             }
 
             #[async_test]
-            async fn test_remember_thread() {
+            async fn test_load_and_update_thread_info() {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
-                event_cache_store.test_remember_thread().await;
+                event_cache_store.test_load_and_update_thread_info().await;
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -31,8 +31,10 @@ use matrix_sdk_common::{
 use ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId, events::relation::RelationType};
 use tracing::error;
 
-use super::{EventCacheStore, EventCacheStoreError, Result, extract_event_relation};
-use crate::event_cache::{Event, Gap};
+use super::{
+    super::{Event, Gap, thread::ThreadInfo},
+    EventCacheStore, EventCacheStoreError, Result, extract_event_relation,
+};
 
 /// In-memory, non-persistent implementation of the `EventCacheStore`.
 ///
@@ -57,7 +59,7 @@ struct MemoryStoreInner {
     events: RelationalLinkedChunk<OwnedEventId, Event, Gap>,
 
     /// List of all threads.
-    threads: Vec<(OwnedRoomId, OwnedEventId)>,
+    threads: HashMap<(OwnedRoomId, OwnedEventId), ThreadInfo>,
 }
 
 impl Default for MemoryStore {
@@ -66,7 +68,7 @@ impl Default for MemoryStore {
             inner: Arc::new(StdRwLock::new(MemoryStoreInner {
                 leases: Default::default(),
                 events: RelationalLinkedChunk::new(),
-                threads: Vec::new(),
+                threads: HashMap::new(),
             })),
         }
     }
@@ -170,11 +172,9 @@ impl EventCacheStore for MemoryStore {
         let mut inner = self.inner.write().unwrap();
         let threads = &mut inner.threads;
 
-        let pair = (room_id.to_owned(), thread_id.to_owned());
+        let key = (room_id.to_owned(), thread_id.to_owned());
 
-        if !threads.contains(&pair) {
-            threads.push(pair);
-        }
+        threads.entry(key).or_default();
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -164,17 +164,33 @@ impl EventCacheStore for MemoryStore {
             .map_err(|err| EventCacheStoreError::InvalidData { details: err })
     }
 
-    async fn remember_thread(
+    async fn load_thread_info(
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
+    ) -> Result<ThreadInfo, Self::Error> {
+        let mut inner = self.inner.write().unwrap();
+        let threads = &mut inner.threads;
+
+        let key = (room_id.to_owned(), thread_id.to_owned());
+
+        let thread_info = threads.entry(key).or_default();
+
+        Ok(thread_info.clone())
+    }
+
+    async fn update_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        thread_info: &ThreadInfo,
     ) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().unwrap();
         let threads = &mut inner.threads;
 
         let key = (room_id.to_owned(), thread_id.to_owned());
 
-        threads.entry(key).or_default();
+        *threads.get_mut(&key).expect("The thread entry must exist") = thread_info.clone();
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/event_cache/store/traits.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/traits.rs
@@ -25,8 +25,10 @@ use matrix_sdk_common::{
 };
 use ruma::{EventId, OwnedEventId, RoomId, events::relation::RelationType};
 
-use super::EventCacheStoreError;
-use crate::event_cache::{Event, Gap};
+use super::{
+    super::{Event, Gap, thread::ThreadInfo},
+    EventCacheStoreError,
+};
 
 /// A default capacity for linked chunks, when manipulating in conjunction with
 /// an `EventCacheStore` implementation.
@@ -95,17 +97,30 @@ pub trait EventCacheStore: AsyncTraitDeps {
         before_chunk_identifier: ChunkIdentifier,
     ) -> Result<Option<RawChunk<Event, Gap>>, Self::Error>;
 
-    /// Register a new thread.
+    /// Load the [`ThreadInfo`] associated to `room_id` and `thread_id`.
     ///
-    /// It does nothing regarding events or linked chunks: it simply remembers
-    /// that a thread has been created. This is important if one wants to list
-    /// all threads, or remove specific events or linked chunks.
+    /// If the `ThreadInfo` does not exist, this method **must create** it.
+    /// Consequently, this method is also a way to remember a thread.
     ///
-    /// If the thread already exists, it returns successfully.
-    async fn remember_thread(
+    /// It does nothing regarding events or linked chunks.
+    /// This is important if one wants to list all threads, or remove specific
+    /// events or linked chunks.
+    async fn load_thread_info(
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
+    ) -> Result<ThreadInfo, Self::Error>;
+
+    /// Update the [`ThreadInfo`] associated to `room_id` and `thread_id`.
+    ///
+    /// If it does not exist, this method **must fail**! Normally, the
+    /// `ThreadInfo` must be created automatically with
+    /// [`Self::load_thread_info`], so it must always exist.
+    async fn update_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        thread_info: &ThreadInfo,
     ) -> Result<(), Self::Error>;
 
     /// Clear persisted events for all the rooms if `room_id` is `None`, or a
@@ -269,12 +284,21 @@ impl<T: EventCacheStore> EventCacheStore for EraseEventCacheStoreError<T> {
             .map_err(Into::into)
     }
 
-    async fn remember_thread(
+    async fn load_thread_info(
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
+    ) -> Result<ThreadInfo, Self::Error> {
+        self.0.load_thread_info(room_id, thread_id).await.map_err(Into::into)
+    }
+
+    async fn update_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        thread_info: &ThreadInfo,
     ) -> Result<(), Self::Error> {
-        self.0.remember_thread(room_id, thread_id).await.map_err(Into::into)
+        self.0.update_thread_info(room_id, thread_id, thread_info).await.map_err(Into::into)
     }
 
     async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-base/src/event_cache/thread.rs
+++ b/crates/matrix-sdk-base/src/event_cache/thread.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Threads types related to the Event Cache.
+
+use serde::{Deserialize, Serialize};
+
+use crate::read_receipts::ReadReceipts;
+
+/// All the information about a thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadInfo {
+    /// Read receipts for the current thread.
+    pub read_receipts: ReadReceipts,
+}
+
+impl ThreadInfo {
+    /// Create a new [`ThreadInfo`].
+    pub fn new() -> Self {
+        Self { read_receipts: ReadReceipts::default() }
+    }
+}
+
+impl Default for ThreadInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -18,14 +18,16 @@
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId,
     events::{
-        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-        MessageLikeEventType,
+        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, MessageLikeEventType,
+        receipt::{ReceiptEventContent, SyncReceiptEvent},
         relation::{BundledThread, RelationType},
     },
     room_version_rules::RedactionRules,
     serde::Raw,
 };
 use serde::Deserialize;
+use tracing::error;
 
 use crate::deserialized_responses::{ThreadSummary, ThreadSummaryStatus};
 
@@ -159,6 +161,28 @@ pub fn extract_timestamp(
     }
 
     Some(origin_server_ts)
+}
+
+/// Extract the first valid read receipt event from a list of ephemeral events,
+/// if available.
+pub fn extract_read_receipt(
+    ephemeral_events: &[Raw<AnySyncEphemeralRoomEvent>],
+) -> Option<ReceiptEventContent> {
+    for raw_ephemeral in ephemeral_events {
+        match raw_ephemeral.deserialize() {
+            Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {
+                return Some(content);
+            }
+
+            Ok(_) => {}
+
+            Err(err) => {
+                error!(%err, "error when deserializing an ephemeral event");
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -78,7 +78,8 @@ impl Version {
             Self::V3 => v3::upgrade(transaction).map(Some),
             Self::V4 => v4::upgrade(transaction).map(Some),
             Self::V5 => v5::upgrade(transaction).map(Some),
-            Self::V6 => Ok(None),
+            Self::V6 => v6::upgrade(transaction).map(Some),
+            Self::V7 => Ok(None),
         }
     }
 }
@@ -98,6 +99,8 @@ impl TryFrom<u32> for Version {
             3 => Ok(Version::V3),
             4 => Ok(Version::V4),
             5 => Ok(Version::V5),
+            6 => Ok(Version::V6),
+            7 => Ok(Version::V7),
             v => Err(UnknownVersionError(v)),
         }
     }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v6};
+    use super::{Version, v7};
 
-    pub const VERSION: Version = Version::V6;
-    pub use v6::keys;
+    pub const VERSION: Version = Version::V7;
+    pub use v7::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -64,6 +64,8 @@ pub enum Version {
     V5 = 5,
     /// Version 6 of the database, for details see [`v6`].
     V6 = 6,
+    /// Version 7 of the database, for details see [`v7`].
+    V7 = 7,
 }
 
 impl Version {
@@ -383,7 +385,7 @@ pub mod v5 {
         Ok(())
     }
 
-    /// Upgrade database from `v4` to `v5`
+    /// Upgrade database from `v5` to `v6`
     pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
         v6::empty_event_cache(transaction)?;
         Ok(Version::V6)
@@ -415,6 +417,27 @@ mod v6 {
         let events = transaction.object_store(keys::EVENTS)?;
         events.clear()?;
 
+        let threads = transaction.object_store(keys::THREADS)?;
+        threads.clear()?;
+
+        Ok(())
+    }
+
+    /// Upgrade database from `v6` to `v7`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v7::empty_threads(transaction)?;
+        Ok(Version::V7)
+    }
+}
+
+mod v7 {
+    // Re-use all the same keys from `v6`.
+    pub use super::v6::keys;
+    use super::*;
+
+    /// Clear the threads table, so we can add the new non-optional, encoded
+    /// `info` column at runtime.
+    pub fn empty_threads(transaction: &Transaction<'_>) -> Result<(), Error> {
         let threads = transaction.object_store(keys::THREADS)?;
         threads.clear()?;
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -18,8 +18,9 @@ use std::{collections::HashMap, rc::Rc, time::Duration};
 
 use indexed_db_futures::{Build, database::Database};
 #[cfg(target_family = "wasm")]
-use matrix_sdk_base::cross_process_lock::{
-    CrossProcessLockGeneration, FIRST_CROSS_PROCESS_LOCK_GENERATION,
+use matrix_sdk_base::{
+    cross_process_lock::{CrossProcessLockGeneration, FIRST_CROSS_PROCESS_LOCK_GENERATION},
+    event_cache::thread::ThreadInfo,
 };
 use matrix_sdk_base::{
     event_cache::{Event, Gap, store::EventCacheStore},
@@ -424,7 +425,11 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         let _timer = timer!("method");
 
         let transaction = self.transaction(&[keys::THREADS], IdbTransactionMode::Readwrite)?;
-        let thread = Thread { room_id: room_id.to_owned(), thread_id: thread_id.to_owned() };
+        let thread = Thread {
+            room_id: room_id.to_owned(),
+            thread_id: thread_id.to_owned(),
+            info: ThreadInfo::new(),
+        };
 
         transaction.put_thread(&thread).await?;
         transaction.commit().await?;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -417,21 +417,51 @@ impl EventCacheStore for IndexeddbEventCacheStore {
     }
 
     #[instrument(skip(self))]
-    async fn remember_thread(
+    async fn load_thread_info(
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<ThreadInfo, Self::Error> {
         let _timer = timer!("method");
 
+        let transaction = self.transaction(&[keys::THREADS], IdbTransactionMode::Readonly)?;
+
+        if let Some(thread) = transaction.load_thread_info(room_id, thread_id).await? {
+            return Ok(thread.info);
+        }
+
+        drop(transaction);
+
         let transaction = self.transaction(&[keys::THREADS], IdbTransactionMode::Readwrite)?;
+
         let thread = Thread {
             room_id: room_id.to_owned(),
             thread_id: thread_id.to_owned(),
             info: ThreadInfo::new(),
         };
+        transaction.update_thread_info(&thread).await?;
+        transaction.commit().await?;
 
-        transaction.put_thread(&thread).await?;
+        Ok(thread.info)
+    }
+
+    #[instrument(skip(self))]
+    async fn update_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        thread_info: &ThreadInfo,
+    ) -> Result<(), Self::Error> {
+        let _timer = timer!("method");
+
+        let transaction = self.transaction(&[keys::THREADS], IdbTransactionMode::Readwrite)?;
+
+        let thread = Thread {
+            room_id: room_id.to_owned(),
+            thread_id: thread_id.to_owned(),
+            info: thread_info.clone(),
+        };
+        transaction.update_thread_info(&thread).await?;
         transaction.commit().await?;
 
         Ok(())

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -575,13 +575,25 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         self.delete_items_by_linked_chunk_id::<Gap, IndexedGapIdKey>(linked_chunk_id).await
     }
 
-    /// Remember a thread.
-    pub async fn put_thread(&self, thread: &Thread) -> Result<IndexedThread, TransactionError> {
+    /// Load a thread info.
+    pub async fn load_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+    ) -> Result<Option<Thread>, TransactionError> {
+        self.get_item_by_key_components::<Thread, IndexedThreadIdKey>((room_id, thread_id)).await
+    }
+
+    /// Update a thread info.
+    pub async fn update_thread_info(
+        &self,
+        thread: &Thread,
+    ) -> Result<IndexedThread, TransactionError> {
         self.put_item(thread).await
     }
 
-    /// List all threads (remembered with [`Self::put_thread`]) for a particular
-    /// room ID.
+    /// List all threads (remembered with [`Self::update_thread_info`]) for a
+    /// particular room ID.
     pub async fn get_threads_by_room_id(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use matrix_sdk_base::{
     cross_process_lock::CrossProcessLockGeneration,
     deserialized_responses::TimelineEvent,
-    event_cache::store::extract_event_relation,
+    event_cache::{store::extract_event_relation, thread::ThreadInfo},
     linked_chunk::{ChunkIdentifier, LinkedChunkId, OwnedLinkedChunkId},
 };
 use ruma::{EventId, OwnedEventId, OwnedRoomId, RoomId};
@@ -241,6 +241,8 @@ pub struct Thread {
     pub room_id: OwnedRoomId,
     /// The root of the thread.
     pub thread_id: OwnedEventId,
+    /// Information about the thread.
+    pub info: ThreadInfo,
 }
 
 impl Thread {

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/017_threads_with_thread_infos.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/017_threads_with_thread_infos.sql
@@ -1,0 +1,45 @@
+-- We need a place to store `ThreadInfo`, and this is in the `threads` table!
+
+-- We delete the table because we don't want the new column to be optional, and
+-- we cannot provide a default value (because it is encoded).
+DROP TABLE "threads";
+
+CREATE TABLE "threads" (
+    -- This table offers a mapping between encoded `LinkedChunkId::Thread` and
+    -- encoded `RoomId`.
+    --
+    -- Given a `RoomId`, it can be encoded, and then, thanks to this table,
+    -- the encoded `LinkedChunkId` can be retrieved, which allows to query the
+    -- other tables, like `linked_chunks`. In addition, the `EventId` can be
+    -- retrieved, decoded, and used to built back the `LinkedChunkId`.
+
+    -- The encoded `LinkedChunkId` (which is necessarily a `Thread` variant).
+    --
+    -- This value cannot be decoded.
+    linked_chunk_id BLOB NOT NULL,
+
+    -- The encoded `RoomId` from `LinkedChunkId::room_id()`.
+    --
+    -- This value cannot be decoded.
+    room_id BLOB NOT NULL,
+
+    -- The encoded `EventId` from `LinkedChunkId::Thread(_, event_id)`, so it is
+    -- the thread root.
+    --
+    -- This value can be decoded.
+    event_id BLOB NOT NULL,
+
+    -- The encoded `ThreadInfo`.
+    --
+    -- This value can be decodedd.
+    info BLOB NOT NULL,
+
+    -- The unique values are `linked_chunk_id` and `event_id` (`room_id`
+    -- cannot be unique — imagine two threads for the same room, the room ID is
+    -- repeated twice). Having `event_id` in the primary key is not necessary.
+    -- However, having `room_id` in the primary key is important to provide fast
+    -- query from `room_id` to `linked_chunk_id`, which the primary purpose of
+    -- this table (because a `PRIMARY KEY` will create an index automatically)!
+    PRIMARY KEY (linked_chunk_id, room_id)
+)
+WITHOUT ROWID;

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -31,6 +31,7 @@ use matrix_sdk_base::{
     event_cache::{
         Event, Gap,
         store::{EventCacheStore, extract_event_relation},
+        thread::ThreadInfo,
     },
     linked_chunk::{
         ChunkContent, ChunkIdentifier, ChunkIdentifierGenerator, ChunkMetadata, LinkedChunkId,
@@ -137,6 +138,11 @@ impl Encryption {
         let as_str = str::from_utf8(as_slice.as_ref())?;
 
         Ok(EventId::parse(as_str)?)
+    }
+
+    /// Encode a [`ThreadInfo`]).
+    fn encode_thread_info(&self, thread_info: &ThreadInfo) -> Result<Vec<u8>> {
+        self.encode_value(serde_json::to_vec(thread_info)?)
     }
 }
 
@@ -636,6 +642,17 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/016_threads.sql"))?;
             txn.set_db_version(16)
+        })
+        .await?;
+    }
+
+    if version < 17 {
+        debug!("Upgrading database to version 17");
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!(
+                "../migrations/event_cache_store/017_threads_with_thread_infos.sql"
+            ))?;
+            txn.set_db_version(17)
         })
         .await?;
     }
@@ -1372,13 +1389,14 @@ impl EventCacheStore for SqliteEventCacheStore {
             .encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Thread(room_id, thread_id));
         let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
         let hashed_thread_id = self.encryption.encode_thread_id(thread_id)?;
+        let encoded_thread_id = self.encryption.encode_thread_info(&ThreadInfo::new())?;
 
         self.write()
             .await?
             .with_transaction(move |txn| {
                 txn.execute(
-                    "INSERT OR IGNORE INTO threads VALUES (?, ?, ?)",
-                    (hashed_linked_chunk_id, hashed_room_id, hashed_thread_id),
+                    "INSERT OR IGNORE INTO threads VALUES (?, ?, ?, ?)",
+                    (hashed_linked_chunk_id, hashed_room_id, hashed_thread_id, encoded_thread_id),
                 )?;
 
                 Ok(())

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -144,6 +144,11 @@ impl Encryption {
     fn encode_thread_info(&self, thread_info: &ThreadInfo) -> Result<Vec<u8>> {
         self.encode_value(serde_json::to_vec(thread_info)?)
     }
+
+    /// Decode a [`ThreadInfo`].
+    fn decode_thread_info(&self, encoded_thread_info: &[u8]) -> Result<ThreadInfo> {
+        Ok(serde_json::from_slice(&self.decode_value(encoded_thread_info)?)?)
+    }
 }
 
 impl EncryptableStore for Encryption {
@@ -1379,24 +1384,85 @@ impl EventCacheStore for SqliteEventCacheStore {
             .await
     }
 
-    async fn remember_thread(
+    async fn load_thread_info(
         &self,
         room_id: &RoomId,
         thread_id: &EventId,
-    ) -> Result<(), Self::Error> {
-        let hashed_linked_chunk_id = self
-            .encryption
-            .encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Thread(room_id, thread_id));
+    ) -> Result<ThreadInfo, Self::Error> {
+        let linked_chunk_id = LinkedChunkId::Thread(room_id, thread_id);
+        let hashed_linked_chunk_id =
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
+        let encryption = self.encryption.clone();
+
+        // First off, try by selecting the thread info. It's the most common case. If it
+        // doesn't exist, create an empty one.
+        //
+        // We do that with 2 transactions.
+        let maybe_thread_info = self
+            .read()
+            .await?
+            .with_transaction(move |txn| {
+                let maybe_encoded_thread_info = txn
+                    .query_one(
+                        "SELECT info FROM threads WHERE linked_chunk_id = ?",
+                        (hashed_linked_chunk_id,),
+                        |row| row.get::<_, Vec<u8>>(0),
+                    )
+                    .optional()?;
+
+                maybe_encoded_thread_info
+                    .map(|encoded_thread_info| {
+                        encryption.decode_thread_info(encoded_thread_info.as_slice())
+                    })
+                    .transpose()
+            })
+            .await?;
+
+        if let Some(thread_info) = maybe_thread_info {
+            return Ok(thread_info);
+        }
+
+        // The thread doesn't exist, let's create it.
+
+        let thread_info = ThreadInfo::new();
+        let hashed_linked_chunk_id =
+            self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let hashed_room_id = self.encryption.encode_room_id(keys::EVENTS, room_id);
         let hashed_thread_id = self.encryption.encode_thread_id(thread_id)?;
-        let encoded_thread_id = self.encryption.encode_thread_info(&ThreadInfo::new())?;
+        let encoded_thread_id = self.encryption.encode_thread_info(&thread_info)?;
 
         self.write()
             .await?
             .with_transaction(move |txn| {
                 txn.execute(
-                    "INSERT OR IGNORE INTO threads VALUES (?, ?, ?, ?)",
+                    "INSERT INTO threads VALUES (?, ?, ?, ?)",
                     (hashed_linked_chunk_id, hashed_room_id, hashed_thread_id, encoded_thread_id),
+                )?;
+
+                Ok::<(), Self::Error>(())
+            })
+            .await?;
+
+        Ok(thread_info)
+    }
+
+    async fn update_thread_info(
+        &self,
+        room_id: &RoomId,
+        thread_id: &EventId,
+        thread_info: &ThreadInfo,
+    ) -> Result<(), Self::Error> {
+        let hashed_linked_chunk_id = self
+            .encryption
+            .encode_linked_chunk(keys::LINKED_CHUNKS, &LinkedChunkId::Thread(room_id, thread_id));
+        let encoded_thread_info = self.encryption.encode_thread_info(thread_info)?;
+
+        self.write()
+            .await?
+            .with_transaction(move |txn| {
+                txn.execute(
+                    "UPDATE threads SET info = ? WHERE linked_chunk_id = ?",
+                    (encoded_thread_info, hashed_linked_chunk_id),
                 )?;
 
                 Ok(())

--- a/crates/matrix-sdk/changelog.d/6893.added.md
+++ b/crates/matrix-sdk/changelog.d/6893.added.md
@@ -1,0 +1,9 @@
+`ThreadEventCache` gains 4 new methods:
+
+1. `read_receipts` to get the `ReadReceipts` associated to the `ThreadInfo`,
+2. `num_unread_messages` to get the number of unread messages (alias of
+   `read_receipts().await?.num_unread`),
+3. `num_unread_notifications` to get the number of unread notifications (alias
+   of `read_receipts().await?.num_notifications`),
+4. `num_unread_mentions` to get the number of unread mentions (alias of
+   `read_receipts().await?.num_mentions`).

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -18,7 +18,17 @@ use matrix_sdk_base::{
     serde_helpers::{extract_redaction_target, extract_relation, extract_thread_root},
     sync::Timeline,
 };
-use ruma::{OwnedEventId, events::relation::RelationType, room_version_rules::RedactionRules};
+use ruma::{
+    OwnedEventId,
+    events::{
+        AnySyncEphemeralRoomEvent,
+        receipt::{ReceiptThread, SyncReceiptEvent},
+        relation::RelationType,
+    },
+    room_version_rules::RedactionRules,
+    serde::Raw,
+};
+use tracing::error;
 
 use super::{
     super::{Result, states::StateLockReadGuard},
@@ -32,6 +42,7 @@ pub fn aggregate_timeline_for_room(timeline: Timeline) -> Timeline {
 
 pub async fn aggregate_timeline_for_threads<'sync, 'state>(
     timeline: &'sync Timeline,
+    ephemerals: &'sync [Raw<AnySyncEphemeralRoomEvent>],
     existing_threads: StateLockReadGuard<'state, HashMap<OwnedEventId, ThreadEventCacheState>>,
     maybe_room: Option<StateLockReadGuard<'state, RoomEventCacheState>>,
     redaction_rules: &'sync RedactionRules,
@@ -144,6 +155,34 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                             .push(event.clone());
                     }
                 }
+            }
+        }
+    }
+
+    // We must also look in the `ephemeral` events. Maybe the `timeline` is empty,
+    // but some ephemeral events target specific threads.
+    for ephemeral in ephemerals {
+        match ephemeral.deserialize() {
+            Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {
+                for thread_root in content.values().flat_map(|receipts_by_event| {
+                    receipts_by_event.values().flat_map(|receipts| {
+                        receipts.values().filter_map(|receipt| match &receipt.thread {
+                            ReceiptThread::Thread(thread_id) => Some(thread_id),
+                            _ => None,
+                        })
+                    })
+                }) {
+                    new_events_by_thread
+                        .entry(thread_root.to_owned())
+                        .or_insert_with(default_timeline);
+                }
+            }
+
+            // Not a read receipt; not interested for now.
+            Ok(_) => {}
+
+            Err(err) => {
+                error!(%err, "error when deserializing an ephemeral event");
             }
         }
     }

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::Not, sync::Arc};
 
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
@@ -317,6 +317,7 @@ impl Caches {
 
                 aggregator::aggregate_timeline_for_threads(
                     &updates.timeline,
+                    &updates.ephemeral,
                     all_states.threads(),
                     all_states.room(),
                     &internals.room_version_rules.redaction,
@@ -328,13 +329,18 @@ impl Caches {
                 let mut updates = updates.clone();
                 updates.timeline = timeline;
 
+                // Update the thread summary if and only if there are new events.
+                let update_thread_summary = updates.timeline.events.is_empty().not();
+
                 let thread = self.thread(thread_id).await?;
                 thread.handle_joined_room_update(updates).await?;
 
-                let new_thread_summary =
-                    thread.state().read().await?.compute_thread_summary().await?;
+                if update_thread_summary {
+                    let new_thread_summary =
+                        thread.state().read().await?.compute_thread_summary().await?;
 
-                room.update_thread_summary(thread.thread_id(), new_thread_summary).await?;
+                    room.update_thread_summary(thread.thread_id(), new_thread_summary).await?;
+                }
             }
         }
 
@@ -390,6 +396,7 @@ impl Caches {
 
                 aggregator::aggregate_timeline_for_threads(
                     &updates.timeline,
+                    &[],
                     all_caches_states.threads(),
                     all_caches_states.room(),
                     &internals.room_version_rules.redaction,
@@ -403,11 +410,6 @@ impl Caches {
 
                 let thread = self.thread(thread_id).await?;
                 thread.handle_left_room_update(updates).await?;
-
-                let new_thread_summary =
-                    thread.state().read().await?.compute_thread_summary().await?;
-
-                room.update_thread_summary(thread.thread_id(), new_thread_summary).await?;
             }
         }
 

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -99,6 +99,8 @@
 //! [`RoomEventCache`]: super::room::RoomEventCache
 //! [`ThreadEventCache`]: super::thread::ThreadEventCache
 
+use std::ops::Not;
+
 use matrix_sdk_base::{
     read_receipts::{LatestReadReceipt, ReadReceipts},
     serde_helpers::extract_relation,
@@ -112,7 +114,7 @@ use ruma::{
     EventId, OwnedEventId, OwnedUserId, RoomId, UserId,
     events::{
         AnySyncTimelineEvent, MessageLikeEventType,
-        receipt::{ReceiptEventContent, ReceiptThread, ReceiptType},
+        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         relation::RelationType,
     },
     serde::Raw,
@@ -128,12 +130,7 @@ trait ReadReceiptsExt {
     /// event.
     ///
     /// Returns whether a new event triggered a new unread/notification/mention.
-    fn process_event(
-        &mut self,
-        event: &TimelineEvent,
-        user_id: &UserId,
-        with_threading_support: bool,
-    );
+    fn process_event(&mut self, event: &TimelineEvent, user_id: &UserId);
 
     fn reset(&mut self);
 
@@ -143,8 +140,7 @@ trait ReadReceiptsExt {
         &mut self,
         receipt_event_id: &EventId,
         user_id: &UserId,
-        events: impl IntoIterator<Item = &'a TimelineEvent>,
-        with_threading_support: bool,
+        events: impl Iterator<Item = &'a TimelineEvent>,
     ) -> bool;
 }
 
@@ -154,16 +150,7 @@ impl ReadReceiptsExt for ReadReceipts {
     ///
     /// Returns whether a new event triggered a new unread/notification/mention.
     #[inline(always)]
-    fn process_event(
-        &mut self,
-        event: &TimelineEvent,
-        user_id: &UserId,
-        with_threading_support: bool,
-    ) {
-        if with_threading_support && extract_thread_root(event.raw()).is_some() {
-            return;
-        }
-
+    fn process_event(&mut self, event: &TimelineEvent, user_id: &UserId) {
         if marks_as_unread(event.raw(), user_id) {
             self.num_unread += 1;
         }
@@ -201,8 +188,7 @@ impl ReadReceiptsExt for ReadReceipts {
         &mut self,
         receipt_event_id: &EventId,
         user_id: &UserId,
-        events: impl IntoIterator<Item = &'a TimelineEvent>,
-        with_threading_support: bool,
+        events: impl Iterator<Item = &'a TimelineEvent>,
     ) -> bool {
         let mut counting_receipts = false;
 
@@ -220,11 +206,102 @@ impl ReadReceiptsExt for ReadReceipts {
             }
 
             if counting_receipts {
-                self.process_event(event, user_id, with_threading_support);
+                self.process_event(event, user_id);
             }
         }
 
         counting_receipts
+    }
+}
+
+/// A trait to filter events from a [`LinkedChunk`] that will be consumed by
+/// this module.
+pub trait EventFilter {
+    /// Room ID of the room containing all the events.
+    fn room_id(&self) -> &RoomId;
+
+    /// Decide whether an event is a candidate for a read receipt.
+    fn filter(&self, event: &TimelineEvent) -> bool;
+
+    /// Check whether a given [`ReceiptThread`] is valid, i.e. matches our
+    /// expectation of possible `ReceiptThread` for `Self`.
+    fn receipt_thread_matches(&self, receipt_thread: &ReceiptThread) -> bool;
+
+    /// Find the receipt event for a specific user in the store.
+    async fn stored_receipt_event_for_user(
+        &self,
+        user_id: &UserId,
+        receipt_type: ReceiptType,
+    ) -> Option<(OwnedEventId, Receipt)>;
+}
+
+/// Type to filter room events that are candidates for read receipts.
+pub struct RoomReadReceiptEventFilter<'cache> {
+    /// The room ID.
+    room_id: &'cache RoomId,
+
+    /// Whether thread support is enabled.
+    with_threading_support: bool,
+
+    /// The state store to access stored receipt events.
+    state_store: &'cache DynStateStore,
+}
+
+impl<'cache> RoomReadReceiptEventFilter<'cache> {
+    /// Construct a new [`ReadReceiptsForRoom`].
+    pub fn new(
+        room_event_cache_state: &'cache super::room::RoomEventCacheState,
+        state_store: &'cache DynStateStore,
+    ) -> Self {
+        Self {
+            room_id: &room_event_cache_state.room_id,
+            with_threading_support: room_event_cache_state.enabled_thread_support,
+            state_store,
+        }
+    }
+}
+
+impl<'cache> EventFilter for RoomReadReceiptEventFilter<'cache> {
+    fn room_id(&self) -> &RoomId {
+        self.room_id
+    }
+
+    fn filter(&self, event: &TimelineEvent) -> bool {
+        // This type is built from a `RoomEventCacheState`. The room event cache
+        // contains all events, including in-thread events. We need to filter them!
+        (self.with_threading_support && extract_thread_root(event.raw()).is_some()).not()
+    }
+
+    fn receipt_thread_matches(&self, receipt_thread: &ReceiptThread) -> bool {
+        matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
+    }
+
+    async fn stored_receipt_event_for_user(
+        &self,
+        user_id: &UserId,
+        receipt_type: ReceiptType,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        // We want to prioritize an `Unthreaded` receipt over a `Main`-threaded one, for
+        // better compatibility with thread-unaware clients.
+        for receipt_thread in [ReceiptThread::Unthreaded, ReceiptThread::Main] {
+            let receipt_event = self
+                .state_store
+                .get_user_room_receipt_event(
+                    self.room_id,
+                    receipt_type.clone(),
+                    &receipt_thread,
+                    user_id,
+                )
+                .await
+                .ok()
+                .flatten();
+
+            if receipt_event.is_some() {
+                return receipt_event;
+            }
+        }
+
+        None
     }
 }
 
@@ -243,14 +320,17 @@ const ALL_RECEIPT_TYPES: [ReceiptType; 2] = [ReceiptType::ReadPrivate, ReceiptTy
 ///
 /// A receipt returned in this function **must** point to an event that is in
 /// the linked chunk.
-fn select_best_receipt(
+fn select_best_receipt<T>(
     user_id: &UserId,
     linked_chunk: &EventLinkedChunk,
+    event_filter: &T,
     pending_receipts: &mut RingBuffer<OwnedEventId>,
     new_receipt_event: Option<&ReceiptEventContent>,
     latest_active: Option<&EventId>,
-    with_threading_support: bool,
-) -> Option<OwnedEventId> {
+) -> Option<OwnedEventId>
+where
+    T: EventFilter,
+{
     // If we had a new receipt event, add the main/unthreaded receipts it contains
     // to the pending receipts list. We'll try to chase them later.
     if let Some(receipt_event) = new_receipt_event {
@@ -258,7 +338,7 @@ fn select_best_receipt(
             for ty in ALL_RECEIPT_TYPES {
                 if let Some(receipts) = receipts.get(&ty)
                     && let Some(receipt) = receipts.get(user_id)
-                    && matches!(receipt.thread, ReceiptThread::Main | ReceiptThread::Unthreaded)
+                    && event_filter.receipt_thread_matches(&receipt.thread)
                 {
                     // Add it to the pending receipts list.
                     trace!(%event_id, "found new receipt (added to pending)");
@@ -280,9 +360,9 @@ fn select_best_receipt(
 
     let mut receipt = None;
 
-    for (event, event_id) in
-        linked_chunk.revents().filter_map(|(_pos, ev)| Some((ev, ev.event_id()?)))
-    {
+    for (event, event_id) in linked_chunk.revents().filter_map(|(_pos, event)| {
+        event_filter.filter(event).then_some((event, event.event_id()?))
+    }) {
         if receipt.is_none() {
             // Try to see if the latest active receipt is still the most recent receipt.
             if latest_active == Some(event_id) {
@@ -292,11 +372,7 @@ fn select_best_receipt(
             }
             // Try to find an implicit read receipt (i.e. an event sent by the current
             // user).
-            //
-            // If the client is enabled with threading support, skip events that are in threads.
-            else if event.sender().as_deref() == Some(user_id)
-                && (!with_threading_support || extract_thread_root(event.raw()).is_none())
-            {
+            else if event.sender().as_deref() == Some(user_id) {
                 trace!(implicit = %event_id, "found an implicit receipt; stopping search");
                 receipt = Some(event_id.to_owned());
             }
@@ -341,35 +417,26 @@ fn select_best_receipt(
 /// Doesn't return a `Result`, because this is entirely optional; if the store
 /// fails to load these receipts, the worst that can happen is incorrect unread
 /// counts until the next receipt event is received from sync.
-async fn try_find_store_receipts(
-    store: &DynStateStore,
+async fn try_find_stored_receipts<T>(
     user_id: &UserId,
-    room_id: &RoomId,
+    event_filter: &T,
     read_receipts: &mut ReadReceipts,
-) {
+) where
+    T: EventFilter,
+{
     for receipt_type in ALL_RECEIPT_TYPES {
-        // Implementation note: we want to prioritize an `Unthreaded` receipt over a
-        // `Main`-threaded one, for better compatibility with thread-unaware clients.
-        for receipt_thread in [ReceiptThread::Unthreaded, ReceiptThread::Main] {
-            if let Ok(Some((event_id, _receipt))) = store
-                .get_user_room_receipt_event(
-                    room_id,
-                    receipt_type.clone(),
-                    &receipt_thread,
-                    user_id,
-                )
-                .await
-            {
-                trace!(%event_id, ?receipt_type, ?receipt_thread, "Found a dormant receipt in the store");
+        if let Some((event_id, _receipt)) =
+            event_filter.stored_receipt_event_for_user(user_id, receipt_type).await
+        {
+            trace!(%event_id, "Found a dormant receipt in the store");
 
-                if read_receipts.latest_active.is_none() {
-                    read_receipts.latest_active = Some(LatestReadReceipt { event_id });
-                } else {
-                    // This loop has already flagged a read receipt as the new `latest_active`.
-                    // Extra read receipts can go to the pending receipts list, as they're lower
-                    // priority, by the implementation notes above.
-                    read_receipts.pending.push(event_id);
-                }
+            if read_receipts.latest_active.is_none() {
+                read_receipts.latest_active = Some(LatestReadReceipt { event_id });
+            } else {
+                // This loop has already flagged a read receipt as the new `latest_active`.
+                // Extra read receipts can go to the pending receipts list, as they're lower
+                // priority, by the implementation notes above.
+                read_receipts.pending.push(event_id);
             }
         }
     }
@@ -380,33 +447,32 @@ async fn try_find_store_receipts(
 /// highlights' in place.
 ///
 /// See this module's documentation for more information.
-#[instrument(skip_all, fields(room_id = %room_id))]
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn compute_unread_counts(
+#[instrument(skip_all, fields(room_id = %event_filter.room_id()))]
+pub(crate) async fn compute_unread_counts<T>(
     user_id: &UserId,
-    room_id: &RoomId,
     receipt_event: Option<&ReceiptEventContent>,
     linked_chunk: &EventLinkedChunk,
+    event_filter: &T,
     read_receipts: &mut ReadReceipts,
-    with_threading_support: bool,
     automatic_pagination: Option<&AutomaticPagination>,
-    state_store: &DynStateStore,
-) {
+) where
+    T: EventFilter,
+{
     debug!(?read_receipts, "Starting");
 
     // If we don't have a latest active receipt for this timeline, try to reload one
     // from the state store into the `ReadReceipts`.
     if read_receipts.latest_active.is_none() {
-        try_find_store_receipts(state_store, user_id, room_id, read_receipts).await;
+        try_find_stored_receipts(user_id, event_filter, read_receipts).await;
     }
 
     let better_receipt = select_best_receipt(
         user_id,
         linked_chunk,
+        event_filter,
         &mut read_receipts.pending,
         receipt_event,
         read_receipts.latest_active.as_ref().map(|latest_active| latest_active.event_id.as_ref()),
-        with_threading_support,
     );
 
     if let Some(event_id) = better_receipt {
@@ -424,8 +490,9 @@ pub(crate) async fn compute_unread_counts(
         read_receipts.find_and_process_events(
             &event_id,
             user_id,
-            linked_chunk.events().map(|(_pos, event)| event),
-            with_threading_support,
+            linked_chunk
+                .events()
+                .filter_map(|(_pos, event)| event_filter.filter(event).then_some(event)),
         );
 
         debug!(?read_receipts, "after finding a better receipt");
@@ -435,7 +502,7 @@ pub(crate) async fn compute_unread_counts(
     // Request a pagination: we haven't found a better receipt, but we haven't even
     // found the latest active receipt!
     if let Some(automatic_pagination) = automatic_pagination {
-        if automatic_pagination.run_once(room_id) {
+        if automatic_pagination.run_once(event_filter.room_id()) {
             trace!("Requested pagination to find a better receipt");
         } else {
             warn!("Failed to request pagination to find a better receipt");
@@ -450,8 +517,11 @@ pub(crate) async fn compute_unread_counts(
     // events. Reset the number of unreads, and recount them all.
     read_receipts.reset();
 
-    for (_pos, event) in linked_chunk.events() {
-        read_receipts.process_event(event, user_id, with_threading_support);
+    for event in linked_chunk
+        .events()
+        .filter_map(|(_pos, event)| event_filter.filter(event).then_some(event))
+    {
+        read_receipts.process_event(event, user_id);
     }
 
     debug!(?read_receipts, "no better receipt");
@@ -516,11 +586,11 @@ fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool 
 mod tests {
     use std::{num::NonZeroUsize, ops::Not as _};
 
-    use matrix_sdk_base::read_receipts::ReadReceipts;
+    use matrix_sdk_base::{read_receipts::ReadReceipts, store::MemoryStore};
     use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
     use matrix_sdk_test::{ALICE, event_factory::EventFactory};
     use ruma::{
-        EventId, UserId, event_id,
+        EventId, RoomId, UserId, event_id,
         events::{
             receipt::{ReceiptThread, ReceiptType},
             room::{member::MembershipState, message::MessageType},
@@ -530,11 +600,11 @@ mod tests {
         room_id, user_id,
     };
 
-    use super::marks_as_unread;
-    use crate::event_cache::caches::{
-        event_linked_chunk::EventLinkedChunk,
-        read_receipts::{ReadReceiptsExt as _, select_best_receipt},
+    use super::{
+        EventFilter, ReadReceiptsExt as _, RoomReadReceiptEventFilter, marks_as_unread,
+        select_best_receipt,
     };
+    use crate::event_cache::caches::event_linked_chunk::EventLinkedChunk;
 
     #[test]
     fn test_room_message_marks_as_unread() {
@@ -553,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_room_edit_doesnt_mark_as_unread() {
+    fn test_room_edit_does_not_mark_as_unread() {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
@@ -572,7 +642,7 @@ mod tests {
     }
 
     #[test]
-    fn test_redaction_doesnt_mark_room_as_unread() {
+    fn test_redaction_does_not_mark_room_as_unread() {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
@@ -587,7 +657,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reaction_doesnt_mark_room_as_unread() {
+    fn test_reaction_does_not_mark_room_as_unread() {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
@@ -602,7 +672,7 @@ mod tests {
     }
 
     #[test]
-    fn test_state_event_doesnt_mark_as_unread() {
+    fn test_state_event_does_not_mark_as_unread() {
         let user_id = user_id!("@alice:example.org");
         let event_id = event_id!("$1");
 
@@ -631,12 +701,11 @@ mod tests {
         }
 
         let user_id = user_id!("@alice:example.org");
-        let threading_support = false;
 
         // An interesting event from oneself doesn't count as a new unread message.
         let event = make_event(user_id, Vec::new());
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
@@ -644,7 +713,7 @@ mod tests {
         // An interesting event from someone else does count as a new unread message.
         let event = make_event(user_id!("@bob:example.org"), Vec::new());
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
@@ -652,7 +721,7 @@ mod tests {
         // Push actions computed beforehand are respected.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify]);
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 1);
@@ -662,7 +731,7 @@ mod tests {
             vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
         );
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
         assert_eq!(receipts.num_notifications, 0);
@@ -672,7 +741,7 @@ mod tests {
             vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)), Action::Notify],
         );
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 1);
         assert_eq!(receipts.num_notifications, 1);
@@ -681,7 +750,7 @@ mod tests {
         // make sure to resist against it.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify, Action::Notify]);
         let mut receipts = ReadReceipts::default();
-        receipts.process_event(&event, user_id, threading_support);
+        receipts.process_event(&event, user_id);
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 1);
@@ -691,12 +760,11 @@ mod tests {
     fn test_find_and_process_events() {
         let ev0 = event_id!("$0");
         let user_id = user_id!("@alice:example.org");
-        let thread_support = false;
 
         // When provided with no events, we report not finding the event to which the
         // receipt relates.
         let mut receipts = ReadReceipts::default();
-        assert!(receipts.find_and_process_events(ev0, user_id, &[], thread_support).not());
+        assert!(receipts.find_and_process_events(ev0, user_id, [].iter()).not());
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -719,12 +787,7 @@ mod tests {
         };
         assert!(
             receipts
-                .find_and_process_events(
-                    ev0,
-                    user_id,
-                    &[make_event(event_id!("$1"))],
-                    thread_support
-                )
+                .find_and_process_events(ev0, user_id, [make_event(event_id!("$1"))].iter())
                 .not()
         );
         assert_eq!(receipts.num_unread, 42);
@@ -740,7 +803,7 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts.find_and_process_events(ev0, user_id, &[make_event(ev0)], thread_support),);
+        assert!(receipts.find_and_process_events(ev0, user_id, [make_event(ev0)].iter()));
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -758,12 +821,12 @@ mod tests {
                 .find_and_process_events(
                     ev0,
                     user_id,
-                    &[
+                    [
                         make_event(event_id!("$1")),
                         make_event(event_id!("$2")),
                         make_event(event_id!("$3"))
-                    ],
-                    thread_support
+                    ]
+                    .iter(),
                 )
                 .not()
         );
@@ -779,17 +842,19 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts.find_and_process_events(
-            ev0,
-            user_id,
-            &[
-                make_event(event_id!("$1")),
-                make_event(ev0),
-                make_event(event_id!("$2")),
-                make_event(event_id!("$3"))
-            ],
-            thread_support
-        ));
+        assert!(
+            receipts.find_and_process_events(
+                ev0,
+                user_id,
+                [
+                    make_event(event_id!("$1")),
+                    make_event(ev0),
+                    make_event(event_id!("$2")),
+                    make_event(event_id!("$3"))
+                ]
+                .iter(),
+            )
+        );
         assert_eq!(receipts.num_unread, 2);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -801,18 +866,20 @@ mod tests {
             num_mentions: 37,
             ..Default::default()
         };
-        assert!(receipts.find_and_process_events(
-            ev0,
-            user_id,
-            &[
-                make_event(ev0),
-                make_event(event_id!("$1")),
-                make_event(ev0),
-                make_event(event_id!("$2")),
-                make_event(event_id!("$3"))
-            ],
-            thread_support
-        ));
+        assert!(
+            receipts.find_and_process_events(
+                ev0,
+                user_id,
+                [
+                    make_event(ev0),
+                    make_event(event_id!("$1")),
+                    make_event(ev0),
+                    make_event(event_id!("$2")),
+                    make_event(event_id!("$3"))
+                ]
+                .iter(),
+            )
+        );
         assert_eq!(receipts.num_unread, 2);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
@@ -820,8 +887,13 @@ mod tests {
 
     #[test]
     fn test_compute_unread_counts_with_threading_enabled() {
-        fn make_event(user_id: &UserId, thread_root: &EventId) -> TimelineEvent {
+        fn make_in_thread_event(
+            user_id: &UserId,
+            room_id: &RoomId,
+            thread_root: &EventId,
+        ) -> TimelineEvent {
             EventFactory::new()
+                .room(room_id)
                 .text_msg("A")
                 .sender(user_id)
                 .event_id(event_id!("$ida"))
@@ -831,45 +903,47 @@ mod tests {
 
         let mut receipts = ReadReceipts::default();
 
+        let state_store = MemoryStore::new();
+        let room_id = room_id!("!r");
         let own_alice = user_id!("@alice:example.org");
         let bob = user_id!("@bob:example.org");
 
-        let threading_support = true;
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: true,
+            state_store: &state_store,
+        };
 
         // Threaded messages from myself or other users shouldn't change the
         // unread counts.
-        receipts.process_event(
-            &make_event(own_alice, event_id!("$some_thread_root")),
-            own_alice,
-            threading_support,
-        );
-        receipts.process_event(
-            &make_event(own_alice, event_id!("$some_other_thread_root")),
-            own_alice,
-            threading_support,
-        );
-
-        receipts.process_event(
-            &make_event(bob, event_id!("$some_thread_root")),
-            own_alice,
-            threading_support,
-        );
-        receipts.process_event(
-            &make_event(bob, event_id!("$some_other_thread_root")),
-            own_alice,
-            threading_support,
-        );
+        for event in [
+            make_in_thread_event(own_alice, room_id, event_id!("$some_thread_root")),
+            make_in_thread_event(own_alice, room_id, event_id!("$some_other_thread_root")),
+            make_in_thread_event(bob, room_id, event_id!("$some_thread_root")),
+            make_in_thread_event(bob, room_id, event_id!("$some_other_thread_root")),
+        ]
+        .into_iter()
+        .filter(|event| event_filter.filter(event))
+        {
+            receipts.process_event(&event, own_alice);
+        }
 
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
 
         // Processing an unthreaded message should still count as unread.
-        receipts.process_event(
-            &EventFactory::new().text_msg("A").sender(bob).event_id(event_id!("$ida")).into_event(),
-            own_alice,
-            threading_support,
-        );
+        for event in [EventFactory::new()
+            .room(room_id)
+            .text_msg("A")
+            .sender(bob)
+            .event_id(event_id!("$ida"))
+            .into_event()]
+        .into_iter()
+        .filter(|event| event_filter.filter(event))
+        {
+            receipts.process_event(&event, own_alice);
+        }
 
         assert_eq!(receipts.num_unread, 1);
         assert_eq!(receipts.num_mentions, 0);
@@ -882,14 +956,21 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
         // Create a non-empty linked chunk, with no messages sent by the current user.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
         ]);
 
+        let state_store = MemoryStore::new();
         let own_user_id = user_id!("@not_alice:example.org");
+
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // When there are no pending receipts,
         let mut pending_receipts = RingBuffer::new(NonZeroUsize::new(16).unwrap());
@@ -897,16 +978,15 @@ mod tests {
         let new_receipt_event = None;
         // And no active receipt,
         let active_receipt = None;
-        let with_threading_support = false;
 
         // Then there's no best receipt.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
-            with_threading_support,
         );
         assert!(receipt.is_none());
         // And there are no pending receipts.
@@ -921,8 +1001,8 @@ mod tests {
 
         // Create a non-empty linked chunk, with one message sent by the current user,
         // which will act as an implicit read receipt.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).sender(own_user_id).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
@@ -934,16 +1014,22 @@ mod tests {
         let new_receipt_event = None;
         // And no active receipt,
         let active_receipt = None;
-        let with_threading_support = false;
+
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then there's a new best receipt, which is the implicit one.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
-            with_threading_support,
         );
         assert_eq!(receipt.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -956,8 +1042,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
         // Create a non-empty linked chunk, with no messages sent by the current user.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
@@ -971,16 +1057,22 @@ mod tests {
         let new_receipt_event = None;
         // And an active receipt pointing at $2,
         let active_receipt = Some(event_id!("$2"));
-        let with_threading_support = false;
+
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then the best receipt is still $2.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event,
             active_receipt,
-            with_threading_support,
         );
         assert_eq!(receipt.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -994,8 +1086,8 @@ mod tests {
         let own_user_id = user_id!("@not_alice:example.org");
 
         // Create a non-empty linked chunk, with no messages sent by the current user.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
@@ -1013,16 +1105,22 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
-        let with_threading_support = false;
+
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then there's a new best receipt, which is the explicit one from the event
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
-            with_threading_support,
         );
         assert_eq!(receipt.unwrap(), event_id!("$2"));
         // And there are no pending receipts.
@@ -1036,8 +1134,8 @@ mod tests {
         let own_user_id = user_id!("@not_alice:example.org");
 
         // Create a non-empty linked chunk, with no messages sent by the current user.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
@@ -1055,16 +1153,22 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
-        let with_threading_support = false;
+
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then there's no new best receipts.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
-            with_threading_support,
         );
 
         assert!(receipt.is_none());
@@ -1080,8 +1184,8 @@ mod tests {
         let own_user_id = user_id!("@not_alice:example.org");
 
         // Create a non-empty linked chunk, with no messages sent by the current user.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).into_event(),
@@ -1096,16 +1200,22 @@ mod tests {
 
         // And no active receipt,
         let active_receipt = None;
-        let with_threading_support = false;
+
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then there's a new best receipt, which is the matched pending receipt.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
-            with_threading_support,
         );
         assert_eq!(receipt.unwrap(), event_id!("$2"));
         // And there are no more pending receipts.
@@ -1120,8 +1230,8 @@ mod tests {
 
         // Create a non-empty linked chunk, with one message sent by the current user,
         // which will act as an implicit read receipt.
-        let mut lc = EventLinkedChunk::new();
-        lc.push_events(vec![
+        let mut linked_chunk = EventLinkedChunk::new();
+        linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
             f.text_msg("Event 2").event_id(event_id!("$2")).into_event(),
             f.text_msg("Event 3").event_id(event_id!("$3")).sender(own_user_id).into_event(),
@@ -1145,17 +1255,22 @@ mod tests {
         // And an active receipt point at $1,
         let active_receipt = Some(event_id!("$1"));
 
-        let with_threading_support = false;
+        let state_store = MemoryStore::new();
+        let event_filter = RoomReadReceiptEventFilter {
+            room_id,
+            with_threading_support: false,
+            state_store: &state_store,
+        };
 
         // Then there's a new best receipt, which is the most advanced in the linked
-        // chunk: $4.
+        // chunk: $4.
         let receipt = select_best_receipt(
             own_user_id,
-            &lc,
+            &linked_chunk,
+            &event_filter,
             &mut pending_receipts,
             new_receipt_event.as_ref(),
             active_receipt,
-            with_threading_support,
         );
         assert_eq!(receipt.unwrap(), event_id!("$4"));
 

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -305,6 +305,64 @@ impl<'cache> EventFilter for RoomReadReceiptEventFilter<'cache> {
     }
 }
 
+/// Type to filter in-thread events that are candidates for read receipts.
+pub struct ThreadReadReceiptEventFilter<'cache> {
+    room_id: &'cache RoomId,
+    thread_id: &'cache EventId,
+    state_store: &'cache DynStateStore,
+}
+
+impl<'cache> ThreadReadReceiptEventFilter<'cache> {
+    /// Construct a new [`ReadReceiptsForThread`].
+    pub fn new(
+        thread_event_cache_state: &'cache super::thread::ThreadEventCacheState,
+        state_store: &'cache DynStateStore,
+    ) -> Self {
+        Self {
+            room_id: &thread_event_cache_state.room_id,
+            thread_id: &thread_event_cache_state.thread_id,
+            state_store,
+        }
+    }
+}
+
+impl<'cache> EventFilter for ThreadReadReceiptEventFilter<'cache> {
+    fn room_id(&self) -> &RoomId {
+        self.room_id
+    }
+
+    fn filter(&self, _event: &TimelineEvent) -> bool {
+        // This type is built from a `ThreadEventCacheState`. The thread event cache
+        // contains all in-thread events for this particular thread. No need to filter
+        // them.
+        true
+    }
+
+    fn receipt_thread_matches(&self, receipt_thread: &ReceiptThread) -> bool {
+        matches!(
+            receipt_thread,
+            ReceiptThread::Thread(thread_id) if self.thread_id == thread_id
+        )
+    }
+
+    async fn stored_receipt_event_for_user(
+        &self,
+        user_id: &UserId,
+        receipt_type: ReceiptType,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        self.state_store
+            .get_user_room_receipt_event(
+                self.room_id,
+                receipt_type,
+                &ReceiptThread::Thread(self.thread_id.to_owned()),
+                user_id,
+            )
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
 /// The receipt types we look for, in order of priority (the first ones are more
 /// likely to be ahead in the timeline, so we look for them first).
 const ALL_RECEIPT_TYPES: [ReceiptType; 2] = [ReceiptType::ReadPrivate, ReceiptType::Read];

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -237,7 +237,7 @@ impl RoomEventCache {
         self.inner
             .handle_timeline(
                 updates.timeline,
-                updates.ephemeral.clone(),
+                updates.ephemeral,
                 updates.ambiguity_changes,
                 updates.avatar_changes,
             )

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -23,16 +23,14 @@ use matrix_sdk_base::{
     linked_chunk::{
         ChunkIdentifierGenerator, LinkedChunkId, OwnedLinkedChunkId, Position, Update, lazy_loader,
     },
-    serde_helpers::extract_redaction_target,
+    serde_helpers::{extract_read_receipt, extract_redaction_target},
     sync::Timeline,
 };
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId,
     events::{
-        AnySyncEphemeralRoomEvent,
-        receipt::{ReceiptEventContent, SyncReceiptEvent},
-        relation::RelationType,
+        AnySyncEphemeralRoomEvent, receipt::ReceiptEventContent, relation::RelationType,
         room::redaction::SyncRoomRedactionEvent,
     },
     room_version_rules::RoomVersionRules,
@@ -834,31 +832,6 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     pub fn is_dirty(&self) -> bool {
         EventCacheStoreLockGuard::is_dirty(&self.store)
     }
-}
-
-/// Extract a valid read receipt event from the ephemeral events, if
-/// available.
-fn extract_read_receipt(
-    ephemeral_events: &[Raw<AnySyncEphemeralRoomEvent>],
-) -> Option<ReceiptEventContent> {
-    let mut receipt_event = None;
-
-    for raw_ephemeral in ephemeral_events {
-        match raw_ephemeral.deserialize() {
-            Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {
-                receipt_event = Some(content);
-                break;
-            }
-
-            Ok(_) => {}
-
-            Err(err) => {
-                error!("error when deserializing an ephemeral event from sync: {err}");
-            }
-        }
-    }
-
-    receipt_event
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -56,7 +56,7 @@ use super::{
         EventLocation,
         event_linked_chunk::EventLinkedChunk,
         pagination::SharedPaginationStatus,
-        read_receipts::compute_unread_counts,
+        read_receipts::{RoomReadReceiptEventFilter, compute_unread_counts},
         subscriber::SubscribersHandle,
     },
     RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdateSender, sort_positions_descending,
@@ -65,7 +65,7 @@ use crate::room::WeakRoom;
 
 pub struct RoomEventCacheState {
     /// Whether thread support has been enabled for the event cache.
-    enabled_thread_support: bool,
+    pub enabled_thread_support: bool,
 
     /// The room this state relates to.
     pub room_id: OwnedRoomId,
@@ -644,21 +644,19 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             return Ok(());
         };
 
-        let user_id = &self.state.own_user_id;
-        let room_id = &self.state.room_id;
-
         let prev_read_receipts = room.read_receipts().clone();
         let mut read_receipts = prev_read_receipts.clone();
 
+        let client = room.client();
+        let event_filter = RoomReadReceiptEventFilter::new(&self.state, client.state_store());
+
         compute_unread_counts(
-            user_id,
-            room_id,
+            &self.state.own_user_id,
             receipt_event,
             &self.state.room_linked_chunk,
+            &event_filter,
             &mut read_receipts,
-            self.state.enabled_thread_support,
             self.state.automatic_pagination.as_ref(),
-            room.client().state_store(),
         )
         .await;
 
@@ -672,6 +670,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
                     (room_info, RoomInfoNotableUpdateReasons::READ_RECEIPT)
                 })
                 .await;
+
             if let Err(error) = result {
                 error!(room_id = ?room.room_id(), ?error, "Failed to save the changes");
             }

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::empty;
+
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
@@ -556,12 +558,13 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         if all_duplicates {
             // No new events and no gap (per the previous check), thus no need to change the
             // room state. We're done!
-
+            //
             // We might have a new read receipt, though! If that's the case, handle it for
             // unread counts tracking.
-            if let Some(new_receipt) = extract_read_receipt(ephemeral_events) {
-                self.update_read_receipts(Some(&new_receipt)).await?;
-            }
+            //
+            // Post-process the ephemeral events.
+            self.post_process_upserted_events(empty(), extract_read_receipt(ephemeral_events))
+                .await?;
 
             return Ok((false, Vec::new()));
         }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -113,6 +113,7 @@ impl ThreadEventCache {
                     ThreadEventCacheState::new(
                         room_id.clone(),
                         thread_id.clone(),
+                        weak_room.clone(),
                         own_user_id,
                         room_version_rules,
                         store_guard,

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -25,8 +25,10 @@ use matrix_sdk_base::{
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
-    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, events::relation::RelationType,
+    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
+    events::{AnySyncEphemeralRoomEvent, relation::RelationType},
     room_version_rules::RoomVersionRules,
+    serde::Raw,
 };
 use tokio::sync::{Notify, broadcast::Sender, mpsc};
 use tracing::{instrument, trace};
@@ -197,7 +199,7 @@ impl ThreadEventCache {
     /// Handle a [`JoinedRoomUpdate`].
     #[instrument(skip_all, fields(room_id = %self.inner.room_id, thread_root = %self.inner.thread_id))]
     pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline).await?;
+        self.handle_timeline(updates.timeline, updates.ephemeral).await?;
 
         Ok(())
     }
@@ -205,15 +207,22 @@ impl ThreadEventCache {
     /// Handle a [`LeftRoomUpdate`].
     #[instrument(skip_all, fields(room_id = %self.inner.room_id, thread_root = %self.inner.thread_id))]
     pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline).await?;
+        self.handle_timeline(updates.timeline, Vec::new()).await?;
 
         Ok(())
     }
 
     /// Handle a [`Timeline`], i.e. new events received by a sync for this
     /// thread.
-    async fn handle_timeline(&self, timeline: Timeline) -> Result<()> {
-        if timeline.events.is_empty() && timeline.prev_batch.is_none() {
+    async fn handle_timeline(
+        &self,
+        timeline: Timeline,
+        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+    ) -> Result<()> {
+        if timeline.events.is_empty()
+            && timeline.prev_batch.is_none()
+            && ephemeral_events.is_empty()
+        {
             return Ok(());
         }
 
@@ -221,7 +230,8 @@ impl ThreadEventCache {
 
         let mut state = self.inner.state.write().await?;
 
-        let (stored_prev_batch_token, timeline_event_diffs) = state.handle_sync(timeline).await?;
+        let (stored_prev_batch_token, timeline_event_diffs) =
+            state.handle_sync(timeline, ephemeral_events).await?;
 
         // Now that all events have been added, we can trigger the
         // `pagination_token_notifier`.
@@ -302,6 +312,14 @@ impl ThreadEventCache {
         state
             .post_process_upserted_events(
                 resolved_events.iter().filter_map(|resolved_event| resolved_event.as_resolved()),
+                // Read receipt events aren't encrypted, so we can't have decrypted a new
+                // one here. As a result, we don't have any new receipt events to
+                // post-process, so we can just pass `None` here.
+                //
+                // Note: read receipts may be updated anyhow in the post-processing step,
+                // as the redecryption may have decrypted some events that don't count as
+                // unreads.
+                None,
             )
             .await?;
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -22,6 +22,7 @@ use std::{fmt, sync::Arc};
 
 use matrix_sdk_base::{
     event_cache::Event,
+    read_receipts::ReadReceipts,
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
@@ -157,6 +158,36 @@ impl ThreadEventCache {
     /// Get the thread ID for this thread.
     pub fn thread_id(&self) -> &EventId {
         &self.inner.thread_id
+    }
+
+    /// Get the number of unread messages.
+    ///
+    /// To get multiple information about the read receipts, use
+    /// [`Self::read_receipts`] as it involves a single lock.
+    pub async fn num_unread_messages(&self) -> Result<u64> {
+        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_unread)
+    }
+
+    /// Get the number of unread notifications.
+    ///
+    /// To get multiple information about the read receipts, use
+    /// [`Self::read_receipts`] as it involves a single lock.
+    pub async fn num_unread_notifications(&self) -> Result<u64> {
+        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_notifications)
+    }
+
+    /// Get the number of unread mentions, that is, messages causing a highlight
+    /// in a room.
+    ///
+    /// To get multiple information about the read receipts, use
+    /// [`Self::read_receipts`] as it involves a single lock.
+    pub async fn num_unread_mentions(&self) -> Result<u64> {
+        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_mentions)
+    }
+
+    /// Get the detailed information about read receipts for this thread.
+    pub async fn read_receipts(&self) -> Result<ReadReceipts> {
+        Ok(self.inner.state.read().await?.thread_info.read_receipts.clone())
     }
 
     /// Subscribe to this thread updates, after getting the initial list of

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -379,8 +379,17 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         // Update the store.
         state.state.propagate_changes(&state.store).await?;
 
+        // A back-pagination can't include new read receipt events, as those are
+        // ephemeral events not included in /relations responses, so we can
+        // safely set the receipt event to None here.
+        //
+        // Note: read receipts may be updated anyhow in the post-processing step, as the
+        // back-pagination may have revealed the event pointed to by the latest read
+        // receipt.
+        let receipt_event = None;
+
         // Post-process newly inserted events.
-        state.post_process_upserted_events(topo_ordered_events.iter()).await?;
+        state.post_process_upserted_events(topo_ordered_events.iter(), receipt_event).await?;
 
         // Notify observers about the updates.
         let timeline_event_diffs = state.thread_linked_chunk_mut().updates_as_vector_diffs();

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -16,7 +16,7 @@ use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     apply_redaction, check_validity_of_replacement_events,
     deserialized_responses::ThreadSummary,
-    event_cache::{Event, Gap, store::EventCacheStoreLockGuard},
+    event_cache::{Event, Gap, store::EventCacheStoreLockGuard, thread::ThreadInfo},
     linked_chunk::{
         ChunkIdentifierGenerator, LinkedChunkId, OwnedLinkedChunkId, Position, Update, lazy_loader,
     },
@@ -70,6 +70,9 @@ pub struct ThreadEventCacheState {
     /// The linked chunk for this thread.
     thread_linked_chunk: EventLinkedChunk,
 
+    /// The information related to this thread, [`ThreadInfo`].
+    thread_info: ThreadInfo,
+
     /// A clone of [`super::ThreadEventCacheInner::update_sender`].
     ///
     /// This is used only by the [`LockedThreadEventCacheState::read`] and
@@ -114,10 +117,11 @@ impl ThreadEventCacheState {
     ) -> Result<Self> {
         let linked_chunk_id = LinkedChunkId::Thread(&room_id, &thread_id);
 
-        // Register the thread in the list of threads. It does nothing regarding events
-        // or linked chunks: it only remembers the thread exists for the thread list
-        // feature.
-        store_guard.remember_thread(&room_id, &thread_id).await?;
+        // Load the thread info.
+        //
+        // It will register the thread in the list of threads. It does nothing regarding
+        // events or linked chunks.
+        let thread_info = store_guard.load_thread_info(&room_id, &thread_id).await?;
 
         // Load the full linked chunk's metadata, so as to feed the order tracker.
         //
@@ -169,6 +173,7 @@ impl ThreadEventCacheState {
                 linked_chunk,
                 full_linked_chunk_metadata,
             ),
+            thread_info,
             update_sender,
             linked_chunk_update_sender,
             waited_for_initial_prev_token: false,

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -82,7 +82,7 @@ pub struct ThreadEventCacheState {
     thread_linked_chunk: EventLinkedChunk,
 
     /// The information related to this thread, [`ThreadInfo`].
-    thread_info: ThreadInfo,
+    pub thread_info: ThreadInfo,
 
     /// A clone of [`super::ThreadEventCacheInner::update_sender`].
     ///

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -53,11 +53,13 @@ use super::{
         },
         EventLocation,
         event_linked_chunk::{EventLinkedChunk, sort_positions_descending},
+        read_receipts::{ThreadReadReceiptEventFilter, compute_unread_counts},
         room::RoomEventCacheLinkedChunkUpdate,
         subscriber::SubscribersHandle,
     },
     ThreadEventCacheUpdateSender,
 };
+use crate::room::WeakRoom;
 
 pub struct ThreadEventCacheState {
     /// The room owning this thread.
@@ -66,6 +68,9 @@ pub struct ThreadEventCacheState {
     /// The ID of the thread root event, which is the first event in the thread
     /// (and eventually the first in the linked chunk).
     pub thread_id: OwnedEventId,
+
+    /// A weak reference to the actual room.
+    weak_room: WeakRoom,
 
     /// The user's own user id.
     pub own_user_id: OwnedUserId,
@@ -112,9 +117,11 @@ impl ThreadEventCacheState {
     ///
     /// [`LinkedChunk`]: matrix_sdk_common::linked_chunk::LinkedChunk
     /// [`ThreadPagination`]: super::pagination::ThreadPagination
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         room_id: OwnedRoomId,
         thread_id: OwnedEventId,
+        weak_room: WeakRoom,
         own_user_id: OwnedUserId,
         room_version_rules: RoomVersionRules,
         store_guard: EventCacheStoreLockGuard,
@@ -173,6 +180,7 @@ impl ThreadEventCacheState {
         Ok(ThreadEventCacheState {
             room_id,
             thread_id,
+            weak_room,
             own_user_id,
             room_version_rules,
             thread_linked_chunk: EventLinkedChunk::with_initial_linked_chunk(
@@ -540,8 +548,52 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             }
         }
 
-        // do something with `receipt_event`.
-        let _ = receipt_event;
+        self.update_read_receipts(receipt_event.as_ref()).await?;
+
+        Ok(())
+    }
+
+    /// Update read receipts for all events in the thread, based on the current
+    /// state of the in-memory linked chunk.
+    pub async fn update_read_receipts(
+        &mut self,
+        receipt_event: Option<&ReceiptEventContent>,
+    ) -> Result<()> {
+        let Some(room) = self.state.weak_room.get() else {
+            debug!("can't update read receipts: client's closing");
+            return Ok(());
+        };
+
+        let prev_read_receipts = &self.state.thread_info.read_receipts;
+        let mut read_receipts = prev_read_receipts.clone();
+
+        let client = room.client();
+        let event_filter = ThreadReadReceiptEventFilter::new(&self.state, client.state_store());
+
+        compute_unread_counts(
+            &self.state.own_user_id,
+            receipt_event,
+            &self.state.thread_linked_chunk,
+            &event_filter,
+            &mut read_receipts,
+            None,
+        )
+        .await;
+
+        if prev_read_receipts != &read_receipts {
+            // The read receipt has changed! Do a little dance to update the `ThreadInfo` in
+            // the store.
+            self.state.thread_info.read_receipts = read_receipts;
+
+            let room_id = &self.state.room_id;
+            let thread_id = &self.state.thread_id;
+
+            if let Err(error) =
+                self.store.update_thread_info(room_id, thread_id, &self.state.thread_info).await
+            {
+                error!(?room_id, ?thread_id, ?error, "Failed to update the `ThreadInfo`");
+            }
+        }
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::empty;
+
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     apply_redaction, check_validity_of_replacement_events,
@@ -20,14 +22,18 @@ use matrix_sdk_base::{
     linked_chunk::{
         ChunkIdentifierGenerator, LinkedChunkId, OwnedLinkedChunkId, Position, Update, lazy_loader,
     },
-    serde_helpers::extract_redaction_target,
+    serde_helpers::{extract_read_receipt, extract_redaction_target},
     sync::Timeline,
 };
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId,
-    events::{relation::RelationType, room::redaction::SyncRoomRedactionEvent},
+    events::{
+        AnySyncEphemeralRoomEvent, receipt::ReceiptEventContent, relation::RelationType,
+        room::redaction::SyncRoomRedactionEvent,
+    },
     room_version_rules::RoomVersionRules,
+    serde::Raw,
 };
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
@@ -443,6 +449,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     pub async fn handle_sync(
         &mut self,
         timeline: Timeline,
+        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
     ) -> Result<(bool, Vec<VectorDiff<Event>>)> {
         let prev_batch_token = &timeline.prev_batch;
 
@@ -463,6 +470,14 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         if all_duplicates {
             // If all events are duplicates, we don't need to do anything; ignore
             // the new events.
+            //
+            // We might have a new read receipt, though! If that's the case, handle it for
+            // unread counts tracking.
+            //
+            // Post-process the ephemeral events.
+            self.post_process_upserted_events(empty(), extract_read_receipt(&ephemeral_events))
+                .await?;
+
             return Ok((false, Vec::new()));
         }
 
@@ -489,7 +504,8 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         self.state.propagate_changes(&self.store).await?;
 
         // Post-process newly inserted events.
-        self.post_process_upserted_events(events.iter()).await?;
+        self.post_process_upserted_events(events.iter(), extract_read_receipt(&ephemeral_events))
+            .await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -506,7 +522,11 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     }
 
     /// Post-process newly inserted or updated events.
-    pub(super) async fn post_process_upserted_events<'i, I>(&mut self, events: I) -> Result<()>
+    pub(super) async fn post_process_upserted_events<'i, I>(
+        &mut self,
+        events: I,
+        receipt_event: Option<ReceiptEventContent>,
+    ) -> Result<()>
     where
         I: Iterator<Item = &'i Event>,
     {
@@ -519,6 +539,9 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
                 self.save_events([*bundled_thread.clone()]).await?;
             }
         }
+
+        // do something with `receipt_event`.
+        let _ = receipt_event;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -1257,6 +1257,7 @@ mod tests {
         event_cache::{
             Event, Gap,
             store::{EventCacheStore, EventCacheStoreError, MemoryStore},
+            thread::ThreadInfo,
         },
         linked_chunk::{
             ChunkIdentifier, ChunkIdentifierGenerator, ChunkMetadata, LinkedChunkId, Position,
@@ -1397,12 +1398,21 @@ mod tests {
             self.memory_store.load_previous_chunk(linked_chunk_id, before_chunk_identifier).await
         }
 
-        async fn remember_thread(
+        async fn load_thread_info(
             &self,
             room_id: &RoomId,
             thread_id: &EventId,
+        ) -> Result<ThreadInfo, Self::Error> {
+            self.memory_store.load_thread_info(room_id, thread_id).await
+        }
+
+        async fn update_thread_info(
+            &self,
+            room_id: &RoomId,
+            thread_id: &EventId,
+            thread_info: &ThreadInfo,
         ) -> Result<(), Self::Error> {
-            self.memory_store.remember_thread(room_id, thread_id).await
+            self.memory_store.update_thread_info(room_id, thread_id, thread_info).await
         }
 
         async fn clear_all_events(&self, room_id: Option<&RoomId>) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
@@ -1,3 +1,5 @@
+mod read_receipts;
+
 use std::time::Duration;
 
 use assert_matches2::assert_let;

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
@@ -1,0 +1,717 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! All the tests in this file follow the same pattern:
+//!
+//! - join a room with no events at first,
+//! - then, start a listener to get notified when the read receipt state is
+//!   updated,
+//! - then, sync a batch of events (messages, receipts, etc.) that should
+//!   trigger an update for the listener,
+//! - then, run assertions on the thread unread counts.
+//!
+//! This avoids potential race conditions where a sync could be done, but the
+//! processing by the event cache isn't, at the time we check the unread counts.
+
+use std::time::Duration;
+
+use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
+use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use ruma::{
+    event_id,
+    events::{
+        Mentions,
+        receipt::{ReceiptThread, ReceiptType},
+        room::member::MembershipState,
+    },
+    room_id,
+};
+use tokio::time::sleep;
+
+/// Test that the unread count increases when new messages arrive and no read
+/// receipt is known.
+#[async_test]
+async fn test_unread_count_new_message_no_receipt() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+
+    assert!(thread_updates.is_empty());
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("hello").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("world").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Both messages from Alice count as unread since there is no read receipt.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
+}
+
+/// Test that the unread count only includes messages after the last known read
+/// receipt.
+#[async_test]
+async fn test_unread_count_new_message_with_known_receipt() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let own_user_id = client.user_id().unwrap();
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("ev1").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev3").in_thread(thread_id, thread_id).event_id(event_id!("$3")),
+                )
+                // The current user has read up to ev1.
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            event_id!("$2"),
+                            own_user_id,
+                            ReceiptType::Read,
+                            ReceiptThread::Thread(thread_id.to_owned()),
+                        )
+                        .into_event(),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Only ev3 (after the receipt) is unread.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+}
+
+/// Test that a message sent by the current user creates an implicit read
+/// receipt so that only messages after the user's own message count as unread.
+#[async_test]
+async fn test_unread_count_implicit_receipt_own_message() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+    let own_user_id = client.user_id().unwrap();
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("ev1").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                )
+                // The current user sends ev3: implicit read receipt up to here.
+                .add_timeline_event(
+                    f.text_msg("ev3")
+                        .in_thread(thread_id, thread_id)
+                        .sender(own_user_id)
+                        .event_id(event_id!("$3")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev4").in_thread(thread_id, thread_id).event_id(event_id!("$4")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev5").in_thread(thread_id, thread_id).event_id(event_id!("$5")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // ev4 and ev5 (after our own ev3) are unread; ev1/ev2/ev3 are read via
+    // implicit receipt.
+    let read_receipts = thread.read_receipts().await.unwrap();
+    assert_eq!(read_receipts.num_unread, 2);
+    assert_eq!(read_receipts.latest_active.unwrap().event_id, event_id!("$3"));
+}
+
+/// Test that receiving only a new read receipt event (with no new messages)
+/// decreases the unread count.
+#[async_test]
+async fn test_unread_count_receipt_only_no_new_message() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+    let own_user_id = client.user_id().unwrap();
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // First sync: three messages from Alice, no receipt.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("ev1").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev3").in_thread(thread_id, thread_id).event_id(event_id!("$3")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 3);
+
+    // Second sync: a read receipt for ev2 arrives, no new messages.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_receipt(
+                f.read_receipts()
+                    .add(
+                        event_id!("$2"),
+                        own_user_id,
+                        ReceiptType::Read,
+                        ReceiptThread::Thread(thread_id.to_owned()),
+                    )
+                    .into_event(),
+            ),
+        )
+        .await;
+
+    // Can't wait on `thread_updates` because there is no update “read receipt
+    // update” for threads.
+    sleep(Duration::from_millis(100)).await;
+
+    // Only ev3 (after the receipt) is unread now.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+}
+
+/// Test that a read receipt for an unknown event is stored as pending, and
+/// resolves once that event arrives in a subsequent sync.
+#[async_test]
+async fn test_unread_count_pending_receipt() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+    let own_user_id = client.user_id().unwrap();
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // First sync: three messages from Alice plus a receipt for a future event.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("ev1").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev3").in_thread(thread_id, thread_id).event_id(event_id!("$3")),
+                )
+                // Receipt refers to $future, which isn't known yet.
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            event_id!("$future"),
+                            own_user_id,
+                            ReceiptType::Read,
+                            ReceiptThread::Thread(thread_id.to_owned()),
+                        )
+                        .into_event(),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // All three events are unread because the receipt target is unknown.
+    let read_receipts = thread.read_receipts().await.unwrap();
+    assert_eq!(read_receipts.num_unread, 3);
+    // The receipt is stored as pending.
+    assert!(read_receipts.pending.iter().any(|id| id == event_id!("$future")));
+    assert_eq!(read_receipts.pending.len(), 1);
+
+    // Second sync: $future arrives along with another message.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("the future event")
+                        .in_thread(thread_id, thread_id)
+                        .event_id(event_id!("$future")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev4").in_thread(thread_id, thread_id).event_id(event_id!("$4")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // The pending receipt resolves: only ev4 (after $future) is unread.
+    let read_receipts = thread.read_receipts().await.unwrap();
+    assert_eq!(read_receipts.num_unread, 1);
+    assert!(read_receipts.pending.is_empty());
+}
+
+/// Test that unread counts accumulate across multiple syncs when no read
+/// receipt is updated.
+#[async_test]
+async fn test_unread_count_accumulates_across_syncs() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // First sync: two messages.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("ev1").in_thread(thread_id, thread_id).event_id(event_id!("$1")),
+                )
+                .add_timeline_event(
+                    f.text_msg("ev2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
+
+    // Second sync: one more message, still no receipt.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("ev3").in_thread(thread_id, thread_id).event_id(event_id!("$3")),
+            ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Three messages are now unread in total.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 3);
+}
+
+/// Test that state events (e.g. a membership change) in the timeline do not
+/// increment the unread count.
+#[async_test]
+async fn test_state_event_does_not_increment_unread() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+
+    server
+        .sync_room(
+            &client,
+            // Alice joining the room is a state event, not a message.
+            JoinedRoomBuilder::new(room_id).add_timeline_state_bulk([f
+                .member(*ALICE)
+                .membership(MembershipState::Join)
+                .event_id(event_id!("$1"))
+                .into_raw_sync_state()]),
+        )
+        .await;
+
+    sleep(Duration::from_millis(100)).await;
+
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 0);
+}
+
+/// Test that reactions don't count in the unread message count.
+#[async_test]
+async fn test_reaction_does_not_increment_unread() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.text_msg("hello")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$1"))
+                    .into_raw(),
+                f.reaction(event_id!("$1"), "👍").event_id(event_id!("$2")).into(),
+            ]),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Only the text message counts as unread, the reaction doesn't.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+}
+
+/// Test that messages with mentions increment the number of mentions.
+#[async_test]
+async fn test_mentions_increments_unread_mentions() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // For mentions to be properly counted, we need to have a member event for the
+    // current user.
+    let member_event = f
+        .member(client.user_id().unwrap())
+        .membership(MembershipState::Join)
+        .event_id(event_id!("$member"));
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("hello example")
+                        .in_thread(thread_id, thread_id)
+                        .event_id(event_id!("$1"))
+                        .mentions(Mentions::with_user_ids([client.user_id().unwrap().to_owned()])),
+                )
+                .add_state_event(member_event),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // The message counts as unread and also increments the mentions count.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+    assert_eq!(thread.num_unread_mentions().await.unwrap(), 1);
+}
+
+/// Test that the unread count computation doesn't skip a more-recent active
+/// receipt, when iterating over events.
+#[async_test]
+async fn test_compute_unread_counts_considers_active_receipt() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let own_user_id = client.user_id().unwrap();
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // Starting with a room with 1 implicit receipt, then two messages from Alice,
+    // and a receipt on Alice's first message $2,
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_bulk([
+                    f.text_msg("hello 1")
+                        .in_thread(thread_id, thread_id)
+                        .sender(own_user_id)
+                        .event_id(event_id!("$1"))
+                        .into_raw(),
+                    f.text_msg("hello 2")
+                        .in_thread(thread_id, thread_id)
+                        .event_id(event_id!("$2"))
+                        .into_raw(),
+                    f.text_msg("hello 3")
+                        .in_thread(thread_id, thread_id)
+                        .event_id(event_id!("$3"))
+                        .into_raw(),
+                ])
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            event_id!("$2"),
+                            own_user_id,
+                            ReceiptType::Read,
+                            ReceiptThread::Thread(thread_id.to_owned()),
+                        )
+                        .into_event(),
+                ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // The message counts are properly updated (one new message unread after $2).
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+
+    // Provided a sync with one new message from Alice in the same room.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("hello 4").in_thread(thread_id, thread_id).event_id(event_id!("$4")),
+            ),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // The message counts are properly updated (two messages after $2).
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
+}
+
+/// Test that the unread count gets updated when the sync update only contains
+/// duplicate events and a new read receipt.
+#[async_test]
+async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    let own_user_id = client.user_id().unwrap();
+
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    server.sync_joined_room(&client, room_id).await;
+
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    // Starting with a message from Bob, and no read receipt,
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.text_msg("hello 1")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$1"))
+                    .into_raw(),
+                f.text_msg("hello 2")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$2"))
+                    .into_raw(),
+            ]),
+        )
+        .await;
+
+    // We receive the thread update for the two new messages.
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Then, provided a sync with a single duplicated message sent by somebody else,
+    // but a read receipt for the existing message $2,
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(
+                    f.text_msg("hello 2").in_thread(thread_id, thread_id).event_id(event_id!("$2")),
+                )
+                .add_receipt(
+                    f.read_receipts()
+                        .add(
+                            event_id!("$2"),
+                            own_user_id,
+                            ReceiptType::Read,
+                            ReceiptThread::Thread(thread_id.to_owned()),
+                        )
+                        .into_event(),
+                ),
+        )
+        .await;
+
+    // We don't get an update about the read receipt (because threads can't do
+    // that), and we don't get an update about new event because it's been
+    // deduplicated. So. Just wait a little bit :-].
+    sleep(Duration::from_millis(100)).await;
+
+    // The message counts are properly updated (zero new message unread after $2).
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 0);
+}
+
+/// Test that a read receipt saved in the state store but not marked as active
+/// is selected for unread count computation.
+#[async_test]
+async fn test_read_receipt_from_store_used_as_latest_active() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let own_user_id = client.user_id().unwrap();
+    let room_id = room_id!("!r");
+    let thread_id = event_id!("$t");
+    let f = EventFactory::new().room(room_id).sender(*ALICE);
+
+    // Important test note: the read receipt must be in the state store *before* the
+    // event cache is subscribed to, so that it's not marked as active at start.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_receipt(
+                f.read_receipts()
+                    .add(
+                        event_id!("$2"),
+                        own_user_id,
+                        ReceiptType::Read,
+                        ReceiptThread::Thread(thread_id.to_owned()),
+                    )
+                    .into_event(),
+            ),
+        )
+        .await;
+
+    // Then, subscribe the event cache.
+    let event_cache = client.event_cache();
+    event_cache.subscribe().unwrap();
+
+    let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    assert!(thread_updates.is_empty());
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+                f.text_msg("ev1")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$1"))
+                    .into_raw(),
+                f.text_msg("ev2")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$2"))
+                    .into_raw(),
+                f.text_msg("ev3")
+                    .in_thread(thread_id, thread_id)
+                    .event_id(event_id!("$3"))
+                    .into_raw(),
+            ]),
+        )
+        .await;
+
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Only ev3 (after the receipt) is unread.
+    assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+}


### PR DESCRIPTION
These patches add the ability to compute `ReadReceipts` for thread. It does several things (in logical order):

- It creates the new:
  ```rust
  struct ThreadInfo {
      read_receipts: ReadReceipts,
  }
  ```
- It updates the `threads` table to add a new `info` column/field,
- It updates `EventCacheStore` to remove `remember_thread` and to add `load_thread_info` and `update_thread_info`,
- It makes `event_cache::read_receipts::compute_unread_counts` “timeline agnostic” so that it supports both room and thread,
- It updates `ThreadEventCache::handle_timeline` to receive ephemeral events (which include the read receipt events),
- It combines all that to compute the read receipts for threads!

Don't be fooled by the diff size. A **lot** of it is about tests. It's highly recommended to review one patch at a time. Many sub-tasks have been extracted to reduce the size of this contribution.

### Tasks

- [x] Write more tests
- [x] Extracted task: https://github.com/matrix-org/matrix-rust-sdk/pull/6879
- [x] Extracted task: https://github.com/matrix-org/matrix-rust-sdk/pull/6888
- [x] Extracted task: https://github.com/matrix-org/matrix-rust-sdk/issues/6917
- [x] Extracted task: https://github.com/matrix-org/matrix-rust-sdk/issues/6916
- [x] Extracted task: https://github.com/matrix-org/matrix-rust-sdk/issues/6915

---

- ~Stacked on top of https://github.com/matrix-org/matrix-rust-sdk/pull/6888, waiting to be merged.~
- Related to https://github.com/matrix-org/matrix-rust-sdk/issues/4113.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
