### PR TITLE
Converged on a single subscription behavior all through the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6895.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6895.changed.md
@@ -1,0 +1,2 @@
+[**breaking**] Converged on a single subscription behavior all through the FFI layer in which 
+the initial value is published immediately and outside of the update task.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1848,6 +1848,9 @@ impl Client {
         listener: Box<dyn IgnoredUsersListener>,
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.subscribe_to_ignore_user_list_changes();
+
+        listener.call(subscriber.next_now());
+
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(user_ids) = subscriber.next().await {
                 listener.call(user_ids);
@@ -2218,9 +2221,11 @@ impl Client {
         listener: Box<dyn MediaPreviewConfigListener>,
     ) -> Result<Arc<TaskHandle>, ClientError> {
         let (initial_value, stream) = self.inner.account().observe_media_preview_config().await?;
+
+        // Send the initial value to the listener.
+        listener.on_change(initial_value.map(|config| config.into()));
+
         Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            // Send the initial value to the listener.
-            listener.on_change(initial_value.map(|config| config.into()));
             // Listen for changes and notify the listener.
             pin_mut!(stream);
             while let Some(media_preview_config) = stream.next().await {

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -792,6 +792,8 @@ impl Encryption {
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.verification_state();
 
+        listener.on_update(subscriber.next_now().into());
+
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(verification_state) = subscriber.next().await {
                 listener.on_update(verification_state.into());

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -92,11 +92,11 @@ pub struct RoomListService {
 #[matrix_sdk_ffi_macros::export]
 impl RoomListService {
     fn state(&self, listener: Box<dyn RoomListServiceStateListener>) -> Arc<TaskHandle> {
-        let state_stream = self.inner.state();
+        let mut state_stream = self.inner.state();
+
+        listener.on_update(state_stream.next_now().into());
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            pin_mut!(state_stream);
-
             while let Some(state) = state_stream.next().await {
                 listener.on_update(state.into());
             }

--- a/bindings/matrix-sdk-ffi/src/search_service.rs
+++ b/bindings/matrix-sdk-ffi/src/search_service.rs
@@ -15,7 +15,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use eyeball_im::VectorDiff;
-use futures_util::{StreamExt as _, pin_mut};
+use futures_util::StreamExt as _;
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::search_service::{
     MessageResult as UIMessageResult, PaginationState as SearchServicePaginationState,
@@ -75,11 +75,11 @@ impl SearchService {
         &self,
         listener: Box<dyn SearchServicePaginationStateListener>,
     ) -> Arc<TaskHandle> {
-        let pagination_state = self.inner.subscribe_to_pagination_state_updates();
+        let mut pagination_state = self.inner.subscribe_to_pagination_state_updates();
+
+        listener.on_update(pagination_state.next_now());
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            pin_mut!(pagination_state);
-
             while let Some(state) = pagination_state.next().await {
                 listener.on_update(state);
             }

--- a/bindings/matrix-sdk-ffi/src/spaces.rs
+++ b/bindings/matrix-sdk-ffi/src/spaces.rs
@@ -15,7 +15,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use eyeball_im::VectorDiff;
-use futures_util::{StreamExt, pin_mut};
+use futures_util::StreamExt;
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::spaces::{
     SpaceFilter as UISpaceFilter, SpaceRoom as UISpaceRoom, SpaceRoomList as UISpaceRoomList,
@@ -219,11 +219,11 @@ impl SpaceRoomList {
         &self,
         listener: Box<dyn SpaceRoomListSpaceListener>,
     ) -> Arc<TaskHandle> {
-        let space_updates = self.inner.subscribe_to_space_updates();
+        let mut space_updates = self.inner.subscribe_to_space_updates();
+
+        listener.on_update(space_updates.next_now().map(Into::into));
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            pin_mut!(space_updates);
-
             while let Some(space) = space_updates.next().await {
                 listener.on_update(space.map(Into::into));
             }
@@ -240,11 +240,11 @@ impl SpaceRoomList {
         &self,
         listener: Box<dyn SpaceRoomListPaginationStateListener>,
     ) -> Arc<TaskHandle> {
-        let pagination_state = self.inner.subscribe_to_pagination_state_updates();
+        let mut pagination_state = self.inner.subscribe_to_pagination_state_updates();
+
+        listener.on_update(pagination_state.next_now());
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            pin_mut!(pagination_state);
-
             while let Some(state) = pagination_state.next().await {
                 listener.on_update(state);
             }

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -14,7 +14,6 @@
 
 use std::{fmt::Debug, sync::Arc};
 
-use futures_util::pin_mut;
 use matrix_sdk::Client;
 use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use matrix_sdk_ui::{
@@ -80,11 +79,11 @@ impl SyncService {
     }
 
     pub fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {
-        let state_stream = self.inner.state();
+        let mut state_stream = self.inner.state();
+
+        listener.on_update(state_stream.next_now().into());
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            pin_mut!(state_stream);
-
             while let Some(state) = state_stream.next().await {
                 listener.on_update(state.into());
             }

--- a/bindings/matrix-sdk-ffi/src/timeline/threads.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/threads.rs
@@ -281,13 +281,16 @@ impl ThreadListService {
 
     /// Subscribes to changes in the pagination state.
     ///
-    /// The `listener` is called once for every state transition. The returned
-    /// [`TaskHandle`] keeps the subscription alive
+    /// The `listener` is immediately called with the current state, then once
+    /// for every state transition. The returned [`TaskHandle`] keeps the
+    /// subscription alive
     pub fn subscribe_to_pagination_state_updates(
         &self,
         listener: Box<dyn ThreadListPaginationStateListener>,
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.subscribe_to_pagination_state_updates();
+
+        listener.on_update(subscriber.next_now());
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(state) = subscriber.next().await {


### PR DESCRIPTION
In which the initial value is published immediately and outside of the update task.

Prompted by https://github.com/matrix-org/matrix-rust-sdk/commit/a804ac7fc