### PR TITLE
fix(sdk): Make `Media::get_media_content` to return a determinist content for local media

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6896.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/6896.changed.md
@@ -1,0 +1,4 @@
+The `MediaStore::get_media_content_for_uri` method has been removed. This is
+no longer useful and was error-prone as the URI is not unique in the database:
+the tuple (uri, format) is unique though; without the format, it was not
+possible to know which content from which media to return.

--- a/crates/matrix-sdk-base/src/media/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/media/store/integration_tests.rs
@@ -392,7 +392,7 @@ where
         let stored = self.get_media_content_inner(&request_small_5, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
-        let stored = self.get_media_content_for_uri_inner(uri_avg, time).await.unwrap();
+        let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
 
         // Cleanup removes the oldest content first.
@@ -737,7 +737,7 @@ where
         let stored = self.get_media_content_inner(&request_small, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
-        let stored = self.get_media_content_for_uri_inner(uri_avg, time).await.unwrap();
+        let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
 
         // Ignore the average content for now so the max cache size is not reached.
@@ -753,7 +753,7 @@ where
         let stored = self.get_media_content_inner(&request_small, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
-        let stored = self.get_media_content_for_uri_inner(uri_avg, time).await.unwrap();
+        let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
         let stored = self.get_media_content_inner(&request_big, time).await.unwrap();
@@ -771,7 +771,7 @@ where
         let stored = self.get_media_content_inner(&request_small, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
-        let stored = self.get_media_content_for_uri_inner(uri_avg, time).await.unwrap();
+        let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
         let stored = self.get_media_content_inner(&request_big, time).await.unwrap();
@@ -790,7 +790,7 @@ where
         let stored = self.get_media_content_inner(&request_small, time).await.unwrap();
         assert!(stored.is_none());
         time += Duration::from_secs(1);
-        let stored = self.get_media_content_for_uri_inner(uri_avg, time).await.unwrap();
+        let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
         time += Duration::from_secs(1);
         let stored = self.get_media_content_inner(&request_big, time).await.unwrap();
@@ -1123,11 +1123,6 @@ where
             Some(&content),
             "media not found though added"
         );
-        assert_eq!(
-            self.get_media_content_for_uri(uri).await.unwrap().as_ref(),
-            Some(&content),
-            "media not found by URI though added"
-        );
 
         // Let's remove the media.
         self.remove_media_content(&request_file).await.expect("removing media failed");
@@ -1136,10 +1131,6 @@ where
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "media still there after removing"
-        );
-        assert!(
-            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
-            "media still found by URI after removing"
         );
 
         // Let's add the media again.
@@ -1169,12 +1160,6 @@ where
             "thumbnail not found"
         );
 
-        // We get a file with the URI, we don't know which one.
-        assert!(
-            self.get_media_content_for_uri(uri).await.unwrap().is_some(),
-            "media not found by URI though two where added"
-        );
-
         // Let's add another media with a different URI.
         self.add_media_content(
             &request_other_file,
@@ -1189,11 +1174,6 @@ where
             self.get_media_content(&request_other_file).await.unwrap().as_ref(),
             Some(&other_content),
             "other file not found"
-        );
-        assert_eq!(
-            self.get_media_content_for_uri(other_uri).await.unwrap().as_ref(),
-            Some(&other_content),
-            "other file not found by URI"
         );
 
         // Let's remove media based on URI.
@@ -1210,14 +1190,6 @@ where
         assert!(
             self.get_media_content(&request_other_file).await.unwrap().is_some(),
             "other media was removed"
-        );
-        assert!(
-            self.get_media_content_for_uri(uri).await.unwrap().is_none(),
-            "media found by URI wasn't removed"
-        );
-        assert!(
-            self.get_media_content_for_uri(other_uri).await.unwrap().is_some(),
-            "other media found by URI was removed"
         );
     }
 

--- a/crates/matrix-sdk-base/src/media/store/media_service.rs
+++ b/crates/matrix-sdk-base/src/media/store/media_service.rs
@@ -19,7 +19,7 @@ use matrix_sdk_common::{
     executor::{JoinHandle, spawn},
     locks::Mutex,
 };
-use ruma::{MxcUri, time::SystemTime};
+use ruma::time::SystemTime;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::error;
 
@@ -223,27 +223,6 @@ where
         Ok(content)
     }
 
-    /// Get a media file's content associated to an `MxcUri` from the
-    /// media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `store` - The `MediaStoreInner`.
-    ///
-    /// * `uri` - The `MxcUri` of the media file.
-    pub async fn get_media_content_for_uri<Store: MediaStoreInner + 'static>(
-        &self,
-        store: &Store,
-        uri: &MxcUri,
-    ) -> Result<Option<Vec<u8>>, Store::Error> {
-        let current_time = self.now();
-        let content = store.get_media_content_for_uri_inner(uri, current_time).await?;
-
-        self.maybe_spawn_automatic_media_cache_cleanup(store, current_time);
-
-        Ok(content)
-    }
-
     /// Clean up the media cache with the current `MediaRetentionPolicy`.
     ///
     /// If there is already an ongoing cleanup, this is a noop.
@@ -408,7 +387,7 @@ mod tests {
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::async_test;
     use ruma::{
-        MxcUri, OwnedMxcUri,
+        OwnedMxcUri,
         events::room::MediaSource,
         mxc_uri,
         time::{Duration, SystemTime},
@@ -588,24 +567,6 @@ mod tests {
             Ok(Some(media_content.content.clone()))
         }
 
-        async fn get_media_content_for_uri_inner(
-            &self,
-            uri: &MxcUri,
-            current_time: SystemTime,
-        ) -> Result<Option<Vec<u8>>, Self::Error> {
-            let mut inner = self.inner();
-
-            let Some(media_content) =
-                inner.media_list.iter_mut().find(|content| content.uri == uri)
-            else {
-                return Ok(None);
-            };
-
-            media_content.last_access = current_time;
-
-            Ok(Some(media_content.content.clone()))
-        }
-
         async fn clean_inner(
             &self,
             _policy: MediaRetentionPolicy,
@@ -695,15 +656,6 @@ mod tests {
         let now = now + Duration::from_secs(60);
         service.inner.time_provider.set_now(now);
         store.reset_accessed();
-
-        // Get media from URI.
-        let loaded_content = service.get_media_content_for_uri(&store, uri).await.unwrap();
-        assert!(store.accessed());
-        assert_eq!(loaded_content.as_deref(), Some(content.as_slice()));
-
-        // The last access time was updated.
-        let media = store.inner().media_list[0].clone();
-        assert_eq!(media.last_access, now);
 
         // Update ignore_policy.
         service
@@ -799,15 +751,6 @@ mod tests {
         service.inner.time_provider.set_now(now);
         store.reset_accessed();
 
-        // Get media from URI.
-        let loaded_content = service.get_media_content_for_uri(&store, small_uri).await.unwrap();
-        assert!(store.accessed());
-        assert_eq!(loaded_content.as_deref(), Some(small_content.as_slice()));
-
-        // The last access time was updated.
-        let media = store.inner().media_list[0].clone();
-        assert_eq!(media.last_access, now);
-
         let now = now + Duration::from_secs(60);
         service.inner.time_provider.set_now(now);
         store.reset_accessed();
@@ -833,10 +776,6 @@ mod tests {
 
         store.reset_accessed();
 
-        let loaded_content = service.get_media_content_for_uri(&store, big_uri).await.unwrap();
-        assert!(store.accessed());
-        assert_eq!(loaded_content, None);
-
         // Add big media, but this time ignore the policy.
         service
             .add_media_content(
@@ -854,19 +793,6 @@ mod tests {
 
         // Get media from request.
         let loaded_content = service.get_media_content(&store, &big_request).await.unwrap();
-        assert!(store.accessed());
-        assert_eq!(loaded_content.as_deref(), Some(big_content.as_slice()));
-
-        // The last access time was updated.
-        let media = store.inner().media_list[1].clone();
-        assert_eq!(media.last_access, now);
-
-        let now = now + Duration::from_secs(60);
-        service.inner.time_provider.set_now(now);
-        store.reset_accessed();
-
-        // Get media from URI.
-        let loaded_content = service.get_media_content_for_uri(&store, big_uri).await.unwrap();
         assert!(store.accessed());
         assert_eq!(loaded_content.as_deref(), Some(big_content.as_slice()));
 
@@ -965,7 +891,7 @@ mod tests {
         // Try again 2 hours in the future, another cleanup is spawned.
         let now = now + Duration::from_secs(2 * 60 * 60);
         service.inner.time_provider.set_now(now);
-        service.get_media_content_for_uri(&store, uri_1).await.unwrap();
+        service.get_media_content(&store, &request_1).await.unwrap();
 
         let join_handle = service.inner.automatic_media_cleanup_join_handle.lock().take().unwrap();
         join_handle.await.unwrap();

--- a/crates/matrix-sdk-base/src/media/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/media/store/memory_store.rs
@@ -171,13 +171,6 @@ impl MediaStore for MemoryMediaStore {
         Ok(())
     }
 
-    async fn get_media_content_for_uri(
-        &self,
-        uri: &MxcUri,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.media_service.get_media_content_for_uri(self, uri).await
-    }
-
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().unwrap();
 
@@ -313,34 +306,6 @@ impl MediaStoreInner for MemoryMediaStore {
         // First get the content out of the buffer, we are going to put it back at the
         // end.
         let Some(index) = inner.media.iter().position(|media| media.key == expected_key) else {
-            return Ok(None);
-        };
-        let Some(mut content) = inner.media.remove(index) else {
-            return Ok(None);
-        };
-
-        // Clone the data.
-        let data = content.data.clone();
-
-        // Update the last access time.
-        content.last_access = current_time;
-
-        // Put it back in the buffer.
-        inner.media.push(content);
-
-        Ok(Some(data))
-    }
-
-    async fn get_media_content_for_uri_inner(
-        &self,
-        expected_uri: &MxcUri,
-        current_time: SystemTime,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let mut inner = self.inner.write().unwrap();
-
-        // First get the content out of the buffer, we are going to put it back at the
-        // end.
-        let Some(index) = inner.media.iter().position(|media| media.uri == expected_uri) else {
             return Ok(None);
         };
         let Some(mut content) = inner.media.remove(index) else {

--- a/crates/matrix-sdk-base/src/media/store/traits.rs
+++ b/crates/matrix-sdk-base/src/media/store/traits.rs
@@ -102,23 +102,6 @@ pub trait MediaStore: AsyncTraitDeps {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error>;
 
-    /// Get a media file's content associated to an `MxcUri` from the
-    /// media store.
-    ///
-    /// In theory, there could be several files stored using the same URI and a
-    /// different `MediaFormat`. This API is meant to be used with a media file
-    /// that has only been stored with a single format.
-    ///
-    /// If there are several media files for a given URI in different formats,
-    /// this API will only return one of them. Which one is left as an
-    /// implementation detail.
-    ///
-    /// # Arguments
-    ///
-    /// * `uri` - The `MxcUri` of the media file.
-    async fn get_media_content_for_uri(&self, uri: &MxcUri)
-    -> Result<Option<Vec<u8>>, Self::Error>;
-
     /// Remove all the media files' content associated to an `MxcUri` from the
     /// media store.
     ///
@@ -276,21 +259,6 @@ pub trait MediaStoreInner: AsyncTraitDeps + Clone {
         current_time: SystemTime,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    /// Get a media file's content associated to an `MxcUri` from the
-    /// media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `uri` - The `MxcUri` of the media file.
-    ///
-    /// * `current_time` - The current time, to update the last access time of
-    ///   the media.
-    async fn get_media_content_for_uri_inner(
-        &self,
-        uri: &MxcUri,
-        current_time: SystemTime,
-    ) -> Result<Option<Vec<u8>>, Self::Error>;
-
     /// Clean up the media cache with the given policy.
     ///
     /// For the integration tests, it is expected that content that does not
@@ -368,13 +336,6 @@ impl<T: MediaStore> MediaStore for EraseMediaStoreError<T> {
         request: &MediaRequestParameters,
     ) -> Result<(), Self::Error> {
         self.0.remove_media_content(request).await.map_err(Into::into)
-    }
-
-    async fn get_media_content_for_uri(
-        &self,
-        uri: &MxcUri,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.0.get_media_content_for_uri(uri).await.map_err(Into::into)
     }
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -216,15 +216,6 @@ impl MediaStore for IndexeddbMediaStore {
     }
 
     #[instrument(skip(self))]
-    async fn get_media_content_for_uri(
-        &self,
-        uri: &MxcUri,
-    ) -> Result<Option<Vec<u8>>, IndexeddbMediaStoreError> {
-        let _timer = timer!("method");
-        self.media_service.get_media_content_for_uri(self, uri).await
-    }
-
-    #[instrument(skip(self))]
     async fn remove_media_content_for_uri(
         &self,
         uri: &MxcUri,
@@ -376,23 +367,6 @@ impl MediaStoreInner for IndexeddbMediaStore {
             TransactionMode::Readwrite,
         )?;
         let media = transaction.access_media_by_id(request, current_time).await?;
-        transaction.commit().await?;
-        Ok(media.map(|m| m.content))
-    }
-
-    #[instrument(skip_all)]
-    async fn get_media_content_for_uri_inner(
-        &self,
-        uri: &MxcUri,
-        current_time: SystemTime,
-    ) -> Result<Option<Vec<u8>>, IndexeddbMediaStoreError> {
-        let _timer = timer!("method");
-
-        let transaction = self.transaction(
-            &[MediaMetadata::OBJECT_STORE, MediaContent::OBJECT_STORE],
-            TransactionMode::Readwrite,
-        )?;
-        let media = transaction.access_media_by_uri(uri, current_time).await?.pop();
         transaction.commit().await?;
         Ok(media.map(|m| m.content))
     }

--- a/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/transaction.rs
@@ -138,31 +138,6 @@ impl<'a> IndexeddbMediaStoreTransaction<'a> {
         }
     }
 
-    /// Query IndexedDB for [`MediaMetadata`] and [`MediaContent`] that matches
-    /// the given [`MxcUri`]. If an item is found, update
-    /// [`MediaMetadata::last_access`] using `current_time`. If more than
-    /// one item is found, an error is returned.
-    pub async fn access_media_by_uri(
-        &self,
-        uri: &MxcUri,
-        current_time: impl Into<UnixTime>,
-    ) -> Result<Vec<Media>, TransactionError> {
-        let mut medias = Vec::new();
-        for metadata in self.access_media_metadata_by_uri(uri, current_time).await? {
-            let content = self
-                .get_media_content_by_id(metadata.content_id)
-                .await?
-                .ok_or(TransactionError::ItemNotFound)?;
-            medias.push(Media {
-                request_parameters: metadata.request_parameters,
-                last_access: metadata.last_access,
-                ignore_policy: metadata.ignore_policy,
-                content: content.data,
-            });
-        }
-        Ok(medias)
-    }
-
     /// Query IndexedDB for the size recorded in each
     /// [`MediaMetadata::content_size`] which match
     /// the given [`IgnoreMediaRetentionPolicy`]. Returns the sum of all sizes

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -11,12 +11,12 @@ rust-version.workspace = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
-default = ["state-store", "event-cache"]
+default = ["state-store", "event-cache-store"]
 testing = ["matrix-sdk-crypto?/testing"]
 
 bundled = ["rusqlite/bundled"]
 crypto-store = ["dep:matrix-sdk-base", "dep:matrix-sdk-crypto"]
-event-cache = ["dep:matrix-sdk-base"]
+event-cache-store = ["dep:matrix-sdk-base"]
 state-store = ["dep:matrix-sdk-base"]
 
 experimental-encrypted-state-events = [

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -11,12 +11,13 @@ rust-version.workspace = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]
-default = ["state-store", "event-cache-store"]
+default = ["state-store", "event-cache-store", "media-store"]
 testing = ["matrix-sdk-crypto?/testing"]
 
 bundled = ["rusqlite/bundled"]
 crypto-store = ["dep:matrix-sdk-base", "dep:matrix-sdk-crypto"]
 event-cache-store = ["dep:matrix-sdk-base"]
+media-store = ["dep:matrix-sdk-base"]
 state-store = ["dep:matrix-sdk-base"]
 
 experimental-encrypted-state-events = [

--- a/crates/matrix-sdk-sqlite/changelog.d/6896.changed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/6896.changed.md
@@ -1,0 +1,2 @@
+The `event-cache` feature flag has been split into `event-cache-store` and
+`media-store`. Both are enabled by default.

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -786,7 +786,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         session_id: Key,
     ) -> Result<Option<(Vec<u8>, Vec<u8>, bool)>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT room_id, data, backed_up FROM inbound_group_session WHERE session_id = ?",
                 (session_id,),
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
@@ -808,10 +808,10 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         _backup_version: Option<&str>,
     ) -> Result<RoomKeyCounts> {
         let total = self
-            .query_row("SELECT count(*) FROM inbound_group_session", (), |row| row.get(0))
+            .query_one("SELECT count(*) FROM inbound_group_session", (), |row| row.get(0))
             .await?;
         let backed_up = self
-            .query_row(
+            .query_one(
                 "SELECT count(*) FROM inbound_group_session WHERE backed_up = TRUE",
                 (),
                 |row| row.get(0),
@@ -913,7 +913,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_outbound_group_session(&self, room_id: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM outbound_group_session WHERE room_id = ?",
                 (room_id,),
                 |row| row.get(0),
@@ -924,7 +924,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_device(&self, user_id: Key, device_id: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM device WHERE user_id = ? AND device_id = ?",
                 (user_id, device_id),
                 |row| row.get(0),
@@ -943,14 +943,14 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_user_identity(&self, user_id: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row("SELECT data FROM identity WHERE user_id = ?", (user_id,), |row| row.get(0))
+            .query_one("SELECT data FROM identity WHERE user_id = ?", (user_id,), |row| row.get(0))
             .await
             .optional()?)
     }
 
     async fn has_olm_hash(&self, data: Vec<u8>) -> Result<bool> {
         Ok(self
-            .query_row("SELECT count(*) FROM olm_hash WHERE data = ?", (data,), |row| {
+            .query_one("SELECT count(*) FROM olm_hash WHERE data = ?", (data,), |row| {
                 row.get::<_, i32>(0)
             })
             .await?
@@ -987,7 +987,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         request_id: Key,
     ) -> Result<Option<(Vec<u8>, bool)>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data, sent_out FROM key_requests WHERE request_id = ?",
                 (request_id,),
                 |row| Ok((row.get(0)?, row.get(1)?)),
@@ -998,7 +998,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_secret_request_by_info(&self, info: Key) -> Result<Option<(Vec<u8>, bool)>> {
         Ok(self
-            .query_row("SELECT data, sent_out FROM key_requests WHERE info = ?", (info,), |row| {
+            .query_one("SELECT data, sent_out FROM key_requests WHERE info = ?", (info,), |row| {
                 Ok((row.get(0)?, row.get(1)?))
             })
             .await
@@ -1037,7 +1037,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         room_id: Key,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM direct_withheld_info WHERE session_id = ?1 AND room_id = ?2",
                 (session_id, room_id),
                 |row| row.get(0),
@@ -1056,7 +1056,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_room_settings(&self, room_id: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row("SELECT data FROM room_settings WHERE room_id = ?", (room_id,), |row| {
+            .query_one("SELECT data FROM room_settings WHERE room_id = ?", (room_id,), |row| {
                 row.get(0)
             })
             .await
@@ -1069,7 +1069,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         sender_user: Key,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT bundle_data FROM received_room_key_bundle WHERE room_id = ? AND sender_user_id = ?",
                 (room_id, sender_user),
                 |row| { row.get(0) },
@@ -1080,7 +1080,7 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
 
     async fn get_room_pending_key_bundle(&self, room_id: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM rooms_pending_key_bundle WHERE room_id = ?",
                 (room_id,),
                 |row| row.get(0),
@@ -1843,7 +1843,7 @@ impl CryptoStore for SqliteCryptoStore {
             .write()
             .await?
             .with_transaction(move |txn| {
-                txn.query_row(
+                txn.query_one(
                     "INSERT INTO lease_locks (key, holder, expiration)
                     VALUES (?1, ?2, ?3)
                     ON CONFLICT (key)

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 use std::sync::Arc;
 
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 use matrix_sdk_base::event_cache::store::EventCacheStoreError;
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 use matrix_sdk_base::media::store::MediaStoreError;
 #[cfg(feature = "state-store")]
 use matrix_sdk_base::store::StoreError as StateStoreError;
@@ -177,7 +177,7 @@ impl From<Error> for StateStoreError {
     }
 }
 
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 impl From<Error> for EventCacheStoreError {
     fn from(e: Error) -> Self {
         match e {
@@ -187,7 +187,7 @@ impl From<Error> for EventCacheStoreError {
     }
 }
 
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 impl From<Error> for MediaStoreError {
     fn from(e: Error) -> Self {
         match e {

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "event-cache-store")]
 use matrix_sdk_base::event_cache::store::EventCacheStoreError;
-#[cfg(feature = "event-cache-store")]
+#[cfg(feature = "media-store")]
 use matrix_sdk_base::media::store::MediaStoreError;
 #[cfg(feature = "state-store")]
 use matrix_sdk_base::store::StoreError as StateStoreError;
@@ -187,7 +187,7 @@ impl From<Error> for EventCacheStoreError {
     }
 }
 
-#[cfg(feature = "event-cache-store")]
+#[cfg(feature = "media-store")]
 impl From<Error> for MediaStoreError {
     fn from(e: Error) -> Self {
         match e {

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -425,9 +425,9 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Gap> {
-        // There's at most one row for it in the database, so a call to `query_row` is
+        // There's at most one row for it in the database, so a call to `query_one` is
         // sufficient.
-        let encoded_prev_token: Vec<u8> = self.query_row(
+        let encoded_prev_token: Vec<u8> = self.query_one(
             "SELECT prev_token FROM gap_chunks WHERE chunk_id = ? AND linked_chunk_id = ?",
             (chunk_id.index(), &linked_chunk_id),
             |row| row.get(0),
@@ -665,7 +665,7 @@ impl EventCacheStore for SqliteEventCacheStore {
             .write()
             .await?
             .with_transaction(move |txn| {
-                txn.query_row(
+                txn.query_one(
                     "INSERT INTO lease_locks (key, holder, expiration) \
                     VALUES (?1, ?2, ?3) \
                     ON CONFLICT (key) \
@@ -763,7 +763,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                         trace!("removing chunk @ {chunk_id}");
 
                         // Find chunk to delete.
-                        let (previous, next): (Option<usize>, Option<usize>) = txn.query_row(
+                        let (previous, next): (Option<usize>, Option<usize>) = txn.query_one(
                             "SELECT previous, next FROM linked_chunks WHERE id = ? AND linked_chunk_id = ?",
                             (chunk_id, &hashed_linked_chunk_id),
                             |row| Ok((row.get(0)?, row.get(1)?))
@@ -1235,7 +1235,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     .prepare(
                         "SELECT MAX(id), COUNT(*) FROM linked_chunks WHERE linked_chunk_id = ?"
                     )?
-                    .query_row(
+                    .query_one(
                         (&hashed_linked_chunk_id,),
                         |row| {
                             Ok((
@@ -1263,7 +1263,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     .prepare(
                         "SELECT id, previous, type FROM linked_chunks WHERE linked_chunk_id = ? AND next IS NULL"
                     )?
-                    .query_row(
+                    .query_one(
                         (&hashed_linked_chunk_id,),
                         |row| {
                             Ok((
@@ -1330,7 +1330,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                     .prepare(
                         "SELECT id, previous, next, type FROM linked_chunks WHERE linked_chunk_id = ? AND next = ?"
                     )?
-                    .query_row(
+                    .query_one(
                         (&hashed_linked_chunk_id, before_chunk_identifier.index()),
                         |row| {
                             Ok((
@@ -1586,7 +1586,7 @@ impl EventCacheStore for SqliteEventCacheStore {
             .with_transaction(move |txn| -> Result<_> {
                 let Some(event) = txn
                     .prepare("SELECT content FROM events WHERE event_id = ? AND room_id = ?")?
-                    .query_row((hashed_event_id, hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
+                    .query_one((hashed_event_id, hashed_room_id), |row| row.get::<_, Vec<u8>>(0))
                     .optional()?
                 else {
                     // Event is not found.
@@ -2043,7 +2043,7 @@ mod tests {
             .await
             .unwrap()
             .with_transaction(move |txn| {
-                txn.query_row(
+                txn.query_one(
                     "SELECT COUNT(*) FROM event_chunks WHERE chunk_id = 42 AND linked_chunk_id = ? AND position IN (2, 3, 4)",
                     (hashed_linked_chunk_id,),
                     |row| row.get(0),
@@ -2069,12 +2069,12 @@ mod tests {
             .with_transaction(|txn| -> rusqlite::Result<_> {
                 let num_gaps = txn
                     .prepare("SELECT COUNT(chunk_id) FROM gap_chunks ORDER BY chunk_id")?
-                    .query_row((), |row| row.get::<_, u64>(0))?;
+                    .query_one((), |row| row.get::<_, u64>(0))?;
                 assert_eq!(num_gaps, 0);
 
                 let num_events = txn
                     .prepare("SELECT COUNT(event_id) FROM event_chunks ORDER BY chunk_id")?
-                    .query_row((), |row| row.get::<_, u64>(0))?;
+                    .query_one((), |row| row.get::<_, u64>(0))?;
                 assert_eq!(num_events, 0);
 
                 Ok(())

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 #![cfg_attr(
-    not(any(feature = "state-store", feature = "crypto-store", feature = "event-cache-store")),
+    not(any(
+        feature = "state-store",
+        feature = "crypto-store",
+        feature = "event-cache-store",
+        feature = "media-store"
+    )),
     allow(dead_code, unused_imports)
 )]
 
@@ -23,7 +28,7 @@ mod crypto_store;
 mod error;
 #[cfg(feature = "event-cache-store")]
 mod event_cache_store;
-#[cfg(feature = "event-cache-store")]
+#[cfg(feature = "media-store")]
 mod media_store;
 #[cfg(feature = "state-store")]
 mod state_store;
@@ -42,7 +47,7 @@ pub use self::crypto_store::SqliteCryptoStore;
 pub use self::error::OpenStoreError;
 #[cfg(feature = "event-cache-store")]
 pub use self::event_cache_store::SqliteEventCacheStore;
-#[cfg(feature = "event-cache-store")]
+#[cfg(feature = "media-store")]
 pub use self::media_store::SqliteMediaStore;
 #[cfg(feature = "state-store")]
 pub use self::state_store::{DATABASE_NAME as STATE_STORE_DATABASE_NAME, SqliteStateStore};

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #![cfg_attr(
-    not(any(feature = "state-store", feature = "crypto-store", feature = "event-cache")),
+    not(any(feature = "state-store", feature = "crypto-store", feature = "event-cache-store")),
     allow(dead_code, unused_imports)
 )]
 
@@ -21,9 +21,9 @@ mod connection;
 #[cfg(feature = "crypto-store")]
 mod crypto_store;
 mod error;
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 mod event_cache_store;
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 mod media_store;
 #[cfg(feature = "state-store")]
 mod state_store;
@@ -40,9 +40,9 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 #[cfg(feature = "crypto-store")]
 pub use self::crypto_store::SqliteCryptoStore;
 pub use self::error::OpenStoreError;
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 pub use self::event_cache_store::SqliteEventCacheStore;
-#[cfg(feature = "event-cache")]
+#[cfg(feature = "event-cache-store")]
 pub use self::media_store::SqliteMediaStore;
 #[cfg(feature = "state-store")]
 pub use self::state_store::{DATABASE_NAME as STATE_STORE_DATABASE_NAME, SqliteStateStore};

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -318,7 +318,7 @@ impl MediaStore for SqliteMediaStore {
             .write()
             .await?
             .with_transaction(move |txn| {
-                txn.query_row(
+                txn.query_one(
                     "INSERT INTO lease_locks (key, holder, expiration)
                     VALUES (?1, ?2, ?3)
                     ON CONFLICT (key)

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -592,6 +592,8 @@ impl MediaStoreInner for SqliteMediaStore {
                 // See: https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions
                 txn.execute("UPDATE media SET last_access = ? WHERE uri = ?", (timestamp, &uri))?;
 
+                // We can have more than one row (the URI is not unique, however, the tuple
+                // (URI, format) _is_ unique). Pick the first one here.
                 txn.query_row::<Vec<u8>, _, _>(
                     "SELECT data FROM media WHERE uri = ?",
                     (&uri,),

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -402,16 +402,6 @@ impl MediaStore for SqliteMediaStore {
     }
 
     #[instrument(skip(self))]
-    async fn get_media_content_for_uri(
-        &self,
-        uri: &MxcUri,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let _timer = timer!("method");
-
-        self.media_service.get_media_content_for_uri(self, uri).await
-    }
-
-    #[instrument(skip(self))]
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
         let _timer = timer!("method");
 
@@ -567,36 +557,6 @@ impl MediaStoreInner for SqliteMediaStore {
                 txn.query_row::<Vec<u8>, _, _>(
                     "SELECT data FROM media WHERE uri = ? AND format = ?",
                     (&uri, &format),
-                    |row| row.get(0),
-                )
-                .optional()
-            })
-            .await?;
-
-        data.map(|v| self.decode_value(&v).map(Into::into)).transpose()
-    }
-
-    async fn get_media_content_for_uri_inner(
-        &self,
-        uri: &MxcUri,
-        current_time: SystemTime,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let uri = self.encode_key(keys::MEDIA, uri);
-        let timestamp = time_to_timestamp(current_time);
-
-        let conn = self.write().await?;
-        let data = conn
-            .with_transaction::<_, rusqlite::Error, _>(move |txn| {
-                // Update the last access.
-                // We need to do this first so the transaction is in write mode right away.
-                // See: https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions
-                txn.execute("UPDATE media SET last_access = ? WHERE uri = ?", (timestamp, &uri))?;
-
-                // We can have more than one row (the URI is not unique, however, the tuple
-                // (URI, format) _is_ unique). Pick the first one here.
-                txn.query_row::<Vec<u8>, _, _>(
-                    "SELECT data FROM media WHERE uri = ?",
-                    (&uri,),
                     |row| row.get(0),
                 )
                 .optional()

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -248,7 +248,7 @@ impl SqliteStateStore {
                             "SELECT stripped, data FROM state_event
                              WHERE room_id = ? AND event_type = ?",
                         )?
-                        .query_row([room_id, event_type], |row| {
+                        .query_one([room_id, event_type], |row| {
                             Ok((row.get::<_, bool>(0)?, row.get::<_, Vec<u8>>(1)?))
                         })
                         .optional()?;
@@ -749,7 +749,7 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
     }
 
     fn get_room_info(&self, room_id: &[u8]) -> rusqlite::Result<Option<Vec<u8>>> {
-        self.query_row("SELECT data FROM room_info WHERE room_id = ?", (room_id,), |row| row.get(0))
+        self.query_one("SELECT data FROM room_info WHERE room_id = ?", (room_id,), |row| row.get(0))
             .optional()
     }
 
@@ -782,7 +782,7 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
         room_id: &[u8],
         event_id: &[u8],
     ) -> rusqlite::Result<Option<Vec<u8>>> {
-        self.query_row(
+        self.query_one(
             "SELECT data FROM state_event WHERE room_id = ? AND event_id = ?",
             (room_id, event_id),
             |row| row.get(0),
@@ -922,7 +922,7 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
 trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
     async fn get_kv_blob(&self, key: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row("SELECT value FROM kv_blob WHERE key = ?", (key,), |row| row.get(0))
+            .query_one("SELECT value FROM kv_blob WHERE key = ?", (key,), |row| row.get(0))
             .await
             .optional()?)
     }
@@ -1088,7 +1088,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
 
     async fn get_global_account_data(&self, event_type: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM global_account_data WHERE event_type = ?",
                 (event_type,),
                 |row| row.get(0),
@@ -1103,7 +1103,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         event_type: Key,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM room_account_data WHERE room_id = ? AND event_type = ?",
                 (room_id, event_type),
                 |row| row.get(0),
@@ -1144,7 +1144,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         user_id: Key,
     ) -> Result<Option<Vec<u8>>> {
         Ok(self
-            .query_row(
+            .query_one(
                 "SELECT data FROM receipt
                  WHERE room_id = ? AND receipt_type = ? AND thread = ? and user_id = ?",
                 (room_id, receipt_type, receipt_thread, user_id),
@@ -1610,7 +1610,7 @@ impl StateStore for SqliteStateStore {
                                 .prepare_cached(
                                     "SELECT profile_data FROM global_profiles WHERE user_id = ?",
                                 )?
-                                .query_row([&user_id], |row| row.get(0))
+                                .query_one([&user_id], |row| row.get(0))
                                 .optional()?;
 
                             let mut profile: UserProfile = existing_data
@@ -2427,7 +2427,7 @@ impl StateStore for SqliteStateStore {
         Ok(self
             .read()
             .await?
-            .query_row(
+            .query_one(
                 "SELECT status, bump_stamp FROM thread_subscriptions WHERE room_id = ? AND event_id = ?",
                 (room_id, thread_id),
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<u64>>(1)?))

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -97,6 +97,17 @@ pub(crate) trait SqliteAsyncConnExt {
         P: Params + Send + 'static,
         F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Send + 'static;
 
+    async fn query_one<T, P, F>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<T>
+    where
+        T: Send + 'static,
+        P: Params + Send + 'static,
+        F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Send + 'static;
+
     async fn query_many<T, P, F>(
         &self,
         sql: impl AsRef<str> + Send + 'static,
@@ -285,6 +296,22 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
         F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
     {
         self.interact(move |conn| conn.query_row(sql.as_ref(), params, f))
+            .await
+            .map_err(map_interact_err)?
+    }
+
+    async fn query_one<T, P, F>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<T>
+    where
+        T: Send + 'static,
+        P: Params + Send + 'static,
+        F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.interact(move |conn| conn.query_one(sql.as_ref(), params, f))
             .await
             .map_err(map_interact_err)?
     }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -42,6 +42,7 @@ sqlite = [
     "dep:matrix-sdk-sqlite",
     "matrix-sdk-sqlite?/state-store",
     "matrix-sdk-sqlite?/event-cache-store",
+    "matrix-sdk-sqlite?/media-store",
 ]
 bundled-sqlite = ["sqlite", "matrix-sdk-sqlite?/bundled"]
 indexeddb = [

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -41,7 +41,7 @@ js = [
 sqlite = [
     "dep:matrix-sdk-sqlite",
     "matrix-sdk-sqlite?/state-store",
-    "matrix-sdk-sqlite?/event-cache",
+    "matrix-sdk-sqlite?/event-cache-store",
 ]
 bundled-sqlite = ["sqlite", "matrix-sdk-sqlite?/bundled"]
 indexeddb = [

--- a/crates/matrix-sdk/changelog.d/6896.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6896.fixed.md
@@ -1,0 +1,2 @@
+`Media::get_media_content` now deterministically returns the content of
+a local media (i.e. a media sent by the user not yet received from the server).

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -432,13 +432,22 @@ impl Media {
         request: &MediaRequestParameters,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
-        // Ignore request parameters for local medias, notably those pending in the send
-        // queue.
-        if let Some(uri) = Self::as_local_uri(&request.source) {
-            return self.get_local_media_content(uri).await;
+        // This is a local media. Force to read the media's content from the store: it
+        // cannot exist somewhere else!
+        if let Some(_uri) = Self::as_local_uri(&request.source) {
+            if let Some(content) =
+                self.client.media_store().lock().await?.get_media_content(request).await?
+            {
+                return Ok(content);
+            } else {
+                return Err(Error::MediaStore(Box::new(store::MediaStoreError::InvalidData {
+                    details: format!("Media does not exist: `{request:?}`"),
+                })));
+            }
         }
 
-        // Read from the cache.
+        // Read from the cache: if it doesn't exist, the execution continues by reading
+        // the media from the network.
         if use_cache
             && let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
@@ -465,22 +474,6 @@ impl Media {
         }
 
         Ok(content)
-    }
-
-    /// Get a media file's content that is only available in the media cache.
-    ///
-    /// # Arguments
-    ///
-    /// * `uri` - The local MXC URI of the media content.
-    async fn get_local_media_content(&self, uri: &MxcUri) -> Result<Vec<u8>> {
-        // Read from the cache.
-        self.client
-            .media_store()
-            .lock()
-            .await?
-            .get_media_content_for_uri(uri)
-            .await?
-            .ok_or_else(|| MediaError::LocalMediaNotFound.into())
     }
 
     /// Remove a media file's content from the store.

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -434,7 +434,7 @@ impl Media {
     ) -> Result<Vec<u8>> {
         // This is a local media. Force to read the media's content from the store: it
         // cannot exist somewhere else!
-        if let Some(_uri) = Self::as_local_uri(&request.source) {
+        if Self::is_local_uri(&request.source) {
             if let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
             {
@@ -704,18 +704,17 @@ impl Media {
         }
     }
 
-    /// Returns the local MXC URI contained by the given source, if any.
+    /// Checks whether the MXC represents a local URI.
     ///
-    /// A local MXC URI is a URI that was generated with `make_local_uri`.
-    fn as_local_uri(source: &MediaSource) -> Option<&MxcUri> {
+    /// A local MXC URI is a URI that was generated with
+    /// [`Self::make_local_uri`].
+    fn is_local_uri(source: &MediaSource) -> bool {
         let uri = match source {
             MediaSource::Plain(uri) => uri,
             MediaSource::Encrypted(file) => &file.url,
         };
 
-        uri.server_name()
-            .is_ok_and(|server_name| server_name == LOCAL_MXC_SERVER_NAME)
-            .then_some(uri)
+        uri.server_name().is_ok_and(|server_name| server_name == LOCAL_MXC_SERVER_NAME)
     }
 }
 
@@ -821,7 +820,8 @@ impl MediaFetcher for DefaultMediaFetcher {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use std::ops::Not;
+
     use ruma::{
         MxcUri,
         events::room::{EncryptedFile, MediaSource},
@@ -854,34 +854,39 @@ mod tests {
     }
 
     #[test]
-    fn test_as_local_uri() {
+    fn test_make_local_uri() {
+        let txn_id = "abcdef";
+
+        let uri = Media::make_local_uri(txn_id.into());
+        assert_eq!(uri.media_id().unwrap(), txn_id);
+    }
+
+    #[test]
+    fn test_is_local_uri() {
         let txn_id = "abcdef";
 
         // Request generated with `make_local_file_media_request`.
         let request = Media::make_local_file_media_request(txn_id.into());
-        assert_matches!(Media::as_local_uri(&request.source), Some(uri));
-        assert_eq!(uri.media_id(), Ok(txn_id));
+        assert!(Media::is_local_uri(&request.source));
 
         // Local plain source.
         let source = MediaSource::Plain(Media::make_local_uri(txn_id.into()));
-        assert_matches!(Media::as_local_uri(&source), Some(uri));
-        assert_eq!(uri.media_id(), Ok(txn_id));
+        assert!(Media::is_local_uri(&source));
 
         // Local encrypted source.
         let source = MediaSource::Encrypted(encrypted_file(&Media::make_local_uri(txn_id.into())));
-        assert_matches!(Media::as_local_uri(&source), Some(uri));
-        assert_eq!(uri.media_id(), Ok(txn_id));
+        assert!(Media::is_local_uri(&source));
 
         // Test non-local plain source.
         let source = MediaSource::Plain(owned_mxc_uri!("mxc://server.local/poiuyt"));
-        assert_matches!(Media::as_local_uri(&source), None);
+        assert!(Media::is_local_uri(&source).not());
 
         // Test non-local encrypted source.
         let source = MediaSource::Encrypted(encrypted_file(mxc_uri!("mxc://server.local/mlkjhg")));
-        assert_matches!(Media::as_local_uri(&source), None);
+        assert!(Media::is_local_uri(&source).not());
 
         // Test invalid MXC URI.
         let source = MediaSource::Plain("https://server.local/nbvcxw".into());
-        assert_matches!(Media::as_local_uri(&source), None);
+        assert!(Media::is_local_uri(&source).not());
     }
 }

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -2180,23 +2180,6 @@ async fn test_media_uploads() {
         .expect("media should be found");
     assert_eq!(thumbnail_media, b"thumbnail");
 
-    // The format should be ignored when requesting a local media.
-    let thumbnail_media = client
-        .media()
-        .get_media_content(
-            &MediaRequestParameters {
-                source: local_thumbnail_source.clone(),
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
-            },
-            true,
-        )
-        .await
-        .expect("media should be found");
-    assert_eq!(thumbnail_media, b"thumbnail");
-
     // ----------------------
     // Send handle operations.
 
@@ -2519,23 +2502,6 @@ async fn test_gallery_uploads() {
         .expect("media should be found");
     assert_eq!(thumbnail_media, b"thumbnail");
 
-    // The format should be ignored when requesting a local media.
-    let thumbnail_media = client
-        .media()
-        .get_media_content(
-            &MediaRequestParameters {
-                source: local_thumbnail_source1.clone(),
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
-            },
-            true,
-        )
-        .await
-        .expect("media should be found");
-    assert_eq!(thumbnail_media, b"thumbnail");
-
     // ----------------------
     // Media 2.
     assert_let!(GalleryItemType::Image(img_content) = gallery_content.itemtypes.get(1).unwrap());
@@ -2587,23 +2553,6 @@ async fn test_gallery_uploads() {
             &MediaRequestParameters {
                 source: local_thumbnail_source2.clone(),
                 format: MediaFormat::File,
-            },
-            true,
-        )
-        .await
-        .expect("media should be found");
-    assert_eq!(thumbnail_media, b"another thumbnail");
-
-    // The format should be ignored when requesting a local media.
-    let thumbnail_media = client
-        .media()
-        .get_media_content(
-            &MediaRequestParameters {
-                source: local_thumbnail_source2.clone(),
-                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
-                    tinfo.width.unwrap(),
-                    tinfo.height.unwrap(),
-                )),
             },
             true,
         )


### PR DESCRIPTION
This small adventure has started when I noticed [the `rusqlite::Transaction::query_one` method](https://docs.rs/rusqlite/latest/rusqlite/struct.Transaction.html#method.query_one), sibling of `query_row`. In various places in the code, we assume many requests must return a single row, but we never check it. How fool we are. By replacing `query_row` by `query_one`, admittedly it adds one call to `sqlite3_next` ([[1]] [[2]]) but, it guarantees the query is correct, ensuring the data are valid!

I was then in a quest to replace all `query_row` by `query_one` when it made sense of course. Which led me to notice that `matrix_sdk_sqlite::SqliteMediaStore::get_media_content_for_uri` uses `query_row`; perhaps it should use `query_one`, I've asked myself, as it's supposed to return a single media's content, right?

https://github.com/matrix-org/matrix-rust-sdk/blob/136d7cd7df1b08e9cf0dd1047a7ee6ec673b21f6/crates/matrix-sdk-sqlite/src/media_store.rs#L590-L604

Turns out it doesn't always return at most one row because the `uri` is not unique in the database!

https://github.com/matrix-org/matrix-rust-sdk/blob/136d7cd7df1b08e9cf0dd1047a7ee6ec673b21f6/crates/matrix-sdk-sqlite/migrations/media_store/001_init.sql#L7-L15

In some tests, it returns two rows: one with the `MediaFormat::File` format, and another one with the `MediaFormat::Thumbnail` format. The `uri` and the `format` form the unique key. Hence, using `query_one` was failing. So, you may rightfully ask, what was happening with `query_row`? The media's content from either the file or the thumbnail was randomly returned, in a nondeterministic way!

After a bit of investigation, it appears that `get_media_content_for_uri` is only for local media (like local event: sent to the server by the own user but not received from the server yet):

https://github.com/matrix-org/matrix-rust-sdk/blob/136d7cd7df1b08e9cf0dd1047a7ee6ec673b21f6/crates/matrix-sdk/src/media.rs#L430-L439

These patches solve this bug by relying on `get_media_content` for remote _and_ local media. Just like that, we can remove all the implementations related to `get_media_content_for_uri` everywhere.

These patches also clarifies the feature flag in `matrix-sdk-sqlite`:

- `event-cache` is renamed `event-cache-store` to align with other feature naming convention,
- `event-cache-store` is split into `event-cache-store` and `media-store` (an artefact from when the Media store was part of the Event Cache store).

Finally, we use `query_one` in more places now. It turns to be useful as we've found one bug ^^.

[1]: https://docs.rs/rusqlite/0.40.2/src/rusqlite/row.rs.html#214-217
[2]: https://docs.rs/rusqlite/0.40.2/src/rusqlite/raw_statement.rs.html#144-178

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
