### PR TITLE
fix(ui): Keep thread summary in redacted messages

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6897.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6897.fixed.md
@@ -1,0 +1,1 @@
+Fixed redacted messages not having thread summaries.

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -238,8 +238,12 @@ impl TimelineAction {
         let redaction_rules = room_data_provider.room_version_rules().redaction;
 
         let redacted_message_or_none = |event_type: MessageLikeEventType| {
-            (event_type != MessageLikeEventType::Reaction)
-                .then_some(TimelineItemContent::MsgLike(MsgLikeContent::redacted()))
+            (event_type != MessageLikeEventType::Reaction).then_some(TimelineItemContent::MsgLike(
+                MsgLikeContent {
+                    thread_summary: thread_summary.clone(),
+                    ..MsgLikeContent::redacted()
+                },
+            ))
         };
 
         match event {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -440,7 +440,13 @@ impl TimelineItemContent {
 
     pub(in crate::timeline) fn redact(&self, rules: &RedactionRules) -> Self {
         match self {
-            Self::MsgLike(_) | Self::CallInvite | Self::RtcNotification { .. } => {
+            Self::MsgLike(msglike) => TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::Redacted,
+                reactions: Default::default(),
+                in_reply_to: None,
+                ..msglike.clone()
+            }),
+            Self::CallInvite | Self::RtcNotification { .. } => {
                 TimelineItemContent::MsgLike(MsgLikeContent::redacted())
             }
             Self::MembershipChange(ev) => Self::MembershipChange(ev.redact(rules)),

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -220,7 +220,7 @@ async fn test_redact_thread_reply_keeps_thread_root() {
 
     timeline
         .handle_live_event(
-            f.text_msg("reply").event_id(reply_id).sender(&BOB).in_thread(root_id, reply_id),
+            f.text_msg("reply").event_id(reply_id).sender(&BOB).in_thread(root_id, root_id),
         )
         .await;
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -206,6 +206,36 @@ async fn test_reaction_redaction_timeline_filter() {
 }
 
 #[async_test]
+async fn test_redact_thread_reply_keeps_thread_root() {
+    let timeline = TestTimeline::new().await;
+    let mut stream = timeline.subscribe_events().await;
+
+    let f = &timeline.factory;
+
+    let root_id = event_id!("$root");
+    let reply_id = event_id!("$reply");
+
+    timeline.handle_live_event(f.text_msg("root").event_id(root_id).sender(&ALICE)).await;
+    let _ = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    timeline
+        .handle_live_event(
+            f.text_msg("reply").event_id(reply_id).sender(&BOB).in_thread(root_id, reply_id),
+        )
+        .await;
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    assert_eq!(item.content().thread_root().as_deref(), Some(root_id));
+
+    // The thread reply is redacted.
+    timeline.handle_live_event(f.redaction(reply_id).sender(&BOB)).await;
+
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    assert!(item.content().is_redacted());
+    // The redacted reply is still recognized as part of the thread.
+    assert_eq!(item.content().thread_root().as_deref(), Some(root_id));
+}
+
+#[async_test]
 async fn test_local_and_remote_echo_of_redaction() {
     let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -481,12 +481,19 @@ mod tests {
     use futures_util::pin_mut;
     use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
-    use ruma::{event_id, events::AnyTimelineEvent, room_id, serde::Raw, user_id};
+    use ruma::{
+        event_id,
+        events::{AnyTimelineEvent, room::message::RedactedRoomMessageEventContent},
+        room_id,
+        serde::Raw,
+        user_id,
+    };
     use serde_json::json;
     use stream_assert::{assert_next_matches, assert_pending};
     use wiremock::ResponseTemplate;
 
     use super::{ThreadListPaginationState, ThreadListService};
+    use crate::timeline::{MsgLikeContent, MsgLikeKind, TimelineItemContent};
 
     #[async_test]
     async fn test_initial_state() {
@@ -797,6 +804,53 @@ mod tests {
         let latest = items[0].latest_event.as_ref().expect("should have latest_event");
         assert_eq!(latest.event_id, reply_id);
         assert_eq!(latest.sender.as_str(), sender_id.as_str());
+    }
+
+    #[async_test]
+    async fn test_redacted_root_content_is_preserved() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+        let sender_id = user_id!("@alice:b.c");
+        let f = EventFactory::new().room(room_id).sender(sender_id);
+        let root_id = event_id!("$root");
+        let reply_id = event_id!("$reply");
+
+        let reply_event =
+            f.text_msg("Reply in thread").event_id(reply_id).into_raw_sync().cast_unchecked();
+
+        // Redacted thread root, still carrying a bundled thread summary.
+        let thread_root = f
+            .redacted(sender_id, RedactedRoomMessageEventContent::new())
+            .event_id(root_id)
+            .with_bundled_thread_summary(reply_event, 3, false)
+            .into_raw();
+
+        server.mock_room_threads().ok(vec![thread_root], None).mock_once().mount().await;
+
+        let room = server.sync_joined_room(&client, room_id).await;
+        let service = ThreadListService::new(room);
+
+        service.paginate().await.expect("paginate failed");
+
+        let items = service.items();
+        assert_eq!(items.len(), 1);
+
+        // The redacted root is surfaced as a redacted message.
+        assert!(matches!(
+            items[0].root_event.content,
+            Some(TimelineItemContent::MsgLike(MsgLikeContent { kind: MsgLikeKind::Redacted, .. }))
+        ));
+
+        // The plaintext latest reply is surfaced as a regular message.
+        let latest = items[0].latest_event.as_ref().expect("should have latest_event");
+        assert!(matches!(
+            latest.content,
+            Some(TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::Message(_),
+                ..
+            }))
+        ));
     }
 
     /// Builds a [`ThreadListService`] and makes the room known to the client

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -807,7 +807,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_redacted_root_content_is_preserved() {
+    async fn test_redacted_root_still_listed_with_summary() {
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let room_id = room_id!("!a:b.c");
@@ -835,6 +835,8 @@ mod tests {
 
         let items = service.items();
         assert_eq!(items.len(), 1);
+        assert_eq!(items[0].root_event.event_id, root_id);
+        assert_eq!(items[0].num_replies, 3);
 
         // The redacted root is surfaced as a redacted message.
         assert!(matches!(
@@ -844,6 +846,7 @@ mod tests {
 
         // The plaintext latest reply is surfaced as a regular message.
         let latest = items[0].latest_event.as_ref().expect("should have latest_event");
+        assert_eq!(latest.event_id, reply_id);
         assert!(matches!(
             latest.content,
             Some(TimelineItemContent::MsgLike(MsgLikeContent {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -43,8 +43,8 @@ use ruma::{
         room::{
             ImageInfo,
             message::{
-                Relation, ReplacementMetadata, RoomMessageEventContent,
-                RoomMessageEventContentWithoutRelation,
+                RedactedRoomMessageEventContent, Relation, ReplacementMetadata,
+                RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             },
         },
         sticker::{StickerEventContent, StickerMediaSource},
@@ -304,6 +304,133 @@ async fn test_extract_bundled_thread_summary() {
 
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
     assert!(value.is_date_divider());
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_redact_thread_root_keeps_thread_summary() {
+    // Redacting the thread root must not hide the thread: the thread summary
+    // is preserved on the redacted item.
+
+    let server = MatrixMockServer::new().await;
+    let client = client_with_threading_support(&server).await;
+
+    let room_id = room_id!("!a:b.c");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut stream) = timeline.subscribe().await;
+
+    let f = EventFactory::new().room(room_id).sender(&ALICE);
+    let thread_event_id = event_id!("$thread_root");
+    let latest_event_id = event_id!("$latest_event");
+
+    // `with_bundled_thread_summary` expects `Raw<AnySyncMessageLikeEvent>`,
+    // so we cast from the more general `Raw<AnySyncTimelineEvent>`.
+    let reply_event = f
+        .text_msg("the last reply")
+        .event_id(latest_event_id)
+        .sender(&BOB)
+        .into_raw_sync()
+        .cast_unchecked();
+
+    // A thread root message, with a bundled thread summary.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.text_msg("thread root").event_id(thread_event_id).with_bundled_thread_summary(
+                    reply_event,
+                    42,
+                    false,
+                ),
+            ),
+        )
+        .await;
+
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    // Message + day divider.
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    assert_eq!(summary.num_replies, 42);
+
+    // Redact the thread root.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_timeline_event(f.redaction(thread_event_id).sender(&ALICE)),
+        )
+        .await;
+
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert!(event_item.content().is_redacted());
+    // The thread summary is preserved, so the thread stays accessible from the
+    // main timeline.
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    assert_eq!(summary.num_replies, 42);
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_already_redacted_thread_root_keeps_bundled_thread_summary() {
+    // A thread root that arrives in the timeline already redacted (e.g. after a
+    // fresh sync or pagination) must keep its bundled thread summary, so that
+    // the thread stays accessible from the main timeline.
+
+    let server = MatrixMockServer::new().await;
+    let client = client_with_threading_support(&server).await;
+
+    let room_id = room_id!("!a:b.c");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut stream) = timeline.subscribe().await;
+
+    let f = EventFactory::new().room(room_id).sender(&ALICE);
+    let thread_event_id = event_id!("$thread_root");
+    let latest_event_id = event_id!("$latest_event");
+
+    // `with_bundled_thread_summary` expects `Raw<AnySyncMessageLikeEvent>`,
+    // so we cast from the more general `Raw<AnySyncTimelineEvent>`.
+    let reply_event = f
+        .text_msg("the last reply")
+        .event_id(latest_event_id)
+        .sender(&BOB)
+        .into_raw_sync()
+        .cast_unchecked();
+
+    // An already-redacted thread root, still carrying its bundled thread
+    // summary in the unsigned section.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.redacted(&ALICE, RedactedRoomMessageEventContent::new())
+                    .event_id(thread_event_id)
+                    .with_bundled_thread_summary(reply_event, 42, false),
+            ),
+        )
+        .await;
+
+    assert_let_timeout!(Some(timeline_updates) = stream.next());
+    // Message + day divider.
+    assert_eq!(timeline_updates.len(), 2);
+
+    assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
+    let event_item = value.as_event().unwrap();
+    assert!(event_item.content().is_redacted());
+    // The thread summary is preserved, so the thread stays accessible from the
+    // main timeline.
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    assert_eq!(summary.num_replies, 42);
 
     assert_pending!(stream);
 }


### PR DESCRIPTION
SDK part to fix https://github.com/element-hq/element-x-android/issues/7397
We technically also now keep the in-thread messages' thread info for live-redacted messages, which is related to https://github.com/matrix-org/matrix-spec-proposals/pull/3389

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
