### PR TITLE
fix(ui): Expose UTD info on `TimelineItemContent::from_event()`

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6898.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6898.fixed.md
@@ -1,0 +1,1 @@
+Show the UTD error for events from `TimelineItemContent::from_event()` instead of the generic "Unsupported event".

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -15,7 +15,10 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use matrix_sdk::{Room, deserialized_responses::TimelineEvent};
+use matrix_sdk::{
+    Room,
+    deserialized_responses::{TimelineEvent, TimelineEventKind},
+};
 use matrix_sdk_base::crypto::types::events::UtdCause;
 use ruma::{
     OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, UserId,
@@ -164,16 +167,20 @@ impl TimelineItemContent {
 
     /// Create a raw [`TimelineItemContent`] for a given [`TimelineEvent`],
     /// without providing extra information (about thread root, replied-to
-    /// information, UTD info, and so on).
+    /// information, and so on).
     pub async fn from_event(room: &Room, timeline_event: TimelineEvent) -> Option<Self> {
-        let raw_event = timeline_event.into_raw();
+        let (utd_info, raw_event) = match timeline_event.kind {
+            TimelineEventKind::UnableToDecrypt { utd_info, event } => (Some(utd_info), event),
+            _ => (None, timeline_event.into_raw()),
+        };
+
         let deserialized_event = raw_event.deserialize().ok()?;
 
         let actions = TimelineAction::from_event(
             deserialized_event,
             &raw_event,
             room,
-            None,
+            utd_info.map(|utd_info| (utd_info, None)),
             None,
             None,
             None,

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -481,12 +481,27 @@ mod tests {
     use futures_util::pin_mut;
     use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
-    use ruma::{event_id, events::AnyTimelineEvent, room_id, serde::Raw, user_id};
+    use ruma::{
+        event_id,
+        events::{
+            AnyTimelineEvent,
+            room::{
+                encrypted::{
+                    EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
+                },
+                message::RedactedRoomMessageEventContent,
+            },
+        },
+        room_id,
+        serde::Raw,
+        user_id,
+    };
     use serde_json::json;
     use stream_assert::{assert_next_matches, assert_pending};
     use wiremock::ResponseTemplate;
 
     use super::{ThreadListPaginationState, ThreadListService};
+    use crate::timeline::{MsgLikeContent, MsgLikeKind, TimelineItemContent};
 
     #[async_test]
     async fn test_initial_state() {
@@ -797,6 +812,64 @@ mod tests {
         let latest = items[0].latest_event.as_ref().expect("should have latest_event");
         assert_eq!(latest.event_id, reply_id);
         assert_eq!(latest.sender.as_str(), sender_id.as_str());
+    }
+
+    #[async_test]
+    async fn test_redacted_root_with_encrypted_latest_event() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+        let room_id = room_id!("!a:b.c");
+        let sender_id = user_id!("@alice:b.c");
+        let f = EventFactory::new().room(room_id).sender(sender_id);
+        let root_id = event_id!("$root");
+        let latest_id = event_id!("$latest");
+
+        // The bundled latest reply is encrypted (E2EE room).
+        let encrypted_latest = f
+            .event(RoomEncryptedEventContent::new(
+                EncryptedEventScheme::MegolmV1AesSha2(
+                    MegolmV1AesSha2ContentInit {
+                        ciphertext: "ciphertext".to_owned(),
+                        sender_key: "sender-key".to_owned(),
+                        device_id: "device-id".to_owned().into(),
+                        session_id: "session-id".to_owned(),
+                    }
+                    .into(),
+                ),
+                None,
+            ))
+            .event_id(latest_id)
+            .into_raw_sync()
+            .cast_unchecked();
+
+        // Redacted thread root, still carrying a bundled thread summary whose
+        // latest event is still encrypted.
+        let thread_root = f
+            .redacted(sender_id, RedactedRoomMessageEventContent::new())
+            .event_id(root_id)
+            .with_bundled_thread_summary(encrypted_latest, 3, false)
+            .into_raw();
+
+        server.mock_room_threads().ok(vec![thread_root], None).mock_once().mount().await;
+
+        let room = server.sync_joined_room(&client, room_id).await;
+        let service = ThreadListService::new(room);
+
+        service.paginate().await.expect("paginate failed");
+
+        let items = service.items();
+        assert_eq!(items.len(), 1);
+
+        // The latest event is still encrypted: it must be surfaced as a UTD,
+        // not as an unsupported/other event.
+        let latest = items[0].latest_event.as_ref().expect("should have latest_event");
+        assert!(matches!(
+            latest.content,
+            Some(TimelineItemContent::MsgLike(MsgLikeContent {
+                kind: MsgLikeKind::UnableToDecrypt(_),
+                ..
+            }))
+        ));
     }
 
     /// Builds a [`ThreadListService`] and makes the room known to the client

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -478,6 +478,7 @@ struct ThreadList {
 mod tests {
     use std::time::Duration;
 
+    use assert_matches::assert_matches;
     use futures_util::pin_mut;
     use matrix_sdk::test_utils::mocks::MatrixMockServer;
     use matrix_sdk_test::{async_test, event_factory::EventFactory};
@@ -497,7 +498,6 @@ mod tests {
         user_id,
     };
     use serde_json::json;
-    use assert_matches::assert_matches;
     use stream_assert::{assert_next_matches, assert_pending};
     use wiremock::ResponseTemplate;
 

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -497,6 +497,7 @@ mod tests {
         user_id,
     };
     use serde_json::json;
+    use assert_matches::assert_matches;
     use stream_assert::{assert_next_matches, assert_pending};
     use wiremock::ResponseTemplate;
 
@@ -863,13 +864,13 @@ mod tests {
         // The latest event is still encrypted: it must be surfaced as a UTD,
         // not as an unsupported/other event.
         let latest = items[0].latest_event.as_ref().expect("should have latest_event");
-        assert!(matches!(
+        assert_matches!(
             latest.content,
             Some(TimelineItemContent::MsgLike(MsgLikeContent {
                 kind: MsgLikeKind::UnableToDecrypt(_),
                 ..
             }))
-        ));
+        );
     }
 
     #[async_test]


### PR DESCRIPTION
Not exposing UTD info there leads to a generic "Unsupported event" error if the latest message is UTD in the thread/room list or the search results.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
