### PR TITLE
FFI: Rename `ClientBuilder::username` to `server_name_from_user_id`.

### DIFF
--- a/bindings/apple/Tests/MatrixRustSDKTests/ClientTests.swift
+++ b/bindings/apple/Tests/MatrixRustSDKTests/ClientTests.swift
@@ -23,13 +23,13 @@ final class ClientTests: XCTestCase {
         }
     }
     
-    func testBuildingWithInvalidUsername() async {
+    func testBuildingWithInvalidUserID() async {
         do {
             _ = try await ClientBuilder()
-                .username(username: "@test:invalid")
+                .serverNameFromUserId(userId: "@test:invalid")
                 .build()
             
-            XCTFail("The client should not build when given an invalid username.")
+            XCTFail("The client should not build when given an invalid user ID.")
         } catch ClientBuildError.ServerUnreachable(let message) {
             XCTAssertTrue(message.contains(".well-known"), "The client should fail to do the well-known lookup.")
         } catch {

--- a/bindings/matrix-sdk-ffi/changelog.d/6900.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6900.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] `ClientBuilder::username` has been renamed to `ClientBuilder::server_name_from_user_id`. Make sure to only build a `Client` with one of `homeserver_url`, `server_name`, `server_name_or_homeserver_url` or `server_name_from_user_id`. There's no need to use this method when the built `Client` will be restored from a `Session` (and there never was).

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -67,6 +67,7 @@ enum HomeserverConfig {
     Url(String),
     ServerName(String),
     ServerNameOrUrl(String),
+    ServerNameFromUserId(String),
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -153,7 +154,6 @@ impl From<ClientError> for ClientBuildError {
 pub struct ClientBuilder {
     store: Option<StoreBuilder>,
     system_is_memory_constrained: bool,
-    username: Option<String>,
     homeserver_cfg: Option<HomeserverConfig>,
     sliding_sync_version_builder: SlidingSyncVersionBuilder,
     disable_automatic_token_refresh: bool,
@@ -203,7 +203,6 @@ impl ClientBuilder {
         Arc::new(Self {
             store: None,
             system_is_memory_constrained: false,
-            username: None,
             homeserver_cfg: None,
             #[cfg(not(target_family = "wasm"))]
             user_agent: None,
@@ -283,17 +282,20 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
-    /// Set the user ID the homeserver is derived from, when none of
-    /// `homeserver_url`, `server_name` or `server_name_or_homeserver_url` was
-    /// called.
+    /// Uses the server name from the supplied the user ID to discover the 
+    /// homeserver. 
     ///
-    /// The homeserver is then discovered from the server name of that user ID,
-    /// which requires a `.well-known/matrix/client` lookup. This is therefore
-    /// incompatible with `disable_well_known_lookup`, which makes `build` fail
-    /// with `ClientBuildError::WellKnownLookupDisabled`.
-    pub fn username(self: Arc<Self>, username: String) -> Arc<Self> {
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`], [`Self::server_name_or_homeserver_url`] and
+    /// [`Self::server_name_from_user_id`]. If you set more than one, then
+    /// whichever was set last will be used.
+    ///
+    /// This performs a `.well-known/matrix/client` lookup, and is therefore
+    /// incompatible with [`Self::disable_well_known_lookup`]: [`Self::build`]
+    /// then fails with [`ClientBuildError::WellKnownLookupDisabled`].
+    pub fn server_name_from_user_id(self: Arc<Self>, user_id: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.username = Some(username);
+        builder.homeserver_cfg = Some(HomeserverConfig::ServerNameFromUserId(user_id));
         Arc::new(builder)
     }
 
@@ -402,9 +404,10 @@ impl ClientBuilder {
     ///
     /// The homeserver must then be resolvable without a well-known lookup, so
     /// `ClientBuilder::homeserver_url` must be used.
-    /// `ClientBuilder::server_name` and `ClientBuilder::username` can only
-    /// be resolved through the well-known, and `ClientBuilder::build` fails
-    /// with `ClientBuildError::WellKnownLookupDisabled` in that case.
+    /// `ClientBuilder::server_name` and
+    /// `ClientBuilder::server_name_from_user_id` can only be resolved through
+    /// the well-known, and `ClientBuilder::build` fails with
+    /// `ClientBuildError::WellKnownLookupDisabled` in that case.
     /// `ClientBuilder::server_name_or_homeserver_url` skips the well-known step
     /// and works only when given a homeserver URL.
     pub fn disable_well_known_lookup(
@@ -500,15 +503,14 @@ impl ClientBuilder {
             Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url)) => {
                 inner_builder.server_name_or_homeserver_url(server_name_or_url)
             }
+            Some(HomeserverConfig::ServerNameFromUserId(user_id)) => {
+                let user = UserId::parse(user_id)?;
+                inner_builder.server_name(user.server_name())
+            }
             None => {
-                if let Some(username) = builder.username {
-                    let user = UserId::parse(username)?;
-                    inner_builder.server_name(user.server_name())
-                } else {
-                    return Err(ClientBuildError::Generic {
-                        message: "Failed to build: One of homeserver_url, server_name, server_name_or_homeserver_url or username must be called.".to_owned(),
-                    });
-                }
+                return Err(ClientBuildError::Generic {
+                    message: "Failed to build: One of homeserver_url, server_name, server_name_or_homeserver_url or server_name_from_user_id must be called.".to_owned(),
+                });
             }
         };
 

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -282,8 +282,66 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
-    /// Uses the server name from the supplied the user ID to discover the 
-    /// homeserver. 
+    /// Set the homeserver URL to use.
+    ///
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`], [`Self::server_name_or_homeserver_url`] and
+    /// [`Self::server_name_from_user_id`]. If you set more than one, then
+    /// whichever was set last will be used.
+    ///
+    /// This is the only one of them that never performs a
+    /// `.well-known/matrix/client` lookup, so it is the one to use together
+    /// with [`Self::disable_well_known_lookup`].
+    pub fn homeserver_url(self: Arc<Self>, url: String) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.homeserver_cfg = Some(HomeserverConfig::Url(url));
+        Arc::new(builder)
+    }
+
+    /// Set the server name to discover the homeserver from.
+    ///
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`], [`Self::server_name_or_homeserver_url`] and
+    /// [`Self::server_name_from_user_id`]. If you set more than one, then
+    /// whichever was set last will be used.
+    ///
+    /// This performs a `.well-known/matrix/client` lookup, and is therefore
+    /// incompatible with [`Self::disable_well_known_lookup`]: [`Self::build`]
+    /// then fails with [`ClientBuildError::WellKnownLookupDisabled`].
+    pub fn server_name(self: Arc<Self>, server_name: String) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.homeserver_cfg = Some(HomeserverConfig::ServerName(server_name));
+        Arc::new(builder)
+    }
+
+    /// Set the server name to discover the homeserver from, falling back to
+    /// using it as a homeserver URL if discovery fails. When falling back to a
+    /// homeserver URL, a check is made to ensure that the server exists (unlike
+    /// [`Self::homeserver_url`], so you can guarantee that the client is ready
+    /// to use.
+    ///
+    /// The following methods are mutually exclusive: [`Self::homeserver_url`],
+    /// [`Self::server_name`], [`Self::server_name_or_homeserver_url`] and
+    /// [`Self::server_name_from_user_id`]. If you set more than one, then
+    /// whichever was set last will be used.
+    ///
+    /// With [`Self::disable_well_known_lookup`], the discovery step is skipped
+    /// and only the homeserver URL check is performed, so a homeserver URL
+    /// still works while a delegating server name fails with
+    /// [`ClientBuildError::InvalidServerName`].
+    pub fn server_name_or_homeserver_url(self: Arc<Self>, server_name_or_url: String) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.homeserver_cfg = Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url));
+        Arc::new(builder)
+    }
+
+    /// Uses the server name from the supplied the user ID to discover the
+    /// homeserver.
+    ///
+    /// When building a client for restoration, prefer to use
+    /// [`Self::homeserver_url`] as the restoration will pick up the user ID
+    /// from the [`Session`], and using this will result in a needless request
+    /// to re-discover the homeserver.
     ///
     /// The following methods are mutually exclusive: [`Self::homeserver_url`],
     /// [`Self::server_name`], [`Self::server_name_or_homeserver_url`] and
@@ -296,24 +354,6 @@ impl ClientBuilder {
     pub fn server_name_from_user_id(self: Arc<Self>, user_id: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.homeserver_cfg = Some(HomeserverConfig::ServerNameFromUserId(user_id));
-        Arc::new(builder)
-    }
-
-    pub fn server_name(self: Arc<Self>, server_name: String) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.homeserver_cfg = Some(HomeserverConfig::ServerName(server_name));
-        Arc::new(builder)
-    }
-
-    pub fn homeserver_url(self: Arc<Self>, url: String) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.homeserver_cfg = Some(HomeserverConfig::Url(url));
-        Arc::new(builder)
-    }
-
-    pub fn server_name_or_homeserver_url(self: Arc<Self>, server_name_or_url: String) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.homeserver_cfg = Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url));
         Arc::new(builder)
     }
 


### PR DESCRIPTION
Personally I don't think it's ever been clear that `ClientBuilder::username` has nothing to do with restoration so this PR renames it to `server_name_from_user_id` (and gives it a bonafide `HomserverConfig` case to match).

Sorry, the diff is a bit messy as the second commit re-orders the methods to match the main crate (and the `HomeserverConfig` cases) and adds new documentation.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
