### PR TITLE
chore: bump Ruma to its latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6215,7 +6215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,8 +935,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
  "const-oid 0.9.6",
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
  "x509-cert",
 ]
 
@@ -1325,22 +1325,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -1349,7 +1333,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.2",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rand_core 0.10.1",
  "rustc_version",
  "serde",
@@ -1553,6 +1537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,7 +1712,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1755,36 +1749,13 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
+ "pkcs8",
  "serdect",
- "signature 3.0.0",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -1793,12 +1764,12 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
+ "curve25519-dalek",
+ "ed25519",
  "rand_core 0.10.1",
  "serde",
  "sha2 0.11.0",
- "signature 3.0.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -1848,7 +1819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2179,12 +2150,6 @@ name = "fastrand"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -4771,18 +4736,18 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der",
- "spki",
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4974,7 +4939,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.7",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5426,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "assign",
  "js_int",
@@ -5444,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "as_variant",
  "assign",
@@ -5466,7 +5431,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5499,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5523,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "headers",
  "http",
@@ -5544,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5555,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5564,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5573,23 +5538,23 @@ dependencies = [
  "quote",
  "ruma-identifiers-validation",
  "serde",
- "syn 2.0.117",
+ "syn 3.0.3",
  "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/matrix-org/ruma?rev=2a1d714314f6f711d5bca755c73cf2ce3053c3d1#2a1d714314f6f711d5bca755c73cf2ce3053c3d1"
+source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek 2.1.1",
+ "ed25519-dalek",
  "pkcs8",
  "rand 0.10.2",
  "ruma-common",
  "ruma-events",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
 ]
 
@@ -5657,7 +5622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5715,7 +5680,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6156,15 +6121,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
@@ -6269,7 +6225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -6575,10 +6541,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7506,8 +7472,8 @@ dependencies = [
  "cbc",
  "chacha20poly1305",
  "cipher",
- "curve25519-dalek 5.0.0",
- "ed25519-dalek 3.0.0",
+ "curve25519-dalek",
+ "ed25519-dalek",
  "getrandom 0.4.3",
  "hkdf",
  "hmac",
@@ -8350,7 +8316,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "rand_core 0.10.1",
  "serde",
  "zeroize",
@@ -8363,8 +8329,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.1", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "db24422e03aea7c7974230098fe9aeb5481cddc6", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0af525f726717fd", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -255,4 +255,4 @@ const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a
 [patch."https://github.com/ruma/ruma"]
 # Needed to disable checksums since they're incorrect in 32bit devices.
 # Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "2a1d714314f6f711d5bca755c73cf2ce3053c3d1" }
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "bf21677a8fcba04fd01e341809eb5991908441a2" }

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -25,7 +25,7 @@ use ruma::{
     DeviceKeyAlgorithm, EventId, OneTimeKeyAlgorithm, OwnedTransactionId, OwnedUserId, RoomId,
     UserId,
     api::{
-        IncomingResponse,
+        IncomingResponseExt as _,
         client::{
             backup::add_backup_keys::v3::Response as KeysBackupResponse,
             keys::{

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -235,11 +235,8 @@ impl From<&Box<RoomMessageRequest>> for Request {
     }
 }
 
-pub(crate) fn response_from_string(body: &str) -> Response<Vec<u8>> {
-    Response::builder()
-        .status(200)
-        .body(body.as_bytes().to_vec())
-        .expect("Can't create HTTP response")
+pub(crate) fn response_from_string(body: &str) -> Response<&[u8]> {
+    Response::builder().status(200).body(body.as_bytes()).expect("Can't create HTTP response")
 }
 
 #[derive(uniffi::Enum)]

--- a/crates/matrix-sdk-contentscanner/src/api/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/mod.rs
@@ -16,8 +16,8 @@ use matrix_sdk::{RumaApiError, encryption::vodozemac::pk_encryption::PkEncryptio
 use matrix_sdk_crypto::vodozemac::Curve25519PublicKey;
 use ruma::{
     api::{
-        EndpointError, IncomingResponse,
-        error::{FromHttpResponseError, IntoHttpError},
+        IncomingResponse,
+        error::{DeserializationError, IntoHttpError},
     },
     events::room::EncryptedFile,
     exports::{http::Response, serde_json},
@@ -42,14 +42,10 @@ pub struct DownloadAndScanMediaResponse {
 impl IncomingResponse for DownloadAndScanMediaResponse {
     type EndpointError = RumaApiError;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: Response<T>,
-    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
-        if response.status().is_success() {
-            Ok(Self { content: response.body().as_ref().to_vec() })
-        } else {
-            Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(response)))
-        }
+    fn try_from_http_response_inner(
+        response: Response<&[u8]>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(Self { content: response.body().to_vec() })
     }
 }
 

--- a/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/public_server_key.rs
@@ -17,7 +17,7 @@ use ruma::{
     api::{
         EmptyBody, IncomingResponse, Metadata, OutgoingRequest,
         auth_scheme::NoAuthentication,
-        error::{FromHttpResponseError, IntoHttpError},
+        error::{DeserializationError, IntoHttpError},
         path_builder::PathBuilder,
     },
     exports::{
@@ -74,9 +74,9 @@ pub(crate) struct PublicServerKeyResponse {
 impl IncomingResponse for PublicServerKeyResponse {
     type EndpointError = RumaApiError;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: Response<T>,
-    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
-        Ok(serde_json::from_slice::<PublicServerKeyResponse>(response.body().as_ref())?)
+    fn try_from_http_response_inner(
+        response: Response<&[u8]>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(serde_json::from_slice::<PublicServerKeyResponse>(response.body())?)
     }
 }

--- a/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
+++ b/crates/matrix-sdk-contentscanner/src/api/scan/mod.rs
@@ -14,7 +14,7 @@
 
 use matrix_sdk::RumaApiError;
 use ruma::{
-    api::{EndpointError, IncomingResponse, error::FromHttpResponseError},
+    api::{IncomingResponse, error::DeserializationError},
     exports::{http::Response, serde_json},
 };
 use serde::Deserialize;
@@ -36,15 +36,9 @@ pub struct MediaScanResponse {
 impl IncomingResponse for MediaScanResponse {
     type EndpointError = RumaApiError;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: Response<T>,
-    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
-        if response.status().is_success() {
-            let content = response.body().as_ref().to_vec();
-            let media_scan_response: MediaScanResponse = serde_json::from_slice(&content)?;
-            Ok(media_scan_response)
-        } else {
-            Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(response)))
-        }
+    fn try_from_http_response_inner(
+        response: Response<&[u8]>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(serde_json::from_slice(response.body())?)
     }
 }

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
@@ -52,7 +52,7 @@ fn get_header(
     Ok(header)
 }
 
-fn response_to_error(status: StatusCode, body: Vec<u8>) -> HttpError {
+fn response_to_error(status: StatusCode, body: &[u8]) -> HttpError {
     match http::Response::builder().status(status).body(body).map_err(IntoHttpError::from) {
         Ok(response) => {
             let error = FromHttpResponseError::<RumaApiError>::Server(RumaApiError::MatrixError(
@@ -198,7 +198,7 @@ impl Channel {
             Ok(())
         } else {
             let body = response.bytes().await?;
-            let error = response_to_error(status, body.to_vec());
+            let error = response_to_error(status, &body);
 
             return Err(error);
         }
@@ -230,7 +230,7 @@ impl Channel {
                 sleep::sleep(POLL_TIMEOUT).await;
                 continue;
             } else {
-                let error = response_to_error(message.status_code, message.body);
+                let error = response_to_error(message.status_code, &message.body);
 
                 return Err(error);
             }
@@ -256,7 +256,7 @@ impl Channel {
         let status_code = response.status();
 
         if status_code.is_client_error() {
-            return Err(response_to_error(status_code, response.bytes().await?.to_vec()));
+            return Err(response_to_error(status_code, &response.bytes().await?));
         }
 
         let headers = response.headers();

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -27,7 +27,7 @@ use http::header::CONTENT_LENGTH;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::Certificate;
 use reqwest::tls;
-use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
+use ruma::api::{IncomingResponseExt as _, OutgoingRequest, error::FromHttpResponseError};
 use tracing::{debug, info, warn};
 
 use super::{DEFAULT_REQUEST_TIMEOUT, HttpClient, TransmissionProgress, response_to_http_response};
@@ -152,6 +152,8 @@ impl HttpClient {
                     send_progress,
                 )
                 .await?;
+                let (parts, body) = response.into_parts();
+                let response: http::Response<&[u8]> = http::Response::from_parts(parts, &body);
                 R::IncomingResponse::try_from_http_response(response).map_err(HttpError::from)
             }
         };

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use bytes::Bytes;
 use bytesize::ByteSize;
 use eyeball::SharedObservable;
-use ruma::api::{IncomingResponse, OutgoingRequest, error::FromHttpResponseError};
+use ruma::api::{IncomingResponseExt as _, OutgoingRequest, error::FromHttpResponseError};
 
 use super::{HttpClient, TransmissionProgress, response_to_http_response};
 use crate::{config::RequestConfig, error::HttpError};
@@ -50,6 +50,8 @@ impl HttpClient {
             .record("response_size", response_size.display().si_short().to_string())
             .record("request_duration", tracing::field::debug(request_duration));
 
+        let (parts, body) = response.into_parts();
+        let response: http::Response<&[u8]> = http::Response::from_parts(parts, &body);
         Ok(R::IncomingResponse::try_from_http_response(response)?)
     }
 }

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -4,7 +4,7 @@ use http::Response;
 pub use matrix_sdk_test_macros::async_test;
 use ruma::{
     RoomId, UserId,
-    api::{IncomingResponse, OutgoingResponse},
+    api::{IncomingResponse, IncomingResponseExt as _, OutgoingResponse, OutgoingResponseExt as _},
     room_id,
     serde::{Base64, base64::UrlSafe},
     user_id,
@@ -97,8 +97,10 @@ pub fn ruma_response_from_json<ResponseType: IncomingResponse>(
     json: &serde_json::Value,
 ) -> ResponseType {
     let json_bytes = serde_json::to_vec(json).expect("JSON-serialization of response value failed");
-    let http_response =
-        Response::builder().status(200).body(json_bytes).expect("Failed to build HTTP response");
+    let http_response = Response::builder()
+        .status(200)
+        .body(json_bytes.as_slice())
+        .expect("Failed to build HTTP response");
     ResponseType::try_from_http_response(http_response).expect("Can't parse the response json")
 }
 

--- a/testing/matrix-sdk-test/src/sync_builder/mod.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/mod.rs
@@ -4,7 +4,7 @@ use http::Response;
 use ruma::{
     OwnedRoomId, OwnedUserId, UserId,
     api::{
-        IncomingResponse,
+        IncomingResponseExt as _,
         client::sync::sync_events::v3::{
             InvitedRoom, JoinedRoom, KnockedRoom, LeftRoom, Response as SyncResponse, State,
         },
@@ -201,9 +201,9 @@ impl SyncResponseBuilder {
     /// [build_json_sync_response()](#method.build_json_sync_response) if you
     /// need an untyped response.
     pub fn build_sync_response(&mut self) -> SyncResponse {
-        let body = self.build_json_sync_response();
+        let body = serde_json::to_vec(&self.build_json_sync_response()).unwrap();
 
-        let response = Response::builder().body(serde_json::to_vec(&body).unwrap()).unwrap();
+        let response = Response::builder().body(body.as_slice()).unwrap();
 
         SyncResponse::try_from_http_response(response).unwrap()
     }


### PR DESCRIPTION
Mainly to bring in message retention constructors from https://github.com/ruma/ruma/pull/2563