### PR TITLE
fix(base): Ignore inactive members when computing display name ambiguity

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6903.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6903.fixed.md
@@ -1,0 +1,5 @@
+Only count members who joined, were invited or knocked when the ambiguity of a
+display name is computed from a `/members` response. Members who left or were
+banned kept their display name in the ambiguity map, so `RoomMember::name_ambiguous()`
+reported `true` for a name that only one active member used. The sync path
+already ignored those members, so the two paths now agree.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -69,7 +69,8 @@ use crate::{
     store::{
         AvatarCache, BaseStateStore, DynStateStore, MemoryStore, Result as StoreResult,
         RoomLoadSettings, StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt,
-        StoreConfig, ambiguity_map::AmbiguityCache,
+        StoreConfig,
+        ambiguity_map::{AmbiguityCache, is_member_active},
     },
     sync::{RoomUpdates, SyncResponse},
 };
@@ -924,6 +925,7 @@ impl BaseClient {
             }
 
             if let StateEvent::Original(e) = &member
+                && is_member_active(&e.content.membership)
                 && let Some(d) = &e.content.displayname
             {
                 let display_name = DisplayName::new(d);
@@ -1312,6 +1314,7 @@ mod tests {
         ProfileFieldValue, StatusProfileField, UserProfileChanges, UserProfileUpdate,
     };
     use ruma::{
+        RoomId,
         api::client::{self as api, sync::sync_events::v5},
         event_id,
         events::{StateEventType, room::member::MembershipState},
@@ -1804,6 +1807,77 @@ mod tests {
         assert_eq!(member.user_id(), user_id);
         assert_eq!(member.display_name().unwrap(), "Invited Alice");
         assert_eq!(member.avatar_url().unwrap().to_string(), "mxc://localhost/fewjilfewjil42");
+    }
+
+    async fn base_client_with_joined_room(room_id: &RoomId) -> BaseClient {
+        let client = logged_in_base_client(Some(user_id!("@alice:example.org"))).await;
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id))
+            .build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        client
+    }
+
+    #[async_test]
+    async fn test_inactive_members_do_not_make_a_display_name_ambiguous() {
+        let joined_user_id = user_id!("@bob:example.org");
+        let left_user_id = user_id!("@carol:example.org");
+        let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
+
+        let client = base_client_with_joined_room(room_id).await;
+
+        // A joined member and a member who left share a display name.
+        let f = EventFactory::new().room(room_id);
+        let request = api::membership::get_member_events::v3::Request::new(room_id.to_owned());
+        let response = api::membership::get_member_events::v3::Response::new(vec![
+            f.member(joined_user_id).display_name("Amandine").into_raw(),
+            f.member(left_user_id)
+                .display_name("Amandine")
+                .membership(MembershipState::Leave)
+                .into_raw(),
+        ]);
+
+        client.receive_all_members(room_id, &request, &response).await.unwrap();
+
+        let room = client.get_room(room_id).unwrap();
+        let member = room.get_member(joined_user_id).await.expect("ok").expect("exists");
+
+        assert_eq!(member.display_name().unwrap(), "Amandine");
+        assert!(!member.name_ambiguous());
+    }
+
+    #[async_test]
+    async fn test_active_members_make_a_display_name_ambiguous() {
+        let joined_user_id = user_id!("@bob:example.org");
+        let invited_user_id = user_id!("@carol:example.org");
+        let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
+
+        let client = base_client_with_joined_room(room_id).await;
+
+        // A joined member and an invited member share a display name.
+        let f = EventFactory::new().room(room_id);
+        let request = api::membership::get_member_events::v3::Request::new(room_id.to_owned());
+        let response = api::membership::get_member_events::v3::Response::new(vec![
+            f.member(joined_user_id).display_name("Amandine").into_raw(),
+            f.member(invited_user_id)
+                .display_name("Amandine")
+                .membership(MembershipState::Invite)
+                .into_raw(),
+        ]);
+
+        client.receive_all_members(room_id, &request, &response).await.unwrap();
+
+        // Then both display names are ambiguous.
+        let room = client.get_room(room_id).unwrap();
+
+        let joined = room.get_member(joined_user_id).await.expect("ok").expect("exists");
+        assert!(joined.name_ambiguous());
+
+        let invited = room.get_member(invited_user_id).await.expect("ok").expect("exists");
+        assert!(invited.name_ambiguous());
     }
 
     #[cfg(feature = "unstable-msc4426")]

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -65,7 +65,7 @@ impl DisplayNameUsers {
     }
 }
 
-fn is_member_active(membership: &MembershipState) -> bool {
+pub(crate) fn is_member_active(membership: &MembershipState) -> bool {
     use MembershipState::*;
     matches!(membership, Join | Invite | Knock)
 }


### PR DESCRIPTION
Fixes #5774. Alice and Bob share the display name "Amandine", Bob leaves the room, and clients keep disambiguating Alice as `Amandine (@alice:example.org)` although she is the only Amandine left. A restart does not clear it: the wrong state comes back with the next `/members` request.

`BaseClient::receive_all_members` put every member event carrying a `displayname` into the ambiguity map, with no check on the membership. A user who left or was banned kept its slot, so a name that only one active member used ended up with two users behind it, `is_display_name_ambiguous` returned `true`, and `RoomMember::name_ambiguous()` reported an ambiguity that is not there. The sync path never had the bug: `ambiguity_map.rs` gates the same computation on `is_member_active`. So `Room::members_no_sync`, which feeds `/members` into `receive_all_members`, disagreed with sync on the very same room.

This PR gates the insertion on the shared `is_member_active` helper, which is now `pub(crate)`, so the two paths cannot drift apart again.

Two new unit tests in `crates/matrix-sdk-base/src/client.rs`:

- `test_inactive_members_do_not_make_a_display_name_ambiguous` feeds a `/members` response where a joined member and a member who left share the name "Amandine", and asserts the joined member is not ambiguous. It fails on `main`.
- `test_active_members_make_a_display_name_ambiguous` covers the other direction with a joined member and an invited member, so the new check does not filter out too much.

**Note:** `is_member_active` accepts `Join | Invite | Knock`, while the [spec](https://spec.matrix.org/v1.16/client-server-api/#calculating-the-display-name-for-a-user) counts join and invite only. I kept `Knock` here so that `/members` and sync stay identical. Happy to drop it in a follow-up if you agree it is a second bug.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>
