### PR TITLE
Switch to using Duration for the certificate validity period

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -39,7 +39,7 @@ use matrix_sdk::{
     },
 };
 #[cfg(feature = "experimental-x509-identity-verification")]
-use matrix_sdk_base::crypto::x509::{DateTime, RawX509Signature, ValidityError};
+use matrix_sdk_base::crypto::x509::{RawX509Signature, ValidityError};
 use matrix_sdk_base::{
     DmRoomDefinition,
     crypto::{CollectStrategy, DecryptionSettings, TrustRequirement},
@@ -677,12 +677,12 @@ impl ClientBuilder {
                     Box::pin(ready(result))
                 }
 
-                fn validity_not_after(&self) -> Result<DateTime, ValidityError> {
-                    let Ok(validity_not_after) = self.0.validity_not_after() else {
-                        return Err(ValidityError);
-                    };
-                    DateTime::from_unix_duration(std::time::Duration::from_secs(validity_not_after))
-                        .or(Err(ValidityError))
+                fn validity_not_after(&self) -> Result<Duration, ValidityError> {
+                    if let Ok(validity_not_after) = self.0.validity_not_after() {
+                        Ok(std::time::Duration::from_secs(validity_not_after))
+                    } else {
+                        Err(ValidityError)
+                    }
                 }
             }
 

--- a/crates/matrix-sdk-crypto/changelog.d/6904.changed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6904.changed.md
@@ -1,0 +1,1 @@
+Change the return type of X509Signer::validity_not_after to Duration to make it easier for downstream crates to implement.

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -113,7 +113,6 @@ mod raw_x509_signature;
 mod x509_signer;
 mod x509_verify;
 
-pub use cms::cert::x509::der::DateTime;
 pub use errors::{
     IntoX509SignatureError, X509SignatureSigningError, X509SignatureVerificationError,
 };

--- a/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/rust_raw_x509_signer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{future::ready, pin::Pin, sync::Arc};
+use std::{future::ready, pin::Pin, sync::Arc, time::Duration};
 
 use cms::cert::x509::{Certificate, der};
 use rustls::{
@@ -44,11 +44,12 @@ pub struct RustRawX509Signer {
     /// The private signing key for this device.
     signing_key: Arc<dyn SigningKey>,
 
-    /// The "not after" time for the certificate's validity period.
+    /// The "not after" time for the certificate's validity period (as a
+    /// duration since the unix epoch).
     ///
     /// We pre-calculate this on creation to avoid needing to re-parse the
     /// certificate chain every time.
-    validity_not_after: der::DateTime,
+    validity_not_after: Duration,
 }
 
 /// An enum of possible errors that can occur while instantiating
@@ -93,7 +94,7 @@ impl RustRawX509Signer {
         // chain itself will not be valid after that time.
         let validity_not_after = cert_chain
             .into_iter()
-            .map(|cert| cert.tbs_certificate.validity.not_after.to_date_time())
+            .map(|cert| cert.tbs_certificate.validity.not_after.to_unix_duration())
             .min()
             .ok_or(RustX509SignError::CertificateNotFound)?;
 
@@ -148,7 +149,7 @@ impl RawX509Signer for RustRawX509Signer {
         Box::pin(ready(ret))
     }
 
-    fn validity_not_after(&self) -> Result<der::DateTime, ValidityError> {
+    fn validity_not_after(&self) -> Result<Duration, ValidityError> {
         Ok(self.validity_not_after)
     }
 }
@@ -191,7 +192,7 @@ mod tests {
 
         assert_eq!(
             x509_sign.validity_not_after,
-            der::DateTime::new(2027, 6, 5, 15, 2, 16).unwrap()
+            der::DateTime::new(2027, 6, 5, 15, 2, 16).unwrap().unix_duration()
         );
     }
 

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
-use cms::cert::x509::der;
 use ruma::{DeviceKeyId, UserId, canonical_json::to_canonical_value};
 use thiserror::Error;
 use tracing::info;
@@ -120,7 +119,7 @@ impl X509Signer {
                     .iter()
                     .filter_map(|cert| match cert {
                         cms::cert::CertificateChoices::Certificate(c) => {
-                            Some(c.tbs_certificate.validity.not_after.to_date_time())
+                            Some(c.tbs_certificate.validity.not_after.to_unix_duration())
                         }
                         _ => None,
                     })
@@ -159,8 +158,9 @@ pub trait RawX509Signer: std::fmt::Debug + Send + Sync {
         message: Vec<u8>,
     ) -> Pin<Box<dyn Future<Output = Result<RawX509Signature, SignatureError>>>>;
 
-    /// Return the "not after" time for the certificate's validity period.
-    fn validity_not_after(&self) -> Result<der::DateTime, ValidityError>;
+    /// Return the "not after" time for the certificate's validity period as a
+    /// duration since the unix epoch.
+    fn validity_not_after(&self) -> Result<Duration, ValidityError>;
 }
 
 /// Failure to get the validity period of the X.509 certificate.


### PR DESCRIPTION
This type is easier to re-use in downstream crates like `matrix-rust-sdk-crypto-wasm` without adding another dependency, and is equivalent since DateTime uses "unix duration" as part of its definitive representation https://docs.rs/der/latest/src/der/datetime.rs.html#56

- [x] I've documented the public API changes in the appropriate changelog files 
- No AI was used
