### PR TITLE
Message Retention RoomInfo and Room State Tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0
     "unstable-msc4308",
     "unstable-msc4310",
     "unstable-msc4388",
+    "unstable-msc1763",
 ] }
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0
     "compat-encrypted-stickers",
     "compat-lax-room-create-deser",
     "compat-lax-room-topic-deser",
+    "unstable-msc1763",
     "unstable-msc3230",
     "unstable-msc3401",
     "unstable-msc3417",
@@ -94,7 +95,6 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0
     "unstable-msc4308",
     "unstable-msc4310",
     "unstable-msc4388",
-    "unstable-msc1763",
 ] }
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }

--- a/crates/matrix-sdk-base/changelog.d/6905.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6905.added.md
@@ -1,0 +1,1 @@
+RoomInfo gained `m.room.retention` state event and provided room retention values on `RoomInfo::retention()`. If it's absent, that means no policy.

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -56,6 +56,7 @@ use ruma::{
             join_rules::JoinRule,
             member::MembershipState,
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent, RoomPowerLevelsSource},
+            retention::RoomRetentionEventContent,
         },
     },
     room::RoomType,
@@ -375,6 +376,11 @@ impl Room {
     /// 0-100 where 100 would be the max power level.
     pub fn max_power_level(&self) -> i64 {
         self.info.read().base_info.max_power_level
+    }
+
+    /// Get the message retention policy of this room, if set.
+    pub fn retention(&self) -> Option<RoomRetentionEventContent> {
+        self.info.read().retention().cloned()
     }
 
     /// Get the service members in this room, if available.

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -47,6 +47,7 @@ use ruma::{
                 PossiblyRedactedRoomPinnedEventsEventContent, RoomPinnedEventsEventContent,
             },
             redaction::SyncRoomRedactionEvent,
+            retention::RoomRetentionEventContent,
             tombstone::PossiblyRedactedRoomTombstoneEventContent,
             topic::PossiblyRedactedRoomTopicEventContent,
         },
@@ -199,6 +200,8 @@ pub struct BaseRoomInfo {
     pub(crate) member_hints: Option<MinimalStateEvent<PossiblyRedactedMemberHintsEventContent>>,
     /// The `m.room.name` of this room.
     pub(crate) name: Option<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>,
+    /// The message retention policy of this room.
+    pub(crate) retention: Option<MinimalStateEvent<RoomRetentionEventContent>>,
     /// The `m.room.tombstone` event content of this room.
     pub(crate) tombstone: Option<MinimalStateEvent<PossiblyRedactedRoomTombstoneEventContent>>,
     /// The topic of this room.
@@ -317,6 +320,17 @@ impl BaseRoomInfo {
                 } else {
                     // Remove the previous content if the new content is unknown.
                     self.history_visibility.take().is_some()
+                }
+            }
+            (StateEventType::RoomRetention, "") => {
+                if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
+                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomRetention)
+                }) {
+                    self.retention = Some(event);
+                    true
+                } else {
+                    // Remove the previous content if the new content is unknown.
+                    self.retention.take().is_some()
                 }
             }
             (StateEventType::RoomGuestAccess, "") => {
@@ -511,6 +525,10 @@ impl BaseRoomInfo {
             && ev.event_id.as_deref() == Some(redacts)
         {
             ev.redact(&redaction_rules);
+        } else if let Some(ev) = &mut self.retention
+            && ev.event_id.as_deref() == Some(redacts)
+        {
+            ev.redact(&redaction_rules);
         } else if let Some(ev) = &mut self.tombstone
             && ev.event_id.as_deref() == Some(redacts)
         {
@@ -554,6 +572,7 @@ impl Default for BaseRoomInfo {
             join_rules: None,
             max_power_level: DEFAULT_MAX_POWER_LEVEL,
             name: None,
+            retention: None,
             tombstone: None,
             topic: None,
             rtc_member_events: BTreeMap::new(),
@@ -1070,6 +1089,13 @@ impl RoomInfo {
         self.history_visibility().unwrap_or(&HistoryVisibility::Shared)
     }
 
+    /// Returns the message retention policy for this room.
+    ///
+    /// Returns `None` if the event was never seen during sync.
+    pub fn retention(&self) -> Option<&RoomRetentionEventContent> {
+        self.base_info.retention.as_ref().map(|e| &e.content)
+    }
+
     /// Return the join rule for this room, if the `m.room.join_rules` event is
     /// available.
     pub fn join_rule(&self) -> Option<&JoinRule> {
@@ -1500,7 +1526,10 @@ mod tests {
         assign,
         events::{
             AnyRoomAccountDataEvent,
-            room::pinned_events::RoomPinnedEventsEventContent,
+            room::{
+                pinned_events::RoomPinnedEventsEventContent,
+                retention::RoomRetentionEventContent,
+            },
             tag::{TagInfo, TagName, Tags, UserTagName},
         },
         owned_event_id, owned_mxc_uri, owned_user_id, room_id,
@@ -2201,5 +2230,32 @@ mod tests {
                 .expect("task completes successfully")
                 .expect("update and save room info");
         });
+    }
+
+    #[test]
+    fn test_retention_stored_on_handle_state_event() {
+        let mut info = RoomInfo::new(
+            room_id!("!gda78o:server.tld"),
+            RoomState::Joined,
+        );
+        assert!(info.retention().is_none(), "retention should be absent before any event");
+
+        let max_lifetime = Duration::from_secs(86_400); // 1 day
+        let content = RoomRetentionEventContent::new().at_most(max_lifetime).unwrap();
+
+        let mut raw = RawStateEventWithKeys::try_from_raw_state_event(
+            EventFactory::new()
+                .sender(user_id!("@alice:example.org"))
+                .event(content)
+                .state_key("")
+                .into_raw_sync_state(),
+        )
+        .expect("retention state event should be constructable");
+
+        info.handle_state_event(&mut raw);
+
+        let retention = info.retention().expect("retention should be set after event");
+        assert_eq!(retention.max_lifetime(), Some(max_lifetime));
+        assert!(retention.min_lifetime().is_none());
     }
 }

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -1527,8 +1527,7 @@ mod tests {
         events::{
             AnyRoomAccountDataEvent,
             room::{
-                pinned_events::RoomPinnedEventsEventContent,
-                retention::RoomRetentionEventContent,
+                pinned_events::RoomPinnedEventsEventContent, retention::RoomRetentionEventContent,
             },
             tag::{TagInfo, TagName, Tags, UserTagName},
         },
@@ -1626,6 +1625,7 @@ mod tests {
                 "max_power_level": 100,
                 "member_hints": null,
                 "name": null,
+                "retention": null,
                 "tombstone": null,
                 "topic": null,
                 "pinned_events": {
@@ -2234,10 +2234,7 @@ mod tests {
 
     #[test]
     fn test_retention_stored_on_handle_state_event() {
-        let mut info = RoomInfo::new(
-            room_id!("!gda78o:server.tld"),
-            RoomState::Joined,
-        );
+        let mut info = RoomInfo::new(room_id!("!gda78o:server.tld"), RoomState::Joined);
         assert!(info.retention().is_none(), "retention should be absent before any event");
 
         let max_lifetime = Duration::from_secs(86_400); // 1 day

--- a/crates/matrix-sdk/changelog.d/6905.added.md
+++ b/crates/matrix-sdk/changelog.d/6905.added.md
@@ -1,3 +1,3 @@
 Added `Room::retention()` to retrieve the current retention policy and `RoomPrivacySettings::update_room_retention()` to set new values.
 
-Gated behind MSC1763, `org.matrix.msc1763.retention`
+Leverages Ruma's `unstable-msc1763` feature flag.

--- a/crates/matrix-sdk/changelog.d/6905.added.md
+++ b/crates/matrix-sdk/changelog.d/6905.added.md
@@ -1,0 +1,3 @@
+Added `Room::retention()` to retrieve the current retention policy and `RoomPrivacySettings::update_room_retention()` to set new values.
+
+Gated behind MSC1763, `org.matrix.msc1763.retention`

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -140,8 +140,9 @@ impl<'a> RoomPrivacySettings<'a> {
 
     /// Update the message retention policy for this room.
     ///
-    /// Requires the caller to have a power level sufficient to send the
-    /// `m.room.retention` state event (typically room admin, power level 50).
+    /// The caller must have a power level sufficient to send the
+    /// `m.room.retention` state event (typically power level 50). The
+    /// server will reject the request if the power level is insufficient.
     ///
     /// The `content` must satisfy `max_lifetime >= min_lifetime`; use
     /// [`RoomRetentionEventContent`]'s builder methods to construct a valid
@@ -426,6 +427,9 @@ mod tests {
         server
             .mock_room_send_state()
             .for_type(StateEventType::RoomRetention)
+            .body_matches_partial_json(serde_json::json!({
+                "max_lifetime": Duration::from_secs(86_400).as_millis() as u64,
+            }))
             .ok(event_id!("$a:b.c"))
             .mock_once()
             .mount()

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -13,6 +13,7 @@ use ruma::{
             canonical_alias::RoomCanonicalAliasEventContent,
             history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
             join_rules::{JoinRule, RoomJoinRulesEventContent},
+            retention::RoomRetentionEventContent,
         },
     },
 };
@@ -137,6 +138,26 @@ impl<'a> RoomPrivacySettings<'a> {
         Ok(())
     }
 
+    /// Update the message retention policy for this room.
+    ///
+    /// Requires the caller to have a power level sufficient to send the
+    /// `m.room.retention` state event (typically room admin, power level 50).
+    ///
+    /// The `content` must satisfy `max_lifetime >= min_lifetime`; use
+    /// [`RoomRetentionEventContent`]'s builder methods to construct a valid
+    /// value.
+    ///
+    /// See [MSC1763](https://github.com/matrix-org/matrix-spec-proposals/pull/1763) for more info.
+    pub async fn update_room_retention(&'a self, content: RoomRetentionEventContent) -> Result<()> {
+        let request = send_state_event::v3::Request::new(
+            self.room.room_id().to_owned(),
+            &EmptyStateKey,
+            &content,
+        )?;
+        self.client.send(request).await?;
+        Ok(())
+    }
+
     /// Returns the visibility for this room in the room directory.
     ///
     /// [Public](`Visibility::Public`) rooms are listed in the room directory
@@ -163,7 +184,7 @@ impl<'a> RoomPrivacySettings<'a> {
 
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
-    use std::ops::Not;
+    use std::{ops::Not, time::Duration};
 
     use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
     use ruma::{
@@ -171,7 +192,10 @@ mod tests {
         event_id,
         events::{
             StateEventType,
-            room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
+            room::{
+                history_visibility::HistoryVisibility, join_rules::JoinRule,
+                retention::RoomRetentionEventContent,
+            },
         },
         owned_room_alias_id, room_id, user_id,
     };
@@ -388,6 +412,31 @@ mod tests {
             .await;
 
         let ret = room.privacy_settings().update_join_rule(JoinRule::Public).await;
+        assert!(ret.is_ok());
+    }
+
+    #[async_test]
+    async fn test_update_room_retention() {
+        let server = MatrixMockServer::new().await;
+        let client = server.client_builder().build().await;
+
+        let room_id = room_id!("!a:b.c");
+        let room = server.sync_joined_room(&client, room_id).await;
+
+        server
+            .mock_room_send_state()
+            .for_type(StateEventType::RoomRetention)
+            .ok(event_id!("$a:b.c"))
+            .mock_once()
+            .mount()
+            .await;
+
+        let ret = room
+            .privacy_settings()
+            .update_room_retention(
+                RoomRetentionEventContent::new().at_most(Duration::from_secs(86_400)).unwrap(),
+            )
+            .await;
         assert!(ret.is_ok());
     }
 


### PR DESCRIPTION
The first of several PRs (#6713)

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
