### PR TITLE
docs: Drop the reference to the decommissioned OIDC playground

### DIFF
--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -50,8 +50,8 @@ use url::Url;
 /// an OAuth 2.0 authorization server for a Matrix client, using the
 /// Authorization Code flow.
 ///
-/// You can test this against one of the servers from the OIDC playground:
-/// <https://github.com/element-hq/oidc-playground>.
+/// You can test this against any homeserver supporting next-gen auth, like
+/// `matrix.org`.
 ///
 /// To use this, just run `cargo run -p example-oauth-cli`, and everything
 /// is interactive after that. You might want to set the `RUST_LOG` environment


### PR DESCRIPTION
The [OIDC playground](https://github.com/element-hq/oidc-playground) has been decommissioned, so the `oauth_cli` example now points at 'any homeserver supporting next-gen auth' instead.

Note that `crates/matrix-sdk-sqlite/src/crypto_store.rs` still uses `@pjtest:synapse-oidc.element.dev` as a test fixture user ID; that is opaque test data and is left alone.

- [ ] I've documented the public API Changes in the appropriate `CHANGELOG.md` files.
- [x] This PR was made with the help of AI.

The AI usage here is mostly because I've been using it to find references to the playground and preparing patches for me. See https://github.com/element-hq/oidc-playground/pull/6

Signed-off-by: Quentin Gliech <quenting@element.io>