### PR TITLE
feat(widget): MatrixRTC widget api livekit actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5391,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "assign",
  "js_int",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "as_variant",
  "assign",
@@ -5431,7 +5431,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5464,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5488,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "headers",
  "http",
@@ -5509,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5520,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5529,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/toger5/ruma?rev=b3d44d209a1a087332945fd435201376ff48cffd#b3d44d209a1a087332945fd435201376ff48cffd"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.1", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0af525f726717fd", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "b3d44d209a1a087332945fd435201376ff48cffd", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -254,6 +254,17 @@ async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
 
 [patch."https://github.com/ruma/ruma"]
-# Needed to disable checksums since they're incorrect in 32bit devices.
-# Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "bf21677a8fcba04fd01e341809eb5991908441a2" }
+# Points at https://github.com/ruma/ruma/pull/2570, which adds the MSC4195
+# LiveKit endpoints the widget driver delegates to. Swap this back to
+# `ruma/ruma` once that PR has been merged.
+#
+# NOTE: this temporarily drops the JNA checksum workaround that
+# `matrix-org/ruma` carried on top of `ruma/ruma`:
+#
+#     ruma = { git = "https://github.com/matrix-org/ruma", rev = "bf21677a8fcba04fd01e341809eb5991908441a2" }
+#
+# That fork only adds `crates/ruma-events/uniffi.toml` with
+# `omit_checksums = true`, because checksums are incorrect on 32bit devices.
+# It needs to be restored (here or on top of the PR branch) before shipping
+# Kotlin bindings. See https://github.com/mozilla/uniffi-rs/issues/2939.
+ruma = { git = "https://github.com/toger5/ruma", rev = "b3d44d209a1a087332945fd435201376ff48cffd" }

--- a/bindings/matrix-sdk-ffi/changelog.d/6907.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6907.added.md
@@ -1,5 +1,5 @@
 Add `WidgetCapabilities::rtc_livekit_get_token` and
 `WidgetCapabilities::rtc_livekit_delegate_delayed_leave`, gating the two new
 MatrixRTC LiveKit widget actions defined by
-[MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515).
+[MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533).
 Both are enabled by default in `get_element_call_required_permissions`.

--- a/bindings/matrix-sdk-ffi/changelog.d/6907.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6907.added.md
@@ -1,0 +1,5 @@
+Add `WidgetCapabilities::rtc_livekit_get_token` and
+`WidgetCapabilities::rtc_livekit_delegate_delayed_leave`, gating the two new
+MatrixRTC LiveKit widget actions defined by
+[MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515).
+Both are enabled by default in `get_element_call_required_permissions`.

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -268,6 +268,8 @@ pub fn get_element_call_required_permissions(
         send_delayed_event: true,
         download_files: true,
         rtc_transports: true,
+        rtc_livekit_get_token: true,
+        rtc_livekit_delegate_delayed_leave: true,
     }
 }
 
@@ -338,6 +340,12 @@ pub struct WidgetCapabilities {
     /// This allows the widget to discover the RTC transports advertised by the
     /// homeserver (MSC4515).
     pub rtc_transports: bool,
+    /// This allows the widget to ask the client to obtain a LiveKit SFU
+    /// access token on its behalf (MSC4515).
+    pub rtc_livekit_get_token: bool,
+    /// This allows the widget to ask the client to delegate management of a
+    /// delayed leave event to the homeserver (MSC4515).
+    pub rtc_livekit_delegate_delayed_leave: bool,
 }
 
 impl From<WidgetCapabilities> for matrix_sdk::widget::Capabilities {
@@ -350,6 +358,8 @@ impl From<WidgetCapabilities> for matrix_sdk::widget::Capabilities {
             send_delayed_event: value.send_delayed_event,
             download_file: value.download_files,
             rtc_transports: value.rtc_transports,
+            rtc_livekit_get_token: value.rtc_livekit_get_token,
+            rtc_livekit_delegate_delayed_leave: value.rtc_livekit_delegate_delayed_leave,
         }
     }
 }
@@ -364,6 +374,8 @@ impl From<matrix_sdk::widget::Capabilities> for WidgetCapabilities {
             send_delayed_event: value.send_delayed_event,
             download_files: value.download_file,
             rtc_transports: value.rtc_transports,
+            rtc_livekit_get_token: value.rtc_livekit_get_token,
+            rtc_livekit_delegate_delayed_leave: value.rtc_livekit_delegate_delayed_leave,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -341,10 +341,10 @@ pub struct WidgetCapabilities {
     /// homeserver (MSC4515).
     pub rtc_transports: bool,
     /// This allows the widget to ask the client to obtain a LiveKit SFU
-    /// access token on its behalf (MSC4515).
+    /// access token on its behalf (MSC4533).
     pub rtc_livekit_get_token: bool,
     /// This allows the widget to ask the client to delegate management of a
-    /// delayed leave event to the homeserver (MSC4515).
+    /// delayed leave event to the homeserver (MSC4533).
     pub rtc_livekit_delegate_delayed_leave: bool,
 }
 

--- a/crates/matrix-sdk/changelog.d/6907.added.md
+++ b/crates/matrix-sdk/changelog.d/6907.added.md
@@ -1,0 +1,13 @@
+Add two widget actions for MatrixRTC's LiveKit CS API endpoints, as per
+[MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515):
+`rtc_livekit_get_token` (`POST /_matrix/client/v1/rtc/livekit/get_token`) lets
+a widget obtain a LiveKit SFU access token, and
+`rtc_livekit_delegate_delayed_leave`
+(`POST /_matrix/client/v1/rtc/livekit/delegate_delayed_leave`) lets a widget
+delegate management of a delayed leave event to the homeserver. Both actions
+are gated behind new `Capabilities::rtc_livekit_get_token` and
+`Capabilities::rtc_livekit_delegate_delayed_leave` capabilities.
+
+Note: the underlying CS API endpoints are not yet available in Ruma, so
+`MatrixDriver` currently returns an error for both actions until Ruma support
+lands.

--- a/crates/matrix-sdk/changelog.d/6907.added.md
+++ b/crates/matrix-sdk/changelog.d/6907.added.md
@@ -1,5 +1,5 @@
 Add two widget actions for MatrixRTC's LiveKit CS API endpoints, as per
-[MSC4515](https://github.com/matrix-org/matrix-spec-proposals/pull/4515):
+[MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533):
 `rtc_livekit_get_token` (`POST /_matrix/client/v1/rtc/livekit/get_token`) lets
 a widget obtain a LiveKit SFU access token, and
 `rtc_livekit_delegate_delayed_leave`
@@ -7,7 +7,3 @@ a widget obtain a LiveKit SFU access token, and
 delegate management of a delayed leave event to the homeserver. Both actions
 are gated behind new `Capabilities::rtc_livekit_get_token` and
 `Capabilities::rtc_livekit_delegate_delayed_leave` capabilities.
-
-Note: the underlying CS API endpoints are not yet available in Ruma, so
-`MatrixDriver` currently returns an error for both actions until Ruma support
-lands.

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -9,7 +9,8 @@ following MSC's:
 - [MSC2762: Allowing widgets to send/receive events](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/widgets-send-receive-events/proposals/2762-widget-event-receiving.md)
 - [MSC4157: Delayed Events (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4157)
 - [MSC3819: Allowing widgets to send/receive to-device messages](https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
-- [MSC4515: MatrixRTC-specific widget actions (RTC transports discovery, LiveKit CS API delegation)](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)
+- [MSC4515: RTC transports discovery (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)
+- [MSC4533: MatrixRTC widget actions for authenticated LiveKit related endpoints](https://github.com/matrix-org/matrix-spec-proposals/pull/4533)
 
 It supports sending and reading events and provides some rudimentary client
 navigation features. There are some additional actions:

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -9,7 +9,7 @@ following MSC's:
 - [MSC2762: Allowing widgets to send/receive events](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/widgets-send-receive-events/proposals/2762-widget-event-receiving.md)
 - [MSC4157: Delayed Events (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4157)
 - [MSC3819: Allowing widgets to send/receive to-device messages](https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
-- [MSC4515: RTC transports discovery (widget api)](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)
+- [MSC4515: MatrixRTC-specific widget actions (RTC transports discovery, LiveKit CS API delegation)](https://github.com/matrix-org/matrix-spec-proposals/pull/4515)
 
 It supports sending and reading events and provides some rudimentary client
 navigation features. There are some additional actions:
@@ -18,6 +18,11 @@ navigation features. There are some additional actions:
 - Ask for supported API versions.
 - Inform the client that the widget has loaded its content and is ready.
 - Discover the RTC transports advertised by the homeserver.
+- Obtain a LiveKit SFU access token on behalf of the widget, via the CS API
+  `/_matrix/client/v1/rtc/livekit/get_token` endpoint.
+- Delegate management of a delayed leave event to the homeserver on behalf of
+  the widget, via the CS API
+  `/_matrix/client/v1/rtc/livekit/delegate_delayed_leave` endpoint.
 
 ## The widget api
 

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -67,13 +67,13 @@ pub struct Capabilities {
 
     /// This allows the widget to ask the client to obtain a LiveKit SFU
     /// access token on its behalf, via the
-    /// `/_matrix/client/v1/rtc/livekit/get_token` endpoint, as per MSC4515.
+    /// `/_matrix/client/v1/rtc/livekit/get_token` endpoint, as per MSC4533.
     pub rtc_livekit_get_token: bool,
 
     /// This allows the widget to ask the client to delegate management of a
     /// delayed leave event to the homeserver, via the
     /// `/_matrix/client/v1/rtc/livekit/delegate_delayed_leave` endpoint, as
-    /// per MSC4515.
+    /// per MSC4533.
     pub rtc_livekit_delegate_delayed_leave: bool,
 }
 
@@ -135,9 +135,9 @@ pub(super) const UPDATE_DELAYED_EVENT: &str = "org.matrix.msc4157.update_delayed
 pub(super) const DOWNLOAD_FILE: &str = "org.matrix.msc4039.download_file";
 
 pub(super) const RTC_TRANSPORTS: &str = "org.matrix.msc4515.rtc_transports";
-pub(super) const RTC_LIVEKIT_GET_TOKEN: &str = "org.matrix.msc4515.rtc_livekit_get_token";
+pub(super) const RTC_LIVEKIT_GET_TOKEN: &str = "org.matrix.msc4533.rtc_livekit_get_token";
 pub(super) const RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE: &str =
-    "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave";
+    "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave";
 
 impl Serialize for Capabilities {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -383,8 +383,8 @@ mod tests {
             "org.matrix.msc4157.update_delayed_event",
             "org.matrix.msc4039.download_file",
             "org.matrix.msc4515.rtc_transports",
-            "org.matrix.msc4515.rtc_livekit_get_token",
-            "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave"
+            "org.matrix.msc4533.rtc_livekit_get_token",
+            "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave"
         ]"#;
 
         let parsed = serde_json::from_str::<Capabilities>(capabilities_str).unwrap();

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -64,6 +64,17 @@ pub struct Capabilities {
     /// This allows the widget to discover the RTC transports advertised by the
     /// homeserver as per MSC4515.
     pub rtc_transports: bool,
+
+    /// This allows the widget to ask the client to obtain a LiveKit SFU
+    /// access token on its behalf, via the
+    /// `/_matrix/client/v1/rtc/livekit/get_token` endpoint, as per MSC4515.
+    pub rtc_livekit_get_token: bool,
+
+    /// This allows the widget to ask the client to delegate management of a
+    /// delayed leave event to the homeserver, via the
+    /// `/_matrix/client/v1/rtc/livekit/delegate_delayed_leave` endpoint, as
+    /// per MSC4515.
+    pub rtc_livekit_delegate_delayed_leave: bool,
 }
 
 impl Capabilities {
@@ -124,6 +135,9 @@ pub(super) const UPDATE_DELAYED_EVENT: &str = "org.matrix.msc4157.update_delayed
 pub(super) const DOWNLOAD_FILE: &str = "org.matrix.msc4039.download_file";
 
 pub(super) const RTC_TRANSPORTS: &str = "org.matrix.msc4515.rtc_transports";
+pub(super) const RTC_LIVEKIT_GET_TOKEN: &str = "org.matrix.msc4515.rtc_livekit_get_token";
+pub(super) const RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE: &str =
+    "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave";
 
 impl Serialize for Capabilities {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -191,6 +205,12 @@ impl Serialize for Capabilities {
         if self.rtc_transports {
             seq.serialize_element(RTC_TRANSPORTS)?;
         }
+        if self.rtc_livekit_get_token {
+            seq.serialize_element(RTC_LIVEKIT_GET_TOKEN)?;
+        }
+        if self.rtc_livekit_delegate_delayed_leave {
+            seq.serialize_element(RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE)?;
+        }
         for filter in &self.read {
             let name = match filter {
                 Filter::MessageLike(_) => READ_EVENT,
@@ -223,6 +243,8 @@ impl<'de> Deserialize<'de> for Capabilities {
             SendDelayedEvent,
             DownloadFile,
             RtcTransports,
+            RtcLivekitGetToken,
+            RtcLivekitDelegateDelayedLeave,
             Read(Filter),
             Send(Filter),
             Unknown,
@@ -248,6 +270,12 @@ impl<'de> Deserialize<'de> for Capabilities {
                 }
                 if s == RTC_TRANSPORTS {
                     return Ok(Self::RtcTransports);
+                }
+                if s == RTC_LIVEKIT_GET_TOKEN {
+                    return Ok(Self::RtcLivekitGetToken);
+                }
+                if s == RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE {
+                    return Ok(Self::RtcLivekitDelegateDelayedLeave);
                 }
 
                 match s.split_once(':') {
@@ -311,6 +339,10 @@ impl<'de> Deserialize<'de> for Capabilities {
                 Permission::SendDelayedEvent => capabilities.send_delayed_event = true,
                 Permission::DownloadFile => capabilities.download_file = true,
                 Permission::RtcTransports => capabilities.rtc_transports = true,
+                Permission::RtcLivekitGetToken => capabilities.rtc_livekit_get_token = true,
+                Permission::RtcLivekitDelegateDelayedLeave => {
+                    capabilities.rtc_livekit_delegate_delayed_leave = true
+                }
             }
         }
 
@@ -350,7 +382,9 @@ mod tests {
             "org.matrix.msc4157.send.delayed_event",
             "org.matrix.msc4157.update_delayed_event",
             "org.matrix.msc4039.download_file",
-            "org.matrix.msc4515.rtc_transports"
+            "org.matrix.msc4515.rtc_transports",
+            "org.matrix.msc4515.rtc_livekit_get_token",
+            "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave"
         ]"#;
 
         let parsed = serde_json::from_str::<Capabilities>(capabilities_str).unwrap();
@@ -382,6 +416,8 @@ mod tests {
             send_delayed_event: true,
             download_file: true,
             rtc_transports: true,
+            rtc_livekit_get_token: true,
+            rtc_livekit_delegate_delayed_leave: true,
         };
 
         assert_eq!(parsed, expected);
@@ -414,6 +450,8 @@ mod tests {
             send_delayed_event: false,
             download_file: false,
             rtc_transports: true,
+            rtc_livekit_get_token: true,
+            rtc_livekit_delegate_delayed_leave: false,
         };
 
         let capabilities_str = serde_json::to_string(&capabilities).unwrap();

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -17,10 +17,10 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
-    OwnedMxcUri, OwnedRoomId, OwnedUserId,
+    OwnedMxcUri, OwnedRoomId, OwnedServerName, OwnedUserId,
     api::client::{account::request_openid_token, delayed_events::update_delayed_event},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
-    serde::Raw,
+    serde::{JsonObject, Raw},
     to_device::DeviceIdOrAllDevices,
 };
 use serde::{Deserialize, Serialize};
@@ -402,14 +402,24 @@ pub(crate) struct RtcLivekitMember {
     pub(crate) claimed_device_id: String,
 }
 
+impl From<RtcLivekitMember> for JsonObject {
+    fn from(RtcLivekitMember { id, claimed_device_id }: RtcLivekitMember) -> Self {
+        JsonObject::from_iter([
+            ("id".to_owned(), id.into()),
+            ("claimed_device_id".to_owned(), claimed_device_id.into()),
+        ])
+    }
+}
+
 /// Ask the client to obtain a LiveKit SFU access token on behalf of the
 /// widget. This is a 1:1 copy of the request body of `POST
-/// /_matrix/client/v1/rtc/livekit/get_token`.
-/// See [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).
+/// /_matrix/client/v1/rtc/livekit/get_token` ([MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195)),
+/// as delegated to the client by the widget action defined in
+/// [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533).
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct RtcLivekitGetTokenRequest {
     /// The server name of the `m.rtc.member` event sender.
-    pub(crate) server_name: Option<String>,
+    pub(crate) server_name: Option<OwnedServerName>,
     /// The WebSocket URL of the LiveKit SFU.
     pub(crate) url: String,
     /// The room in which the `m.rtc.member` event exists.
@@ -432,8 +442,10 @@ impl MatrixDriverRequest for RtcLivekitGetTokenRequest {
 
 /// Ask the client to delegate management of a delayed leave event to the
 /// homeserver on behalf of the widget. This is a 1:1 copy of the request body
-/// of `POST /_matrix/client/v1/rtc/livekit/delegate_delayed_leave`.
-/// See [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).
+/// of `POST /_matrix/client/v1/rtc/livekit/delegate_delayed_leave`
+/// ([MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195)),
+/// as delegated to the client by the widget action defined in
+/// [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533).
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct RtcLivekitDelegateDelayedLeaveRequest {
     /// The room in which the `m.rtc.member` event exists.

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -17,13 +17,13 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use ruma::{
-    OwnedMxcUri, OwnedUserId,
+    OwnedMxcUri, OwnedRoomId, OwnedUserId,
     api::client::{account::request_openid_token, delayed_events::update_delayed_event},
     events::{AnyStateEvent, AnyTimelineEvent, AnyToDeviceEventContent},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
@@ -33,7 +33,10 @@ use super::{
 };
 use crate::widget::{
     Capabilities, StateKeySelector,
-    machine::from_widget::{DownloadFileResponse, RtcTransportsResponse},
+    machine::from_widget::{
+        DownloadFileResponse, RtcLivekitDelegateDelayedLeaveResponse, RtcLivekitGetTokenResponse,
+        RtcTransportsResponse,
+    },
 };
 
 #[derive(Clone, Debug)]
@@ -68,6 +71,15 @@ pub(crate) enum MatrixDriverRequestData {
 
     /// Get the RTC transports advertised by the homeserver.
     GetRtcTransports,
+
+    /// Obtain a LiveKit SFU access token via the CS API `POST
+    /// /_matrix/client/v1/rtc/livekit/get_token` endpoint.
+    GetRtcLivekitToken(RtcLivekitGetTokenRequest),
+
+    /// Delegate management of a delayed leave event to the homeserver, via
+    /// the CS API `POST /_matrix/client/v1/rtc/livekit/delegate_delayed_leave`
+    /// endpoint.
+    DelegateRtcLivekitDelayedLeave(RtcLivekitDelegateDelayedLeaveRequest),
 }
 
 /// A handle to a pending `toWidget` request.
@@ -377,4 +389,69 @@ impl From<DownloadFileRequest> for MatrixDriverRequestData {
     fn from(req: DownloadFileRequest) -> Self {
         MatrixDriverRequestData::DownloadFile(req)
     }
+}
+
+/// The `member` field of an `m.rtc.member` event, as required by the LiveKit
+/// CS API endpoints. See [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct RtcLivekitMember {
+    /// The `id` field of the `m.rtc.member` event's `member` object.
+    pub(crate) id: String,
+    /// The `claimed_device_id` field of the `m.rtc.member` event's `member`
+    /// object.
+    pub(crate) claimed_device_id: String,
+}
+
+/// Ask the client to obtain a LiveKit SFU access token on behalf of the
+/// widget. This is a 1:1 copy of the request body of `POST
+/// /_matrix/client/v1/rtc/livekit/get_token`.
+/// See [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct RtcLivekitGetTokenRequest {
+    /// The server name of the `m.rtc.member` event sender.
+    pub(crate) server_name: Option<String>,
+    /// The WebSocket URL of the LiveKit SFU.
+    pub(crate) url: String,
+    /// The room in which the `m.rtc.member` event exists.
+    pub(crate) room_id: OwnedRoomId,
+    /// The `slot_id` from the `m.rtc.member` event.
+    pub(crate) slot_id: String,
+    /// The `member` field of the `m.rtc.member` event.
+    pub(crate) member: RtcLivekitMember,
+}
+
+impl From<RtcLivekitGetTokenRequest> for MatrixDriverRequestData {
+    fn from(value: RtcLivekitGetTokenRequest) -> Self {
+        MatrixDriverRequestData::GetRtcLivekitToken(value)
+    }
+}
+
+impl MatrixDriverRequest for RtcLivekitGetTokenRequest {
+    type Response = RtcLivekitGetTokenResponse;
+}
+
+/// Ask the client to delegate management of a delayed leave event to the
+/// homeserver on behalf of the widget. This is a 1:1 copy of the request body
+/// of `POST /_matrix/client/v1/rtc/livekit/delegate_delayed_leave`.
+/// See [MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195).
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct RtcLivekitDelegateDelayedLeaveRequest {
+    /// The room in which the `m.rtc.member` event exists.
+    pub(crate) room_id: OwnedRoomId,
+    /// The `slot_id` from the `m.rtc.member` event.
+    pub(crate) slot_id: String,
+    /// The `member` field of the `m.rtc.member` event.
+    pub(crate) member: RtcLivekitMember,
+    /// The delayed event ID of the leave event to delegate.
+    pub(crate) delay_id: String,
+}
+
+impl From<RtcLivekitDelegateDelayedLeaveRequest> for MatrixDriverRequestData {
+    fn from(value: RtcLivekitDelegateDelayedLeaveRequest) -> Self {
+        MatrixDriverRequestData::DelegateRtcLivekitDelayedLeave(value)
+    }
+}
+
+impl MatrixDriverRequest for RtcLivekitDelegateDelayedLeaveRequest {
+    type Response = RtcLivekitDelegateDelayedLeaveResponse;
 }

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -62,9 +62,9 @@ pub(super) enum FromWidgetRequest {
     DownloadFile(DownloadFileRequest),
     #[serde(rename = "org.matrix.msc4515.get_rtc_transports")]
     GetRtcTransports {},
-    #[serde(rename = "org.matrix.msc4515.rtc_livekit_get_token")]
+    #[serde(rename = "org.matrix.msc4533.rtc_livekit_get_token")]
     RtcLivekitGetToken(RtcLivekitGetTokenRequest),
-    #[serde(rename = "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave")]
+    #[serde(rename = "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave")]
     RtcLivekitDelegateDelayedLeave(RtcLivekitDelegateDelayedLeaveRequest),
 }
 
@@ -134,6 +134,15 @@ struct FromWidgetError {
 }
 
 /// Serializable section of a widget response that represents a Matrix error.
+///
+/// [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533)
+/// (which relies on this to let a widget tell an unsupported endpoint apart
+/// from another kind of failure) specifies this envelope with two additional
+/// fields, `http_headers` and `url`, that are not implemented here. This
+/// applies to every widget action that can report a Matrix API error, not
+/// just the endpoints introduced by MSC4533. Missing `http_status` and
+/// `response.errcode` are already sufficient to detect an unsupported
+/// endpoint, so this is a known gap rather than a blocker.
 #[derive(Serialize)]
 struct FromWidgetMatrixErrorBody {
     /// Status code of the http response.
@@ -164,6 +173,7 @@ impl SupportedApiVersionsResponse {
                 ApiVersion::MSC3819,
                 ApiVersion::MSC4039,
                 ApiVersion::MSC4515,
+                ApiVersion::MSC4533,
             ],
         }
     }
@@ -218,6 +228,11 @@ pub(super) enum ApiVersion {
     /// Supports discovering the RTC transports advertised by the homeserver.
     #[serde(rename = "org.matrix.msc4515")]
     MSC4515,
+
+    /// Supports delegating the LiveKit `get_token` and
+    /// `delegate_delayed_leave` CS API endpoints to the client.
+    #[serde(rename = "org.matrix.msc4533")]
+    MSC4533,
 }
 
 #[derive(Deserialize, Debug)]
@@ -350,14 +365,14 @@ impl FromMatrixDriverResponse for RtcTransportsResponse {
 }
 
 /// Response for a `rtc_livekit_get_token` request. This is a 1:1 copy of the
-/// response body of `POST /_matrix/client/v1/rtc/livekit/get_token`.
-/// <https://github.com/matrix-org/matrix-spec-proposals/pull/4195>
+/// response body of `POST /_matrix/client/v1/rtc/livekit/get_token`
+/// ([MSC4195](https://github.com/matrix-org/matrix-spec-proposals/pull/4195)),
+/// forwarded verbatim as per the widget action defined in
+/// [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533).
 #[derive(Clone, Serialize, Debug)]
 pub(crate) struct RtcLivekitGetTokenResponse {
     /// The JWT token to use to authenticate with the LiveKit SFU.
     pub(crate) jwt: String,
-    /// The WebSocket URL of the LiveKit SFU.
-    pub(crate) url: String,
 }
 
 impl FromMatrixDriverResponse for RtcLivekitGetTokenResponse {
@@ -372,10 +387,11 @@ impl FromMatrixDriverResponse for RtcLivekitGetTokenResponse {
     }
 }
 
-/// Response for a `rtc_livekit_delegate_delayed_leave` request.
+/// Response for a `rtc_livekit_delegate_delayed_leave` request, as per the
+/// widget action defined in
+/// [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533).
 /// This is intentionally an empty tuple struct (not a unit struct), so that it
 /// serializes to `{}` instead of `Null` when returned to the widget as json.
-/// <https://github.com/matrix-org/matrix-spec-proposals/pull/4195>
 #[derive(Clone, Serialize, Debug)]
 pub(crate) struct RtcLivekitDelegateDelayedLeaveResponse {}
 

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -38,7 +38,10 @@ use crate::{
     Error, HttpError, RumaApiError,
     widget::{
         StateKeySelector,
-        machine::driver_req::{DownloadFileRequest, FromMatrixDriverResponse},
+        machine::driver_req::{
+            DownloadFileRequest, FromMatrixDriverResponse, RtcLivekitDelegateDelayedLeaveRequest,
+            RtcLivekitGetTokenRequest,
+        },
     },
 };
 
@@ -59,6 +62,10 @@ pub(super) enum FromWidgetRequest {
     DownloadFile(DownloadFileRequest),
     #[serde(rename = "org.matrix.msc4515.get_rtc_transports")]
     GetRtcTransports {},
+    #[serde(rename = "org.matrix.msc4515.rtc_livekit_get_token")]
+    RtcLivekitGetToken(RtcLivekitGetTokenRequest),
+    #[serde(rename = "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave")]
+    RtcLivekitDelegateDelayedLeave(RtcLivekitDelegateDelayedLeaveRequest),
 }
 
 /// The full response a client sends to a [`FromWidgetRequest`] in case of an
@@ -334,6 +341,48 @@ impl FromMatrixDriverResponse for RtcTransportsResponse {
             MatrixDriverResponse::RtcTransportsReceived(rtc_transports) => {
                 Some(Self { rtc_transports })
             }
+            _ => {
+                error!("bug in MatrixDriver, received wrong event response");
+                None
+            }
+        }
+    }
+}
+
+/// Response for a `rtc_livekit_get_token` request. This is a 1:1 copy of the
+/// response body of `POST /_matrix/client/v1/rtc/livekit/get_token`.
+/// <https://github.com/matrix-org/matrix-spec-proposals/pull/4195>
+#[derive(Clone, Serialize, Debug)]
+pub(crate) struct RtcLivekitGetTokenResponse {
+    /// The JWT token to use to authenticate with the LiveKit SFU.
+    pub(crate) jwt: String,
+    /// The WebSocket URL of the LiveKit SFU.
+    pub(crate) url: String,
+}
+
+impl FromMatrixDriverResponse for RtcLivekitGetTokenResponse {
+    fn from_response(matrix_driver_response: MatrixDriverResponse) -> Option<Self> {
+        match matrix_driver_response {
+            MatrixDriverResponse::RtcLivekitTokenReceived(response) => Some(response),
+            _ => {
+                error!("bug in MatrixDriver, received wrong event response");
+                None
+            }
+        }
+    }
+}
+
+/// Response for a `rtc_livekit_delegate_delayed_leave` request.
+/// This is intentionally an empty tuple struct (not a unit struct), so that it
+/// serializes to `{}` instead of `Null` when returned to the widget as json.
+/// <https://github.com/matrix-org/matrix-spec-proposals/pull/4195>
+#[derive(Clone, Serialize, Debug)]
+pub(crate) struct RtcLivekitDelegateDelayedLeaveResponse {}
+
+impl FromMatrixDriverResponse for RtcLivekitDelegateDelayedLeaveResponse {
+    fn from_response(matrix_driver_response: MatrixDriverResponse) -> Option<Self> {
+        match matrix_driver_response {
+            MatrixDriverResponse::RtcLivekitDelayedLeaveDelegated(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -28,7 +28,12 @@ use super::{
     from_widget::{FromWidgetRequest, SendEventResponse},
     to_widget::ToWidgetResponse,
 };
-use crate::widget::{Capabilities, machine::from_widget::DownloadFileResponse};
+use crate::widget::{
+    Capabilities,
+    machine::from_widget::{
+        DownloadFileResponse, RtcLivekitDelegateDelayedLeaveResponse, RtcLivekitGetTokenResponse,
+    },
+};
 
 /// Incoming message for the widget client side module that it must process.
 pub(crate) enum IncomingMessage {
@@ -92,6 +97,15 @@ pub(crate) enum MatrixDriverResponse {
     /// Client fetched the RTC transports advertised by the homeserver.
     /// A response to a [`MatrixDriverRequestData::GetRtcTransports`] command.
     RtcTransportsReceived(Vec<RtcTransport>),
+    /// Client obtained a LiveKit SFU access token.
+    /// A response to a [`MatrixDriverRequestData::GetRtcLivekitToken`]
+    /// command.
+    RtcLivekitTokenReceived(RtcLivekitGetTokenResponse),
+    /// Client delegated management of a delayed leave event to the
+    /// homeserver.
+    /// A response to a
+    /// [`MatrixDriverRequestData::DelegateRtcLivekitDelayedLeave`] command.
+    RtcLivekitDelayedLeaveDelegated(RtcLivekitDelegateDelayedLeaveResponse),
 }
 
 pub(super) struct IncomingWidgetMessage {
@@ -215,5 +229,79 @@ mod tests {
         assert_let!(
             FromWidgetRequest::GetRtcTransports {} = incoming_request.deserialize().unwrap()
         );
+    }
+
+    #[test]
+    fn parse_rtc_livekit_get_token_widget_action() {
+        let raw = r#"
+        {
+            "api": "fromWidget",
+            "widgetId": "aGNStSuL3hhIISSCXgpt15j2",
+            "requestId": "generated-id-1234",
+            "action": "org.matrix.msc4515.rtc_livekit_get_token",
+            "data": {
+                "server_name": "example.com",
+                "url": "ws://livekit.example.com",
+                "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+                "slot_id": "the_id",
+                "member": {
+                    "id": "xyzABCDEF10123",
+                    "claimed_device_id": "DEVICEID"
+                }
+            }
+        }
+        "#;
+
+        assert_let!(
+            IncomingWidgetMessageKind::Request(incoming_request) =
+                serde_json::from_str::<IncomingWidgetMessage>(raw).unwrap().kind
+        );
+        assert_let!(
+            FromWidgetRequest::RtcLivekitGetToken(req) =
+                incoming_request.deserialize().unwrap()
+        );
+
+        assert_eq!(req.server_name.as_deref(), Some("example.com"));
+        assert_eq!(req.url, "ws://livekit.example.com");
+        assert_eq!(req.room_id, "!tDLCaLXijNtYcJZEey:example.com");
+        assert_eq!(req.slot_id, "the_id");
+        assert_eq!(req.member.id, "xyzABCDEF10123");
+        assert_eq!(req.member.claimed_device_id, "DEVICEID");
+    }
+
+    #[test]
+    fn parse_rtc_livekit_delegate_delayed_leave_widget_action() {
+        let raw = r#"
+        {
+            "api": "fromWidget",
+            "widgetId": "aGNStSuL3hhIISSCXgpt15j2",
+            "requestId": "generated-id-1234",
+            "action": "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave",
+            "data": {
+                "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+                "slot_id": "the_id",
+                "member": {
+                    "id": "xyzABCDEF10123",
+                    "claimed_device_id": "DEVICEID"
+                },
+                "delay_id": "1234567890"
+            }
+        }
+        "#;
+
+        assert_let!(
+            IncomingWidgetMessageKind::Request(incoming_request) =
+                serde_json::from_str::<IncomingWidgetMessage>(raw).unwrap().kind
+        );
+        assert_let!(
+            FromWidgetRequest::RtcLivekitDelegateDelayedLeave(req) =
+                incoming_request.deserialize().unwrap()
+        );
+
+        assert_eq!(req.room_id, "!tDLCaLXijNtYcJZEey:example.com");
+        assert_eq!(req.slot_id, "the_id");
+        assert_eq!(req.member.id, "xyzABCDEF10123");
+        assert_eq!(req.member.claimed_device_id, "DEVICEID");
+        assert_eq!(req.delay_id, "1234567890");
     }
 }

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -159,6 +159,7 @@ impl<'de> Deserialize<'de> for IncomingWidgetMessage {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
+    use ruma::server_name;
 
     use crate::widget::machine::{
         from_widget::FromWidgetRequest,
@@ -238,7 +239,7 @@ mod tests {
             "api": "fromWidget",
             "widgetId": "aGNStSuL3hhIISSCXgpt15j2",
             "requestId": "generated-id-1234",
-            "action": "org.matrix.msc4515.rtc_livekit_get_token",
+            "action": "org.matrix.msc4533.rtc_livekit_get_token",
             "data": {
                 "server_name": "example.com",
                 "url": "ws://livekit.example.com",
@@ -257,11 +258,10 @@ mod tests {
                 serde_json::from_str::<IncomingWidgetMessage>(raw).unwrap().kind
         );
         assert_let!(
-            FromWidgetRequest::RtcLivekitGetToken(req) =
-                incoming_request.deserialize().unwrap()
+            FromWidgetRequest::RtcLivekitGetToken(req) = incoming_request.deserialize().unwrap()
         );
 
-        assert_eq!(req.server_name.as_deref(), Some("example.com"));
+        assert_eq!(req.server_name.as_deref(), Some(server_name!("example.com")));
         assert_eq!(req.url, "ws://livekit.example.com");
         assert_eq!(req.room_id, "!tDLCaLXijNtYcJZEey:example.com");
         assert_eq!(req.slot_id, "the_id");
@@ -276,7 +276,7 @@ mod tests {
             "api": "fromWidget",
             "widgetId": "aGNStSuL3hhIISSCXgpt15j2",
             "requestId": "generated-id-1234",
-            "action": "org.matrix.msc4515.rtc_livekit_delegate_delayed_leave",
+            "action": "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave",
             "data": {
                 "room_id": "!tDLCaLXijNtYcJZEey:example.com",
                 "slot_id": "the_id",

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -58,7 +58,10 @@ use crate::{
     Error, Result,
     widget::{
         Filter,
-        capabilities::{DOWNLOAD_FILE, RTC_TRANSPORTS},
+        capabilities::{
+            DOWNLOAD_FILE, RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE, RTC_LIVEKIT_GET_TOKEN,
+            RTC_TRANSPORTS,
+        },
         machine::driver_req::DownloadFileRequest,
     },
 };
@@ -73,8 +76,14 @@ mod tests;
 mod to_widget;
 
 pub(crate) use self::{
-    driver_req::{MatrixDriverRequestData, SendEventRequest, SendToDeviceRequest},
-    from_widget::{DownloadFileResponse, SendEventResponse, SendToDeviceEventResponse},
+    driver_req::{
+        MatrixDriverRequestData, RtcLivekitDelegateDelayedLeaveRequest, RtcLivekitGetTokenRequest,
+        SendEventRequest, SendToDeviceRequest,
+    },
+    from_widget::{
+        DownloadFileResponse, RtcLivekitDelegateDelayedLeaveResponse, RtcLivekitGetTokenResponse,
+        SendEventResponse, SendToDeviceEventResponse,
+    },
     incoming::{IncomingMessage, MatrixDriverResponse},
 };
 
@@ -395,6 +404,14 @@ impl WidgetMachine {
                 .unwrap_or_default(),
             FromWidgetRequest::GetRtcTransports {} => self
                 .process_get_rtc_transports_request(raw_request)
+                .map(|a| vec![a])
+                .unwrap_or_default(),
+            FromWidgetRequest::RtcLivekitGetToken(req) => self
+                .process_rtc_livekit_get_token_request(req, raw_request)
+                .map(|a| vec![a])
+                .unwrap_or_default(),
+            FromWidgetRequest::RtcLivekitDelegateDelayedLeave(req) => self
+                .process_rtc_livekit_delegate_delayed_leave_request(req, raw_request)
                 .map(|a| vec![a])
                 .unwrap_or_default(),
         }
@@ -957,6 +974,69 @@ impl WidgetMachine {
         }
 
         let (request, action) = self.send_matrix_driver_request(RequestRtcTransports)?;
+
+        request.add_response_handler(|result, _| {
+            vec![Self::send_from_widget_response(
+                raw_request,
+                result.map_err(FromWidgetErrorResponse::from_error),
+            )]
+        });
+        Some(action)
+    }
+
+    fn process_rtc_livekit_get_token_request(
+        &mut self,
+        req: RtcLivekitGetTokenRequest,
+        raw_request: Raw<FromWidgetRequest>,
+    ) -> Option<Action> {
+        let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                "Received RTC LiveKit get token request before capabilities negotiation",
+            ));
+        };
+
+        if !capabilities.rtc_livekit_get_token {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                format!("Not allowed: missing the {RTC_LIVEKIT_GET_TOKEN} capability."),
+            ));
+        }
+
+        let (request, action) = self.send_matrix_driver_request(req)?;
+
+        request.add_response_handler(|result, _| {
+            vec![Self::send_from_widget_response(
+                raw_request,
+                result.map_err(FromWidgetErrorResponse::from_error),
+            )]
+        });
+        Some(action)
+    }
+
+    fn process_rtc_livekit_delegate_delayed_leave_request(
+        &mut self,
+        req: RtcLivekitDelegateDelayedLeaveRequest,
+        raw_request: Raw<FromWidgetRequest>,
+    ) -> Option<Action> {
+        let CapabilitiesState::Negotiated(capabilities) = &self.capabilities else {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                "Received RTC LiveKit delegate delayed leave request before capabilities \
+                 negotiation",
+            ));
+        };
+
+        if !capabilities.rtc_livekit_delegate_delayed_leave {
+            return Some(Self::send_from_widget_error_string_response(
+                raw_request,
+                format!(
+                    "Not allowed: missing the {RTC_LIVEKIT_DELEGATE_DELAYED_LEAVE} capability."
+                ),
+            ));
+        }
+
+        let (request, action) = self.send_matrix_driver_request(req)?;
 
         request.add_response_handler(|result, _| {
             vec![Self::send_from_widget_response(

--- a/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/api_versions.rs
@@ -53,6 +53,7 @@ fn test_get_supported_api_versions() {
                     "org.matrix.msc3819",
                     "org.matrix.msc4039",
                     "org.matrix.msc4515",
+                    "org.matrix.msc4533",
                 ]
             },
         }),

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -30,6 +30,7 @@ use ruma::{
         account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
         delayed_events::{self, update_delayed_event::UpdateAction},
         filter::RoomEventFilter,
+        rtc::livekit::{delegate_delayed_leave, get_token},
         to_device::send_event_to_device::v3::Request as RumaToDeviceRequest,
     },
     assign,
@@ -116,25 +117,26 @@ impl MatrixDriver {
     /// API `POST /_matrix/client/v1/rtc/livekit/get_token` endpoint
     /// ([MSC4195]).
     ///
+    /// The request body is forwarded verbatim, as required by [MSC4533]: the
+    /// homeserver, not the client, authorises the widget's request against the
+    /// user's actual room membership.
+    ///
     /// [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
-    // TODO: this endpoint is not yet implemented in ruma, so this always
-    // returns an error. Once ruma exposes a typed request/response for it,
-    // forward `req` to `self.room.client` like `get_rtc_transports` does.
-    #[allow(clippy::unused_async)]
+    /// [MSC4533]: https://github.com/matrix-org/matrix-spec-proposals/pull/4533
     pub(crate) async fn get_rtc_livekit_token(
         &self,
         req: RtcLivekitGetTokenRequest,
     ) -> Result<RtcLivekitGetTokenResponse> {
         let RtcLivekitGetTokenRequest { server_name, url, room_id, slot_id, member } = req;
-        Err(Error::UnknownError(
-            format!(
-                "the rtc/livekit/get_token endpoint is not yet supported by this client \
-                 (server_name: {server_name:?}, url: {url}, room_id: {room_id}, \
-                 slot_id: {slot_id}, member.id: {}, member.claimed_device_id: {})",
-                member.id, member.claimed_device_id
-            )
-            .into(),
-        ))
+
+        let request = assign!(get_token::v1::Request::new(url, room_id, slot_id, member.into()), {
+            server_name
+        });
+
+        let response =
+            self.room.client.send(request).await.map_err(|error| Error::Http(Box::new(error)))?;
+
+        Ok(RtcLivekitGetTokenResponse { jwt: response.jwt })
     }
 
     /// Delegates management of a delayed leave event to the homeserver on
@@ -142,25 +144,23 @@ impl MatrixDriver {
     /// /_matrix/client/v1/rtc/livekit/delegate_delayed_leave` endpoint
     /// ([MSC4195]).
     ///
+    /// As with [`Self::get_rtc_livekit_token`], the request body is forwarded
+    /// verbatim ([MSC4533]).
+    ///
     /// [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
-    // TODO: this endpoint is not yet implemented in ruma, so this always
-    // returns an error. Once ruma exposes a typed request/response for it,
-    // forward `req` to `self.room.client` like `get_rtc_transports` does.
-    #[allow(clippy::unused_async)]
+    /// [MSC4533]: https://github.com/matrix-org/matrix-spec-proposals/pull/4533
     pub(crate) async fn delegate_rtc_livekit_delayed_leave(
         &self,
         req: RtcLivekitDelegateDelayedLeaveRequest,
     ) -> Result<RtcLivekitDelegateDelayedLeaveResponse> {
         let RtcLivekitDelegateDelayedLeaveRequest { room_id, slot_id, member, delay_id } = req;
-        Err(Error::UnknownError(
-            format!(
-                "the rtc/livekit/delegate_delayed_leave endpoint is not yet supported by this \
-                 client (room_id: {room_id}, slot_id: {slot_id}, member.id: {}, \
-                 member.claimed_device_id: {}, delay_id: {delay_id})",
-                member.id, member.claimed_device_id
-            )
-            .into(),
-        ))
+
+        let request =
+            delegate_delayed_leave::v1::Request::new(room_id, slot_id, member.into(), delay_id);
+
+        self.room.client.send(request).await.map_err(|error| Error::Http(Box::new(error)))?;
+
+        Ok(RtcLivekitDelegateDelayedLeaveResponse {})
     }
 
     /// Reads the latest `limit` events of a given `event_type` from the room's

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -50,7 +50,13 @@ use tokio::sync::{
 };
 use tracing::{error, trace, warn};
 
-use super::{StateKeySelector, machine::SendEventResponse};
+use super::{
+    StateKeySelector,
+    machine::{
+        RtcLivekitDelegateDelayedLeaveRequest, RtcLivekitDelegateDelayedLeaveResponse,
+        RtcLivekitGetTokenRequest, RtcLivekitGetTokenResponse, SendEventResponse,
+    },
+};
 use crate::{
     Client, Error, Result, Room, event_handler::EventHandlerDropGuard, room::MessagesOptions,
     sync::RoomUpdate, widget::machine::SendToDeviceEventResponse,
@@ -104,6 +110,57 @@ impl MatrixDriver {
             .ok_or_else(|| {
                 Error::UnknownError("the homeserver does not advertise any RTC transport".into())
             })
+    }
+
+    /// Obtains a LiveKit SFU access token on behalf of the widget, via the CS
+    /// API `POST /_matrix/client/v1/rtc/livekit/get_token` endpoint
+    /// ([MSC4195]).
+    ///
+    /// [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
+    // TODO: this endpoint is not yet implemented in ruma, so this always
+    // returns an error. Once ruma exposes a typed request/response for it,
+    // forward `req` to `self.room.client` like `get_rtc_transports` does.
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn get_rtc_livekit_token(
+        &self,
+        req: RtcLivekitGetTokenRequest,
+    ) -> Result<RtcLivekitGetTokenResponse> {
+        let RtcLivekitGetTokenRequest { server_name, url, room_id, slot_id, member } = req;
+        Err(Error::UnknownError(
+            format!(
+                "the rtc/livekit/get_token endpoint is not yet supported by this client \
+                 (server_name: {server_name:?}, url: {url}, room_id: {room_id}, \
+                 slot_id: {slot_id}, member.id: {}, member.claimed_device_id: {})",
+                member.id, member.claimed_device_id
+            )
+            .into(),
+        ))
+    }
+
+    /// Delegates management of a delayed leave event to the homeserver on
+    /// behalf of the widget, via the CS API `POST
+    /// /_matrix/client/v1/rtc/livekit/delegate_delayed_leave` endpoint
+    /// ([MSC4195]).
+    ///
+    /// [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
+    // TODO: this endpoint is not yet implemented in ruma, so this always
+    // returns an error. Once ruma exposes a typed request/response for it,
+    // forward `req` to `self.room.client` like `get_rtc_transports` does.
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn delegate_rtc_livekit_delayed_leave(
+        &self,
+        req: RtcLivekitDelegateDelayedLeaveRequest,
+    ) -> Result<RtcLivekitDelegateDelayedLeaveResponse> {
+        let RtcLivekitDelegateDelayedLeaveRequest { room_id, slot_id, member, delay_id } = req;
+        Err(Error::UnknownError(
+            format!(
+                "the rtc/livekit/delegate_delayed_leave endpoint is not yet supported by this \
+                 client (room_id: {room_id}, slot_id: {slot_id}, member.id: {}, \
+                 member.claimed_device_id: {}, delay_id: {delay_id})",
+                member.id, member.claimed_device_id
+            )
+            .into(),
+        ))
     }
 
     /// Reads the latest `limit` events of a given `event_type` from the room's

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -266,6 +266,16 @@ impl WidgetDriver {
                         .get_rtc_transports()
                         .await
                         .map(MatrixDriverResponse::RtcTransportsReceived),
+
+                    MatrixDriverRequestData::GetRtcLivekitToken(req) => matrix_driver
+                        .get_rtc_livekit_token(req)
+                        .await
+                        .map(MatrixDriverResponse::RtcLivekitTokenReceived),
+
+                    MatrixDriverRequestData::DelegateRtcLivekitDelayedLeave(req) => matrix_driver
+                        .delegate_rtc_livekit_delayed_leave(req)
+                        .await
+                        .map(MatrixDriverResponse::RtcLivekitDelayedLeaveDelegated),
                 };
 
                 // Forward the Matrix driver response to the incoming message stream.

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -54,7 +54,7 @@ use serde_json::{Value as JsonValue, Value, json};
 use tracing::error;
 use wiremock::{
     Mock, Request, ResponseTemplate,
-    matchers::{method, path_regex},
+    matchers::{body_json, method, path_regex},
 };
 
 /// Create a JSON string from a [`json!`][serde_json::json] "literal".
@@ -2156,6 +2156,208 @@ async fn test_get_rtc_transports_falls_back_to_well_known() {
             ]
         })
     );
+}
+
+#[async_test]
+async fn test_rtc_livekit_get_token() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4533.rtc_livekit_get_token"]))
+        .await;
+
+    // The client forwards the widget's `data` verbatim as the request body.
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/unstable/io.element.msc4195/rtc/livekit/get_token$"))
+        .and(body_json(json!({
+            "server_name": "example.com",
+            "url": "ws://livekit.example.com",
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "jwt": "thejwt" })))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "get-token",
+        "org.matrix.msc4533.rtc_livekit_get_token",
+        json!({
+            "server_name": "example.com",
+            "url": "ws://livekit.example.com",
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+        }),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["api"], "fromWidget");
+    assert_eq!(response["action"], "org.matrix.msc4533.rtc_livekit_get_token");
+    assert_eq!(response["requestId"], "get-token");
+    assert_eq!(response["response"], json!({ "jwt": "thejwt" }));
+}
+
+#[async_test]
+async fn test_rtc_livekit_get_token_without_server_name() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!(["org.matrix.msc4533.rtc_livekit_get_token"]))
+        .await;
+
+    // `server_name` is optional; when the widget omits it the homeserver uses
+    // its own, so it must not be sent as `null` either.
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/unstable/io.element.msc4195/rtc/livekit/get_token$"))
+        .and(body_json(json!({
+            "url": "ws://livekit.example.com",
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "jwt": "thejwt" })))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "get-token",
+        "org.matrix.msc4533.rtc_livekit_get_token",
+        json!({
+            "url": "ws://livekit.example.com",
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+        }),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["response"], json!({ "jwt": "thejwt" }));
+}
+
+#[async_test]
+async fn test_rtc_livekit_get_token_without_permission() {
+    let (_, _mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(&driver_handle, json!([])).await;
+
+    send_request(
+        &driver_handle,
+        "get-token",
+        "org.matrix.msc4533.rtc_livekit_get_token",
+        json!({
+            "url": "ws://livekit.example.com",
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+        }),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["action"], "org.matrix.msc4533.rtc_livekit_get_token");
+    assert_eq!(
+        response["response"]["error"]["message"].as_str().unwrap(),
+        "Not allowed: missing the org.matrix.msc4533.rtc_livekit_get_token capability."
+    );
+}
+
+#[async_test]
+async fn test_rtc_livekit_delegate_delayed_leave() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc4533.rtc_livekit_delegate_delayed_leave"]),
+    )
+    .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"^/_matrix/client/unstable/io.element.msc4195/rtc/livekit/delegate_delayed_leave$",
+        ))
+        .and(body_json(json!({
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+            "delay_id": "1234567890",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "delegate",
+        "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave",
+        json!({
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+            "delay_id": "1234567890",
+        }),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["api"], "fromWidget");
+    assert_eq!(response["action"], "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave");
+    assert_eq!(response["requestId"], "delegate");
+    // An empty object, so that the action stays extensible.
+    assert_eq!(response["response"], json!({}));
+}
+
+#[async_test]
+async fn test_rtc_livekit_delegate_delayed_leave_endpoint_unsupported() {
+    let (_, mock_server, driver_handle) = run_test_driver(false, false).await;
+
+    negotiate_capabilities(
+        &driver_handle,
+        json!(["org.matrix.msc4533.rtc_livekit_delegate_delayed_leave"]),
+    )
+    .await;
+
+    // MSC4195 defines no fallback for homeservers that don't implement the
+    // endpoint, so the widget has to tell this case apart from other failures
+    // and keep refreshing the delayed leave event itself.
+    Mock::given(method("POST"))
+        .and(path_regex(
+            r"^/_matrix/client/unstable/io.element.msc4195/rtc/livekit/delegate_delayed_leave$",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_UNRECOGNIZED",
+            "error": "Unrecognized request",
+        })))
+        .expect(1)
+        .mount(mock_server.server())
+        .await;
+
+    send_request(
+        &driver_handle,
+        "delegate",
+        "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave",
+        json!({
+            "room_id": "!tDLCaLXijNtYcJZEey:example.com",
+            "slot_id": "the_id",
+            "member": { "id": "xyzABCDEF10123", "claimed_device_id": "DEVICEID" },
+            "delay_id": "1234567890",
+        }),
+    )
+    .await;
+
+    let response = recv_message(&driver_handle).await;
+    assert_eq!(response["action"], "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave");
+
+    let error = &response["response"]["error"];
+    assert!(error["message"].is_string());
+    assert_eq!(error["matrix_api_error"]["http_status"], 404);
+    assert_eq!(error["matrix_api_error"]["response"]["errcode"], "M_UNRECOGNIZED");
 }
 
 #[async_test]


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.
   A large part of it was adding a similar logic as the already existing `/transports` endpoint logic. The related MSC defines all the names and types. (the LLM was prompted with the MSC context)
   
[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
