### PR TITLE
feat(bindings): get the server name from the user id

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6922.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6922.added.md
@@ -1,0 +1,4 @@
+Added a `server_name_from_user_id` function that returns the server name of a
+user ID, including the port when there is one. Clients that let people type a
+user ID where a server name is expected, such as when picking an account
+provider, no longer need to parse the ID themselves.

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -38,6 +38,7 @@ mod sync_service;
 mod sync_v2;
 mod task_handle;
 mod timeline;
+mod user_id;
 mod utd;
 mod utils;
 mod widget;

--- a/bindings/matrix-sdk-ffi/src/user_id.rs
+++ b/bindings/matrix-sdk-ffi/src/user_id.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for that specific language governing permissions and
+// limitations under the License.
+
+use ruma::UserId;
+
+use crate::error::ClientError;
+
+/// The server name part of the given user ID, including the port when the
+/// server name has one.
+///
+/// Returns an error if the user ID is invalid.
+#[matrix_sdk_ffi_macros::export]
+pub fn server_name_from_user_id(user_id: String) -> Result<String, ClientError> {
+    let user_id = UserId::parse(user_id)?;
+    Ok(user_id.server_name().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::server_name_from_user_id;
+
+    #[test]
+    fn test_server_name_from_user_id() {
+        assert_eq!(
+            server_name_from_user_id("@alice:example.org".to_owned()).unwrap(),
+            "example.org"
+        );
+    }
+
+    #[test]
+    fn test_server_name_from_user_id_keeps_the_port() {
+        assert_eq!(
+            server_name_from_user_id("@alice:example.org:8448".to_owned()).unwrap(),
+            "example.org:8448"
+        );
+    }
+
+    #[test]
+    fn test_server_name_from_user_id_with_an_invalid_user_id() {
+        assert!(server_name_from_user_id("example.org".to_owned()).is_err());
+        assert!(server_name_from_user_id("@alice".to_owned()).is_err());
+    }
+}


### PR DESCRIPTION
In the apps there is quite a lot of places where we need to get the server name from a user id, so it would be nice to have this helper function featured in the SDK.