### PR TITLE
feat(sdk): carry the notification mode over to an upgraded room

### DIFF
--- a/crates/matrix-sdk/changelog.d/6923.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6923.fixed.md
@@ -1,0 +1,6 @@
+Carry the notification mode a user set on a room over to the room that replaces
+it when that replacement is joined. An upgraded room is a different room to the
+server, so the push rule set on the old one does not apply to it, and following
+an upgrade silently returned the conversation to the default notification mode.
+Only a mode the user set themselves is copied, so a room that was following the
+default keeps following it.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1789,7 +1789,72 @@ impl Client {
         #[cfg(not(feature = "e2e-encryption"))]
         let _ = pre_join_room_info.map(|i| i.inviter);
 
+        self.inherit_notification_mode_from_predecessor(&room).await;
+
         Ok(room)
+    }
+
+    /// Carry the notification mode the user set on a room over to the room that
+    /// replaces it.
+    ///
+    /// An upgraded room is a different room to the server, so the push rule set
+    /// on the old one does not apply to it. Only a mode the user chose
+    /// themselves is copied: a room that was following the default keeps
+    /// following it, rather than being pinned to whatever the default happened
+    /// to be at the time of the upgrade.
+    async fn inherit_notification_mode_from_predecessor(&self, room: &Room) {
+        let notification_settings = self.notification_settings().await;
+
+        let Some(predecessor_room_id) =
+            self.predecessor_room_id(room, &notification_settings).await
+        else {
+            return;
+        };
+
+        let Some(mode) = notification_settings
+            .get_user_defined_room_notification_mode(&predecessor_room_id)
+            .await
+        else {
+            return;
+        };
+
+        if let Err(error) =
+            notification_settings.set_room_notification_mode(room.room_id(), mode).await
+        {
+            warn!(
+                room_id = %room.room_id(),
+                %predecessor_room_id,
+                "Failed to carry the notification mode over from the predecessor room: {error}"
+            );
+        }
+    }
+
+    /// The ID of the room the given room replaces, if it replaces one.
+    ///
+    /// The successor's own `m.room.create` event is the direct answer, but it
+    /// has usually not been synced yet right after joining. The room being
+    /// replaced is one the user was in, so its `m.room.tombstone` is the
+    /// answer that is actually available at that point; only the rooms the
+    /// user gave a notification mode of their own are worth looking at.
+    async fn predecessor_room_id(
+        &self,
+        room: &Room,
+        notification_settings: &NotificationSettings,
+    ) -> Option<OwnedRoomId> {
+        if let Some(predecessor) = room.predecessor_room() {
+            return Some(predecessor.room_id);
+        }
+
+        notification_settings
+            .get_rooms_with_user_defined_rules(None)
+            .await
+            .into_iter()
+            .filter_map(|room_id| RoomId::parse(room_id).ok())
+            .find(|candidate_id| {
+                self.get_room(candidate_id)
+                    .and_then(|candidate| candidate.successor_room())
+                    .is_some_and(|successor| successor.room_id == room.room_id())
+            })
     }
 
     /// Join a room by `RoomId`.

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -11,7 +11,7 @@ use matrix_sdk::{
     assert_next_with_timeout, assert_recv_with_timeout,
     config::SyncSettings,
     room::{Receipts, RoomMemberRole, edit::EditedContent},
-    test_utils::mocks::MatrixMockServer,
+    test_utils::mocks::{MatrixMockServer, PushRuleIdSpec},
 };
 use matrix_sdk_base::{EncryptionState, RoomMembersUpdate, RoomState};
 use matrix_sdk_common::executor::spawn;
@@ -19,6 +19,7 @@ use matrix_sdk_test::{
     DEFAULT_TEST_ROOM_ID, InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder, async_test,
     event_factory::EventFactory,
     mocks::mock_encryption_state,
+    notification_settings::{build_ruleset, get_server_default_ruleset},
     test_json::{self, sync::CUSTOM_ROOM_POWER_LEVELS},
 };
 use ruma::{
@@ -37,7 +38,9 @@ use ruma::{
             message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
         },
     },
-    int, mxc_uri, owned_event_id, owned_user_id, room_id, thirdparty, user_id,
+    int, mxc_uri, owned_event_id, owned_user_id,
+    push::RuleKind,
+    room_id, thirdparty, user_id,
 };
 use serde_json::json;
 use stream_assert::assert_pending;
@@ -1491,4 +1494,166 @@ async fn test_set_own_member_display_name() {
         .await;
 
     room.set_own_member_display_name(Some(new_name.to_owned())).await.unwrap();
+}
+
+#[async_test]
+async fn test_join_carries_the_notification_mode_of_the_replaced_room() -> Result<(), anyhow::Error>
+{
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let user = user_id!("@example:localhost");
+    let old_room_id = room_id!("!old_room:localhost");
+    let new_room_id = room_id!("!new_room:localhost");
+
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            let f = EventFactory::new();
+            builder.add_global_account_data(f.push_rules(build_ruleset(vec![(
+                RuleKind::Room,
+                old_room_id,
+                false,
+            )])));
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(old_room_id).add_state_event(
+                    f.room_tombstone("This room has been replaced", new_room_id)
+                        .room(old_room_id)
+                        .sender(user)
+                        .event_id(event_id!("$tombstone:localhost")),
+                ),
+            );
+        })
+        .await;
+
+    server.mock_room_join(new_room_id).ok().mount().await;
+    server
+        .mock_set_push_rules(RuleKind::Room, PushRuleIdSpec::Some(new_room_id.as_str()))
+        .ok()
+        .expect(1)
+        .named("set the mode on the new room")
+        .mount()
+        .await;
+
+    client.join_room_by_id(new_room_id).await?;
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_join_reads_the_replaced_room_from_the_create_event() -> Result<(), anyhow::Error> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let user = user_id!("@example:localhost");
+    let old_room_id = room_id!("!old_room:localhost");
+    let new_room_id = room_id!("!new_room:localhost");
+
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            let f = EventFactory::new();
+            builder.add_global_account_data(f.push_rules(build_ruleset(vec![(
+                RuleKind::Room,
+                old_room_id,
+                false,
+            )])));
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(new_room_id).add_state_event(
+                    f.create(user, RoomVersionId::V2)
+                        .predecessor(old_room_id)
+                        .room(new_room_id)
+                        .sender(user)
+                        .event_id(event_id!("$create_new_room:localhost")),
+                ),
+            );
+        })
+        .await;
+
+    server.mock_room_join(new_room_id).ok().mount().await;
+    server
+        .mock_set_push_rules(RuleKind::Room, PushRuleIdSpec::Some(new_room_id.as_str()))
+        .ok()
+        .expect(1)
+        .named("set the mode on the new room")
+        .mount()
+        .await;
+
+    client.join_room_by_id(new_room_id).await?;
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_join_leaves_the_default_in_place_when_the_replaced_room_followed_it()
+-> Result<(), anyhow::Error> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let user = user_id!("@example:localhost");
+    let old_room_id = room_id!("!old_room:localhost");
+    let new_room_id = room_id!("!new_room:localhost");
+
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            let f = EventFactory::new();
+            builder.add_global_account_data(f.push_rules(get_server_default_ruleset()));
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(old_room_id).add_state_event(
+                    f.room_tombstone("This room has been replaced", new_room_id)
+                        .room(old_room_id)
+                        .sender(user)
+                        .event_id(event_id!("$tombstone:localhost")),
+                ),
+            );
+        })
+        .await;
+
+    server.mock_room_join(new_room_id).ok().mount().await;
+    server
+        .mock_set_push_rules(RuleKind::Room, PushRuleIdSpec::Any)
+        .ok()
+        .expect(0)
+        .named("no mode is set")
+        .mount()
+        .await;
+
+    client.join_room_by_id(new_room_id).await?;
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_join_a_room_that_replaces_nothing_sets_no_mode() -> Result<(), anyhow::Error> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let old_room_id = room_id!("!old_room:localhost");
+    let new_room_id = room_id!("!new_room:localhost");
+
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            let f = EventFactory::new();
+            builder.add_global_account_data(f.push_rules(build_ruleset(vec![(
+                RuleKind::Room,
+                old_room_id,
+                false,
+            )])));
+        })
+        .await;
+
+    server.mock_room_join(new_room_id).ok().mount().await;
+    server
+        .mock_set_push_rules(RuleKind::Room, PushRuleIdSpec::Any)
+        .ok()
+        .expect(0)
+        .named("no mode is set")
+        .mount()
+        .await;
+
+    client.join_room_by_id(new_room_id).await?;
+
+    Ok(())
 }


### PR DESCRIPTION
A room that has been upgraded is a different room to the server, so the notification rule a user set on the old one does not apply to the new one. Following an upgrade silently returns that conversation to the default, and a room someone had deliberately set to mentions only starts notifying for everything again.

`Client::finish_join_room` now carries the mode over. Every join goes through it, so this applies however the replacement room is reached.

Only a mode the user set themselves is copied. A room that was following the default keeps following it, rather than being pinned to whatever the default happened to be at the moment of the upgrade.

The successor's own `m.room.create` event names the room it replaces, but it has usually not been synced yet at the point a join completes, so that alone would miss the case this is about. The room being replaced is one the user was in, so its `m.room.tombstone` is the answer that is actually available then; only the rooms the user gave a mode of their own are searched for it.

Four integration tests in `room::joined` cover the tombstone path, the create-event path, a predecessor that was following the default, and a room that replaces nothing. The two positive ones were run against the unpatched code and both fail there.

This came out of review on the Element X Android side: element-hq/element-x-android#7563, where the same fix was written in the app and @bmarty asked whether it belonged in the SDK instead.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
