### PR TITLE
feat(base): Add `Room::human_member_ids`

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6925.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6925.added.md
@@ -1,0 +1,3 @@
+Add `Room::human_member_ids`, which returns the user IDs of the room members
+with the given memberships, without the service members declared by the
+`io.element.functional_members` state event.

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -131,6 +131,21 @@ impl Room {
         Ok(members)
     }
 
+    /// Get the user IDs of the members with the given memberships, without the
+    /// service members, see [`Self::service_members`].
+    pub async fn human_member_ids(
+        &self,
+        memberships: RoomMemberships,
+    ) -> StoreResult<Vec<OwnedUserId>> {
+        let user_ids = self.store.get_user_ids(self.room_id(), memberships).await?;
+
+        let Some(service_members) = self.service_members() else {
+            return Ok(user_ids);
+        };
+
+        Ok(user_ids.into_iter().filter(|user_id| !service_members.contains(user_id)).collect())
+    }
+
     /// Returns the number of members who have joined or been invited to the
     /// room.
     pub fn active_members_count(&self) -> u64 {

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -780,6 +780,75 @@ mod tests {
         assert_eq!(heroes[0].user_id, alice_id);
     }
 
+    #[async_test]
+    async fn test_human_member_ids_filters_out_service_members() {
+        let client = logged_in_base_client(None).await;
+        let user_id = &client.session_meta().unwrap().user_id;
+        let service_member_id = user_id!("@service:example.org");
+        let alice_id = user_id!("@alice:example.org");
+        let bob_id = user_id!("@bob:example.org");
+        let room_id = room_id!("!room:example.org");
+
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+        let factory = EventFactory::new().room(room_id);
+
+        let service_member_hint =
+            factory.member_hints(BTreeSet::from([service_member_id.to_owned()])).sender(user_id);
+        let alice_joins = factory.member(alice_id);
+        let service_member_joins = factory.member(service_member_id);
+        let bob_leaves = factory.member(bob_id).membership(MembershipState::Leave);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(service_member_hint)
+                    .add_state_event(alice_joins)
+                    .add_state_event(service_member_joins)
+                    .add_state_event(bob_leaves),
+            )
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert_eq!(
+            room.human_member_ids(RoomMemberships::ACTIVE).await.unwrap(),
+            vec![alice_id.to_owned()]
+        );
+        assert_eq!(
+            room.human_member_ids(RoomMemberships::empty())
+                .await
+                .unwrap()
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([alice_id.to_owned(), bob_id.to_owned()])
+        );
+    }
+
+    #[async_test]
+    async fn test_human_member_ids_without_member_hints() {
+        let client = logged_in_base_client(None).await;
+        let alice_id = user_id!("@alice:example.org");
+        let room_id = room_id!("!room:example.org");
+
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+        let factory = EventFactory::new().room(room_id);
+
+        let alice_joins = factory.member(alice_id);
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
+            .add_joined_room(JoinedRoomBuilder::new(room_id).add_state_event(alice_joins))
+            .build_sync_response();
+
+        client.receive_sync_response(response).await.unwrap();
+
+        assert_eq!(
+            room.human_member_ids(RoomMemberships::ACTIVE).await.unwrap(),
+            vec![alice_id.to_owned()]
+        );
+    }
+
     #[cfg(feature = "unstable-msc4426")]
     #[async_test]
     async fn test_room_heroes_carry_global_profile() {

--- a/crates/matrix-sdk/changelog.d/6925.added.md
+++ b/crates/matrix-sdk/changelog.d/6925.added.md
@@ -1,0 +1,4 @@
+Add `Room::human_member_ids` and `Room::human_member_ids_no_sync`, which return
+the user IDs of the room members with the given memberships, without the service
+members declared by the `io.element.functional_members` state event. This is a
+convenient way to find the other party of a direct message.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1232,6 +1232,23 @@ impl Room {
             .collect())
     }
 
+    /// Get the user IDs of the members with the given memberships, without the
+    /// service members. The current user is part of the result. Fetches the
+    /// member list if it is not synced yet.
+    pub async fn human_member_ids(&self, memberships: RoomMemberships) -> Result<Vec<OwnedUserId>> {
+        self.sync_members().await?;
+        self.human_member_ids_no_sync(memberships).await
+    }
+
+    /// Same as [`Self::human_member_ids`], without a request to the homeserver,
+    /// so members can be missing.
+    pub async fn human_member_ids_no_sync(
+        &self,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>> {
+        Ok(self.inner.human_member_ids(memberships).await?)
+    }
+
     /// Sets the display name of the current user within this room.
     ///
     /// *Note*: This is different to [`crate::Account::set_display_name`] which


### PR DESCRIPTION
Fixes #6523.

Adds `Room::human_member_ids(memberships)`, which returns the user IDs of the room members with the given memberships, without the service members declared in the `io.element.functional_members` state event. The current user is part of the result. This gives clients the general form the issue asked for: for a DM, the other party is the single remaining ID once the caller drops its own.

The base crate reads the IDs from the state store and filters them against `Room::service_members`, so it never loads the full member events. The main crate wraps it with the usual pair: `human_member_ids` syncs the member list first, `human_member_ids_no_sync` does no request.

Not included, on purpose: the `matrix-sdk-ffi` binding. A useful FFI signature needs the membership filter, and `RoomMemberships` is not exposed across uniffi today (`Membership` there is the own user's room state, a different thing). Happy to add it in this PR if you tell me which shape you want.

Tests: two unit tests in `crates/matrix-sdk-base/src/room/mod.rs` cover a room with member hints (service member and a left member filtered out) and a room without them.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>
