### PR TITLE
refactor(sdk): Avoid cloning useless data in `Caches::handle_(joined|left)_room_update`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -36,8 +36,8 @@ use super::{
     thread::ThreadEventCacheState,
 };
 
-pub fn aggregate_timeline_for_room(timeline: Timeline) -> Timeline {
-    timeline
+pub fn aggregate_timeline_for_room(timeline: &Timeline) -> Timeline {
+    timeline.clone()
 }
 
 pub async fn aggregate_timeline_for_threads<'sync, 'state>(

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -291,20 +291,43 @@ impl Caches {
     pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
         let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
+        // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
+        // avoid cloning useless data or to clone as few data as possible. That's a fun
+        // game.
+        let JoinedRoomUpdate {
+            // Read receipts are computed by the Event Cache, see [`read_receipts`], we
+            // don't need the server value.
+            unread_notifications: _,
+            // State-events are not stored in the Event Cache.
+            state: _,
+
+            // Extract the original timeline and ephemeral events as timeline will be used by all
+            // caches, and ephemeral events by the room and thread caches.
+            timeline: original_timeline,
+            ephemeral: original_ephemeral,
+
+            // Extract other data, only useful for the room cache.
+            account_data,
+            ambiguity_changes,
+            avatar_changes,
+        } = updates;
+
         // Room.
         {
-            let mut updates = updates.clone();
-            updates.timeline = aggregator::aggregate_timeline_for_room(updates.timeline);
+            let updates = JoinedRoomUpdate {
+                timeline: aggregator::aggregate_timeline_for_room(&original_timeline),
+                ephemeral: original_ephemeral.clone(),
+                account_data,
+                ambiguity_changes,
+                avatar_changes,
+                ..Default::default()
+            };
 
             room.handle_joined_room_update(updates).await?;
         }
 
         // Threads.
         {
-            let mut updates = updates.clone();
-            updates.account_data.clear();
-            updates.ambiguity_changes.clear();
-
             let timeline_for_threads = {
                 // To aggregate the timelines for threads, we need to lookup in the room cache
                 // and the thread caches. We acquire a read lock over all the caches, and select
@@ -316,8 +339,8 @@ impl Caches {
                 let all_states = all_states_lock.read().await?;
 
                 aggregator::aggregate_timeline_for_threads(
-                    &updates.timeline,
-                    &updates.ephemeral,
+                    &original_timeline,
+                    &original_ephemeral,
                     all_states.threads(),
                     all_states.room(),
                     &internals.room_version_rules.redaction,
@@ -326,8 +349,11 @@ impl Caches {
             };
 
             for (thread_id, timeline) in timeline_for_threads {
-                let mut updates = updates.clone();
-                updates.timeline = timeline;
+                let updates = JoinedRoomUpdate {
+                    timeline,
+                    ephemeral: original_ephemeral.clone(),
+                    ..Default::default()
+                };
 
                 // Update the thread summary if and only if there are new events.
                 let update_thread_summary = updates.timeline.events.is_empty().not();
@@ -346,12 +372,14 @@ impl Caches {
 
         // Pinned-events.
         if let Some(pinned_events) = pinned_events.get() {
-            let mut updates = updates.clone();
-            updates.timeline = aggregator::aggregate_timeline_for_pinned_events(
-                &updates.timeline,
-                &pinned_events.state().read().await?.current_event_ids(),
-                &internals.room_version_rules.redaction,
-            );
+            let updates = JoinedRoomUpdate {
+                timeline: aggregator::aggregate_timeline_for_pinned_events(
+                    &original_timeline,
+                    &pinned_events.state().read().await?.current_event_ids(),
+                    &internals.room_version_rules.redaction,
+                ),
+                ..Default::default()
+            };
 
             pinned_events.handle_joined_room_update(updates).await?;
         }
@@ -370,20 +398,35 @@ impl Caches {
     pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
         let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
+        // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
+        // avoid cloning useless data or to clone as few data as possible. That's a fun
+        // game.
+        let LeftRoomUpdate {
+            // State-events are not stored in the Event Cache.
+            state: _,
+            // Account data are not used by any cache.
+            account_data: _,
+
+            // Extract the original timeline as it's going to be used by all caches.
+            timeline: original_timeline,
+
+            // Extract other data, only useful for the room cache.
+            ambiguity_changes,
+        } = updates;
+
         // Room.
         {
-            let mut updates = updates.clone();
-            updates.timeline = aggregator::aggregate_timeline_for_room(updates.timeline);
+            let updates = LeftRoomUpdate {
+                timeline: aggregator::aggregate_timeline_for_room(&original_timeline),
+                ambiguity_changes,
+                ..Default::default()
+            };
 
             room.handle_left_room_update(updates).await?;
         }
 
         // Threads.
         {
-            let mut updates = updates.clone();
-            updates.account_data.clear();
-            updates.ambiguity_changes.clear();
-
             let timeline_for_threads = {
                 // To aggregate the timelines for threads, we need to lookup in the room cache
                 // and the thread caches. We acquire a read lock over all the caches, and select
@@ -395,7 +438,7 @@ impl Caches {
                 let all_caches_states = all_caches_states_lock.read().await?;
 
                 aggregator::aggregate_timeline_for_threads(
-                    &updates.timeline,
+                    &original_timeline,
                     &[],
                     all_caches_states.threads(),
                     all_caches_states.room(),
@@ -405,8 +448,7 @@ impl Caches {
             };
 
             for (thread_id, timeline) in timeline_for_threads {
-                let mut updates = updates.clone();
-                updates.timeline = timeline;
+                let updates = LeftRoomUpdate { timeline, ..Default::default() };
 
                 let thread = self.thread(thread_id).await?;
                 thread.handle_left_room_update(updates).await?;
@@ -415,12 +457,14 @@ impl Caches {
 
         // Pinned-events.
         if let Some(pinned_events) = pinned_events.get() {
-            let mut updates = updates.clone();
-            updates.timeline = aggregator::aggregate_timeline_for_pinned_events(
-                &updates.timeline,
-                &pinned_events.state().read().await?.current_event_ids(),
-                &internals.room_version_rules.redaction,
-            );
+            let updates = LeftRoomUpdate {
+                timeline: aggregator::aggregate_timeline_for_pinned_events(
+                    &original_timeline,
+                    &pinned_events.state().read().await?.current_event_ids(),
+                    &internals.room_version_rules.redaction,
+                ),
+                ..Default::default()
+            };
 
             pinned_events.handle_left_room_update(updates).await?;
         }


### PR DESCRIPTION
In `Caches::handle_(joined|left)_room_update`, the original `updates` (either a `JoinedRoomUpdate` or a `LeftRoomUpdate`) was cloned for each cache, before updating it. Problem: if the initial `updates` contains many data, they are cloned again and again, and they are likely to be useless.

An initial attempt was made to clear `account_data` and `ambiguity_changes`, but the original `timeline` and the original `ephemeral_events` were cloned regardless.

The aggregators are used to create tailored `Timeline` for each cache, okay, that's great, but if we clone the original `Timeline`, it keeps cloning likely useless events. For example, for the thread caches, it's not useful to clone unthreaded events.

This patch changes that by extracting the data one by one, and by reconstructing new `JoinedRoomUpdate` and `LeftRoomUpdate` manually without using `clone`.

---

- Fix https://github.com/matrix-org/matrix-rust-sdk/issues/6915
- Built on top of https://github.com/matrix-org/matrix-rust-sdk/pull/6893. Need to be merged first.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
