### PR TITLE
refactor!: Rename the room subscription methods

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6927.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6927.changed.md
@@ -1,0 +1,3 @@
+`RoomListService::subscribe_to_rooms` is renamed to
+`RoomListService::set_room_subscriptions`, to match the room subscription
+methods of `SlidingSync`.

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -136,7 +136,7 @@ impl RoomListService {
         })))
     }
 
-    async fn subscribe_to_rooms(&self, room_ids: Vec<String>) -> Result<(), RoomListError> {
+    async fn set_room_subscriptions(&self, room_ids: Vec<String>) -> Result<(), RoomListError> {
         let room_ids = room_ids
             .into_iter()
             .map(|room_id| {
@@ -145,7 +145,7 @@ impl RoomListService {
             .collect::<Result<Vec<_>, _>>()?;
 
         self.inner
-            .subscribe_to_rooms(&room_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>())
+            .set_room_subscriptions(&room_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>())
             .await;
 
         Ok(())

--- a/crates/matrix-sdk-ui/changelog.d/6652.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6652.changed.md
@@ -1,1 +1,1 @@
-`RoomListService::subscribe_to_rooms` now updates subscriptions non-destructively.
+`RoomListService::set_room_subscriptions` now updates subscriptions non-destructively.

--- a/crates/matrix-sdk-ui/changelog.d/6927.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6927.changed.md
@@ -1,0 +1,3 @@
+`RoomListService::subscribe_to_rooms` is renamed to
+`RoomListService::set_room_subscriptions`, to match the room subscription
+methods of `SlidingSync`.

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -531,7 +531,7 @@ impl NotificationClient {
             .build()
             .await?;
 
-        sync.subscribe_to_rooms(
+        sync.add_room_subscriptions(
             &room_ids.iter().map(|id| id.deref()).collect::<Vec<&RoomId>>(),
             Some(assign!(http::request::RoomSubscription::default(), {
                 required_state,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -493,50 +493,61 @@ impl RoomListService {
     /// [listen_to_room]: matrix_sdk::latest_events::LatestEvents::listen_to_room
     /// [`LatestEventValue`]: matrix_sdk::latest_events::LatestEventValue
     pub async fn subscribe_to_rooms(&self, room_ids: &[&RoomId]) {
-        // Calculate the settings for the room subscriptions.
-        let settings = assign!(http::request::RoomSubscription::default(), {
-            required_state: DEFAULT_REQUIRED_STATE.iter().map(|(state_event, value)| {
-                (state_event.clone(), (*value).to_owned())
-            })
-            .chain(
-                DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE.iter().map(|(state_event, value)| {
-                    (state_event.clone(), (*value).to_owned())
-                })
-            )
-            .collect(),
-            timeline_limit: UInt::from(DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT),
-        });
+        // Read the state before the await: the state machine can drift meanwhile.
+        let cancel_in_flight_request = self.must_cancel_in_flight_request();
 
-        // Decide whether the in-flight request (if any) should be cancelled if needed.
-        let cancel_in_flight_request = match self.state_machine.get() {
+        self.listen_to_latest_events(room_ids).await;
+
+        self.sliding_sync.resubscribe_to_rooms(
+            room_ids,
+            Some(room_subscription_settings()),
+            cancel_in_flight_request,
+        )
+    }
+
+    async fn listen_to_latest_events(&self, room_ids: &[&RoomId]) {
+        if !self.client.event_cache().has_subscribed() {
+            return;
+        }
+
+        let latest_events = self.client.latest_events().await;
+
+        for room_id in room_ids {
+            if let Err(error) = latest_events.listen_to_room(room_id).await {
+                // A failure here must not fail the room subscription.
+                error!(?error, ?room_id, "Failed to listen to the latest event for this room");
+            }
+        }
+    }
+
+    fn must_cancel_in_flight_request(&self) -> bool {
+        match self.state_machine.get() {
             State::Init | State::Recovering | State::Error { .. } | State::Terminated { .. } => {
                 false
             }
             State::SettingUp | State::Running => true,
-        };
-
-        // Before subscribing, let's listen these rooms to calculate their latest
-        // events.
-        if self.client.event_cache().has_subscribed() {
-            let latest_events = self.client.latest_events().await;
-
-            for room_id in room_ids {
-                if let Err(error) = latest_events.listen_to_room(room_id).await {
-                    // Let's not fail the room subscription. Instead, emit a log because it's very
-                    // unlikely to happen.
-                    error!(?error, ?room_id, "Failed to listen to the latest event for this room");
-                }
-            }
         }
-
-        // Subscribe to the rooms.
-        self.sliding_sync.resubscribe_to_rooms(room_ids, Some(settings), cancel_in_flight_request)
     }
 
     #[cfg(test)]
     pub fn sliding_sync(&self) -> &SlidingSync {
         &self.sliding_sync
     }
+}
+
+fn room_subscription_settings() -> http::request::RoomSubscription {
+    assign!(http::request::RoomSubscription::default(), {
+        required_state: DEFAULT_REQUIRED_STATE.iter().map(|(state_event, value)| {
+            (state_event.clone(), (*value).to_owned())
+        })
+        .chain(
+            DEFAULT_ROOM_SUBSCRIPTION_EXTRA_REQUIRED_STATE.iter().map(|(state_event, value)| {
+                (state_event.clone(), (*value).to_owned())
+            })
+        )
+        .collect(),
+        timeline_limit: UInt::from(DEFAULT_ROOM_SUBSCRIPTION_TIMELINE_LIMIT),
+    })
 }
 
 /// [`RoomList`]'s errors.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -478,7 +478,7 @@ impl RoomListService {
         self.client.get_room(room_id).ok_or_else(|| Error::RoomNotFound(room_id.to_owned()))
     }
 
-    /// Subscribe to rooms.
+    /// Set the room subscriptions to exactly `room_ids`.
     ///
     /// It means that all events from these rooms will be received every time,
     /// no matter how the `RoomList` is configured.
@@ -487,18 +487,15 @@ impl RoomListService {
     /// room in `room_ids`, so that the [`LatestEventValue`] will automatically
     /// be calculated and updated for these rooms, for free.
     ///
-    /// Previous room subscriptions that are not contained in the specified room
-    /// IDs will be forgotten.
-    ///
     /// [listen_to_room]: matrix_sdk::latest_events::LatestEvents::listen_to_room
     /// [`LatestEventValue`]: matrix_sdk::latest_events::LatestEventValue
-    pub async fn subscribe_to_rooms(&self, room_ids: &[&RoomId]) {
+    pub async fn set_room_subscriptions(&self, room_ids: &[&RoomId]) {
         // Read the state before the await: the state machine can drift meanwhile.
         let cancel_in_flight_request = self.must_cancel_in_flight_request();
 
         self.listen_to_latest_events(room_ids).await;
 
-        self.sliding_sync.resubscribe_to_rooms(
+        self.sliding_sync.set_room_subscriptions(
             room_ids,
             Some(room_subscription_settings()),
             cancel_in_flight_request,

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2295,7 +2295,7 @@ async fn test_room_subscription() -> Result<(), Error> {
     };
 
     // Subscribe.
-    room_list.subscribe_to_rooms(&[room_id_1]).await;
+    room_list.set_room_subscriptions(&[room_id_1]).await;
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2340,7 +2340,7 @@ async fn test_room_subscription() -> Result<(), Error> {
     };
 
     // Subscribe to another room.
-    room_list.subscribe_to_rooms(&[room_id_2]).await;
+    room_list.set_room_subscriptions(&[room_id_2]).await;
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2413,7 +2413,7 @@ async fn test_room_subscription() -> Result<(), Error> {
     };
 
     // Subscribe to an already subscribed room, plus a previously removed one.
-    room_list.subscribe_to_rooms(&[room_id_1, room_id_2]).await;
+    room_list.set_room_subscriptions(&[room_id_1, room_id_2]).await;
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2712,7 +2712,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     let room = room_list.room(room_id)?;
     let timeline = room.timeline_builder().build().await.unwrap();
 
-    // We could subscribe to the room —with `RoomList::subscribe_to_rooms`— to
+    // We could subscribe to the room —with `RoomList::set_room_subscriptions`— to
     // automatically listen to the latest event updates, but we will do it
     // manually here (so that we can ignore the subscription thingies).
     let latest_events = client.latest_events().await;

--- a/crates/matrix-sdk/changelog.d/6652.added.md
+++ b/crates/matrix-sdk/changelog.d/6652.added.md
@@ -1,6 +1,6 @@
-Add `SlidingSync::resubscribe_to_rooms` for updating room subscriptions non-destructively.
-This is similar to `SlidingSync::clear_and_subscribe_to_rooms` but doesn't clear and then
+Add `SlidingSync::set_room_subscriptions` for updating room subscriptions non-destructively.
+This is similar to `SlidingSync::reset_and_add_room_subscriptions` but doesn't clear and then
 recreate all subscriptions. Instead, it removes existing subscriptions for rooms that are
 not resubscribed and adds new subscriptions for resubscribed rooms that don't already exist.
-Unlike `SlidingSync::clear_and_subscribe_to_rooms`, this method does not mark members as
+Unlike `SlidingSync::reset_and_add_room_subscriptions`, this method does not mark members as
 unsynced.

--- a/crates/matrix-sdk/changelog.d/6828.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6828.fixed.md
@@ -1,4 +1,4 @@
-`SlidingSync::resubscribe_to_rooms` now cancels in-flight requests whenever the 
+`SlidingSync::set_room_subscriptions` now cancels in-flight requests whenever the 
 set of room subscriptions changes. It used to do so only when a subscription 
 was added and another one was removed in the same call, so a first-time 
 subscription or a singular removal was not sent until the current long poll 

--- a/crates/matrix-sdk/changelog.d/6927.changed.md
+++ b/crates/matrix-sdk/changelog.d/6927.changed.md
@@ -1,0 +1,5 @@
+The room subscription methods of `SlidingSync` are renamed after what they do to
+the set of subscriptions: `subscribe_to_rooms` becomes `add_room_subscriptions`,
+`unsubscribe_to_rooms` becomes `remove_room_subscriptions`,
+`resubscribe_to_rooms` becomes `set_room_subscriptions`, and
+`clear_and_subscribe_to_rooms` becomes `reset_and_add_room_subscriptions`.

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -127,7 +127,8 @@ position. The details (`required_state`s and timeline items) requested by all
 lists are bundled, together with the common details (e.g. whether it is a `dm`
 or its calculated name). Use the `Room` API to get these updated data.
 
-It is possible [`subscribe_to_rooms()`](SlidingSync::subscribe_to_rooms): any
+It is possible to subscribe to rooms with
+[`add_room_subscriptions()`](SlidingSync::add_room_subscriptions): any
 room subscribed to will receive updates (with the given settings) regardless of
 whether they are visible in any list. The most common case for using this API
 is when the user enters a room - as we want to receive the incoming new messages

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -132,7 +132,8 @@ impl SlidingSync {
         SlidingSyncBuilder::new(id, client)
     }
 
-    /// Add subscriptions to many rooms.
+    /// Add a subscription for each room of `room_ids`, and keep the existing
+    /// subscriptions to other rooms.
     ///
     /// If the associated `Room`s exist, they will be marked as members are
     /// missing, so that it ensures to re-fetch all members.
@@ -140,13 +141,13 @@ impl SlidingSync {
     /// A subscription to an already subscribed room only updates its
     /// `settings`, and only if they differ. In particular, its members are
     /// not marked as missing again.
-    pub fn subscribe_to_rooms(
+    pub fn add_room_subscriptions(
         &self,
         room_ids: &[&RoomId],
         settings: Option<http::request::RoomSubscription>,
         cancel_in_flight_request: bool,
     ) {
-        let subscriptions_have_changed = add_room_subscriptions(
+        let subscriptions_have_changed = upsert_room_subscriptions(
             &mut self.inner.room_subscriptions.write().unwrap(),
             &self.inner.client,
             room_ids,
@@ -158,8 +159,8 @@ impl SlidingSync {
         }
     }
 
-    /// Remove subscriptions to many rooms.
-    pub fn unsubscribe_to_rooms(&self, room_ids: &[&RoomId], cancel_in_flight_request: bool) {
+    /// Remove the subscription of each room of `room_ids`.
+    pub fn remove_room_subscriptions(&self, room_ids: &[&RoomId], cancel_in_flight_request: bool) {
         let mut room_subscriptions = self.inner.room_subscriptions.write().unwrap();
         let mut subscriptions_have_changed = false;
 
@@ -174,12 +175,11 @@ impl SlidingSync {
         }
     }
 
-    /// Add subscriptions to the specified rooms if they don't already exist and
-    /// remove any existing subscriptions to other rooms.
+    /// Set the room subscriptions to exactly `room_ids`.
     ///
-    /// This is similar to [`Self::clear_and_subscribe_to_rooms`] but doesn't
-    /// clear and then recreate all subscriptions. Instead, it will perform
-    /// a delta-like update which involves:
+    /// This is similar to [`Self::reset_and_add_room_subscriptions`] but
+    /// doesn't clear and then recreate all subscriptions. Instead, it will
+    /// perform a delta-like update which involves:
     ///
     /// - refreshing the `settings` of existing subscriptions if the room is
     ///   contained in `room_ids`, and only if they differ
@@ -188,10 +188,10 @@ impl SlidingSync {
     /// - removing existing subscriptions for rooms that are not contained in
     ///   `room_ids`
     ///
-    /// Note that unlike [`Self::clear_and_subscribe_to_rooms`], this method
+    /// Note that unlike [`Self::reset_and_add_room_subscriptions`], this method
     /// will not mark members as unsynced (which would cause them to be
     /// refetched) for subscriptions that already exist.
-    pub fn resubscribe_to_rooms(
+    pub fn set_room_subscriptions(
         &self,
         room_ids: &[&RoomId],
         settings: Option<http::request::RoomSubscription>,
@@ -207,8 +207,12 @@ impl SlidingSync {
 
         // Add the subscriptions to the rooms that aren't subscribed yet, and refresh
         // the settings of the ones that already are.
-        let a_subscription_has_been_added_or_updated =
-            add_room_subscriptions(&mut room_subscriptions, &self.inner.client, room_ids, settings);
+        let a_subscription_has_been_added_or_updated = upsert_room_subscriptions(
+            &mut room_subscriptions,
+            &self.inner.client,
+            room_ids,
+            settings,
+        );
 
         // The in-flight request must be cancelled as soon as the set of subscriptions
         // has changed.
@@ -219,21 +223,27 @@ impl SlidingSync {
         }
     }
 
-    /// Replace all subscriptions to rooms by other ones.
+    /// Remove all the room subscriptions, then add a subscription for each room
+    /// of `room_ids`.
     ///
     /// If the associated `Room`s exist, they will be marked as members are
     /// missing, so that it ensures to re-fetch all members.
-    pub fn clear_and_subscribe_to_rooms(
+    pub fn reset_and_add_room_subscriptions(
         &self,
         room_ids: &[&RoomId],
         settings: Option<http::request::RoomSubscription>,
         cancel_in_flight_request: bool,
     ) {
         let mut room_subscriptions = self.inner.room_subscriptions.write().unwrap();
+
         room_subscriptions.clear();
 
-        let subscriptions_have_changed =
-            add_room_subscriptions(&mut room_subscriptions, &self.inner.client, room_ids, settings);
+        let subscriptions_have_changed = upsert_room_subscriptions(
+            &mut room_subscriptions,
+            &self.inner.client,
+            room_ids,
+            settings,
+        );
 
         if cancel_in_flight_request && subscriptions_have_changed {
             self.inner.cancel_in_flight_request();
@@ -866,7 +876,7 @@ impl SlidingSync {
 /// up to the caller to decide whether this warrants cancelling the in-flight
 /// request: a caller can have other reasons to cancel it, e.g. having removed a
 /// subscription.
-fn add_room_subscriptions(
+fn upsert_room_subscriptions(
     room_subscriptions: &mut BTreeMap<OwnedRoomId, http::request::RoomSubscription>,
     client: &Client,
     room_ids: &[&RoomId],
@@ -1193,7 +1203,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_subscribe_to_rooms() -> Result<()> {
+    async fn test_add_room_subscriptions() -> Result<()> {
         let (server, sliding_sync) = new_sliding_sync(vec![
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
@@ -1264,7 +1274,7 @@ mod tests {
         // Members are now synced! We can start subscribing and see how it goes.
         assert!(room0.are_members_synced());
 
-        sliding_sync.subscribe_to_rooms(&[room_id_0, room_id_1], None, true);
+        sliding_sync.add_room_subscriptions(&[room_id_0, room_id_1], None, true);
 
         // OK, we have subscribed to some rooms. Let's check on `room0` if members are
         // now marked as not synced.
@@ -1304,7 +1314,7 @@ mod tests {
         // Members are synced, good, good.
         assert!(room0.are_members_synced());
 
-        sliding_sync.subscribe_to_rooms(&[room_id_0], None, false);
+        sliding_sync.add_room_subscriptions(&[room_id_0], None, false);
 
         // Members are still synced: because we have already subscribed to the
         // room, the members aren't marked as unsynced.
@@ -1314,7 +1324,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_subscribe_unsubscribe_and_clear_and_subscribe_to_rooms() -> Result<()> {
+    async fn test_add_remove_and_reset_room_subscriptions() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
@@ -1334,7 +1344,7 @@ mod tests {
         }
 
         // Add 2 rooms.
-        sliding_sync.subscribe_to_rooms(&[room_id_0, room_id_1], Default::default(), false);
+        sliding_sync.add_room_subscriptions(&[room_id_0, room_id_1], Default::default(), false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -1345,7 +1355,7 @@ mod tests {
         }
 
         // Remove 1 room.
-        sliding_sync.unsubscribe_to_rooms(&[room_id_0], false);
+        sliding_sync.remove_room_subscriptions(&[room_id_0], false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -1355,7 +1365,7 @@ mod tests {
         }
 
         // Add 2 rooms, but one already exists.
-        sliding_sync.subscribe_to_rooms(&[room_id_0, room_id_1], Default::default(), false);
+        sliding_sync.add_room_subscriptions(&[room_id_0, room_id_1], Default::default(), false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -1366,7 +1376,7 @@ mod tests {
         }
 
         // Replace all rooms with 2 other rooms.
-        sliding_sync.clear_and_subscribe_to_rooms(
+        sliding_sync.reset_and_add_room_subscriptions(
             &[room_id_2, room_id_3],
             Default::default(),
             false,
@@ -1384,7 +1394,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_resubscribe_to_rooms_refreshes_the_settings() -> Result<()> {
+    async fn test_set_room_subscriptions_refreshes_the_settings() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
@@ -1411,7 +1421,7 @@ mod tests {
         let mut internal_channel = sliding_sync.inner.internal_channel.subscribe();
 
         // Subscribe for the first time.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], settings(10), true);
+        sliding_sync.set_room_subscriptions(&[room_id_0], settings(10), true);
 
         assert_eq!(timeline_limit_of_room_0(), Some(10u32.into()));
         assert_matches!(
@@ -1420,14 +1430,14 @@ mod tests {
         );
 
         // Resubscribe with the same settings: nothing changes, no cancellation.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], settings(10), true);
+        sliding_sync.set_room_subscriptions(&[room_id_0], settings(10), true);
 
         assert_eq!(timeline_limit_of_room_0(), Some(10u32.into()));
         assert!(internal_channel.try_recv().is_err());
 
         // Resubscribe with new settings: they must be applied, and the in-flight
         // request must be cancelled so that they are sent right away.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], settings(42), true);
+        sliding_sync.set_room_subscriptions(&[room_id_0], settings(42), true);
 
         assert_eq!(timeline_limit_of_room_0(), Some(42u32.into()));
         assert_matches!(
@@ -1439,7 +1449,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_resubscribe_to_rooms_cancels_the_in_flight_request() -> Result<()> {
+    async fn test_set_room_subscriptions_cancels_the_in_flight_request() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
@@ -1453,7 +1463,7 @@ mod tests {
 
         // A first-ever subscription: nothing is removed, but a subscription is added,
         // so the in-flight request must be cancelled.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], None, true);
+        sliding_sync.set_room_subscriptions(&[room_id_0], None, true);
 
         assert_matches!(
             internal_channel.try_recv(),
@@ -1462,12 +1472,12 @@ mod tests {
 
         // Resubscribing to the same room: nothing is added nor removed, no
         // cancellation.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], None, true);
+        sliding_sync.set_room_subscriptions(&[room_id_0], None, true);
 
         assert!(internal_channel.try_recv().is_err());
 
         // A subscription is removed: the in-flight request must be cancelled.
-        sliding_sync.resubscribe_to_rooms(&[room_id_1], None, true);
+        sliding_sync.set_room_subscriptions(&[room_id_1], None, true);
 
         assert_matches!(
             internal_channel.try_recv(),
@@ -1475,7 +1485,7 @@ mod tests {
         );
 
         // Finally, no cancellation is asked: no cancellation happens.
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], None, false);
+        sliding_sync.set_room_subscriptions(&[room_id_0], None, false);
 
         assert!(internal_channel.try_recv().is_err());
 
@@ -1483,7 +1493,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_resubscribe_to_rooms() -> Result<()> {
+    async fn test_set_room_subscriptions() -> Result<()> {
         let (server, sliding_sync) = new_sliding_sync(vec![
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
@@ -1554,7 +1564,7 @@ mod tests {
         // Members are now synced! We can start subscribing and see how it goes.
         assert!(room0.are_members_synced());
 
-        sliding_sync.resubscribe_to_rooms(&[room_id_0, room_id_1], None, true);
+        sliding_sync.set_room_subscriptions(&[room_id_0, room_id_1], None, true);
 
         // OK, we have subscribed to some rooms. Let's check on `room0` if members are
         // now marked as not synced.
@@ -1595,7 +1605,7 @@ mod tests {
         // Members are synced, good, good.
         assert!(room0.are_members_synced());
 
-        sliding_sync.resubscribe_to_rooms(&[room_id_0], None, false);
+        sliding_sync.set_room_subscriptions(&[room_id_0], None, false);
 
         // Members are still synced: because we have already subscribed to the
         // room, the members aren't marked as unsynced.
@@ -1625,7 +1635,7 @@ mod tests {
         let room_id_2 = room_id!("!r2:bar.org");
 
         // Subscribe to two rooms.
-        sliding_sync.subscribe_to_rooms(&[room_id_0, room_id_1], None, false);
+        sliding_sync.add_room_subscriptions(&[room_id_0, room_id_1], None, false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -1636,7 +1646,7 @@ mod tests {
         }
 
         // Subscribe to one more room.
-        sliding_sync.subscribe_to_rooms(&[room_id_2], None, false);
+        sliding_sync.add_room_subscriptions(&[room_id_2], None, false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -1656,7 +1666,7 @@ mod tests {
         }
 
         // Subscribe to one room again.
-        sliding_sync.subscribe_to_rooms(&[room_id_2], None, false);
+        sliding_sync.add_room_subscriptions(&[room_id_2], None, false);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();

--- a/labs/multiverse/src/widgets/room_list.rs
+++ b/labs/multiverse/src/widgets/room_list.rs
@@ -129,7 +129,7 @@ impl RoomList {
         if let Some(room) =
             self.get_room_id_of_entry(index).and_then(|room_id| self.client.get_room(&room_id))
         {
-            self.sync_service.room_list_service().subscribe_to_rooms(&[room.room_id()]).await;
+            self.sync_service.room_list_service().set_room_subscriptions(&[room.room_id()]).await;
             self.current_room_subscription = Some(room);
         }
     }

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -516,7 +516,7 @@ async fn test_unread_counts_get_updated_after_decryption() -> TestResult {
 
     let sync_service2 = SyncService::builder(alice2.clone()).build().await?;
 
-    sync_service2.room_list_service().subscribe_to_rooms(&[&room_id]).await;
+    sync_service2.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service2.start().await;
 
     alice2.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -737,7 +737,7 @@ async fn test_latest_event_few_rooms() -> Result<()> {
     //warn!("Subscribing to rooms on second client…");
     //bob2_sync_service
     //.room_list_service()
-    //.subscribe_to_rooms(&[room1.room_id(), room2.room_id()])
+    //.set_room_subscriptions(&[room1.room_id(), room2.room_id()])
     //.await;
 
     //// Wait for a bit, for a sync response to be returned.

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -1174,7 +1174,7 @@ async fn test_pinned_events_are_decrypted_after_recovering_with_event_count(
     //
     // Additionally if we subscribe to the room after we already synced, we won't
     // receive the event, likely due to a Synapse bug.
-    sync_service.room_list_service().subscribe_to_rooms(&[&room_id]).await;
+    sync_service.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service.start().await;
     another_alice.encryption().wait_for_e2ee_initialization_tasks().await;
 
@@ -1315,7 +1315,7 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
     //
     // Additionally if we subscribe to the room after we already synced, we won't
     // receive the event, likely due to a Synapse bug.
-    sync_service.room_list_service().subscribe_to_rooms(&[&room_id]).await;
+    sync_service.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service.start().await;
     another_alice.encryption().wait_for_e2ee_initialization_tasks().await;
 
@@ -1446,7 +1446,7 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
 
     let sync_service2 = SyncService::builder(alice2.clone()).build().await?;
 
-    sync_service2.room_list_service().subscribe_to_rooms(&[&room_id]).await;
+    sync_service2.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service2.start().await;
     alice2.encryption().wait_for_e2ee_initialization_tasks().await;
 


### PR DESCRIPTION
Split out of #6906, at the request of the review there.

`SlidingSync` had four methods to manage the same map of room subscriptions: `subscribe_to_rooms`, `unsubscribe_to_rooms`, `resubscribe_to_rooms` and `clear_and_subscribe_to_rooms`. The names said how many times a room was subscribed to, not what happened to the set of subscriptions, and the difference between the last two took a paragraph of documentation to explain. Name each method after its effect on that set:

- `SlidingSync::subscribe_to_rooms` becomes `add_room_subscriptions`, which keeps the subscriptions to other rooms
- `SlidingSync::unsubscribe_to_rooms` becomes `remove_room_subscriptions`
- `SlidingSync::resubscribe_to_rooms` becomes `set_room_subscriptions`, because the set ends up as exactly `room_ids`, updated delta-wise
- `SlidingSync::clear_and_subscribe_to_rooms` becomes `reset_and_add_room_subscriptions`, which empties the map first, so the members of every room are marked as missing
- the private helper `add_room_subscriptions` becomes `upsert_room_subscriptions`, which frees its name for the public method
- `RoomListService::subscribe_to_rooms` becomes `set_room_subscriptions`, since that is the method it forwards to

The FFI method follows the `RoomListService` one, so `subscribeToRooms` becomes `setRoomSubscriptions` for the consumers of the bindings. That is the only breaking change here.

`RoomListService::subscribe_to_rooms` also did three things in one body, each under its own comment: build the subscription settings, read the state machine, and register the rooms for their latest events. Each block becomes a function: `room_subscription_settings()`, `must_cancel_in_flight_request()` and `listen_to_latest_events()`. The methods that #6906 adds reuse all three.

One behaviour changes: the state machine is now read before the `listen_to_latest_events` await, not after. The state can drift during that await, and the value decides whether the in-flight request is cancelled.

The unreleased changelog fragments of #6652 and #6828 name the old methods, so they are updated too. Without that, the release notes would name methods that do not exist.

No test changes beyond the renamed call sites, because no behaviour is added.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>
