### PR TITLE
feat(store-encryption): Derive a sub-key in the export_with_key method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ dependencies = [
  "blake3",
  "chacha20poly1305",
  "getrandom 0.4.3",
+ "hkdf",
  "hmac",
  "pbkdf2",
  "rand 0.10.2",

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -469,8 +469,9 @@ impl IndexeddbCryptoStore {
             None => {
                 debug!("IndexedDbCryptoStore: encrypting new store cipher");
                 let cipher = StoreCipher::new().map_err(CryptoStoreError::backend)?;
-                let export =
-                    cipher.export_with_key(&chacha_key).map_err(CryptoStoreError::backend)?;
+                let export = cipher
+                    .export_with_key(chacha_key.as_slice())
+                    .map_err(CryptoStoreError::backend)?;
                 save_store_cipher(&db, &export).await?;
                 cipher
             }

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -569,14 +569,14 @@ pub(crate) trait SqliteKeyValueStoreAsyncConnExt: SqliteAsyncConnExt {
         let encrypted_cipher = self.get_kv("cipher").await.map_err(OpenStoreError::LoadCipher)?;
 
         let cipher = if let Some(encrypted) = encrypted_cipher {
-            match secret {
-                Secret::PassPhrase(ref passphrase) => StoreCipher::import(passphrase, &encrypted)?,
-                Secret::Key(ref key) => StoreCipher::import_with_key(key, &encrypted)?,
+            match &secret {
+                Secret::PassPhrase(passphrase) => StoreCipher::import(passphrase, &encrypted)?,
+                Secret::Key(key) => StoreCipher::import_with_key(key.as_slice(), &encrypted)?,
             }
         } else {
             let cipher = StoreCipher::new()?;
-            let export = match secret {
-                Secret::PassPhrase(ref passphrase) => {
+            let export = match &secret {
+                Secret::PassPhrase(passphrase) => {
                     #[cfg(not(test))]
                     {
                         cipher.export(passphrase)
@@ -586,7 +586,7 @@ pub(crate) trait SqliteKeyValueStoreAsyncConnExt: SqliteAsyncConnExt {
                         cipher._insecure_export_fast_for_testing(passphrase)
                     }
                 }
-                Secret::Key(ref key) => cipher.export_with_key(key),
+                Secret::Key(key) => cipher.export_with_key(key.as_slice()),
             };
             self.set_kv("cipher", export?).await.map_err(OpenStoreError::SaveCipher)?;
             cipher

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -21,6 +21,7 @@ base64.workspace = true
 blake3 = { version = "1.8.5", default-features = false }
 chacha20poly1305 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 getrandom = { workspace = true, optional = true }
+hkdf.workspace = true
 hmac.workspace = true
 pbkdf2.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }

--- a/crates/matrix-sdk-store-encryption/changelog.d/6929.changed.md
+++ b/crates/matrix-sdk-store-encryption/changelog.d/6929.changed.md
@@ -1,0 +1,4 @@
+**breaking** The `StoreCipher::export_with_key` and
+`StoreCipher::import_with_key` now accept a variable sized key. The functions
+derive a 32-byte sub-key to encrypt and decrypt the `StoreCipher`. Importing
+existing exports which didn't use the sub-key mechanism will continue working.

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -27,6 +27,7 @@ use chacha20poly1305::{
     Key as ChachaKey, KeyInit, XChaCha20Poly1305, XNonce,
     aead::{Aead, Error as EncryptionError},
 };
+use hkdf::Hkdf;
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
 use rand::{Rng, rng};
@@ -70,11 +71,12 @@ pub enum Error {
     #[error("The ciphertext had an invalid length, expected `{0}`, got `{1}`")]
     Length(usize, usize),
 
-    /// Failed to import a store cipher, the export used a passphrase while
-    /// we are trying to import it using a key or vice-versa.
+    /// Failed to import the store cipher. The export was created using a
+    /// different encryption mechanism than the one being used for import
+    /// (passphrase vs. key).
     #[error(
-        "Failed to import a store cipher, the export used a passphrase while we are trying to \
-         import it using a key or vice-versa"
+        "Failed to import the store cipher. The export was created using a different encryption
+         mechanism than the one being used for import (passphrase vs. key)"
     )]
     KdfMismatch,
 }
@@ -174,8 +176,14 @@ impl StoreCipher {
     /// // Save the export in your key/value store.
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn export_with_key(&self, key: &[u8; 32]) -> Result<Vec<u8>, Error> {
-        let store_cipher = self.export_helper(key, KdfInfo::None)?;
+    pub fn export_with_key(&self, key: &[u8]) -> Result<Vec<u8>, Error> {
+        let mut derived_key = Box::new([0u8; 32]);
+
+        Self::expand_key_from_key(key, &mut derived_key);
+        let store_cipher = self.export_helper(&derived_key, KdfInfo::HkdfSha256)?;
+
+        derived_key.zeroize();
+
         Ok(rmp_serde::to_vec_named(&store_cipher).expect("Can't serialize the store cipher"))
     }
 
@@ -294,7 +302,7 @@ impl StoreCipher {
             KdfInfo::Pbkdf2ToChaCha20Poly1305 { rounds, kdf_salt } => {
                 Self::expand_key(passphrase, &kdf_salt, rounds)
             }
-            KdfInfo::None => {
+            KdfInfo::None | KdfInfo::HkdfSha256 => {
                 return Err(Error::KdfMismatch);
             }
         };
@@ -331,16 +339,47 @@ impl StoreCipher {
     /// // Save the export in your key/value store.
     /// # anyhow::Ok(()) };
     /// ```
-    pub fn import_with_key(key: &[u8; 32], encrypted: &[u8]) -> Result<Self, Error> {
+    pub fn import_with_key(key: &[u8], encrypted: &[u8]) -> Result<Self, Error> {
         let encrypted: EncryptedStoreCipher = rmp_serde::from_slice(encrypted)?;
+
+        let mut key = match &encrypted.kdf_info {
+            KdfInfo::None => {
+                // We used to be able to call this method only with a 32-byte array. If we call
+                // this method with a smaller key and the `None` KDF info, then there's a
+                // mismatch between how the export was used.
+                if key.len() != 32 {
+                    return Err(Error::KdfMismatch);
+                }
+
+                // To avoid borrower issues between the two branches we copy the key here to
+                // take ownership over it.
+                let mut key_copy = Box::new([0u8; 32]);
+                key_copy.copy_from_slice(key);
+
+                key_copy
+            }
+            KdfInfo::HkdfSha256 => {
+                let mut derived_key = Box::new([0u8; 32]);
+                Self::expand_key_from_key(key, &mut derived_key);
+
+                derived_key
+            }
+            KdfInfo::Pbkdf2ToChaCha20Poly1305 { .. } => {
+                return Err(Error::KdfMismatch);
+            }
+        };
 
         if let KdfInfo::Pbkdf2ToChaCha20Poly1305 { .. } = encrypted.kdf_info {
             return Err(Error::KdfMismatch);
         }
 
-        let key = ChachaKey::cast_from_core(key);
+        let chacha_key = ChachaKey::cast_from_core(key.as_ref());
 
-        Self::import_helper(key, encrypted)
+        let ret = Self::import_helper(chacha_key, encrypted);
+
+        key.zeroize();
+
+        ret
     }
 
     /// Hash a key before it is inserted into the key/value store.
@@ -618,6 +657,11 @@ impl StoreCipher {
 
         key
     }
+
+    fn expand_key_from_key(key: &[u8], output: &mut [u8; 32]) {
+        let hkdf = Hkdf::<Sha256>::new(None, key);
+        hkdf.expand(b"foo", output).expect("32 bytes is a valid HKDF-SHA256 output length");
+    }
 }
 
 #[derive(ZeroizeOnDrop)]
@@ -774,7 +818,14 @@ impl Keys {
 /// Version specific info for the key derivation method that is used.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 enum KdfInfo {
+    /// Not used anymore. Is kept for backwards compatibility when calling
+    /// [StoreCipher::import].
     None,
+    /// The HKDF-SHA256 key derivation variant.
+    ///
+    /// This is the default key derivation variant when
+    /// [StoreCipher::export_with_key] is used.
+    HkdfSha256,
     /// The PBKDF2 to Chacha key derivation variant.
     Pbkdf2ToChaCha20Poly1305 {
         /// The number of PBKDF rounds that were used when deriving the store
@@ -863,7 +914,9 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{Error, StoreCipher};
-    use crate::{EncryptedValue, EncryptedValueBase64, EncryptedValueBase64DecodeError};
+    use crate::{
+        EncryptedStoreCipher, EncryptedValue, EncryptedValueBase64, EncryptedValueBase64DecodeError,
+    };
 
     #[test]
     fn generating() {
@@ -949,6 +1002,34 @@ mod tests {
             .expect("We can import the old store-cipher export");
 
         Ok(())
+    }
+
+    #[test]
+    fn import_with_key_no_kdf_variant() {
+        let old_export = json!({
+            "kdf_info": "None",
+            "ciphertext_info": {
+                "ChaCha20Poly1305": {
+                    "nonce": [
+                        239,147,78,71,225,166,233,69,75,161,181,241,171,197,174,102,228,176,161,158,
+                        21,32,208,216
+                    ],
+                    "ciphertext":[
+                        63,195,248,146,13,60,40,131,62,209,2,113,184,79,121,242,180,170,51,194,85,
+                        96,11,97,248,68,2,178,108,30,39,215,96,119,216,38,6,203,79,42,32,220,69,41,
+                        120,44,218,88,37,176,79,198,198,209,26,62,251,20,181,55,88,83,196,131,140,
+                        245,89,167,58,146,150,10,136,90,194,123,221,147,128,255
+                    ]
+                }
+            }
+        });
+
+        let old_export: EncryptedStoreCipher = serde_json::from_value(old_export)
+            .expect("We should be able to serialize the old export");
+        let old_export = rmp_serde::to_vec(&old_export).unwrap();
+
+        StoreCipher::import_with_key(&[0u8; 32], &old_export)
+            .expect("We can import the old store-cipher export");
     }
 
     #[test]


### PR DESCRIPTION
This is the first part to get #6878 over the line.

#6878 derives a subkey from the existing passphrase to avoid using the root passphrase as the key when exporting a `StoreCipher`.

Something the indexeddb store also did:

https://github.com/matrix-org/matrix-rust-sdk/blob/3db1b43c2113fac5c06faab644ead61ca66c0f7c/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs#L455-L459

So this seems to be a common useful mechanism.

While this is a breaking change, because the public API has changed, existing exports will continue working as usual.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.
