### PR TITLE
FFI: Expose `Room::human_member_ids`

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6930.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6930.added.md
@@ -1,0 +1,1 @@
+Add `Room::active_human_member_ids` and `Room::active_human_member_ids_no_sync`, which return the user IDs of the joined and invited room members, without the service members declared by the `io.element.functional_members` state event. This is a convenient way to find the other party of a direct message.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -338,6 +338,31 @@ impl Room {
         )))
     }
 
+    /// Get the user IDs of the joined and invited members, without the service
+    /// members. The current user is part of the result. Fetches the member list
+    /// if it is not synced yet.
+    pub async fn active_human_member_ids(&self) -> Result<Vec<String>, ClientError> {
+        Ok(self
+            .inner
+            .human_member_ids(RoomMemberships::ACTIVE)
+            .await?
+            .into_iter()
+            .map(String::from)
+            .collect())
+    }
+
+    /// Same as [`Self::active_human_member_ids`], without a request to the
+    /// homeserver, so members can be missing.
+    pub async fn active_human_member_ids_no_sync(&self) -> Result<Vec<String>, ClientError> {
+        Ok(self
+            .inner
+            .human_member_ids_no_sync(RoomMemberships::ACTIVE)
+            .await?
+            .into_iter()
+            .map(String::from)
+            .collect())
+    }
+
     pub async fn member(&self, user_id: String) -> Result<RoomMember, ClientError> {
         let user_id = UserId::parse(&*user_id)?;
         let member = self.inner.get_member(&user_id).await?.context("User not found")?;


### PR DESCRIPTION
Small follow-up to #6925, I've explicitly gone for `active` here given its only returning IDs and not actual members.

Fixes #6523 (again)

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries