### PR TITLE
feat(send queue): allow attaching a reason to an aborted send's materialized redaction

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6931.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6931.added.md
@@ -1,0 +1,1 @@
+Add `DependentQueuedRequestKind::RedactEventWithReason`, which carries the reason that a raced abort applies to the redaction materializing it. `RedactEvent` is unchanged, so pending requests persisted by older versions load as before.

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -233,6 +233,14 @@ pub enum DependentQueuedRequestKind {
     /// The event should be redacted/aborted/removed.
     RedactEvent,
 
+    /// The event should be redacted/aborted/removed, with a reason applied to
+    /// the redaction if the event was sent by the time the abort was processed
+    /// and must be redacted server-side.
+    RedactEventWithReason {
+        /// Reason for the redaction.
+        reason: String,
+    },
+
     /// The event should be reacted to, with the given key.
     ReactEvent {
         /// Key used for the reaction.
@@ -501,6 +509,7 @@ impl DependentQueuedRequest {
         match self.kind {
             DependentQueuedRequestKind::EditEvent { .. }
             | DependentQueuedRequestKind::RedactEvent
+            | DependentQueuedRequestKind::RedactEventWithReason { .. }
             | DependentQueuedRequestKind::ReactEvent { .. }
             | DependentQueuedRequestKind::UploadFileOrThumbnail { .. } => {
                 // These are all aggregated events, or non-visible items (file upload producing
@@ -528,5 +537,27 @@ impl fmt::Debug for QueuedRequest {
             .field("transaction_id", &self.transaction_id)
             .field("is_wedged", &self.is_wedged())
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::{assert_let, assert_matches};
+
+    use super::DependentQueuedRequestKind;
+
+    #[test]
+    fn test_deserialize_redact_event_variants() {
+        // `RedactEvent` is a unit variant, and must stay one: requests persisted
+        // before `RedactEventWithReason` existed are serialized as a plain string.
+        let deserialized: DependentQueuedRequestKind =
+            serde_json::from_str("\"RedactEvent\"").unwrap();
+        assert_matches!(deserialized, DependentQueuedRequestKind::RedactEvent);
+
+        let kind = DependentQueuedRequestKind::RedactEventWithReason { reason: "spam".to_owned() };
+        let serialized = serde_json::to_string(&kind).unwrap();
+        let deserialized: DependentQueuedRequestKind = serde_json::from_str(&serialized).unwrap();
+        assert_let!(DependentQueuedRequestKind::RedactEventWithReason { reason } = deserialized);
+        assert_eq!(reason, "spam");
     }
 }

--- a/crates/matrix-sdk-ui/changelog.d/6931.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6931.changed.md
@@ -1,0 +1,1 @@
+`Timeline::redact()` now forwards its `reason` when the target is a local echo, instead of silently dropping it: if the echo was being sent and the send completes, the server-side redaction carries the reason.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -733,7 +733,13 @@ impl Timeline {
                 self.room().redact(event_id, reason, None).await.map_err(RedactError::HttpError)?;
             }
             TimelineItemHandle::Local(handle) => {
-                if !handle.abort().await.map_err(RoomSendQueueError::StorageError)? {
+                // Forward the reason: if the local echo was being sent and the send wins the
+                // race, the server-side redaction that materializes the abort carries it.
+                if !handle
+                    .abort_with_reason(reason.map(ToOwned::to_owned))
+                    .await
+                    .map_err(RoomSendQueueError::StorageError)?
+                {
                     return Err(RedactError::InvalidLocalEchoState.into());
                 }
             }

--- a/crates/matrix-sdk/changelog.d/6931.added.md
+++ b/crates/matrix-sdk/changelog.d/6931.added.md
@@ -1,0 +1,1 @@
+`SendHandle::abort_with_reason()` aborts a queued send like `SendHandle::abort()`, and attaches a reason to the redaction that materializes the abort when the event had already been sent by the time the abort was processed. The reason is persisted with the pending redaction, so it survives restarts like the rest of the send queue.

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -1608,6 +1608,7 @@ impl QueueStorage {
     async fn cancel_event(
         &self,
         transaction_id: &TransactionId,
+        reason: Option<String>,
     ) -> Result<bool, RoomSendQueueStorageError> {
         let guard = self.store.lock().await;
 
@@ -1623,7 +1624,12 @@ impl QueueStorage {
                     transaction_id,
                     ChildTransactionId::new(),
                     MilliSecondsSinceUnixEpoch::now(),
-                    DependentQueuedRequestKind::RedactEvent,
+                    match reason {
+                        Some(reason) => {
+                            DependentQueuedRequestKind::RedactEventWithReason { reason }
+                        }
+                        None => DependentQueuedRequestKind::RedactEvent,
+                    },
                 )
                 .await?;
 
@@ -2060,7 +2066,8 @@ impl QueueStorage {
         let reactions_and_medias =
             dependent_requests.into_iter().filter_map(|dep| match dep.kind {
                 DependentQueuedRequestKind::EditEvent { .. }
-                | DependentQueuedRequestKind::RedactEvent => {
+                | DependentQueuedRequestKind::RedactEvent
+                | DependentQueuedRequestKind::RedactEventWithReason { .. } => {
                     // TODO: reflect local edits/redacts too?
                     None
                 }
@@ -2278,7 +2285,13 @@ impl QueueStorage {
                 }
             }
 
-            DependentQueuedRequestKind::RedactEvent => {
+            kind @ (DependentQueuedRequestKind::RedactEvent
+            | DependentQueuedRequestKind::RedactEventWithReason { .. }) => {
+                let reason = match kind {
+                    DependentQueuedRequestKind::RedactEventWithReason { reason } => Some(reason),
+                    _ => None,
+                };
+
                 if let Some(parent_key) = parent_key {
                     let Some(event_id) = parent_key.into_event_id() else {
                         return Err(RoomSendQueueError::StorageError(
@@ -2295,11 +2308,12 @@ impl QueueStorage {
                     // changed the shape of a room.redaction after v11, so keep it simple and try
                     // once here.
 
-                    // Note: no reason is provided because we materialize the intent of "cancel
-                    // sending the parent event".
-
                     if let Err(err) = room
-                        .redact(&event_id, None, Some(dependent_request.own_transaction_id.into()))
+                        .redact(
+                            &event_id,
+                            reason.as_deref(),
+                            Some(dependent_request.own_transaction_id.into()),
+                        )
                         .await
                     {
                         warn!("error when sending a redact for {event_id}: {err}");
@@ -2825,8 +2839,25 @@ impl SendHandle {
     ///
     /// Returns true if the sending could be aborted, false if not (i.e. the
     /// event had already been sent).
-    #[instrument(skip(self), fields(room_id = %self.room.inner.room.room_id(), txn_id = %self.transaction_id))]
     pub async fn abort(&self) -> Result<bool, RoomSendQueueStorageError> {
+        self.abort_with_reason(None).await
+    }
+
+    /// Aborts the sending of the event, if it wasn't sent yet, with an
+    /// optional reason.
+    ///
+    /// If the event was being sent when the abort was requested and the send
+    /// succeeds, the event is redacted server-side; the given reason is
+    /// applied to that redaction. It is unused in every other case (the local
+    /// echo is simply dropped).
+    ///
+    /// Returns true if the sending could be aborted, false if not (i.e. the
+    /// event had already been sent).
+    #[instrument(skip(self), fields(room_id = %self.room.inner.room.room_id(), txn_id = %self.transaction_id))]
+    pub async fn abort_with_reason(
+        &self,
+        reason: Option<String>,
+    ) -> Result<bool, RoomSendQueueStorageError> {
         trace!("received an abort request");
 
         let queue = &self.room.inner.queue;
@@ -2849,7 +2880,7 @@ impl SendHandle {
             // code path below, that handles aborting sending of an event.
         }
 
-        if queue.cancel_event(&self.transaction_id).await? {
+        if queue.cancel_event(&self.transaction_id, reason).await? {
             trace!("successful abort");
 
             // Wake up the queue, in case it was blocked on this request being wedged.
@@ -3113,7 +3144,7 @@ impl SendRedactionHandle {
 
         let queue = &self.room.inner.queue;
 
-        if queue.cancel_event(&self.transaction_id).await? {
+        if queue.cancel_event(&self.transaction_id, None).await? {
             trace!("successful redaction abort");
 
             // Wake up the queue, in case it was blocked on this request being wedged.
@@ -3143,7 +3174,13 @@ fn canonicalize_dependent_requests(
     for d in dependent {
         let prevs = by_txn.entry(d.parent_transaction_id.clone()).or_default();
 
-        if prevs.iter().any(|prev| matches!(prev.kind, DependentQueuedRequestKind::RedactEvent)) {
+        if prevs.iter().any(|prev| {
+            matches!(
+                prev.kind,
+                DependentQueuedRequestKind::RedactEvent
+                    | DependentQueuedRequestKind::RedactEventWithReason { .. }
+            )
+        }) {
             // The parent event has already been flagged for redaction, don't consider the
             // other dependent events.
             continue;
@@ -3175,7 +3212,8 @@ fn canonicalize_dependent_requests(
                 prevs.push(d);
             }
 
-            DependentQueuedRequestKind::RedactEvent => {
+            DependentQueuedRequestKind::RedactEvent
+            | DependentQueuedRequestKind::RedactEventWithReason { .. } => {
                 // Remove every other dependent action.
                 prevs.clear();
                 prevs.push(d);

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1509,6 +1509,69 @@ async fn test_abort_while_being_sent_and_fails() {
 }
 
 #[async_test]
+async fn test_abort_with_reason_while_being_sent_then_sent() {
+    let mock = MatrixMockServer::new().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+    let client = mock.client_builder().build().await;
+    let room = mock.sync_joined_room(&client, room_id).await;
+
+    let q = room.send_queue();
+    let mut global_watch = client.send_queue().subscribe();
+
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+    assert!(watch.is_empty());
+
+    mock.mock_room_state_encryption().plain().mount().await;
+
+    // Sending will take a moment, so the abort happens while the event is being
+    // sent.
+    mock.mock_room_send()
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(1))
+                .set_body_json(json!({ "event_id": "$1" })),
+        )
+        .mock_once()
+        .mount()
+        .await;
+
+    // The send wins the race, so the abort materializes as a server-side
+    // redaction.
+    mock.mock_room_redact().ok(event_id!("$redaction")).mock_once().mount().await;
+
+    let handle = q.send(RoomMessageEventContent::text_plain("hey there").into()).await.unwrap();
+    let (txn, _) = assert_update!((global_watch, watch) => local echo { body = "hey there" });
+
+    // Let the background task pick the request up.
+    sleep(Duration::from_millis(250)).await;
+
+    // While the item is being sent, the system remembers the intent to redact it
+    // later, along with the reason.
+    assert!(handle.abort_with_reason(Some("changed my mind".to_owned())).await.unwrap());
+    assert_update!((global_watch, watch) => cancelled { txn = txn });
+
+    // The event is still sent, then redacted.
+    assert_update!((global_watch, watch) => sent { txn = txn, });
+
+    // Let the redaction endpoint be called.
+    sleep(Duration::from_secs(1)).await;
+
+    // The redaction carried the reason.
+    let requests = mock.server().received_requests().await.unwrap();
+    let redaction = requests
+        .iter()
+        .find(|req| req.url.path().contains("/redact/"))
+        .expect("a redaction request must have been received");
+    let body: serde_json::Value = redaction.body_json().unwrap();
+    assert_eq!(body["reason"], "changed my mind");
+
+    assert!(watch.is_empty());
+}
+
+#[async_test]
 async fn test_unrecoverable_errors() {
     let mock = MatrixMockServer::new().await;
 


### PR DESCRIPTION
When a send is aborted while the event is being sent and the send wins the race, the queue materializes the abort as a server-side redaction. That redaction was always sent without a reason, even when the abort originated from `Timeline::redact()` with a reason attached, the reason was silently dropped on the local echo path.

This adds `SendHandle::abort_with_reason()` (with abort() delegating to it), threads the reason through cancel_event into `DependentQueuedRequestKind::RedactEvent`, and applies it when the pending redaction is sent. Timeline::redact() now forwards its reason for local echoes instead of dropping it.

RedactEvent becomes a struct variant to persist the reason. Deserialization keeps accepting the previous unit-variant shape (a plain "RedactEvent" string), so send queues persisted by older versions still load; there's a unit test for both shapes and a new integration test asserting the raced abort's redaction request carries the reason.