### PR TITLE
feat(ffi): Expose the remove and reset room subscription methods

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6932.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6932.added.md
@@ -1,0 +1,3 @@
+Expose `RoomListService::remove_room_subscriptions` and
+`RoomListService::reset_and_add_room_subscriptions`, so consumers can release
+room subscriptions they no longer need, or replace the whole subscription set.

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -21,7 +21,7 @@ use futures_util::{StreamExt, pin_mut};
 use matrix_sdk::{
     Room as SdkRoom,
     ruma::{
-        RoomId,
+        OwnedRoomId, RoomId,
         api::client::sync::sync_events::UnreadNotificationsCount as RumaUnreadNotificationsCount,
     },
 };
@@ -138,19 +138,44 @@ impl RoomListService {
     }
 
     async fn set_room_subscriptions(&self, room_ids: Vec<String>) -> Result<(), RoomListError> {
-        let room_ids = room_ids
-            .into_iter()
-            .map(|room_id| {
-                RoomId::parse(&room_id).map_err(|_| RoomListError::InvalidRoomId { error: room_id })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let room_ids = parse_room_ids(room_ids)?;
 
-        self.inner
-            .set_room_subscriptions(&room_ids.iter().map(AsRef::as_ref).collect::<Vec<_>>())
-            .await;
+        self.inner.set_room_subscriptions(&borrow_room_ids(&room_ids)).await;
 
         Ok(())
     }
+
+    fn remove_room_subscriptions(&self, room_ids: Vec<String>) -> Result<(), RoomListError> {
+        let room_ids = parse_room_ids(room_ids)?;
+
+        self.inner.remove_room_subscriptions(&borrow_room_ids(&room_ids));
+
+        Ok(())
+    }
+
+    async fn reset_and_add_room_subscriptions(
+        &self,
+        room_ids: Vec<String>,
+    ) -> Result<(), RoomListError> {
+        let room_ids = parse_room_ids(room_ids)?;
+
+        self.inner.reset_and_add_room_subscriptions(&borrow_room_ids(&room_ids)).await;
+
+        Ok(())
+    }
+}
+
+fn parse_room_ids(room_ids: Vec<String>) -> Result<Vec<OwnedRoomId>, RoomListError> {
+    room_ids
+        .into_iter()
+        .map(|room_id| {
+            RoomId::parse(&room_id).map_err(|_| RoomListError::InvalidRoomId { error: room_id })
+        })
+        .collect()
+}
+
+fn borrow_room_ids(room_ids: &[OwnedRoomId]) -> Vec<&RoomId> {
+    room_ids.iter().map(AsRef::as_ref).collect()
 }
 
 #[derive(uniffi::Object)]

--- a/crates/matrix-sdk-ui/changelog.d/6932.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6932.added.md
@@ -1,0 +1,5 @@
+Add `RoomListService::remove_room_subscriptions`, which removes the
+subscriptions of the given rooms, and
+`RoomListService::reset_and_add_room_subscriptions`, which replaces the whole
+subscription set and marks the members of the new rooms as missing. Both forward
+to the room subscription methods of `SlidingSync` with the room list settings.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -502,6 +502,30 @@ impl RoomListService {
         )
     }
 
+    /// Remove the room subscriptions of `room_ids`.
+    ///
+    /// The latest events of these rooms are still listened to.
+    pub fn remove_room_subscriptions(&self, room_ids: &[&RoomId]) {
+        self.sliding_sync.remove_room_subscriptions(room_ids, self.must_cancel_in_flight_request())
+    }
+
+    /// Remove all the room subscriptions, then subscribe to `room_ids`.
+    ///
+    /// Contrary to [`Self::set_room_subscriptions`], the members of every room
+    /// of `room_ids` are marked as missing, so that they are re-fetched.
+    pub async fn reset_and_add_room_subscriptions(&self, room_ids: &[&RoomId]) {
+        // Read the state before the await: the state machine can drift meanwhile.
+        let cancel_in_flight_request = self.must_cancel_in_flight_request();
+
+        self.listen_to_latest_events(room_ids).await;
+
+        self.sliding_sync.reset_and_add_room_subscriptions(
+            room_ids,
+            Some(room_subscription_settings()),
+            cancel_in_flight_request,
+        )
+    }
+
     async fn listen_to_latest_events(&self, room_ids: &[&RoomId]) {
         if !self.client.event_cache().has_subscribed() {
             return;

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2512,6 +2512,242 @@ async fn test_room_subscription() -> Result<(), Error> {
 }
 
 #[async_test]
+async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
+    let (_, server, room_list) = new_room_list_service().await?;
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    let room_id_0 = room_id!("!r0:bar.org");
+    let room_id_1 = room_id!("!r1:bar.org");
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 19]],
+                    "timeline_limit": 1,
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 2,
+                },
+            },
+            "rooms": {
+                room_id_0: {
+                    "initial": true,
+                },
+                room_id_1: {
+                    "initial": true,
+                },
+            },
+        },
+    };
+
+    room_list.set_room_subscriptions(&[room_id_0, room_id_1]).await;
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request >= {
+            "room_subscriptions": {
+                room_id_0: {
+                    "timeline_limit": 20,
+                },
+                room_id_1: {
+                    "timeline_limit": 20,
+                },
+            },
+        },
+        respond with = {
+            "pos": "1",
+            "lists": {},
+            "rooms": {},
+        },
+    };
+
+    room_list.remove_room_subscriptions(&[room_id_0]);
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        // strict comparison to ensure the exact shape of `room_subscriptions`.
+        assert request = {
+            "conn_id": "room-list",
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 1]],
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["org.matrix.msc3672.beacon_info", "*"],
+                    ],
+                    "filters": {},
+                    "timeline_limit": 1,
+                },
+            },
+            "room_subscriptions": {
+                room_id_1: {
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["org.matrix.msc3672.beacon_info", "*"],
+                        ["m.room.pinned_events", ""],
+                    ],
+                    "timeline_limit": 20,
+                },
+            },
+            "extensions": {
+                "account_data": { "enabled": true },
+                "receipts": { "enabled": true, "rooms": [ "*" ] },
+                "typing": { "enabled": true },
+            },
+        },
+        respond with = {
+            "pos": "2",
+            "lists": {},
+            "rooms": {},
+        },
+    };
+
+    server.mock_get_members().ok(vec![]).mount().await;
+
+    let room_1 = room_list.room(room_id_1)?;
+    room_1.sync_members().await.unwrap();
+    assert!(room_1.are_members_synced());
+
+    room_list.reset_and_add_room_subscriptions(&[room_id_0, room_id_1]).await;
+
+    // `set_room_subscriptions` would have kept the members of `room_id_1` synced.
+    assert!(!room_1.are_members_synced());
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        // strict comparison to ensure the exact shape of `room_subscriptions`.
+        assert request = {
+            "conn_id": "room-list",
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 1]],
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["org.matrix.msc3672.beacon_info", "*"],
+                    ],
+                    "filters": {},
+                    "timeline_limit": 1,
+                },
+            },
+            "room_subscriptions": {
+                room_id_0: {
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["org.matrix.msc3672.beacon_info", "*"],
+                        ["m.room.pinned_events", ""],
+                    ],
+                    "timeline_limit": 20,
+                },
+                room_id_1: {
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                        ["m.room.power_levels", ""],
+                        ["org.matrix.msc3401.call.member", "*"],
+                        ["m.room.join_rules", ""],
+                        ["m.room.tombstone", ""],
+                        ["m.room.create", ""],
+                        ["m.room.history_visibility", ""],
+                        ["io.element.functional_members", ""],
+                        ["m.space.parent", "*"],
+                        ["m.space.child", "*"],
+                        ["org.matrix.msc3672.beacon_info", "*"],
+                        ["m.room.pinned_events", ""],
+                    ],
+                    "timeline_limit": 20,
+                },
+            },
+            "extensions": {
+                "account_data": { "enabled": true },
+                "receipts": { "enabled": true, "rooms": [ "*" ] },
+                "typing": { "enabled": true },
+            },
+        },
+        respond with = {
+            "pos": "3",
+            "lists": {},
+            "rooms": {},
+        },
+    };
+
+    Ok(())
+}
+
+#[async_test]
 async fn test_room_unread_notifications() -> Result<(), Error> {
     let (_, server, room_list) = new_room_list_service().await?;
 

--- a/crates/matrix-sdk/changelog.d/6932.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6932.fixed.md
@@ -1,0 +1,5 @@
+`SlidingSync::reset_and_add_room_subscriptions` now cancels the in-flight
+request when it removes the last subscriptions. Called with an empty list of
+rooms, it used to clear the subscriptions without cancelling the request, so the
+server kept sending the rooms until the current long poll expired, up to 30s
+later.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -236,16 +236,19 @@ impl SlidingSync {
     ) {
         let mut room_subscriptions = self.inner.room_subscriptions.write().unwrap();
 
+        let a_subscription_has_been_removed = !room_subscriptions.is_empty();
         room_subscriptions.clear();
 
-        let subscriptions_have_changed = upsert_room_subscriptions(
+        let a_subscription_has_been_added = upsert_room_subscriptions(
             &mut room_subscriptions,
             &self.inner.client,
             room_ids,
             settings,
         );
 
-        if cancel_in_flight_request && subscriptions_have_changed {
+        if cancel_in_flight_request
+            && (a_subscription_has_been_added || a_subscription_has_been_removed)
+        {
             self.inner.cancel_in_flight_request();
         }
     }
@@ -1486,6 +1489,48 @@ mod tests {
 
         // Finally, no cancellation is asked: no cancellation happens.
         sliding_sync.set_room_subscriptions(&[room_id_0], None, false);
+
+        assert!(internal_channel.try_recv().is_err());
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn test_reset_and_add_room_subscriptions_cancels_the_in_flight_request() -> Result<()> {
+        let (_server, sliding_sync) = new_sliding_sync(vec![
+            SlidingSyncList::builder("foo")
+                .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10)),
+        ])
+        .await?;
+
+        let room_id_0 = room_id!("!r0:bar.org");
+
+        let mut internal_channel = sliding_sync.inner.internal_channel.subscribe();
+
+        // Nothing is removed, nothing is added: no cancellation.
+        sliding_sync.reset_and_add_room_subscriptions(&[], None, true);
+
+        assert!(internal_channel.try_recv().is_err());
+
+        // A subscription is added: the in-flight request must be cancelled.
+        sliding_sync.reset_and_add_room_subscriptions(&[room_id_0], None, true);
+
+        assert_matches!(
+            internal_channel.try_recv(),
+            Ok(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
+        );
+
+        // All the subscriptions are removed: the in-flight request must be cancelled.
+        sliding_sync.reset_and_add_room_subscriptions(&[], None, true);
+
+        assert!(sliding_sync.inner.room_subscriptions.read().unwrap().is_empty());
+        assert_matches!(
+            internal_channel.try_recv(),
+            Ok(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
+        );
+
+        // Finally, no cancellation is asked: no cancellation happens.
+        sliding_sync.reset_and_add_room_subscriptions(&[room_id_0], None, false);
 
         assert!(internal_channel.try_recv().is_err());
 


### PR DESCRIPTION
Closes #6527. Rest of #6906, split in two at the request of the review there. #6927 landed the rename and the helper extraction. This PR adds the two missing methods on top, plus the fix that the review asked for.

`RoomListService` only exposed `set_room_subscriptions` over the FFI. Subscriptions live for the whole sync session, so a long-running session accumulates them as the user opens rooms, and a consumer had no way to release the ones it no longer cares about. `SlidingSync` already has the two missing methods, so this PR forwards them through `matrix-sdk-ui` and the FFI.

The three commits read in order.

`fix(sdk): Cancel the in-flight request when all the subscriptions are removed`. `SlidingSync::reset_and_add_room_subscriptions` only looked at the rooms it added to decide whether to cancel the in-flight request. Called with an empty list of rooms, it cleared the subscriptions and cancelled nothing, so the server kept sending the rooms until the current long poll expired, up to 30s later. `test_reset_and_add_room_subscriptions_cancels_the_in_flight_request` covers the four cases.

`feat(ui): Add the remove and reset room subscription methods`. `RoomListService::remove_room_subscriptions` is not `async`, because it needs neither the event cache nor the latest events. `RoomListService::reset_and_add_room_subscriptions` empties the map first, so the members of every room are marked as missing and re-fetched. Both reuse the three helpers that #6927 extracted.

`feat(ffi): Expose the remove and reset room subscription methods`. Both take the same `Vec<String>` shape as `set_room_subscriptions`. The room ID parsing and borrowing moved into `parse_room_ids` and `borrow_room_ids`.

One asymmetry worth a look during review: `remove_room_subscriptions` does not call `LatestEvents::forget_room`. `Client::process_sync` registers every room of a sync response through `LatestEvents::listen_to_room` (`crates/matrix-sdk/src/sync.rs`), so forgetting a room here would be undone by the next sync response. Latest event calculation and room subscriptions look like separate concerns to me, but tell me if you prefer the symmetric behaviour.

The new integration test `test_remove_and_reset_room_subscriptions` subscribes to two rooms, removes one subscription, then resets and adds both. The two assertions after the removal use the strict `assert request = { ... }` form, because a sliding sync request always carries the full `room_subscriptions` map, so a partial match would not prove that a subscription is gone. Before the last step it syncs the members of the room that is still subscribed, then asserts that `reset_and_add_room_subscriptions` marked them as missing again. That is the one behaviour `set_room_subscriptions` would not have produced.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>
