### PR TITLE
[matrix-sdk-ffi] use milliseconds instead of seconds for X.509 validity

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6933.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6933.changed.md
@@ -1,0 +1,2 @@
+Change the return value of `RawX509Signer::validity_not_after` to be in
+milliseconds rather than seconds, to match other interfaces.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -338,7 +338,7 @@ pub trait RawX509Signer: SyncOutsideWasm + SendOutsideWasm + Debug {
     fn sign(&self, message: Vec<u8>) -> Result<RawX509Signature, ClientError>;
 
     /// Return the "not after" time for the certificate's validity period as a
-    /// UNIX timestamp.
+    /// number of milliseconds since the UNIX epoch.
     fn validity_not_after(&self) -> Result<u64, ClientError>;
 }
 

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -679,7 +679,7 @@ impl ClientBuilder {
 
                 fn validity_not_after(&self) -> Result<Duration, ValidityError> {
                     if let Ok(validity_not_after) = self.0.validity_not_after() {
-                        Ok(std::time::Duration::from_secs(validity_not_after))
+                        Ok(std::time::Duration::from_millis(validity_not_after))
                     } else {
                         Err(ValidityError)
                     }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
