### PR TITLE
fix(spaces): use saturating_sub instead of bare subtraction to avoid panics/underflow

### DIFF
--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -99,7 +99,7 @@ impl SpaceRoom {
             summary.name.clone(),
             summary.canonical_alias.as_deref(),
             heroes.iter().flatten().map(RoomHero::from).collect(),
-            num_joined_members - num_joined_service_members,
+            num_joined_members.saturating_sub(num_joined_service_members),
         )
         .to_string();
 
@@ -138,7 +138,7 @@ impl SpaceRoom {
             name.clone(),
             room_info.canonical_alias(),
             heroes.iter().map(RoomHero::from).collect(),
-            known_room.joined_members_count() - joined_service_members_count,
+            known_room.joined_members_count().saturating_sub(joined_service_members_count),
         )
         .to_string();
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Basically it's possible for the two counts used here to differ, as the "hint" value isn't actually a real membership set, and nothing guarantees that the functional_members is >= the num of joined service members, especially if the room member list hasn't been synced up yet.

the other case is slightly worse but similar.

Most other places where similar calculations are done in the code also use saturating_sub, so there's precedent for this imo.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
    * No API changes, just inner logic
- [x] This PR was made with the help of AI.
    * Claude fable discovered the bug initially

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
