### PR TITLE
fix(send queue): keep the original relation when replacing a pending event's content

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6936.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6936.fixed.md
@@ -1,0 +1,1 @@
+`Timeline::edit()` now keeps a local echo's thread or reply relation when replacing its content. The edited content is relation-free by type, and replacing the pending event's content wholesale used to detach it: editing a not-yet-sent thread reply made it go out as a top-level message.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -29,7 +29,7 @@ use ruma::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
             user::PolicyRuleUserEventContent,
         },
-        relation::Replacement,
+        relation::{Replacement, Reply, Thread},
         room::{
             avatar::RoomAvatarEventContent,
             canonical_alias::RoomCanonicalAliasEventContent,
@@ -40,7 +40,10 @@ use ruma::{
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent,
             member::{Change, RoomMemberEventContent},
-            message::{MessageType, RoomMessageEventContent},
+            message::{
+                MessageType, Relation, RoomMessageEventContent,
+                RoomMessageEventContentWithoutRelation,
+            },
             name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::RoomPowerLevelsEventContent,
@@ -471,6 +474,20 @@ impl TimelineItemContent {
     /// Get the event this message is replying to, if any.
     pub fn in_reply_to(&self) -> Option<InReplyToDetails> {
         as_variant!(self, Self::MsgLike)?.in_reply_to.clone()
+    }
+
+    /// The thread or reply relation of this item, rebuilt from its thread root
+    /// and reply target, if any.
+    pub(crate) fn relation(&self) -> Option<Relation<RoomMessageEventContentWithoutRelation>> {
+        if let Some(thread_root) = self.thread_root() {
+            Some(Relation::Thread(match self.in_reply_to() {
+                Some(details) => Thread::reply(thread_root, details.event_id),
+                None => Thread::plain(thread_root.clone(), thread_root),
+            }))
+        } else {
+            self.in_reply_to()
+                .map(|details| Relation::Reply(Reply::with_event_id(details.event_id)))
+        }
     }
 
     /// Return the reactions, grouped by key and then by sender, for a given

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -575,11 +575,14 @@ impl Timeline {
             }
 
             TimelineItemHandle::Local(handle) => {
-                // Relations are filled by the editing code itself.
                 let new_content: AnyMessageLikeEventContent = match new_content {
                     EditedContent::RoomMessage(message) => {
                         if item.content.is_message() {
-                            AnyMessageLikeEventContent::RoomMessage(message.into())
+                            // The replacement becomes the pending event itself, so restore its
+                            // relations, which the payload can't carry by type.
+                            AnyMessageLikeEventContent::RoomMessage(
+                                message.with_relation(item.content.relation()),
+                            )
                         } else {
                             return Err(EditError::ContentMismatch {
                                 original: item.content.debug_string().to_owned(),

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -41,8 +41,9 @@ use ruma::{
             UnstablePollAnswer, UnstablePollAnswers, UnstablePollStartContentBlock,
             UnstablePollStartEventContent,
         },
+        relation::Thread,
         room::message::{
-            MessageType, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+            MessageType, Relation, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
             TextMessageEventContent,
         },
     },
@@ -268,6 +269,88 @@ async fn test_edit_local_echo() {
 
     // No new updates.
     assert_pending!(timeline_stream);
+}
+
+#[async_test]
+async fn test_edit_local_echo_keeps_thread_relation() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    // The first send attempt fails unrecoverably, so the local echo stays editable.
+    let mounted_send =
+        server.mock_room_send().error_too_large().mock_once().mount_as_scoped().await;
+
+    // Send a threaded reply.
+    let thread_root = owned_event_id!("$thread_root");
+    let mut reply = RoomMessageEventContent::text_plain("reply");
+    reply.relates_to =
+        Some(Relation::Thread(Thread::plain(thread_root.clone(), thread_root.clone())));
+    timeline.send(reply.into()).await.unwrap();
+
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 2);
+    assert_let!(VectorDiff::PushBack { value: item } = &timeline_updates[0]);
+    let item = item.as_event().unwrap();
+    let item_identifier = item.identifier();
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
+
+    // The send fails.
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 1);
+    assert_let!(VectorDiff::Set { index: 1, value: item } = &timeline_updates[0]);
+    assert_matches!(
+        item.as_event().unwrap().send_state(),
+        Some(EventSendState::SendingFailed { .. })
+    );
+
+    // Editing with bare, relation-free content works, and the retried send keeps
+    // the thread relation.
+    drop(mounted_send);
+    server.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
+
+    timeline
+        .edit(
+            &item_identifier,
+            EditedContent::RoomMessage(RoomMessageEventContentWithoutRelation::text_plain(
+                "edited reply",
+            )),
+        )
+        .await
+        .unwrap();
+
+    // Observe the local echo being replaced, with its send state reset.
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+    assert_eq!(timeline_updates.len(), 1);
+    assert_let!(VectorDiff::Set { index: 1, value: item } = &timeline_updates[0]);
+    let item = item.as_event().unwrap();
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
+    assert_eq!(item.content().as_message().unwrap().body(), "edited reply");
+
+    // The unrecoverable failure disabled the room's queue; re-enable it so the
+    // edited echo is sent.
+    timeline.room().send_queue().set_enabled(true);
+
+    sleep(Duration::from_millis(500)).await;
+
+    // The event went out with the edited body *and* its original thread relation.
+    let requests = server.server().received_requests().await.unwrap();
+    let sent = requests
+        .iter()
+        .rfind(|req| req.url.path().contains("/send/"))
+        .expect("the edited reply must have been sent");
+    let body: serde_json::Value = sent.body_json().unwrap();
+    assert_eq!(body["body"], "edited reply");
+    assert_eq!(body["m.relates_to"]["rel_type"], "m.thread");
+    assert_eq!(body["m.relates_to"]["event_id"], "$thread_root");
 }
 
 #[async_test]


### PR DESCRIPTION
Editing a local echo takes one of two paths. If the event is already being sent, the edit is stored as a dependent request and later sent as a proper m.replace — that path is fine. But if the event is still pending in the queue, the edit replaces the queued content wholesale, and since editors typically pass bare content (Timeline::edit hands the send queue a content built from a `RoomMessageEventContentWithoutRelation`), the original content's `m.relates_to` was silently dropped. The visible symptom: editing a queued thread reply before it was sent detached it from its thread, and it was published as a top-level message.

This makes `QueueStorage::replace_event` carry over the original queued content's m.relates_to into the replacement when the replacement doesn't set one, using the same raw-JSON merge approach as merge_extra_content. A replacement that sets its own relation is left untouched, and the dependent-edit path is unchanged (an `m.replace` correctly carries no thread relation of its own).

Covered by a unit test for the merge helper (inherits the relation, respects an explicit one, no-op without one) and an integration test asserting that a pending threaded reply edited with bare content is sent with both the edited body and its original `m.thread `relation.