### PR TITLE
fix(sdk): Filter and group read receipts per cache

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6938.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6938.changed.md
@@ -1,0 +1,3 @@
+The `ThreadSummary::public_read_receipt_event_id` and
+`ThreadSummary::private_read_receipt_event_id` fields have been removed. They
+were a hack introduced in the past and no longer make sense.

--- a/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/msg_like.rs
@@ -290,11 +290,6 @@ pub struct PollAnswer {
 pub struct ThreadSummary {
     pub latest_event: EmbeddedEventDetails,
     pub num_replies: u32,
-    /// The user's own public read receipt event id, for this particular thread.
-    pub public_read_receipt_event_id: Option<String>,
-    /// The user's own private read receipt event id, for this particular
-    /// thread.
-    pub private_read_receipt_event_id: Option<String>,
 }
 
 #[matrix_sdk_ffi_macros::export]
@@ -313,10 +308,6 @@ impl From<matrix_sdk_ui::timeline::ThreadSummary> for ThreadSummary {
         Self {
             latest_event: EmbeddedEventDetails::from(value.latest_event),
             num_replies: value.num_replies,
-            public_read_receipt_event_id: value.public_read_receipt_event_id.map(|v| v.to_string()),
-            private_read_receipt_event_id: value
-                .private_read_receipt_event_id
-                .map(|v| v.to_string()),
         }
     }
 }

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -18,16 +18,14 @@
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId,
     events::{
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, MessageLikeEventType,
-        receipt::{ReceiptEventContent, SyncReceiptEvent},
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        MessageLikeEventType,
         relation::{BundledThread, RelationType},
     },
     room_version_rules::RedactionRules,
     serde::Raw,
 };
 use serde::Deserialize;
-use tracing::error;
 
 use crate::deserialized_responses::{ThreadSummary, ThreadSummaryStatus};
 
@@ -161,28 +159,6 @@ pub fn extract_timestamp(
     }
 
     Some(origin_server_ts)
-}
-
-/// Extract the first valid read receipt event from a list of ephemeral events,
-/// if available.
-pub fn extract_read_receipt(
-    ephemeral_events: &[Raw<AnySyncEphemeralRoomEvent>],
-) -> Option<ReceiptEventContent> {
-    for raw_ephemeral in ephemeral_events {
-        match raw_ephemeral.deserialize() {
-            Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {
-                return Some(content);
-            }
-
-            Ok(_) => {}
-
-            Err(err) => {
-                error!(%err, "error when deserializing an ephemeral event");
-            }
-        }
-    }
-
-    None
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-ui/changelog.d/6938.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6938.changed.md
@@ -1,0 +1,5 @@
+The `ThreadSummary::public_read_receipt_event_id` and
+`ThreadSummary::private_read_receipt_event_id` fields have been removed. They
+were a hack introduced in the past and no longer make sense. Use `ThreadInfo` if
+you need information about the read receipts, with
+`matrix_sdk::event_cache::ThreadEventCache::read_receipts()`.

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -28,7 +28,8 @@ use matrix_sdk::{
     deserialized_responses::TimelineEvent,
     event_cache::{
         DecryptionRetryRequest, EventCache, EventFocusedCache, PaginationStatus, PinnedEventsCache,
-        RoomEventCache, Subscriber as EventCacheSubscriber, ThreadEventCache, TimelineVectorDiffs,
+        RoomEventCache, Subscriber as EventCacheSubscriber, ThreadEventCache,
+        ThreadEventCacheUpdate,
     },
     send_queue::{
         LocalEcho, LocalEchoContent, RoomSendQueueUpdate, SendHandle, SendReactionHandle,
@@ -1571,7 +1572,7 @@ impl TimelineController {
     pub(super) async fn init_with_thread_root(
         &self,
         event_cache: &ThreadEventCache,
-    ) -> Result<(bool, EventCacheSubscriber<TimelineVectorDiffs>), Error> {
+    ) -> Result<(bool, EventCacheSubscriber<ThreadEventCacheUpdate>), Error> {
         let (events, subscriber) = event_cache.subscribe().await?;
         let has_events = !events.is_empty();
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -35,23 +35,20 @@ use matrix_sdk::{
     },
     task_monitor::BackgroundTaskHandle,
 };
-#[cfg(test)]
-use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
     TransactionId, UserId,
     api::client::receipt::create_receipt::v3::ReceiptType as SendReceiptType,
     events::{
-        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, MessageLikeEventType,
+        AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        MessageLikeEventType,
         poll::unstable_start::UnstablePollStartEventContent,
         reaction::ReactionEventContent,
-        receipt::{Receipt, ReceiptThread, ReceiptType},
+        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         relation::{Annotation, RelationType},
         room::message::{MessageType, Relation},
     },
     room_version_rules::RoomVersionRules,
-    serde::Raw,
 };
 use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::{
@@ -848,16 +845,14 @@ impl<P: RoomDataProvider> TimelineController<P> {
         txn.commit();
     }
 
-    pub(super) async fn handle_ephemeral_events(
-        &self,
-        events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
-    ) {
+    pub(super) async fn handle_read_receipt_event(&self, event: ReceiptEventContent) {
         // Don't even take the lock if there are no events to process.
-        if events.is_empty() {
+        if event.is_empty() {
             return;
         }
+
         let mut state = self.state.write().await;
-        state.handle_ephemeral_events(events, &self.room_data_provider).await;
+        state.handle_read_receipt(event, &self.room_data_provider).await;
     }
 
     /// Creates the local echo for an event we're sending.

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -28,7 +28,7 @@ use super::{
     AllRemoteEvents, ObservableItemsTransaction, RelativePosition, RoomDataProvider,
     TimelineMetadata, TimelineState, rfind_event_by_id,
 };
-use crate::timeline::{TimelineItem, TimelineItemContent, controller::TimelineStateTransaction};
+use crate::timeline::{TimelineItem, controller::TimelineStateTransaction};
 
 /// In-memory caches for read receipts.
 #[derive(Clone, Debug, Default)]
@@ -541,7 +541,6 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
         own_user_id: &UserId,
     ) {
         trace!("handling explicit read receipts");
-        let own_receipt_thread = self.focus.receipt_thread();
 
         for (event_id, receipt_types) in receipt_event_content.0 {
             for (receipt_type, receipts) in receipt_types {
@@ -551,77 +550,6 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                 }
 
                 for (user_id, receipt) in receipts {
-                    if matches!(own_receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
-                    {
-                        // If the own receipt thread is unthreaded or main, we maintain maximal
-                        // compatibility with clients using either unthreaded or main-thread read
-                        // receipts by allowing both here.
-                        match receipt.thread {
-                            ReceiptThread::Unthreaded | ReceiptThread::Main => {
-                                // Processing happens below.
-                            }
-
-                            ReceiptThread::Thread(thread_root) => {
-                                // Special processing for threads: try to find a timeline item for
-                                // the root, and update its thread summary, if the receipt is for
-                                // ourselves.
-                                //
-                                // TODO: This is temporary code, and should be removed when #4113 is
-                                // done.
-                                if user_id == self.meta.own_user_id
-                                    && let Some((item_pos, item)) =
-                                        rfind_event_by_id(&self.items, &thread_root)
-                                {
-                                    trace!(
-                                        "thread root has been found; will update thread summary with the latest receipts"
-                                    );
-
-                                    let item_id = item.internal_id.to_owned();
-                                    let mut new_item = item.clone();
-
-                                    let TimelineItemContent::MsgLike(msglike) =
-                                        &mut new_item.content
-                                    else {
-                                        // Only MsgLike items have a thread summary.
-                                        continue;
-                                    };
-
-                                    let Some(thread_summary) = &mut msglike.thread_summary else {
-                                        // No thread summary to update.
-                                        continue;
-                                    };
-
-                                    // Assume read receipts only move forward, at the moment.
-                                    if receipt_type == ReceiptType::Read {
-                                        thread_summary.public_read_receipt_event_id =
-                                            Some(event_id.clone());
-                                    } else if receipt_type == ReceiptType::ReadPrivate {
-                                        thread_summary.private_read_receipt_event_id =
-                                            Some(event_id.clone());
-                                    } else {
-                                        // We don't know this receipt type; skip it.
-                                        continue;
-                                    }
-
-                                    self.items
-                                        .replace(item_pos, TimelineItem::new(new_item, item_id));
-                                }
-
-                                // Couldn't find an item for this new read receipt; process the
-                                // next receipt.
-                                continue;
-                            }
-
-                            _ => {
-                                // No processing: ignore.
-                                continue;
-                            }
-                        }
-                    } else if own_receipt_thread != receipt.thread {
-                        // Otherwise, we only keep the receipts of the same thread kind.
-                        continue;
-                    }
-
                     let is_own_user_id = user_id == own_user_id;
                     let full_receipt = FullReceipt {
                         event_id: &event_id,

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -16,15 +16,12 @@ use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
 use matrix_sdk::{deserialized_responses::TimelineEvent, send_queue::SendHandle};
-#[cfg(test)]
-use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    events::{AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent},
+    events::{AnyMessageLikeEventContent, receipt::ReceiptEventContent},
     room_version_rules::RoomVersionRules,
-    serde::Raw,
 };
-use tracing::{instrument, trace, warn};
+use tracing::{instrument, trace};
 
 use super::{
     super::{
@@ -119,32 +116,19 @@ impl<P: RoomDataProvider> TimelineState<P> {
     }
 
     #[instrument(skip_all)]
-    pub(super) async fn handle_ephemeral_events(
+    pub(super) async fn handle_read_receipt(
         &mut self,
-        events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        event: ReceiptEventContent,
         room_data_provider: &P,
     ) {
-        if events.is_empty() {
+        if event.is_empty() {
             return;
         }
 
-        let mut txn = self.transaction();
-
         trace!("Handling ephemeral room events");
-        let own_user_id = room_data_provider.own_user_id();
-        for raw_event in events {
-            match raw_event.deserialize() {
-                Ok(AnySyncEphemeralRoomEvent::Receipt(ev)) => {
-                    txn.handle_explicit_read_receipts(ev.content, own_user_id);
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    let event_type = raw_event.get_field::<String>("type").ok().flatten();
-                    warn!(event_type, "Failed to deserialize ephemeral event: {e}");
-                }
-            }
-        }
 
+        let mut txn = self.transaction();
+        txn.handle_explicit_read_receipts(event, room_data_provider.own_user_id());
         txn.commit();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -17,17 +17,11 @@ use std::collections::{HashMap, HashSet};
 use eyeball_im::VectorDiff;
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::{
-    ThreadSummary as SdkThreadSummary, ThreadSummaryStatus, TimelineEvent, TimelineEventKind,
-    UnsignedEventLocation,
+    ThreadSummaryStatus, TimelineEvent, TimelineEventKind, UnsignedEventLocation,
 };
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
-    events::{
-        AnySyncTimelineEvent,
-        receipt::{ReceiptThread, ReceiptType},
-    },
-    push::Action,
-    serde::Raw,
+    events::AnySyncTimelineEvent, push::Action, serde::Raw,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -704,74 +698,6 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             .map(Box::new)
     }
 
-    /// Compute the thread public and private receipts, for the sake of the
-    /// [`ThreadSummary`] of an event.
-    async fn compute_summary_thread_receipts(
-        &self,
-        event: &TimelineEvent,
-        summary: &SdkThreadSummary,
-        room_data_provider: &P,
-        settings: &TimelineSettings,
-    ) -> (Option<OwnedEventId>, Option<OwnedEventId>) {
-        if !settings.track_read_receipts.is_enabled() {
-            return (None, None);
-        }
-
-        // Load the public and private read receipts for the user, in the thread. In the
-        // future, we might move this code in the event cache, so that read
-        // receipt handling happens there instead.
-
-        // As an exception to handle the latest "implicit" read receipt (which is the
-        // latest event sent by the user): if the latest event has been sent by
-        // the current user, then we consider that as a read receipt.
-        #[allow(clippy::collapsible_if)] // clippy has poor taste
-        if let Some(ref latest_reply) = summary.latest_reply {
-            if let Ok(event) = RoomDataProvider::load_event(room_data_provider, latest_reply)
-                .await
-                .inspect_err(|err| {
-                    warn!("Failed to load thread latest event: {err}");
-                })
-            {
-                // Parse the sender.
-                if let Some(sender) = event.sender()
-                    && sender == self.meta.own_user_id
-                {
-                    let latest = Some(latest_reply.clone());
-                    return (latest.clone(), latest);
-                }
-            }
-        }
-
-        // Otherwise, resort to trying to load receipts from the database.
-        let own_thread_public_receipt = if let Some(event_id) = event.event_id() {
-            room_data_provider
-                .load_user_receipt(
-                    ReceiptType::Read,
-                    &ReceiptThread::Thread(event_id.to_owned()),
-                    &self.meta.own_user_id,
-                )
-                .await
-                .map(|(event_id, _receipt)| event_id)
-        } else {
-            None
-        };
-
-        let own_thread_private_receipt = if let Some(event_id) = event.event_id() {
-            room_data_provider
-                .load_user_receipt(
-                    ReceiptType::ReadPrivate,
-                    &ReceiptThread::Thread(event_id.to_owned()),
-                    &self.meta.own_user_id,
-                )
-                .await
-                .map(|(event_id, _receipt)| event_id)
-        } else {
-            None
-        };
-
-        (own_thread_public_receipt, own_thread_private_receipt)
-    }
-
     /// Handle a remote event.
     ///
     /// Returns whether an item has been removed from the timeline.
@@ -796,15 +722,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 None
             };
 
-            let (own_thread_public_receipt, own_thread_private_receipt) = self
-                .compute_summary_thread_receipts(&event, summary, room_data_provider, settings)
-                .await;
-
             Some(ThreadSummary {
                 latest_event: TimelineDetails::from_initial_value(latest_reply_item),
                 num_replies: summary.num_replies,
-                public_read_receipt_event_id: own_thread_public_receipt,
-                private_read_receipt_event_id: own_thread_private_receipt,
             })
         } else {
             None

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/msg_like.rs
@@ -59,13 +59,6 @@ pub struct ThreadSummary {
     /// thread-focused timeline with the same timeline filter may result in
     /// *fewer* events than this number.
     pub num_replies: u32,
-
-    /// The user's own public read receipt event id, for this particular thread.
-    pub public_read_receipt_event_id: Option<OwnedEventId>,
-
-    /// The user's own private read receipt event id, for this particular
-    /// thread.
-    pub private_read_receipt_event_id: Option<OwnedEventId>,
 }
 
 /// A special kind of [`super::TimelineItemContent`] that groups together

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -258,11 +258,11 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
                 }
             }
 
-            RoomEventCacheUpdate::AddEphemeralEvents { events } => {
-                trace!("Received new ephemeral events from sync.");
+            RoomEventCacheUpdate::AddReadReceiptEvent { event } => {
+                trace!("Received a new read receipt event from sync.");
 
                 // TODO: ephemeral (read receipts) should be handled by the event cache (#4113).
-                timeline_controller.handle_ephemeral_events(events).await;
+                timeline_controller.handle_read_receipt_event(event).await;
             }
 
             RoomEventCacheUpdate::UpdateMembers { ambiguity_changes, avatar_changes } => {

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -188,6 +188,13 @@ pub(in crate::timeline) async fn thread_updates_task(
                     timeline_controller.retry_event_decryption(None).await;
                 }
             }
+
+            ThreadEventCacheUpdate::AddReadReceiptEvent { event } => {
+                trace!("Received a new read receipt event from sync.");
+
+                // TODO: ephemeral (read receipts) should be handled by the event cache (#4113).
+                timeline_controller.handle_read_receipt_event(event).await;
+            }
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -20,7 +20,8 @@ use eyeball::Subscriber as EyeballSubscriber;
 use matrix_sdk::{
     event_cache::{
         EventFocusThreadMode, EventFocusedCache, EventsOrigin, PinnedEventsCache, RoomEventCache,
-        RoomEventCacheUpdate, Subscriber, ThreadEventCache, TimelineVectorDiffs,
+        RoomEventCacheUpdate, Subscriber, ThreadEventCache, ThreadEventCacheUpdate,
+        TimelineVectorDiffs,
     },
     send_queue::RoomSendQueueUpdate,
 };
@@ -145,7 +146,7 @@ pub(in crate::timeline) async fn event_focused_task(
 /// For a thread-focused timeline, a long-lived task that will listen to the
 /// underlying thread updates.
 pub(in crate::timeline) async fn thread_updates_task(
-    mut thread_event_cache_subscriber: Subscriber<TimelineVectorDiffs>,
+    mut thread_event_cache_subscriber: Subscriber<ThreadEventCacheUpdate>,
     event_cache: ThreadEventCache,
     timeline_controller: TimelineController,
 ) {
@@ -169,20 +170,24 @@ pub(in crate::timeline) async fn thread_updates_task(
             }
         };
 
-        trace!("Received new timeline events diffs");
+        match update {
+            ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, origin }) => {
+                trace!("Received new timeline events diffs");
 
-        let origin = match update.origin {
-            EventsOrigin::Sync => RemoteEventOrigin::Sync,
-            EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
-            EventsOrigin::Cache => RemoteEventOrigin::Cache,
-        };
+                let origin = match origin {
+                    EventsOrigin::Sync => RemoteEventOrigin::Sync,
+                    EventsOrigin::Pagination => RemoteEventOrigin::Pagination,
+                    EventsOrigin::Cache => RemoteEventOrigin::Cache,
+                };
 
-        let has_diffs = !update.diffs.is_empty();
+                let has_diffs = !diffs.is_empty();
 
-        timeline_controller.handle_remote_events_with_diffs(update.diffs, origin).await;
+                timeline_controller.handle_remote_events_with_diffs(diffs, origin).await;
 
-        if has_diffs && matches!(origin, RemoteEventOrigin::Cache) {
-            timeline_controller.retry_event_decryption(None).await;
+                if has_diffs && matches!(origin, RemoteEventOrigin::Cache) {
+                    timeline_controller.retry_event_decryption(None).await;
+                }
+            }
         }
     }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -1518,7 +1518,7 @@ async fn test_read_receipts() {
     assert!(initial_items.is_empty());
     assert_pending!(stream);
 
-    // Receive two events from the server, one of which is a read receipt.
+    // Receive three events from the server.
     let f = EventFactory::new();
     server
         .sync_room(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -297,11 +297,6 @@ async fn test_extract_bundled_thread_summary() {
     // We get the count from the bundled thread summary.
     assert_eq!(summary.num_replies, 42);
 
-    // The read receipts haven't been filled, because we didn't have such
-    // information for the current user.
-    assert_eq!(summary.public_read_receipt_event_id, None);
-    assert_eq!(summary.private_read_receipt_event_id, None);
-
     assert_let!(VectorDiff::PushFront { value } = &timeline_updates[1]);
     assert!(value.is_date_divider());
 
@@ -528,11 +523,6 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
     // The thread summary contains the number of replies.
     assert_eq!(summary.num_replies, 1);
 
-    // The read receipts haven't been filled, because we didn't have such
-    // information for the current user.
-    assert_eq!(summary.public_read_receipt_event_id, None);
-    assert_eq!(summary.private_read_receipt_event_id, None);
-
     assert_pending!(stream);
 
     // A new thread reply updates the number of replies in the thread.
@@ -590,11 +580,6 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
 
     // The number of replies has been updated.
     assert_eq!(summary.num_replies, 2);
-
-    // The read receipts haven't been filled, because we didn't have such
-    // information for the current user.
-    assert_eq!(summary.public_read_receipt_event_id, None);
-    assert_eq!(summary.private_read_receipt_event_id, None);
 }
 
 #[async_test]
@@ -2365,120 +2350,4 @@ async fn test_redaction_affects_thread_summary() {
     let event_item = value.as_event().unwrap();
     assert_eq!(event_item.event_id(), Some(thread_root));
     assert!(event_item.content().as_msglike().unwrap().thread_summary.is_none());
-}
-
-#[async_test]
-async fn test_main_timeline_has_receipts_in_thread_summaries() {
-    // The initial read receipts for thread events are filled, as part of the
-    // `ThreadSummary`, for main timeline:
-    // - at start
-    // - upon update of the read receipts events
-
-    let server = MatrixMockServer::new().await;
-    let client = client_with_threading_support(&server).await;
-    client.event_cache().subscribe().unwrap();
-
-    let own_user = client.user_id().unwrap();
-
-    // Sync some initial read receipts, one for the main timeline (that won't be
-    // used) and another one for a threaded timeline, that will be used later.
-    let room_id = room_id!("!a:b.c");
-    let f = EventFactory::new().room(room_id).sender(&ALICE);
-
-    let thread_event_id = event_id!("$thread_root");
-    let latest_event_id = event_id!("$latest_event");
-
-    let room = server
-        .sync_room(
-            &client,
-            JoinedRoomBuilder::new(room_id)
-                .add_receipt(
-                    // Add a receipt for the latest event of the thread.
-                    f.read_receipts()
-                        .add(
-                            latest_event_id,
-                            own_user,
-                            ReceiptType::Read,
-                            ReceiptThread::Thread(thread_event_id.to_owned()),
-                        )
-                        .into_event(),
-                )
-                .add_timeline_event(
-                    // And the thread root itself.
-                    f.text_msg("thready thread mcthreadface")
-                        .with_bundled_thread_summary(
-                            f.text_msg("the last one!").event_id(latest_event_id).into(),
-                            42,
-                            false,
-                        )
-                        .event_id(thread_event_id),
-                ),
-        )
-        .await;
-
-    let timeline = room.timeline().await.unwrap();
-    let (mut initial_items, mut stream) = timeline.subscribe().await;
-
-    // Wait for the initial items.
-    if initial_items.is_empty() {
-        assert_let_timeout!(Some(timeline_updates) = stream.next());
-        for up in timeline_updates {
-            up.apply(&mut initial_items);
-        }
-    }
-
-    // Let's take a look at the items, now that they've been loaded: there will be
-    // the day divider and the thread root itself.
-    let items = timeline.items().await;
-    assert_eq!(items.len(), 2);
-
-    // First, the day divider.
-    let value = &items[0];
-    assert!(value.is_date_divider());
-
-    // Second, the event with the thread summary that has some read receipts.
-    let value = &items[1];
-    let event_item = value.as_event().unwrap();
-    assert_eq!(event_item.event_id().unwrap(), thread_event_id);
-    assert_let!(Some(summary) = event_item.content().thread_summary());
-
-    // We get the latest event from the bundled thread summary, and it's loaded.
-    assert!(summary.latest_event.is_ready());
-
-    // The public read receipt event id is filled (but the private isn't).
-    assert_eq!(summary.public_read_receipt_event_id.as_deref(), Some(latest_event_id));
-    assert_eq!(summary.private_read_receipt_event_id, None);
-
-    // Now, a new read receipt is received for the same thread (we haven't received
-    // the thread event yet).
-    let new_latest_event_id = event_id!("$new_latest_event_id");
-
-    server
-        .sync_room(
-            &client,
-            JoinedRoomBuilder::new(room_id).add_receipt(
-                // Add a receipt for the latest event of the thread.
-                f.read_receipts()
-                    .add(
-                        new_latest_event_id,
-                        own_user,
-                        ReceiptType::ReadPrivate,
-                        ReceiptThread::Thread(thread_event_id.to_owned()),
-                    )
-                    .into_event(),
-            ),
-        )
-        .await;
-
-    assert_let_timeout!(Some(timeline_updates) = stream.next());
-    assert_eq!(timeline_updates.len(), 1);
-    assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[0]);
-
-    let event_item = value.as_event().unwrap();
-    assert_eq!(event_item.event_id().unwrap(), thread_event_id);
-    assert_let!(Some(summary) = event_item.content().thread_summary());
-
-    // Now, the private read receipt is *also* filled.
-    assert_eq!(summary.public_read_receipt_event_id.as_deref(), Some(latest_event_id));
-    assert_eq!(summary.private_read_receipt_event_id.as_deref(), Some(new_latest_event_id));
 }

--- a/crates/matrix-sdk/changelog.d/6038.changed.md
+++ b/crates/matrix-sdk/changelog.d/6038.changed.md
@@ -1,0 +1,10 @@
+`RoomEventCacheUpdate::AddEphemeralEvents` becomes
+`RoomEventCacheUpdate::AddReadReceipt`. It no longer contains an `events:
+Vec<Raw<AnySyncEphemeralRoomEvent>>` but a single `event: ReceiptEventContent`.
+
+In the same vain, `ThreadEventCacheUpdate` is introduced!
+Thus, `ThreadEventCache::subscribe` no longer returns a
+`Subscriber<TimelineVectorDiffs>` but a `Subscriber<ThreadEventCacheUpdate>`.
+The `TimelineVectorDiffs` can be found in
+`ThreadEventCacheUpdate::UpdateTimelineEvents`, just like its sibling type
+`RoomEventCacheUpdate`.

--- a/crates/matrix-sdk/changelog.d/6938.fixed.md
+++ b/crates/matrix-sdk/changelog.d/6938.fixed.md
@@ -1,0 +1,7 @@
+When a sync contained more than one read receipts, only the first one was
+taken into account. Multiple problems arose from this, e.g. (i) perhaps the
+first selected receipt is not the correct one (`RoomEventCache` only cares
+about the `Main` or `Unthreaded` for example, and should ignore the `Thread`
+ones), (ii) or more simply the other read receipts were totally ignored! This
+is now fixed: ephemeral events are triaged similarly to timeline events, inside
+`event_cache::aggregator`.

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use matrix_sdk_base::{
     serde_helpers::{extract_redaction_target, extract_relation, extract_thread_root},
@@ -22,37 +22,54 @@ use ruma::{
     OwnedEventId,
     events::{
         AnySyncEphemeralRoomEvent,
-        receipt::{ReceiptThread, SyncReceiptEvent},
+        receipt::{ReceiptEventContent, ReceiptThread, Receipts},
         relation::RelationType,
     },
     room_version_rules::RedactionRules,
-    serde::Raw,
 };
-use tracing::error;
 
 use super::{
     super::{Result, states::StateLockReadGuard},
+    read_receipts::MaybeReceiptEventContent,
     room::RoomEventCacheState,
     thread::ThreadEventCacheState,
 };
 
-pub fn aggregate_timeline_for_room(timeline: &Timeline) -> Timeline {
-    timeline.clone()
+pub fn aggregate_timeline_and_read_receipts_for_room(
+    timeline: &Timeline,
+    ephemeral: &[AnySyncEphemeralRoomEvent],
+) -> (Timeline, MaybeReceiptEventContent) {
+    (
+        timeline.clone(),
+        filter_read_receipts_and_group_by(ephemeral, |receipt_thread| match receipt_thread {
+            ReceiptThread::Main | ReceiptThread::Unthreaded => Some(()),
+            _ => None,
+        })
+        .map(|(_receipt_thread, (event_id, event_receipts))| {
+            (event_id.clone(), event_receipts.clone())
+        })
+        .collect(),
+    )
 }
 
-pub async fn aggregate_timeline_for_threads<'sync, 'state>(
+pub async fn aggregate_timeline_and_read_receipts_for_threads<'sync, 'state>(
     timeline: &'sync Timeline,
-    ephemerals: &'sync [Raw<AnySyncEphemeralRoomEvent>],
+    ephemeral: &'sync [AnySyncEphemeralRoomEvent],
     existing_threads: StateLockReadGuard<'state, HashMap<OwnedEventId, ThreadEventCacheState>>,
     maybe_room: Option<StateLockReadGuard<'state, RoomEventCacheState>>,
     redaction_rules: &'sync RedactionRules,
-) -> Result<HashMap<OwnedEventId, Timeline>> {
+) -> Result<HashMap<OwnedEventId, (Timeline, MaybeReceiptEventContent)>> {
     let mut new_events_by_thread = HashMap::new();
 
-    let default_timeline = || Timeline {
-        limited: timeline.limited,
-        prev_batch: timeline.prev_batch.clone(),
-        events: Vec::new(),
+    let default_entry = || {
+        (
+            Timeline {
+                limited: timeline.limited,
+                prev_batch: timeline.prev_batch.clone(),
+                events: Vec::new(),
+            },
+            MaybeReceiptEventContent::none(),
+        )
     };
 
     // Look for in-thread events, i.e. events that are part of threads.
@@ -64,7 +81,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                 RelationType::Thread => {
                     new_events_by_thread
                         .entry(related_event_id)
-                        .or_insert_with(default_timeline)
+                        .or_insert_with(default_entry)
+                        .0
                         .events
                         .push(event.clone());
                 }
@@ -99,7 +117,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                     } {
                         new_events_by_thread
                             .entry(thread_root)
-                            .or_insert_with(default_timeline)
+                            .or_insert_with(default_entry)
+                            .0
                             .events
                             .push(event.clone());
                     }
@@ -115,7 +134,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                 {
                     new_events_by_thread
                         .entry(event_id.to_owned())
-                        .or_insert_with(default_timeline)
+                        .or_insert_with(default_entry)
+                        .0
                         .events
                         .push(event.clone());
                 }
@@ -150,7 +170,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                     if let Some(thread_root) = associated_thread_root {
                         new_events_by_thread
                             .entry(thread_root)
-                            .or_insert_with(default_timeline)
+                            .or_insert_with(default_entry)
+                            .0
                             .events
                             .push(event.clone());
                     }
@@ -159,32 +180,21 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
         }
     }
 
-    // We must also look in the `ephemeral` events. Maybe the `timeline` is empty,
-    // but some ephemeral events target specific threads.
-    for ephemeral in ephemerals {
-        match ephemeral.deserialize() {
-            Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {
-                for thread_root in content.values().flat_map(|receipts_by_event| {
-                    receipts_by_event.values().flat_map(|receipts| {
-                        receipts.values().filter_map(|receipt| match &receipt.thread {
-                            ReceiptThread::Thread(thread_id) => Some(thread_id),
-                            _ => None,
-                        })
-                    })
-                }) {
-                    new_events_by_thread
-                        .entry(thread_root.to_owned())
-                        .or_insert_with(default_timeline);
-                }
-            }
-
-            // Not a read receipt; not interested for now.
-            Ok(_) => {}
-
-            Err(err) => {
-                error!(%err, "error when deserializing an ephemeral event");
-            }
-        }
+    for (thread_root, (read_receipt_event_id, read_receipt_event)) in
+        filter_read_receipts_and_group_by(ephemeral, |receipt_thread| match receipt_thread {
+            ReceiptThread::Thread(thread_id) => Some(thread_id),
+            _ => None,
+        })
+    {
+        // 1. Create an empty `Timeline` if it doesn't exist so that it triggers the
+        //    update for this thread in `Caches`. This is done by `default_entry`.
+        // 2. Accumulate the read receipt event.
+        new_events_by_thread
+            .entry(thread_root.to_owned())
+            .or_insert_with(default_entry)
+            .1
+            .get_or_insert_with(|| ReceiptEventContent(BTreeMap::new()))
+            .insert(read_receipt_event_id.clone(), read_receipt_event.clone());
     }
 
     Ok(new_events_by_thread)

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -243,3 +243,38 @@ pub fn aggregate_timeline_for_pinned_events(
 
     new_timeline
 }
+
+/// Filter (deserialised) ephemeral events to only keep the read receipts
+/// matching a particular predicate.
+///
+/// Read receipts have a deep structure (an entanglement of `BTreeMap`). The
+/// returned iterator returns the tuple `(OwnedEventId, Receipts)`, which is the
+/// second level. However, the `predicate` is applied on the fourth level,
+/// directly on the leaf of the read receipts.
+///
+/// The predicate is used with [`Iterator::filter_map`], and thus can return a
+/// group key (it can be anything). This group key is associated to the tuple
+/// mentioned earlier, and should be used to “group” read receipts. This is
+/// useful when one wants to group read receipts by their `ReceiptThread` for
+/// example.
+fn filter_read_receipts_and_group_by<'e, F, G>(
+    events: &'e [AnySyncEphemeralRoomEvent],
+    predicate: F,
+) -> impl Iterator<Item = (G, (&'e OwnedEventId, &'e Receipts))>
+where
+    F: Fn(&'e ReceiptThread) -> Option<G>,
+{
+    events
+        .iter()
+        .filter_map(|ephemeral| match ephemeral {
+            AnySyncEphemeralRoomEvent::Receipt(receipt_event) => Some(receipt_event),
+            _ => None,
+        })
+        .flat_map(|receipt_event| receipt_event.content.iter())
+        .filter_map(move |(event_id, event_receipts)| {
+            Some((
+                predicate(&event_receipts.first_key_value()?.1.first_key_value()?.1.thread)?,
+                (event_id, event_receipts),
+            ))
+        })
+}

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -312,23 +312,33 @@ impl Caches {
             avatar_changes,
         } = updates;
 
+        // Filter ephemeral events.
+        let original_ephemeral = original_ephemeral
+            .into_iter()
+            .filter_map(|ephemeral_event| ephemeral_event.deserialize().ok())
+            .collect::<Vec<_>>();
+
         // Room.
         {
-            let updates = JoinedRoomUpdate {
-                timeline: aggregator::aggregate_timeline_for_room(&original_timeline),
-                ephemeral: original_ephemeral.clone(),
+            let (timeline, read_receipts) =
+                aggregator::aggregate_timeline_and_read_receipts_for_room(
+                    &original_timeline,
+                    &original_ephemeral,
+                );
+
+            room.handle_joined_room_update(
+                timeline,
+                read_receipts,
                 account_data,
                 ambiguity_changes,
                 avatar_changes,
-                ..Default::default()
-            };
-
-            room.handle_joined_room_update(updates).await?;
+            )
+            .await?;
         }
 
         // Threads.
         {
-            let timeline_for_threads = {
+            let timeline_and_read_receipts_for_threads = {
                 // To aggregate the timelines for threads, we need to lookup in the room cache
                 // and the thread caches. We acquire a read lock over all the caches, and select
                 // the room cache and thread cache' states.
@@ -338,7 +348,7 @@ impl Caches {
                 );
                 let all_states = all_states_lock.read().await?;
 
-                aggregator::aggregate_timeline_for_threads(
+                aggregator::aggregate_timeline_and_read_receipts_for_threads(
                     &original_timeline,
                     &original_ephemeral,
                     all_states.threads(),
@@ -348,18 +358,12 @@ impl Caches {
                 .await?
             };
 
-            for (thread_id, timeline) in timeline_for_threads {
-                let updates = JoinedRoomUpdate {
-                    timeline,
-                    ephemeral: original_ephemeral.clone(),
-                    ..Default::default()
-                };
-
+            for (thread_id, (timeline, read_receipts)) in timeline_and_read_receipts_for_threads {
                 // Update the thread summary if and only if there are new events.
-                let update_thread_summary = updates.timeline.events.is_empty().not();
+                let update_thread_summary = timeline.events.is_empty().not();
 
                 let thread = self.thread(thread_id).await?;
-                thread.handle_joined_room_update(updates).await?;
+                thread.handle_joined_room_update(timeline, read_receipts).await?;
 
                 if update_thread_summary {
                     let new_thread_summary =
@@ -372,16 +376,13 @@ impl Caches {
 
         // Pinned-events.
         if let Some(pinned_events) = pinned_events.get() {
-            let updates = JoinedRoomUpdate {
-                timeline: aggregator::aggregate_timeline_for_pinned_events(
-                    &original_timeline,
-                    &pinned_events.state().read().await?.current_event_ids(),
-                    &internals.room_version_rules.redaction,
-                ),
-                ..Default::default()
-            };
+            let timeline = aggregator::aggregate_timeline_for_pinned_events(
+                &original_timeline,
+                &pinned_events.state().read().await?.current_event_ids(),
+                &internals.room_version_rules.redaction,
+            );
 
-            pinned_events.handle_joined_room_update(updates).await?;
+            pinned_events.handle_joined_room_update(timeline).await?;
         }
 
         // Event-focused.
@@ -416,18 +417,15 @@ impl Caches {
 
         // Room.
         {
-            let updates = LeftRoomUpdate {
-                timeline: aggregator::aggregate_timeline_for_room(&original_timeline),
-                ambiguity_changes,
-                ..Default::default()
-            };
+            let (timeline, _read_receipts) =
+                aggregator::aggregate_timeline_and_read_receipts_for_room(&original_timeline, &[]);
 
-            room.handle_left_room_update(updates).await?;
+            room.handle_left_room_update(timeline, ambiguity_changes).await?;
         }
 
         // Threads.
         {
-            let timeline_for_threads = {
+            let timeline_and_read_receipts_for_threads = {
                 // To aggregate the timelines for threads, we need to lookup in the room cache
                 // and the thread caches. We acquire a read lock over all the caches, and select
                 // the room cache and thread cache' states.
@@ -437,7 +435,7 @@ impl Caches {
                 );
                 let all_caches_states = all_caches_states_lock.read().await?;
 
-                aggregator::aggregate_timeline_for_threads(
+                aggregator::aggregate_timeline_and_read_receipts_for_threads(
                     &original_timeline,
                     &[],
                     all_caches_states.threads(),
@@ -447,26 +445,21 @@ impl Caches {
                 .await?
             };
 
-            for (thread_id, timeline) in timeline_for_threads {
-                let updates = LeftRoomUpdate { timeline, ..Default::default() };
-
+            for (thread_id, (timeline, _read_receipts)) in timeline_and_read_receipts_for_threads {
                 let thread = self.thread(thread_id).await?;
-                thread.handle_left_room_update(updates).await?;
+                thread.handle_left_room_update(timeline).await?;
             }
         }
 
         // Pinned-events.
         if let Some(pinned_events) = pinned_events.get() {
-            let updates = LeftRoomUpdate {
-                timeline: aggregator::aggregate_timeline_for_pinned_events(
-                    &original_timeline,
-                    &pinned_events.state().read().await?.current_event_ids(),
-                    &internals.room_version_rules.redaction,
-                ),
-                ..Default::default()
-            };
+            let timeline = aggregator::aggregate_timeline_for_pinned_events(
+                &original_timeline,
+                &pinned_events.state().read().await?.current_event_ids(),
+                &internals.room_version_rules.redaction,
+            );
 
-            pinned_events.handle_left_room_update(updates).await?;
+            pinned_events.handle_left_room_update(timeline).await?;
         }
 
         // Event-focused.

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -23,7 +23,7 @@ use matrix_sdk_base::{
     event_cache::{Event, Gap},
     linked_chunk::{LinkedChunkId, OwnedLinkedChunkId, Position, Update},
     serde_helpers::extract_redaction_target,
-    sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
+    sync::Timeline,
     task_monitor::BackgroundTaskHandle,
 };
 use matrix_sdk_common::executor::spawn;
@@ -528,20 +528,16 @@ impl PinnedEventsCache {
         Ok(())
     }
 
-    /// Handle a [`JoinedRoomUpdate`].
+    /// Handle an update from a joined room.
     #[instrument(skip_all, fields(room_id = %self.inner.room_id))]
-    pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline).await?;
-
-        Ok(())
+    pub(super) async fn handle_joined_room_update(&self, timeline: Timeline) -> Result<()> {
+        self.handle_timeline(timeline).await
     }
 
-    /// Handle a [`LeftRoomUpdate`].
+    /// Handle an update from a left room.
     #[instrument(skip_all, fields(room_id = %self.inner.room_id))]
-    pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline).await?;
-
-        Ok(())
+    pub(super) async fn handle_left_room_update(&self, timeline: Timeline) -> Result<()> {
+        self.handle_timeline(timeline).await
     }
 
     /// Handle a [`Timeline`], i.e. new events received by a sync for this
@@ -553,9 +549,7 @@ impl PinnedEventsCache {
 
         trace!("adding new {} events", timeline.events.len());
 
-        self.inner.state.write().await?.handle_sync(timeline).await?;
-
-        Ok(())
+        self.inner.state.write().await?.handle_sync(timeline).await
     }
 
     #[instrument(fields(%room_id = room.room_id()), skip(room, inner))]

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -101,7 +101,7 @@
 
 use std::{
     collections::HashSet,
-    ops::{ControlFlow, Not},
+    ops::{ControlFlow, Deref, DerefMut, Not},
 };
 
 use matrix_sdk_base::{
@@ -117,7 +117,7 @@ use ruma::{
     EventId, OwnedEventId, OwnedUserId, RoomId, UserId,
     events::{
         AnySyncTimelineEvent, MessageLikeEventType,
-        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
+        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType, Receipts},
         relation::RelationType,
     },
     serde::Raw,
@@ -695,6 +695,48 @@ fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool 
     true
 }
 
+/// A type representing `Option<ReceiptEventContent>`.
+///
+/// It is useful because it implements [`FromIterator`], similarly to
+/// [`ReceiptEventContent`], except it produces `None` if source iterator is
+/// empty instead of an empty `BTreeMap`.
+pub struct MaybeReceiptEventContent(Option<ReceiptEventContent>);
+
+impl MaybeReceiptEventContent {
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    pub fn into_inner(self) -> Option<ReceiptEventContent> {
+        self.0
+    }
+}
+
+impl Deref for MaybeReceiptEventContent {
+    type Target = Option<ReceiptEventContent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MaybeReceiptEventContent {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<(OwnedEventId, Receipts)> for MaybeReceiptEventContent {
+    fn from_iter<T>(iterator: T) -> Self
+    where
+        T: IntoIterator<Item = (OwnedEventId, Receipts)>,
+    {
+        let mut iterator = iterator.into_iter().peekable();
+
+        Self(if iterator.peek().is_some() { Some(iterator.collect()) } else { None })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{num::NonZeroUsize, ops::Not as _};
@@ -703,9 +745,9 @@ mod tests {
     use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
     use matrix_sdk_test::{ALICE, event_factory::EventFactory};
     use ruma::{
-        EventId, RoomId, UserId, event_id,
+        EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId, event_id,
         events::{
-            receipt::{ReceiptThread, ReceiptType},
+            receipt::{Receipt, ReceiptThread, ReceiptType, UserReceipts},
             room::{member::MembershipState, message::MessageType},
         },
         owned_event_id,
@@ -714,8 +756,8 @@ mod tests {
     };
 
     use super::{
-        EventFilter, ReadReceiptsExt as _, RoomReadReceiptEventFilter, marks_as_unread,
-        select_best_receipt, stop_on_event_ids,
+        EventFilter, MaybeReceiptEventContent, ReadReceiptsExt as _, Receipts,
+        RoomReadReceiptEventFilter, marks_as_unread, select_best_receipt, stop_on_event_ids,
     };
     use crate::event_cache::caches::{
         event_linked_chunk::EventLinkedChunk, pagination::BackPaginationOutcome,
@@ -1420,5 +1462,34 @@ mod tests {
         assert_eq!(pending_receipts.len(), 2);
         assert!(pending_receipts.iter().any(|ev| ev == event_id!("$6")));
         assert!(pending_receipts.iter().any(|ev| ev == event_id!("$7")));
+    }
+
+    #[test]
+    fn test_maybe_receipt_event_content_from_empty_iterator() {
+        let maybe: MaybeReceiptEventContent = std::iter::empty().collect();
+
+        assert!(maybe.is_none());
+    }
+
+    #[test]
+    fn test_maybe_receipt_event_content_from_iterator() {
+        let maybe: MaybeReceiptEventContent = vec![(
+            event_id!("$ev").to_owned(),
+            Receipts::from([(
+                ReceiptType::Read,
+                UserReceipts::from([(
+                    user_id!("@ali:ce").to_owned(),
+                    Receipt::new(MilliSecondsSinceUnixEpoch::now()),
+                )]),
+            )]),
+        )]
+        .into_iter()
+        .collect();
+
+        assert!(maybe.is_some());
+
+        let receipt_event_content = maybe.into_inner().unwrap();
+        assert_eq!(receipt_event_content.len(), 1);
+        assert!(receipt_event_content.contains_key(event_id!("$ev")));
     }
 }

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -22,11 +22,11 @@ use eyeball::SharedObservable;
 use matrix_sdk_base::{
     deserialized_responses::{AmbiguityChange, ThreadSummary},
     event_cache::Event,
-    sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
+    sync::Timeline,
 };
 use ruma::{
     EventId, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId,
-    events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent, relation::RelationType},
+    events::{AnyRoomAccountDataEvent, relation::RelationType},
     serde::Raw,
 };
 use tokio::sync::{Notify, mpsc};
@@ -48,6 +48,7 @@ use super::{
     TimelineVectorDiffs,
     event_linked_chunk::sort_positions_descending,
     pagination::SharedPaginationStatus,
+    read_receipts::MaybeReceiptEventContent,
     subscriber::{AutoShrinkMessage, Subscriber},
 };
 use crate::room::WeakRoom;
@@ -231,27 +232,33 @@ impl RoomEventCache {
         &self.inner.state
     }
 
-    /// Handle a [`JoinedRoomUpdate`].
+    /// Handle an update from a joined room.
     #[instrument(skip_all, fields(room_id = %self.room_id()))]
-    pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
+    pub(super) async fn handle_joined_room_update(
+        &self,
+        timeline: Timeline,
+        read_receipts: MaybeReceiptEventContent,
+        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+        ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
+        avatar_changes: Option<BTreeMap<OwnedUserId, Option<OwnedMxcUri>>>,
+    ) -> Result<()> {
         self.inner
-            .handle_timeline(
-                updates.timeline,
-                updates.ephemeral,
-                updates.ambiguity_changes,
-                updates.avatar_changes,
-            )
+            .handle_timeline(timeline, read_receipts, ambiguity_changes, avatar_changes)
             .await?;
-        self.inner.handle_account_data(updates.account_data);
+        self.inner.handle_account_data(account_data);
 
         Ok(())
     }
 
-    /// Handle a [`LeftRoomUpdate`].
+    /// Handle an update from a left room.
     #[instrument(skip_all, fields(room_id = %self.room_id()))]
-    pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
+    pub(super) async fn handle_left_room_update(
+        &self,
+        timeline: Timeline,
+        ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
+    ) -> Result<()> {
         self.inner
-            .handle_timeline(updates.timeline, Vec::new(), updates.ambiguity_changes, None)
+            .handle_timeline(timeline, MaybeReceiptEventContent::none(), ambiguity_changes, None)
             .await?;
 
         Ok(())
@@ -381,14 +388,14 @@ impl RoomEventCacheInner {
     async fn handle_timeline(
         &self,
         timeline: Timeline,
-        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        read_receipts: MaybeReceiptEventContent,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
         avatar_changes: Option<BTreeMap<OwnedUserId, Option<OwnedMxcUri>>>,
     ) -> Result<()> {
         self.handle_timeline_inner(
             self.state.write().await?,
             timeline,
-            ephemeral_events,
+            read_receipts,
             ambiguity_changes,
             avatar_changes,
         )
@@ -409,7 +416,7 @@ impl RoomEventCacheInner {
                 .handle_timeline_inner(
                     state,
                     Timeline { limited: false, prev_batch: None, events: vec![event] },
-                    Vec::new(),
+                    MaybeReceiptEventContent::none(),
                     BTreeMap::new(),
                     None,
                 )
@@ -423,13 +430,13 @@ impl RoomEventCacheInner {
         &self,
         mut state: StateLockWriteGuard<'_, RoomEventCacheState>,
         timeline: Timeline,
-        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        read_receipts: MaybeReceiptEventContent,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
         avatar_changes: Option<BTreeMap<OwnedUserId, Option<OwnedMxcUri>>>,
     ) -> Result<()> {
         if timeline.events.is_empty()
             && timeline.prev_batch.is_none()
-            && ephemeral_events.is_empty()
+            && read_receipts.is_none()
             && ambiguity_changes.is_empty()
             && avatar_changes.as_ref().is_none_or(|avatars| avatars.is_empty())
         {
@@ -439,7 +446,7 @@ impl RoomEventCacheInner {
         trace!("adding new events");
 
         let (stored_prev_batch_token, timeline_event_diffs) =
-            state.handle_sync(timeline, &ephemeral_events).await?;
+            state.handle_sync(timeline, &read_receipts).await?;
 
         drop(state);
 
@@ -461,9 +468,9 @@ impl RoomEventCacheInner {
             );
         }
 
-        if !ephemeral_events.is_empty() {
+        if let Some(read_receipts) = read_receipts.into_inner() {
             self.update_sender
-                .send(RoomEventCacheUpdate::AddEphemeralEvents { events: ephemeral_events }, None);
+                .send(RoomEventCacheUpdate::AddReadReceiptEvent { event: read_receipts }, None);
         }
 
         if !ambiguity_changes.is_empty() || avatar_changes.as_ref().is_some_and(|c| !c.is_empty()) {
@@ -781,7 +788,7 @@ mod timed_tests {
             lazy_loader::from_all_chunks,
         },
         store::StoreConfig,
-        sync::{JoinedRoomUpdate, Timeline},
+        sync::Timeline,
     };
     use matrix_sdk_common::cross_process_lock::CrossProcessLockConfig;
     use matrix_sdk_test::{ALICE, BOB, async_test, event_factory::EventFactory};
@@ -797,7 +804,8 @@ mod timed_tests {
 
     use super::{
         super::{super::TimelineVectorDiffs, pagination::LoadMoreEventsBackwardsOutcome},
-        RoomEventCache, RoomEventCacheGenericUpdate, RoomEventCacheUpdate,
+        MaybeReceiptEventContent, RoomEventCache, RoomEventCacheGenericUpdate,
+        RoomEventCacheUpdate,
     };
     use crate::{assert_let_timeout, test_utils::client::MockClientBuilder};
 
@@ -838,7 +846,13 @@ mod timed_tests {
         };
 
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                timeline,
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -915,7 +929,13 @@ mod timed_tests {
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![ev] };
 
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                timeline,
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1252,7 +1272,13 @@ mod timed_tests {
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![ev2] };
 
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(
+                timeline,
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1358,14 +1384,17 @@ mod timed_tests {
         // Propagate an update including a limited timeline with one message and a
         // prev-batch token.
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate {
-                timeline: Timeline {
+            .handle_joined_room_update(
+                Timeline {
                     limited: true,
                     prev_batch: Some("raclette".to_owned()),
                     events: vec![f.text_msg("hey yo").into_event()],
                 },
-                ..Default::default()
-            })
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1424,14 +1453,17 @@ mod timed_tests {
         // Now, propagate an update for another message, but the timeline isn't limited
         // this time.
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate {
-                timeline: Timeline {
+            .handle_joined_room_update(
+                Timeline {
                     limited: false,
                     prev_batch: Some("fondue".to_owned()),
                     events: vec![f.text_msg("sup").into_event()],
                 },
-                ..Default::default()
-            })
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1704,14 +1736,17 @@ mod timed_tests {
         // events.
         let evid4 = event_id!("$4");
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate {
-                timeline: Timeline {
+            .handle_joined_room_update(
+                Timeline {
                     limited: true,
                     prev_batch: Some("fondue".to_owned()),
                     events: vec![ev3, f.text_msg("sup").event_id(evid4).into_event()],
                 },
-                ..Default::default()
-            })
+                MaybeReceiptEventContent::none(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -2600,7 +2635,13 @@ mod timed_tests {
         let account_data = vec![read_marker_event; 100];
 
         room_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { account_data, ..Default::default() })
+            .handle_joined_room_update(
+                Default::default(),
+                MaybeReceiptEventContent::none(),
+                account_data,
+                Default::default(),
+                Default::default(),
+            )
             .await
             .unwrap();
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -23,18 +23,17 @@ use matrix_sdk_base::{
     linked_chunk::{
         ChunkIdentifierGenerator, LinkedChunkId, OwnedLinkedChunkId, Position, Update, lazy_loader,
     },
-    serde_helpers::{extract_read_receipt, extract_redaction_target},
+    serde_helpers::extract_redaction_target,
     sync::Timeline,
 };
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId,
     events::{
-        AnySyncEphemeralRoomEvent, receipt::ReceiptEventContent, relation::RelationType,
+        receipt::ReceiptEventContent, relation::RelationType,
         room::redaction::SyncRoomRedactionEvent,
     },
     room_version_rules::RoomVersionRules,
-    serde::Raw,
 };
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
@@ -56,7 +55,9 @@ use super::{
         EventLocation,
         event_linked_chunk::EventLinkedChunk,
         pagination::SharedPaginationStatus,
-        read_receipts::{RoomReadReceiptEventFilter, compute_unread_counts},
+        read_receipts::{
+            MaybeReceiptEventContent, RoomReadReceiptEventFilter, compute_unread_counts,
+        },
         subscriber::SubscribersHandle,
     },
     RoomEventCacheLinkedChunkUpdate, RoomEventCacheUpdateSender, sort_positions_descending,
@@ -517,7 +518,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     pub async fn handle_sync(
         &mut self,
         mut timeline: Timeline,
-        ephemeral_events: &[Raw<AnySyncEphemeralRoomEvent>],
+        read_receipt_event: &MaybeReceiptEventContent,
     ) -> Result<(bool, Vec<VectorDiff<Event>>), EventCacheError> {
         let mut prev_batch_token = timeline.prev_batch.take();
 
@@ -561,8 +562,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             // unread counts tracking.
             //
             // Post-process the ephemeral events.
-            self.post_process_upserted_events(empty(), extract_read_receipt(ephemeral_events))
-                .await?;
+            self.post_process_upserted_events(empty(), read_receipt_event.as_ref()).await?;
 
             return Ok((false, Vec::new()));
         }
@@ -590,8 +590,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         self.propagate_changes().await?;
 
         // Post-process newly inserted events.
-        self.post_process_upserted_events(events.iter(), extract_read_receipt(ephemeral_events))
-            .await?;
+        self.post_process_upserted_events(events.iter(), read_receipt_event.as_ref()).await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -615,7 +614,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     pub(super) async fn post_process_upserted_events<'i, I>(
         &mut self,
         events: I,
-        receipt_event: Option<ReceiptEventContent>,
+        receipt_event: Option<&ReceiptEventContent>,
     ) -> Result<(), EventCacheError>
     where
         I: Iterator<Item = &'i Event>,
@@ -629,7 +628,7 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             }
         }
 
-        self.update_read_receipts(receipt_event.as_ref()).await?;
+        self.update_read_receipts(receipt_event).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/caches/room/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/updates.rs
@@ -52,8 +52,7 @@ pub enum RoomEventCacheUpdate {
 
     /// The room has received a new read receipt event.
     AddReadReceiptEvent {
-        /// XXX: this is temporary, until read receipts are handled in the event
-        /// cache
+        /// The event containing the receipts.
         event: ReceiptEventContent,
     },
 }

--- a/crates/matrix-sdk/src/event_cache/caches/room/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/updates.rs
@@ -20,8 +20,7 @@ use matrix_sdk_base::{
     linked_chunk::{self, OwnedLinkedChunkId},
 };
 use ruma::{
-    OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, events::AnySyncEphemeralRoomEvent,
-    serde::Raw,
+    OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, events::receipt::ReceiptEventContent,
 };
 use tokio::sync::broadcast::{Receiver, Sender};
 
@@ -51,11 +50,11 @@ pub enum RoomEventCacheUpdate {
     /// The room has received updates for the timeline as _diffs_.
     UpdateTimelineEvents(TimelineVectorDiffs),
 
-    /// The room has received new ephemeral events.
-    AddEphemeralEvents {
+    /// The room has received a new read receipt event.
+    AddReadReceiptEvent {
         /// XXX: this is temporary, until read receipts are handled in the event
         /// cache
-        events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        event: ReceiptEventContent,
     },
 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -28,9 +28,9 @@ use ruma::{
 use tokio::sync::{Notify, broadcast::Sender, mpsc};
 use tracing::{instrument, trace};
 
-use self::pagination::ThreadPagination;
 pub(in super::super) use self::state::ThreadEventCacheState;
 pub(super) use self::updates::ThreadEventCacheUpdateSender;
+pub use self::{pagination::ThreadPagination, updates::ThreadEventCacheUpdate};
 #[cfg(feature = "e2e-encryption")]
 use super::super::redecryptor::MaybeResolvedEvent;
 use super::{
@@ -190,7 +190,7 @@ impl ThreadEventCache {
     ///
     /// Creating, and especially dropping, a [`Subscriber`] isn't free, as it
     /// triggers side-effects.
-    pub async fn subscribe(&self) -> Result<(Vec<Event>, Subscriber<TimelineVectorDiffs>)> {
+    pub async fn subscribe(&self) -> Result<(Vec<Event>, Subscriber<ThreadEventCacheUpdate>)> {
         let state = self.inner.state.read().await?;
         let events =
             state.thread_linked_chunk().events().map(|(_position, item)| item.clone()).collect();
@@ -265,7 +265,10 @@ impl ThreadEventCache {
 
         if !timeline_event_diffs.is_empty() {
             state.update_sender.send(
-                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Sync },
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
+                    diffs: timeline_event_diffs,
+                    origin: EventsOrigin::Sync,
+                }),
                 // This function is part of the `RoomEventCache` flow. The generic update is
                 // handled by it.
                 None,
@@ -355,7 +358,10 @@ impl ThreadEventCache {
 
         Ok(if !timeline_event_diffs.is_empty() {
             state.update_sender.send(
-                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Cache },
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
+                    diffs: timeline_event_diffs,
+                    origin: EventsOrigin::Cache,
+                }),
                 Some(RoomEventCacheGenericUpdate { room_id: self.inner.room_id.clone() }),
             );
 
@@ -398,7 +404,7 @@ mod timed_tests {
 
     use super::{
         super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs},
-        MaybeReceiptEventContent,
+        MaybeReceiptEventContent, ThreadEventCacheUpdate,
     };
     use crate::{assert_let_timeout, test_utils::client::MockClientBuilder};
 
@@ -454,7 +460,7 @@ mod timed_tests {
 
         assert_matches!(
             thread_stream.recv().await,
-            Ok(TimelineVectorDiffs { diffs, .. }) => {
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) => {
                 assert_eq!(diffs.len(), 2);
                 assert_matches!(&diffs[0], VectorDiff::Clear);
                 assert_matches!(&diffs[1], VectorDiff::Append { values: events } => {
@@ -696,7 +702,7 @@ mod timed_tests {
 
             assert_matches!(
                 thread_stream.recv().await,
-                Ok(TimelineVectorDiffs { diffs, .. }) => {
+                Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) => {
                     assert_eq!(diffs.len(), 1);
                     assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value: event } => {
                         // Here you are `thread_event_0`!
@@ -721,7 +727,7 @@ mod timed_tests {
         //… we get an update that the content has been cleared.
         assert_matches!(
             thread_stream.recv().await,
-            Ok(TimelineVectorDiffs { diffs, .. }) => {
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) => {
                 assert_eq!(diffs.len(), 1);
                 assert_matches!(&diffs[0], VectorDiff::Clear);
             }
@@ -880,7 +886,7 @@ mod timed_tests {
 
         assert_matches!(
             thread_stream.recv().await,
-            Ok(TimelineVectorDiffs { diffs, .. }) => {
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) => {
                 assert_eq!(diffs.len(), 1);
                 assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value: event } => {
                     assert_eq!(event.event_id(), Some(thread_event_id_0));
@@ -1119,7 +1125,7 @@ mod timed_tests {
             // A new update for `ev_id_0` must be present.
             assert_matches!(
                 updates_stream.recv().await.unwrap(),
-                TimelineVectorDiffs { diffs, .. } => {
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                     assert_eq!(diffs.len(), 1, "{diffs:#?}");
                     assert_matches!(
                         &diffs[0],
@@ -1150,7 +1156,7 @@ mod timed_tests {
             // A new update for `thread_event_id_0` must be present.
             assert_matches!(
                 updates_stream.recv().await.unwrap(),
-                TimelineVectorDiffs { diffs, .. } => {
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                     assert_eq!(diffs.len(), 1, "{diffs:#?}");
                     assert_matches!(
                         &diffs[0],
@@ -1184,7 +1190,7 @@ mod timed_tests {
                 // The reload can be observed via the updates too.
                 assert_matches!(
                     updates_stream.recv().await.unwrap(),
-                    TimelineVectorDiffs { diffs, .. } => {
+                    ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                         assert_eq!(diffs.len(), 2, "{diffs:#?}");
                         assert_matches!(&diffs[0], VectorDiff::Clear);
                         assert_matches!(
@@ -1204,7 +1210,7 @@ mod timed_tests {
                 // The pagination can be observed via the updates.
                 assert_matches!(
                     updates_stream.recv().await.unwrap(),
-                    TimelineVectorDiffs { diffs, .. } => {
+                    ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                         assert_eq!(diffs.len(), 1, "{diffs:#?}");
                         assert_matches!(
                             &diffs[0],
@@ -1234,7 +1240,7 @@ mod timed_tests {
                 // The reload can be observed via the updates too.
                 assert_matches!(
                     updates_stream.recv().await.unwrap(),
-                    TimelineVectorDiffs { diffs, .. } => {
+                    ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                         assert_eq!(diffs.len(), 2, "{diffs:#?}");
                         assert_matches!(&diffs[0], VectorDiff::Clear);
                         assert_matches!(
@@ -1254,7 +1260,7 @@ mod timed_tests {
                 // The pagination can be observed via the updates.
                 assert_matches!(
                     updates_stream.recv().await.unwrap(),
-                    TimelineVectorDiffs { diffs, .. } => {
+                    ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. }) => {
                         assert_eq!(diffs.len(), 1, "{diffs:#?}");
                         assert_matches!(
                             &diffs[0],
@@ -1348,7 +1354,10 @@ mod timed_tests {
 
         // We also get an update about the loading from the store. Ignore it, for this
         // test's sake.
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = stream1.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                stream1.recv()
+        );
         assert_eq!(diffs.len(), 2);
         assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value } => {
             assert_eq!(value.event_id(), Some(thread_id));

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -255,7 +255,7 @@ impl ThreadEventCache {
         let mut state = self.inner.state.write().await?;
 
         let (stored_prev_batch_token, timeline_event_diffs) =
-            state.handle_sync(timeline, read_receipts).await?;
+            state.handle_sync(timeline, &read_receipts).await?;
 
         // Now that all events have been added, we can trigger the
         // `pagination_token_notifier`.
@@ -273,6 +273,12 @@ impl ThreadEventCache {
                 // handled by it.
                 None,
             );
+        }
+
+        if let Some(read_receipts) = read_receipts.into_inner() {
+            state
+                .update_sender
+                .send(ThreadEventCacheUpdate::AddReadReceiptEvent { event: read_receipts }, None);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -20,16 +20,10 @@ mod updates;
 
 use std::{fmt, sync::Arc};
 
-use matrix_sdk_base::{
-    event_cache::Event,
-    read_receipts::ReadReceipts,
-    sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
-};
+use matrix_sdk_base::{event_cache::Event, read_receipts::ReadReceipts, sync::Timeline};
 use ruma::{
-    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
-    events::{AnySyncEphemeralRoomEvent, relation::RelationType},
+    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, events::relation::RelationType,
     room_version_rules::RoomVersionRules,
-    serde::Raw,
 };
 use tokio::sync::{Notify, broadcast::Sender, mpsc};
 use tracing::{instrument, trace};
@@ -45,6 +39,7 @@ use super::{
         states::{CacheStateLock, StateLock, selectors::ThreadStateSelector},
     },
     EventsOrigin, TimelineVectorDiffs,
+    read_receipts::MaybeReceiptEventContent,
     room::{RoomEventCacheGenericUpdate, RoomEventCacheLinkedChunkUpdate},
     subscriber::{AutoShrinkMessage, Subscriber},
 };
@@ -228,20 +223,20 @@ impl ThreadEventCache {
         &self.inner.state
     }
 
-    /// Handle a [`JoinedRoomUpdate`].
+    /// Handle an update from a joined room.
     #[instrument(skip_all, fields(room_id = %self.inner.room_id, thread_root = %self.inner.thread_id))]
-    pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline, updates.ephemeral).await?;
-
-        Ok(())
+    pub(super) async fn handle_joined_room_update(
+        &self,
+        timeline: Timeline,
+        read_receipts: MaybeReceiptEventContent,
+    ) -> Result<()> {
+        self.handle_timeline(timeline, read_receipts).await
     }
 
-    /// Handle a [`LeftRoomUpdate`].
+    /// Handle an update from a left room.
     #[instrument(skip_all, fields(room_id = %self.inner.room_id, thread_root = %self.inner.thread_id))]
-    pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline, Vec::new()).await?;
-
-        Ok(())
+    pub(super) async fn handle_left_room_update(&self, timeline: Timeline) -> Result<()> {
+        self.handle_timeline(timeline, MaybeReceiptEventContent::none()).await
     }
 
     /// Handle a [`Timeline`], i.e. new events received by a sync for this
@@ -249,12 +244,9 @@ impl ThreadEventCache {
     async fn handle_timeline(
         &self,
         timeline: Timeline,
-        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        read_receipts: MaybeReceiptEventContent,
     ) -> Result<()> {
-        if timeline.events.is_empty()
-            && timeline.prev_batch.is_none()
-            && ephemeral_events.is_empty()
-        {
+        if timeline.events.is_empty() && timeline.prev_batch.is_none() && read_receipts.is_none() {
             return Ok(());
         }
 
@@ -263,7 +255,7 @@ impl ThreadEventCache {
         let mut state = self.inner.state.write().await?;
 
         let (stored_prev_batch_token, timeline_event_diffs) =
-            state.handle_sync(timeline, ephemeral_events).await?;
+            state.handle_sync(timeline, read_receipts).await?;
 
         // Now that all events have been added, we can trigger the
         // `pagination_token_notifier`.
@@ -394,7 +386,7 @@ mod timed_tests {
             lazy_loader::from_all_chunks,
         },
         store::StoreConfig,
-        sync::{JoinedRoomUpdate, Timeline},
+        sync::Timeline,
     };
     use matrix_sdk_test::{ALICE, async_test, event_factory::EventFactory};
     use ruma::{
@@ -404,7 +396,10 @@ mod timed_tests {
     };
     use tokio::task::yield_now;
 
-    use super::super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs};
+    use super::{
+        super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs},
+        MaybeReceiptEventContent,
+    };
     use crate::{assert_let_timeout, test_utils::client::MockClientBuilder};
 
     #[async_test]
@@ -453,7 +448,7 @@ mod timed_tests {
         };
 
         thread_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(timeline, MaybeReceiptEventContent::none())
             .await
             .unwrap();
 
@@ -544,7 +539,7 @@ mod timed_tests {
         };
 
         thread_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(timeline, MaybeReceiptEventContent::none())
             .await
             .unwrap();
 
@@ -907,7 +902,7 @@ mod timed_tests {
         let timeline = Timeline { limited: false, prev_batch: None, events: vec![thread_event_1] };
 
         thread_event_cache
-            .handle_joined_room_update(JoinedRoomUpdate { timeline, ..Default::default() })
+            .handle_joined_room_update(timeline, MaybeReceiptEventContent::none())
             .await
             .unwrap();
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -36,6 +36,7 @@ use super::{
         room::RoomEventCacheGenericUpdate,
     },
     ThreadEventCacheInner,
+    updates::ThreadEventCacheUpdate,
 };
 use crate::room::{IncludeRelations, RelationsOptions};
 
@@ -261,7 +262,10 @@ impl PaginatedCache for ThreadEventCacheWrapper {
     ) -> BackPaginationOutcome {
         if !timeline_event_diffs.is_empty() {
             self.cache.update_sender.send(
-                TimelineVectorDiffs { diffs: timeline_event_diffs, origin: EventsOrigin::Cache },
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
+                    diffs: timeline_event_diffs,
+                    origin: EventsOrigin::Cache,
+                }),
                 Some(RoomEventCacheGenericUpdate { room_id: self.cache.room_id.clone() }),
             );
         }
@@ -396,10 +400,10 @@ impl PaginatedCache for ThreadEventCacheWrapper {
 
         if !timeline_event_diffs.is_empty() {
             state.update_sender.send(
-                TimelineVectorDiffs {
+                ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
                     diffs: timeline_event_diffs,
                     origin: EventsOrigin::Pagination,
-                },
+                }),
                 Some(RoomEventCacheGenericUpdate { room_id: state.room_id.clone() }),
             );
         }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -22,18 +22,17 @@ use matrix_sdk_base::{
     linked_chunk::{
         ChunkIdentifierGenerator, LinkedChunkId, OwnedLinkedChunkId, Position, Update, lazy_loader,
     },
-    serde_helpers::{extract_read_receipt, extract_redaction_target},
+    serde_helpers::extract_redaction_target,
     sync::Timeline,
 };
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId,
     events::{
-        AnySyncEphemeralRoomEvent, receipt::ReceiptEventContent, relation::RelationType,
+        receipt::ReceiptEventContent, relation::RelationType,
         room::redaction::SyncRoomRedactionEvent,
     },
     room_version_rules::RoomVersionRules,
-    serde::Raw,
 };
 use tokio::sync::broadcast::Sender;
 use tracing::{debug, error, instrument, trace};
@@ -53,7 +52,9 @@ use super::{
         },
         EventLocation,
         event_linked_chunk::{EventLinkedChunk, sort_positions_descending},
-        read_receipts::{ThreadReadReceiptEventFilter, compute_unread_counts},
+        read_receipts::{
+            MaybeReceiptEventContent, ThreadReadReceiptEventFilter, compute_unread_counts,
+        },
         room::RoomEventCacheLinkedChunkUpdate,
         subscriber::SubscribersHandle,
     },
@@ -457,7 +458,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     pub async fn handle_sync(
         &mut self,
         timeline: Timeline,
-        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        read_receipts: MaybeReceiptEventContent,
     ) -> Result<(bool, Vec<VectorDiff<Event>>)> {
         let prev_batch_token = &timeline.prev_batch;
 
@@ -483,8 +484,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             // unread counts tracking.
             //
             // Post-process the ephemeral events.
-            self.post_process_upserted_events(empty(), extract_read_receipt(&ephemeral_events))
-                .await?;
+            self.post_process_upserted_events(empty(), read_receipts.as_ref()).await?;
 
             return Ok((false, Vec::new()));
         }
@@ -512,8 +512,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         self.state.propagate_changes(&self.store).await?;
 
         // Post-process newly inserted events.
-        self.post_process_upserted_events(events.iter(), extract_read_receipt(&ephemeral_events))
-            .await?;
+        self.post_process_upserted_events(events.iter(), read_receipts.as_ref()).await?;
 
         if timeline.limited && has_new_gap {
             // If there was a previous batch token for a limited timeline, unload the chunks
@@ -533,7 +532,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     pub(super) async fn post_process_upserted_events<'i, I>(
         &mut self,
         events: I,
-        receipt_event: Option<ReceiptEventContent>,
+        receipt_event: Option<&ReceiptEventContent>,
     ) -> Result<()>
     where
         I: Iterator<Item = &'i Event>,
@@ -548,7 +547,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             }
         }
 
-        self.update_read_receipts(receipt_event.as_ref()).await?;
+        self.update_read_receipts(receipt_event).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -458,7 +458,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     pub async fn handle_sync(
         &mut self,
         timeline: Timeline,
-        read_receipts: MaybeReceiptEventContent,
+        read_receipts: &MaybeReceiptEventContent,
     ) -> Result<(bool, Vec<VectorDiff<Event>>)> {
         let prev_batch_token = &timeline.prev_batch;
 

--- a/crates/matrix-sdk/src/event_cache/caches/thread/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/updates.rs
@@ -16,10 +16,17 @@ use tokio::sync::broadcast::{Receiver, Sender};
 
 use super::super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs};
 
+/// An update related to events happened in a thread.
+#[derive(Debug, Clone)]
+pub enum ThreadEventCacheUpdate {
+    /// The thread has received updates for the timeline as _diffs_.
+    UpdateTimelineEvents(TimelineVectorDiffs),
+}
+
 /// A small type to send updates in all channels.
 #[derive(Clone)]
 pub struct ThreadEventCacheUpdateSender {
-    thread_sender: Sender<TimelineVectorDiffs>,
+    thread_sender: Sender<ThreadEventCacheUpdate>,
     generic_sender: Sender<RoomEventCacheGenericUpdate>,
 }
 
@@ -32,7 +39,7 @@ impl ThreadEventCacheUpdateSender {
     /// Send a [`TimelineVectorDiffs`].
     pub fn send(
         &self,
-        thread_update: TimelineVectorDiffs,
+        thread_update: ThreadEventCacheUpdate,
         generic_update: Option<RoomEventCacheGenericUpdate>,
     ) {
         let _ = self.thread_sender.send(thread_update);
@@ -42,8 +49,8 @@ impl ThreadEventCacheUpdateSender {
         }
     }
 
-    /// Create a new [`Receiver`] of [`TimelineVectorDiffs`].
-    pub(super) fn new_thread_receiver(&self) -> Receiver<TimelineVectorDiffs> {
+    /// Create a new [`Receiver`] of [`ThreadEventCacheUpdate`].
+    pub(super) fn new_thread_receiver(&self) -> Receiver<ThreadEventCacheUpdate> {
         self.thread_sender.subscribe()
     }
 }

--- a/crates/matrix-sdk/src/event_cache/caches/thread/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/updates.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ruma::events::receipt::ReceiptEventContent;
 use tokio::sync::broadcast::{Receiver, Sender};
 
 use super::super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs};
@@ -21,6 +22,12 @@ use super::super::{super::RoomEventCacheGenericUpdate, TimelineVectorDiffs};
 pub enum ThreadEventCacheUpdate {
     /// The thread has received updates for the timeline as _diffs_.
     UpdateTimelineEvents(TimelineVectorDiffs),
+
+    /// The thread has received a new read receipt event.
+    AddReadReceiptEvent {
+        /// The event containing the receipts.
+        event: ReceiptEventContent,
+    },
 }
 
 /// A small type to send updates in all channels.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -80,7 +80,7 @@ pub use self::{
             pagination::RoomPagination,
         },
         subscriber::Subscriber,
-        thread::{ThreadEventCache, pagination::ThreadPagination},
+        thread::{ThreadEventCache, ThreadEventCacheUpdate, pagination::ThreadPagination},
     },
 };
 use self::{

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -37,7 +37,7 @@ use super::{
         event_focused::{EventFocusedCacheKey, EventFocusedCacheState},
         pinned_events::PinnedEventsCacheState,
         room::{self, RoomEventCacheState},
-        thread::ThreadEventCacheState,
+        thread::{self, ThreadEventCacheState},
     },
 };
 
@@ -520,10 +520,10 @@ impl<'state> ReloadableStateLockWriteGuard<'state> {
 
                 let updates_as_vector_diffs = thread_state.reload(preprocessing).await?;
                 thread_state.update_sender.send(
-                    TimelineVectorDiffs {
+                    thread::ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
                         diffs: updates_as_vector_diffs,
                         origin: EventsOrigin::Cache,
-                    },
+                    }),
                     Some(room::RoomEventCacheGenericUpdate { room_id: room_id.clone() }),
                 );
             }

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -253,7 +253,7 @@ async fn test_unread_count_pending_receipt() {
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents(..)) = room_cache_updates.recv()
     );
     assert_let_timeout!(
-        Ok(RoomEventCacheUpdate::AddEphemeralEvents { .. }) = room_cache_updates.recv()
+        Ok(RoomEventCacheUpdate::AddReadReceiptEvent { .. }) = room_cache_updates.recv()
     );
 
     // All three events are unread because the receipt target is unknown.
@@ -712,7 +712,7 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
 
     // We get an update only for the read receipt.
     assert_let_timeout!(
-        Ok(RoomEventCacheUpdate::AddEphemeralEvents { .. }) = room_cache_updates.recv()
+        Ok(RoomEventCacheUpdate::AddReadReceiptEvent { .. }) = room_cache_updates.recv()
     );
 
     // The message counts are properly updated (zero new message unread after $2).

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
@@ -8,7 +8,7 @@ use imbl::Vector;
 use matrix_sdk::{
     Client, ThreadingSupport, assert_let_timeout,
     deserialized_responses::TimelineEvent,
-    event_cache::{RoomEventCacheUpdate, Subscriber, TimelineVectorDiffs},
+    event_cache::{RoomEventCacheUpdate, Subscriber, ThreadEventCacheUpdate, TimelineVectorDiffs},
     sleep::sleep,
     test_utils::{
         assert_event_matches_msg,
@@ -32,13 +32,16 @@ use tokio::sync::broadcast;
 /// stabilize.
 async fn wait_for_initial_events(
     mut events: Vec<TimelineEvent>,
-    stream: &mut broadcast::Receiver<TimelineVectorDiffs>,
+    stream: &mut broadcast::Receiver<ThreadEventCacheUpdate>,
 ) -> Vec<TimelineEvent> {
     if events.is_empty() {
         // Wait for a first update.
         let mut vector = Vector::new();
 
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = stream.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                stream.recv()
+        );
 
         for diff in diffs {
             diff.apply(&mut vector);
@@ -118,7 +121,10 @@ async fn test_thread_contains_its_root_event() {
     let outcome = thread_event_cache.pagination().run_backwards_once(42).await.unwrap();
     assert!(outcome.reached_start);
 
-    assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+    assert_let_timeout!(
+        Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+            thread_stream.recv()
+    );
     assert_eq!(diffs.len(), 1);
     assert_let!(VectorDiff::Insert { index: 0, value } = &diffs[0]);
     assert_eq!(value.event_id(), Some(thread_root_id));
@@ -184,7 +190,10 @@ async fn test_ignored_user_empties_threads() {
 
     // We do receive a clear.
     {
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                thread_stream.recv()
+        );
         assert_eq!(diffs.len(), 1);
         assert_let!(VectorDiff::Clear = &diffs[0]);
     }
@@ -205,7 +214,10 @@ async fn test_ignored_user_empties_threads() {
 
     // We do receive the new event.
     {
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                thread_stream.recv()
+        );
         assert_eq!(diffs.len(), 1);
 
         assert_let!(VectorDiff::Append { values: events } = &diffs[0]);
@@ -550,7 +562,10 @@ async fn test_auto_subscribe_on_thread_paginate() {
     assert!(outcome.reached_start);
 
     // Let the event cache process the update.
-    assert_let_timeout!(Ok(TimelineVectorDiffs { .. }) = thread_stream.recv());
+    assert_let_timeout!(
+        Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { .. })) =
+            thread_stream.recv()
+    );
     assert_let_timeout!(Ok(()) = thread_subscriber_updates.recv());
     assert!(thread_subscriber_updates.is_empty());
 }
@@ -633,7 +648,10 @@ async fn test_auto_subscribe_on_thread_paginate_root_event() {
     assert!(outcome.reached_start);
 
     // Let the event cache process the update.
-    assert_let_timeout!(Ok(TimelineVectorDiffs { .. }) = thread_stream.recv());
+    assert_let_timeout!(
+        Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { .. })) =
+            thread_stream.recv()
+    );
     assert_let_timeout!(Ok(()) = thread_subscriber_updates.recv());
 }
 
@@ -741,7 +759,10 @@ async fn test_redact_touches_threads() {
     // - the redaction event is added to the “timeline”,
     // - the redaction's target is, well, redacted.
     {
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                thread_stream.recv()
+        );
         assert_eq!(diffs.len(), 2);
 
         // The redaction event is appended to the thread cache.
@@ -815,7 +836,10 @@ async fn test_redact_touches_threads() {
     // - the redaction event is added to the “timeline”,
     // - the redaction's target is, well, redacted.
     {
-        assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+        assert_let_timeout!(
+            Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
+                thread_stream.recv()
+        );
         assert_eq!(diffs.len(), 2);
 
         // The redaction event is appended to the thread cache.
@@ -969,7 +993,12 @@ async fn test_edits_touches_threads() {
     {
         // First update.
         {
-            assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+            assert_let_timeout!(
+                Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
+                    diffs,
+                    ..
+                })) = thread_stream.recv()
+            );
             assert_eq!(diffs.len(), 1);
 
             // Oh, an edit event.
@@ -1040,7 +1069,12 @@ async fn test_edits_touches_threads() {
     {
         // First update.
         {
-            assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = thread_stream.recv());
+            assert_let_timeout!(
+                Ok(ThreadEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
+                    diffs,
+                    ..
+                })) = thread_stream.recv()
+            );
             assert_eq!(diffs.len(), 1);
 
             // Oh, an edit event.

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
@@ -24,8 +24,6 @@
 //! This avoids potential race conditions where a sync could be done, but the
 //! processing by the event cache isn't, at the time we check the unread counts.
 
-use std::time::Duration;
-
 use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
@@ -37,7 +35,6 @@ use ruma::{
     },
     room_id,
 };
-use tokio::time::sleep;
 
 /// Test that the unread count increases when new messages arrive and no read
 /// receipt is known.
@@ -245,9 +242,7 @@ async fn test_unread_count_receipt_only_no_new_message() {
         )
         .await;
 
-    // Can't wait on `thread_updates` because there is no update “read receipt
-    // update” for threads.
-    sleep(Duration::from_millis(100)).await;
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
 
     // Only ev3 (after the receipt) is unread now.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
@@ -368,7 +363,6 @@ async fn test_unread_count_accumulates_across_syncs() {
         .await;
 
     assert_let_timeout!(Ok(_) = thread_updates.recv());
-
     assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
 
     // Second sync: one more message, still no receipt.
@@ -403,6 +397,7 @@ async fn test_state_event_does_not_increment_unread() {
 
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
+    let mut generic_room_updates = event_cache.subscribe_to_room_generic_updates();
 
     server
         .sync_room(
@@ -416,8 +411,7 @@ async fn test_state_event_does_not_increment_unread() {
         )
         .await;
 
-    sleep(Duration::from_millis(100)).await;
-
+    assert_let_timeout!(Ok(_) = generic_room_updates.recv());
     assert_eq!(thread.num_unread_messages().await.unwrap(), 0);
 }
 
@@ -643,10 +637,7 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
         )
         .await;
 
-    // We don't get an update about the read receipt (because threads can't do
-    // that), and we don't get an update about new event because it's been
-    // deduplicated. So. Just wait a little bit :-].
-    sleep(Duration::from_millis(100)).await;
+    assert_let_timeout!(Ok(_) = thread_updates.recv());
 
     // The message counts are properly updated (zero new message unread after $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 0);

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
@@ -24,7 +24,9 @@
 //! This avoids potential race conditions where a sync could be done, but the
 //! processing by the event cache isn't, at the time we check the unread counts.
 
-use matrix_sdk::{assert_let_timeout, test_utils::mocks::MatrixMockServer};
+use std::time::Duration;
+
+use matrix_sdk::{assert_let_timeout, sleep::sleep, test_utils::mocks::MatrixMockServer};
 use matrix_sdk_test::{ALICE, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
     event_id,
@@ -323,6 +325,9 @@ async fn test_unread_count_pending_receipt() {
 
     assert_let_timeout!(Ok(_) = thread_updates.recv());
 
+    // Fix a bit of flakiness in some configuration.
+    sleep(Duration::from_millis(100)).await;
+
     // The pending receipt resolves: only ev4 (after $future) is unread.
     let read_receipts = thread.read_receipts().await.unwrap();
     assert_eq!(read_receipts.num_unread, 1);
@@ -569,6 +574,9 @@ async fn test_compute_unread_counts_considers_active_receipt() {
         .await;
 
     assert_let_timeout!(Ok(_) = thread_updates.recv());
+
+    // Fix a bit of flakiness in some configuration.
+    sleep(Duration::from_millis(100)).await;
 
     // The message counts are properly updated (two messages after $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 2);


### PR DESCRIPTION
This patch solves two problems at once.

First, an ephemeral event was at least deserialised 3 times in the best-case. This is a waste of resources. Second, this patch fixes a bug with ephemeral events. Imagine the sync contains two ephemeral events: one for the `Main` timeline, and one for the `Thread("!t0")` timeline. The `extract_read_receipt` helper function was used to deserialised the ephemeral events, and as soon as a read receipt was found, it was returned. Problem: which one is correct? For `RoomEventCache`, it is the `Main` one, for `ThreadEventCache`, it is the `Thread` one. It sounds obvious here, but this is not what the code was doing. Until now.

Please read one commit at a time. Changes are rather small and straightforward, but tests must be updated because some types have changed.

This patch introduces the `MaybeReceiptEventContent` type, and the `ThreadEventCacheUpdate` type (finally!). The rest is refactoring and bug fixing. The `extract_read_receipt` function is deleted at the end.

---

- Fix https://github.com/matrix-org/matrix-rust-sdk/issues/6916
- Fix https://github.com/matrix-org/matrix-rust-sdk/issues/6917
- Built on top of https://github.com/matrix-org/matrix-rust-sdk/pull/6926

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
