### PR TITLE
Bench Ruma's `ThinArc` internal storage representations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,9 @@ crates-io = "https://docs.rs/"
 [unstable]
 rustdoc-map = true
 
+[target.'cfg(all())']
+rustflags = ["--cfg", "ruma_identifiers_storage=\"ThinArc\""]
+
 [target.aarch64-linux-android]
 # These rust flags improve the performance on Android on arm64
 rustflags = ["-C", "target-feature=+neon,+aes,+sha2,+pmuv3"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,7 @@ crates-io = "https://docs.rs/"
 rustdoc-map = true
 
 [target.'cfg(all())']
-rustflags = ["--cfg", "ruma_identifiers_storage=\"ThinArc\""]
+rustflags = ["--cfg", "ruma_identifiers_storage=\"SmallVec\""]
 
 [target.aarch64-linux-android]
 # These rust flags improve the performance on Android on arm64

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -96,8 +96,15 @@ jobs:
       - name: Build the benchmark target(s)
         run: cargo codspeed build -p benchmarks --bench ${{ matrix.benchmark }} --features codspeed
 
-      - name: Run the benchmarks
+      - name: Run the benchmarks in simulation mode
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8
         with:
           run: cargo codspeed run
           mode: simulation
+
+      - name: Run the benchmarks in memory mode
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8
+        if: ${{ matrix.benchmark != 'timeline' }} # The benchmark fails an assertion, maybe due to it being slower?
+        with:
+          run: cargo codspeed run
+          mode: memory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,30 +2564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "assign",
  "js_int",
@@ -5410,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "as_variant",
  "assign",
@@ -5432,10 +5408,10 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "as_variant",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "date_header",
  "form_urlencoded",
@@ -5465,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5489,9 +5465,8 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
- "headers",
  "http",
  "http-auth",
  "httparse",
@@ -5510,7 +5485,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5521,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5530,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5546,9 +5521,9 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "ed25519-dalek",
  "pkcs8",
  "rand 0.10.2",
@@ -6040,17 +6015,6 @@ checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5368,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "assign",
  "js_int",
@@ -5386,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "as_variant",
  "assign",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "as_variant",
  "base64 0.23.0",
@@ -5428,6 +5428,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "smallvec",
  "thiserror 2.0.19",
  "time",
  "tracing",
@@ -5441,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5465,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "http",
  "http-auth",
@@ -5485,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5496,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5505,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5521,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/ruma/ruma?rev=cc6645b98e8a635460eac170ace9fef5b4a59d20#cc6645b98e8a635460eac170ace9fef5b4a59d20"
+source = "git+https://github.com/ruma/ruma?rev=894c7c1d15f9ecfee1d2d109500100e39515cea3#894c7c1d15f9ecfee1d2d109500100e39515cea3"
 dependencies = [
  "base64 0.23.0",
  "ed25519-dalek",
@@ -6150,9 +6151,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.1", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0af525f726717fd", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "cc6645b98e8a635460eac170ace9fef5b4a59d20", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -252,8 +252,3 @@ lto = false
 [patch.crates-io]
 async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27c8b290f1f1dcfc0c4ec22c464e38528aa591" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
-
-[patch."https://github.com/ruma/ruma"]
-# Needed to disable checksums since they're incorrect in 32bit devices.
-# Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "bf21677a8fcba04fd01e341809eb5991908441a2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.1", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "cc6645b98e8a635460eac170ace9fef5b4a59d20", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "894c7c1d15f9ecfee1d2d109500100e39515cea3", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -95,7 +95,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "cc6645b98e8a635460eac170ac
     "unstable-msc4308",
     "unstable-msc4310",
     "unstable-msc4388",
-    "triomphe",
+    "smallvec",
 ] }
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "cc6645b98e8a635460eac170ac
     "unstable-msc4308",
     "unstable-msc4310",
     "unstable-msc4388",
+    "triomphe",
 ] }
 sentry = { version = "0.49.0", default-features = false }
 sentry-tracing = { version = "0.49.0", default-features = false }


### PR DESCRIPTION
Don't mind me, just using the CI to run benchmarks for a new internal storage representation.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

