### PR TITLE
Test possible upcoming Ruma change merging `*EventContent` types for state events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,30 +2564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "assign",
  "js_int",
@@ -5410,7 +5386,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "as_variant",
  "assign",
@@ -5432,10 +5408,10 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "as_variant",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "date_header",
  "form_urlencoded",
@@ -5465,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -5489,9 +5465,8 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.15.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
- "headers",
  "http",
  "http-auth",
  "httparse",
@@ -5510,7 +5485,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5521,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "js_int",
  "thiserror 2.0.19",
@@ -5530,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -5546,9 +5521,9 @@ dependencies = [
 [[package]]
 name = "ruma-signatures"
 version = "0.21.0"
-source = "git+https://github.com/matrix-org/ruma?rev=bf21677a8fcba04fd01e341809eb5991908441a2#bf21677a8fcba04fd01e341809eb5991908441a2"
+source = "git+https://github.com/ruma/ruma?rev=c1d878112f4de4da96e26defefbcdfff97f9153c#c1d878112f4de4da96e26defefbcdfff97f9153c"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "ed25519-dalek",
  "pkcs8",
  "rand 0.10.2",
@@ -6040,17 +6015,6 @@ checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rcgen = { version = "0.14.8", default-features = false }
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 reqwest = { version = "0.13.1", default-features = false }
 rmp-serde = { version = "1.3.1", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "0908aaa9847093ecb32bc6edf0af525f726717fd", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "c1d878112f4de4da96e26defefbcdfff97f9153c", features = [
     "client-api-c",
     "compat-unset-avatar",
     "compat-upload-signatures",
@@ -252,8 +252,3 @@ lto = false
 [patch.crates-io]
 async-compat = { git = "https://github.com/element-hq/async-compat", rev = "5a27c8b290f1f1dcfc0c4ec22c464e38528aa591" }
 const_panic = { git = "https://github.com/jplatte/const_panic", rev = "e0b317a9a7bde2d48a7d15b6a60d70e4a41d3b5f" }
-
-[patch."https://github.com/ruma/ruma"]
-# Needed to disable checksums since they're incorrect in 32bit devices.
-# Delete this once https://github.com/mozilla/uniffi-rs/issues/2939 is fixed.
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "bf21677a8fcba04fd01e341809eb5991908441a2" }

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -354,7 +354,9 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
             AnySyncStateEvent::RoomTopic(content) => {
                 let content = get_state_event_original_content(content)?;
 
-                StateEventContent::RoomTopic { topic: content.topic }
+                StateEventContent::RoomTopic {
+                    topic: content.topic.context("Failed to get topic")?,
+                }
             }
             AnySyncStateEvent::SpaceChild(_) => StateEventContent::SpaceChild,
             AnySyncStateEvent::SpaceParent(_) => StateEventContent::SpaceParent,

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -338,7 +338,7 @@ impl TryFrom<AnySyncStateEvent> for StateEventContent {
             AnySyncStateEvent::RoomHistoryVisibility(_) => StateEventContent::RoomHistoryVisibility,
             AnySyncStateEvent::RoomJoinRules(_) => StateEventContent::RoomJoinRules,
             AnySyncStateEvent::RoomMember(content) => {
-                let state_key = content.state_key().to_string();
+                let state_key = content.state_key.to_string();
                 let original_content = get_state_event_original_content(content)?;
                 StateEventContent::RoomMemberContent {
                     user_id: state_key,

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -20,8 +20,8 @@ use ruma::{
     events::{
         AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent,
         MessageLikeEventContent as RumaMessageLikeEventContent, MessageLikeEventType,
-        RedactContent, RedactedStateEventContent, StateEventType, StaticStateEventContent,
-        SyncMessageLikeEvent, SyncStateEvent, TimelineEventType as RumaTimelineEventType,
+        RedactContent, StateEventType, StaticStateEventContent, SyncMessageLikeEvent,
+        SyncStateEvent, TimelineEventType as RumaTimelineEventType,
         room::{
             encrypted,
             message::{MessageType as RumaMessageType, Relation},
@@ -499,11 +499,8 @@ impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
 fn get_state_event_original_content<C>(event: SyncStateEvent<C>) -> anyhow::Result<C>
 where
     C: StaticStateEventContent + RedactContent + Clone,
-    <C as RedactContent>::Redacted: RedactedStateEventContent<StateKey = C::StateKey>,
 {
-    let original_content =
-        event.as_original().context("Failed to get original content")?.content.clone();
-    Ok(original_content)
+    Ok(event.content.clone())
 }
 
 fn get_message_like_event_original_content<C>(event: SyncMessageLikeEvent<C>) -> anyhow::Result<C>

--- a/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
+++ b/bindings/matrix-sdk-ffi/src/live_locations_observer.rs
@@ -135,7 +135,7 @@ impl LiveLocationsObserver {
 impl From<SdkLiveLocationShare> for LiveLocationShare {
     fn from(share: SdkLiveLocationShare) -> Self {
         let beacon_id = share.beacon_id.into();
-        let start_ts = share.beacon_info.ts.0.into();
+        let start_ts = share.beacon_info.ts.unwrap().0.into();
         let timeout = share.beacon_info.timeout.as_millis() as u64;
         let asset = share.beacon_info.asset.type_.into();
         let last_location = share.last_location.map(|l| LastLocation {

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -17,9 +17,7 @@ use std::collections::HashMap;
 use matrix_sdk::room::power_levels::power_level_user_changes;
 use matrix_sdk_base::CallIntentConsensus;
 use matrix_sdk_ui::timeline::RoomPinnedEventsChange;
-use ruma::events::{
-    StateEventContentChange, room::history_visibility::HistoryVisibility as RumaHistoryVisibility,
-};
+use ruma::events::room::history_visibility::HistoryVisibility as RumaHistoryVisibility;
 
 use crate::{
     client::JoinRule, event::FfiTimelineEventType, ruma::AssetType,
@@ -67,10 +65,7 @@ impl From<matrix_sdk_ui::timeline::TimelineItemContent> for TimelineItemContent 
                     .map(|it| it.0.into()),
             },
             Content::MembershipChange(membership) => {
-                let reason = match membership.content() {
-                    StateEventContentChange::Original { content, .. } => content.reason.clone(),
-                    _ => None,
-                };
+                let reason = membership.content().content.reason.clone();
                 TimelineItemContent::RoomMembership {
                     user_id: membership.user_id().to_string(),
                     user_display_name: membership.display_name(),
@@ -393,37 +388,17 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
             Content::PolicyRuleServer(_) => Self::PolicyRuleServer,
             Content::PolicyRuleUser(_) => Self::PolicyRuleUser,
             Content::RoomAvatar(c) => {
-                let url = match c {
-                    FullContent::Original { content, .. } => {
-                        content.url.as_ref().map(ToString::to_string)
-                    }
-                    FullContent::Redacted(_) => None,
-                };
-                Self::RoomAvatar { url }
+                Self::RoomAvatar { url: c.content.url.as_ref().map(ToString::to_string) }
             }
             Content::RoomCanonicalAlias(_) => Self::RoomCanonicalAlias,
-            Content::RoomCreate(c) => {
-                let federate = match c {
-                    FullContent::Original { content, .. } => content.federate,
-                    FullContent::Redacted(content) => content.federate,
-                };
-                Self::RoomCreate { federate }
-            }
+            Content::RoomCreate(c) => Self::RoomCreate { federate: c.content.federate },
             Content::RoomEncryption(_) => Self::RoomEncryption,
             Content::RoomGuestAccess(_) => Self::RoomGuestAccess,
-            Content::RoomHistoryVisibility(c) => {
-                let history_visibility = match c {
-                    FullContent::Original { content, .. } => &content.history_visibility,
-                    FullContent::Redacted(content) => &content.history_visibility,
-                };
-                Self::RoomHistoryVisibility { history_visibility: history_visibility.into() }
-            }
+            Content::RoomHistoryVisibility(c) => Self::RoomHistoryVisibility {
+                history_visibility: (&c.content.history_visibility).into(),
+            },
             Content::RoomJoinRules(c) => {
-                let ruma_join_rule = match c {
-                    FullContent::Original { content, .. } => &content.join_rule,
-                    FullContent::Redacted(content) => &content.join_rule,
-                };
-                let join_rule = match ruma_join_rule.clone().try_into() {
+                let join_rule = match c.content.join_rule.clone().try_into() {
                     Ok(jr) => Some(jr),
                     Err(err) => {
                         tracing::error!("Failed to convert join rule: {}", err);
@@ -432,19 +407,10 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
                 };
                 Self::RoomJoinRules { join_rule }
             }
-            Content::RoomName(c) => {
-                let name = match c {
-                    FullContent::Original { content, .. } => Some(content.name.clone()),
-                    FullContent::Redacted(_) => None,
-                };
-                Self::RoomName { name }
-            }
+            Content::RoomName(c) => Self::RoomName { name: c.content.name.clone() },
             Content::RoomPinnedEvents(c) => Self::RoomPinnedEvents { change: c.into() },
             Content::RoomPowerLevels(c) => {
-                let (content, prev_content) = match c.clone() {
-                    FullContent::Original { content, prev_content } => (content, prev_content),
-                    FullContent::Redacted(content) => (content.into(), None),
-                };
+                let FullContent { content, prev_content } = c.clone();
 
                 Self::RoomPowerLevels {
                     events: content
@@ -492,20 +458,10 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherStateEventContentChange> for OtherSt
             }
             Content::RoomServerAcl(_) => Self::RoomServerAcl,
             Content::RoomThirdPartyInvite(c) => {
-                let display_name = match c {
-                    FullContent::Original { content, .. } => Some(content.display_name.clone()),
-                    FullContent::Redacted(_) => None,
-                };
-                Self::RoomThirdPartyInvite { display_name }
+                Self::RoomThirdPartyInvite { display_name: c.content.display_name.clone() }
             }
             Content::RoomTombstone(_) => Self::RoomTombstone,
-            Content::RoomTopic(c) => {
-                let topic = match c {
-                    FullContent::Original { content, .. } => Some(content.topic.clone()),
-                    FullContent::Redacted(_) => None,
-                };
-                Self::RoomTopic { topic }
-            }
+            Content::RoomTopic(c) => Self::RoomTopic { topic: c.content.topic.clone() },
             Content::SpaceChild(_) => Self::SpaceChild,
             Content::SpaceParent(_) => Self::SpaceParent,
             Content::_Custom { event_type, .. } => Self::Custom { event_type: event_type.clone() },

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -41,7 +41,7 @@ use ruma::{
     OwnedRoomId, OwnedUserId, RoomId, UserId,
     api::client::{self as api, sync::sync_events::v5},
     events::{
-        StateEvent, StateEventType,
+        StateEventType,
         ignored_user_list::IgnoredUserListEventContent,
         push_rules::{PushRulesEvent, PushRulesEventContent},
         room::member::SyncRoomMemberEvent,
@@ -917,19 +917,19 @@ impl BaseClient {
             // See <https://github.com/matrix-org/matrix-rust-sdk/issues/1205>.
 
             #[cfg(feature = "e2e-encryption")]
-            match member.membership() {
+            match member.content.membership {
                 MembershipState::Join | MembershipState::Invite => {
-                    user_ids.insert(member.state_key().to_owned());
+                    user_ids.insert(member.state_key.clone());
                 }
                 _ => (),
             }
 
-            if let StateEvent::Original(e) = &member
-                && is_member_active(&e.content.membership)
-                && let Some(d) = &e.content.displayname
+            if !member.is_redacted()
+                && is_member_active(&member.content.membership)
+                && let Some(d) = &member.content.displayname
             {
                 let display_name = DisplayName::new(d);
-                ambiguity_map.entry(display_name).or_default().insert(member.state_key().clone());
+                ambiguity_map.entry(display_name).or_default().insert(member.state_key.clone());
             }
 
             let sync_member: SyncRoomMemberEvent = member.clone().into();
@@ -942,7 +942,7 @@ impl BaseClient {
                 .or_default()
                 .entry(member.event_type())
                 .or_default()
-                .insert(member.state_key().to_string(), raw_event.clone().cast());
+                .insert(member.state_key.to_string(), raw_event.clone().cast());
             chunk.push(member);
         }
 
@@ -1064,7 +1064,7 @@ impl BaseClient {
 
                 let members = self.state_store.get_user_ids(room_id, filter).await?;
 
-                let Some(settings) = EncryptionSettings::from_possibly_redacted(
+                let Some(settings) = EncryptionSettings::new(
                     room_encryption_event,
                     history_visibility,
                     self.room_key_recipient_strategy.clone(),

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -14,7 +14,7 @@
 
 //! SDK-specific variations of response types from Ruma.
 
-use std::{collections::BTreeMap, fmt, hash::Hash, iter, sync::LazyLock};
+use std::{collections::BTreeMap, hash::Hash, iter, sync::LazyLock};
 
 pub use matrix_sdk_common::deserialized_responses::*;
 use regex::Regex;
@@ -23,8 +23,7 @@ use ruma::{
     UserId,
     events::{
         AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
-        RedactContent, StateEventContent, StaticStateEventContent, StrippedStateEvent,
-        SyncStateEvent,
+        StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
         room::{
             member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
@@ -301,7 +300,7 @@ impl RawAnySyncOrStrippedState {
     /// without changing the underlying JSON.
     pub fn cast<C>(self) -> RawSyncOrStrippedState<C>
     where
-        C: StaticStateEventContent + RedactContent,
+        C: StaticStateEventContent,
     {
         match self {
             Self::Sync(raw) => RawSyncOrStrippedState::Sync(raw.cast_unchecked()),
@@ -413,7 +412,7 @@ where
     /// The sender of this event.
     pub fn sender(&self) -> &UserId {
         match self {
-            Self::Sync(e) => e.sender(),
+            Self::Sync(e) => &e.sender,
             Self::Stripped(e) => &e.sender,
         }
     }
@@ -421,7 +420,7 @@ where
     /// The ID of this event.
     pub fn event_id(&self) -> Option<&EventId> {
         match self {
-            Self::Sync(e) => Some(e.event_id()),
+            Self::Sync(e) => Some(&e.event_id),
             Self::Stripped(_) => None,
         }
     }
@@ -429,7 +428,7 @@ where
     /// The server timestamp of this event.
     pub fn origin_server_ts(&self) -> Option<MilliSecondsSinceUnixEpoch> {
         match self {
-            Self::Sync(e) => Some(e.origin_server_ts()),
+            Self::Sync(e) => Some(e.origin_server_ts),
             Self::Stripped(_) => None,
         }
     }
@@ -437,7 +436,7 @@ where
     /// The state key associated to this state event.
     pub fn state_key(&self) -> &C::StateKey {
         match self {
-            Self::Sync(e) => e.state_key(),
+            Self::Sync(e) => &e.state_key,
             Self::Stripped(e) => &e.state_key,
         }
     }

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -23,8 +23,8 @@ use ruma::{
     UserId,
     events::{
         AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
-        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
-        StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
+        RedactContent, StateEventContent, StaticStateEventContent, StrippedStateEvent,
+        SyncStateEvent,
         room::{
             member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
@@ -302,7 +302,6 @@ impl RawAnySyncOrStrippedState {
     pub fn cast<C>(self) -> RawSyncOrStrippedState<C>
     where
         C: StaticStateEventContent + RedactContent,
-        C::Redacted: RedactedStateEventContent,
     {
         match self {
             Self::Sync(raw) => RawSyncOrStrippedState::Sync(raw.cast_unchecked()),
@@ -351,26 +350,22 @@ impl AnySyncOrStrippedState {
 #[serde(untagged)]
 pub enum RawSyncOrStrippedState<C>
 where
-    C: StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent,
+    C: StaticStateEventContent,
 {
     /// An event from a room in joined or left state.
     Sync(Raw<SyncStateEvent<C>>),
     /// An event from a room in invited state.
-    Stripped(Raw<StrippedStateEvent<C::PossiblyRedacted>>),
+    Stripped(Raw<StrippedStateEvent<C>>),
 }
 
 impl<C> RawSyncOrStrippedState<C>
 where
-    C: StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent + fmt::Debug + Clone,
+    C: StaticStateEventContent,
 {
     /// Try to deserialize the inner JSON as the expected type.
     pub fn deserialize(&self) -> serde_json::Result<SyncOrStrippedState<C>>
     where
-        C: StaticStateEventContent + EventContentFromType + RedactContent,
-        C::Redacted: RedactedStateEventContent<StateKey = C::StateKey> + EventContentFromType,
-        C::PossiblyRedacted: PossiblyRedactedStateEventContent + EventContentFromType,
+        C: StaticStateEventContent + EventContentFromType,
     {
         match self {
             Self::Sync(ev) => Ok(SyncOrStrippedState::Sync(ev.deserialize()?)),
@@ -386,20 +381,17 @@ pub type RawMemberEvent = RawSyncOrStrippedState<RoomMemberEventContent>;
 #[derive(Clone, Debug)]
 pub enum SyncOrStrippedState<C>
 where
-    C: StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent + fmt::Debug + Clone,
+    C: StaticStateEventContent,
 {
     /// An event from a room in joined or left state.
     Sync(SyncStateEvent<C>),
     /// An event from a room in invited state.
-    Stripped(StrippedStateEvent<C::PossiblyRedacted>),
+    Stripped(StrippedStateEvent<C>),
 }
 
 impl<C> SyncOrStrippedState<C>
 where
-    C: StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent<StateKey = C::StateKey> + fmt::Debug + Clone,
-    C::PossiblyRedacted: PossiblyRedactedStateEventContent<StateKey = C::StateKey>,
+    C: StaticStateEventContent,
 {
     /// If this is a `SyncStateEvent`, return a reference to the inner event.
     pub fn as_sync(&self) -> Option<&SyncStateEvent<C>> {
@@ -411,7 +403,7 @@ where
 
     /// If this is a `StrippedStateEvent`, return a reference to the inner
     /// event.
-    pub fn as_stripped(&self) -> Option<&StrippedStateEvent<C::PossiblyRedacted>> {
+    pub fn as_stripped(&self) -> Option<&StrippedStateEvent<C>> {
         match self {
             Self::Sync(_) => None,
             Self::Stripped(ev) => Some(ev),
@@ -449,22 +441,12 @@ where
             Self::Stripped(e) => &e.state_key,
         }
     }
-}
 
-impl<C> SyncOrStrippedState<C>
-where
-    C: StaticStateEventContent<PossiblyRedacted = C>
-        + RedactContent
-        + PossiblyRedactedStateEventContent,
-    C::Redacted: RedactedStateEventContent<StateKey = <C as StateEventContent>::StateKey>
-        + fmt::Debug
-        + Clone,
-{
     /// The inner content of the wrapped event.
-    pub fn original_content(&self) -> Option<&C> {
+    pub fn content(&self) -> &C {
         match self {
-            Self::Sync(e) => e.as_original().map(|e| &e.content),
-            Self::Stripped(e) => Some(&e.content),
+            Self::Sync(e) => &e.content,
+            Self::Stripped(e) => &e.content,
         }
     }
 }
@@ -475,10 +457,7 @@ pub type MemberEvent = SyncOrStrippedState<RoomMemberEventContent>;
 impl MemberEvent {
     /// The membership state of the user.
     pub fn membership(&self) -> &MembershipState {
-        match self {
-            MemberEvent::Sync(e) => e.membership(),
-            MemberEvent::Stripped(e) => &e.content.membership,
-        }
+        &self.content().membership
     }
 
     /// The user id associated to this member event.
@@ -491,10 +470,7 @@ impl MemberEvent {
     /// [`MemberEvent::display_name()`] should be preferred to get the name to
     /// display for this member event.
     pub fn displayname_value(&self) -> Option<&str> {
-        match self {
-            Self::Sync(event) => event.as_original()?.content.displayname.as_deref(),
-            Self::Stripped(event) => event.content.displayname.as_deref(),
-        }
+        self.content().displayname.as_deref()
     }
 
     /// The name that should be displayed for this member event.
@@ -510,25 +486,18 @@ impl MemberEvent {
     /// [`MemberEvent::display_name()`] should be preferred to get the name to
     /// display for this member event.
     pub fn avatar_url(&self) -> Option<&MxcUri> {
-        match self {
-            Self::Sync(event) => event.as_original()?.content.avatar_url.as_deref(),
-            Self::Stripped(event) => event.content.avatar_url.as_deref(),
-        }
+        self.content().avatar_url.as_deref()
     }
 
     /// The optional reason why the membership changed.
     pub fn reason(&self) -> Option<&str> {
-        match self {
-            MemberEvent::Sync(SyncStateEvent::Original(c)) => c.content.reason.as_deref(),
-            MemberEvent::Stripped(e) => e.content.reason.as_deref(),
-            _ => None,
-        }
+        self.content().reason.as_deref()
     }
 
     /// The optional timestamp for this member event.
     pub fn timestamp(&self) -> Option<UInt> {
         match self {
-            MemberEvent::Sync(SyncStateEvent::Original(c)) => Some(c.origin_server_ts.0),
+            MemberEvent::Sync(ev) => Some(ev.origin_server_ts.0),
             _ => None,
         }
     }

--- a/crates/matrix-sdk-base/src/response_processors/profiles.rs
+++ b/crates/matrix-sdk-base/src/response_processors/profiles.rs
@@ -35,16 +35,16 @@ pub fn upsert_or_delete(
     // We don't want to update the profile if the member is leaving the room, as the
     // server may return a dummy empty profile along the leave event. We want to
     // keep the last known profile in that case.
-    if event.state_key() == event.sender() && *event.membership() != MembershipState::Leave {
+    if event.state_key == event.sender && event.content.membership != MembershipState::Leave {
         context
             .state_changes
             .profiles
             .entry(room_id.to_owned())
             .or_default()
-            .insert(event.sender().to_owned(), event.into());
+            .insert(event.sender.clone(), event.into());
     }
 
-    if matches!(*event.membership(), MembershipState::Invite | MembershipState::Ban) {
+    if matches!(event.content.membership, MembershipState::Invite | MembershipState::Ban) {
         // Remove any profile previously stored for the invited/banned user.
         //
         // A room member could have joined the room and left it later; in that case, the
@@ -56,13 +56,13 @@ pub fn upsert_or_delete(
             .profiles_to_delete
             .entry(room_id.to_owned())
             .or_default()
-            .push(event.state_key().clone());
+            .push(event.state_key.clone());
 
         // Address the edge case of "in-flight" profiles. If an earlier event in
         // this same sync batch inserted a profile (for example user joined then got
         // banned by an admin of a room), we MUST NOT reinsert it.
         if let Some(room_profiles) = context.state_changes.profiles.get_mut(room_id) {
-            room_profiles.remove(event.state_key());
+            room_profiles.remove(&event.state_key);
         }
     }
 }

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -15,11 +15,7 @@
 use std::collections::BTreeSet;
 
 use as_variant::as_variant;
-use ruma::{
-    RoomId,
-    events::{AnySyncStateEvent, SyncStateEvent},
-    serde::Raw,
-};
+use ruma::{RoomId, events::AnySyncStateEvent, serde::Raw};
 use tracing::error;
 
 use super::Context;
@@ -196,9 +192,9 @@ pub mod sync {
         ambiguity_cache.handle_event(&context.state_changes, room_id, event).await?;
         avatar_cache.handle_event(&context.state_changes, room_id, event).await?;
 
-        match event.membership() {
+        match event.content.membership {
             MembershipState::Join | MembershipState::Invite => {
-                new_users.insert(event.state_key());
+                new_users.insert(&event.state_key);
             }
             _ => (),
         }
@@ -249,7 +245,7 @@ pub mod sync {
                 None
             }
         }) {
-            let new_state: RoomState = member.membership().into();
+            let new_state = RoomState::from(&member.content.membership);
 
             if new_state != room_info.state() {
                 room_info.set_state(new_state);
@@ -402,14 +398,8 @@ pub fn validate_create_event_predecessor(
         return;
     };
 
-    // Redacted and non-redacted create events use the same content type.
-    let content = match event {
-        SyncStateEvent::Original(event) => &event.content,
-        SyncStateEvent::Redacted(event) => &event.content,
-    };
-
     let Some(mut predecessor_room_id) =
-        content.predecessor.as_ref().map(|predecessor| predecessor.room_id.clone())
+        event.content.predecessor.as_ref().map(|predecessor| predecessor.room_id.clone())
     else {
         // No predecessor = no problem here.
         return;
@@ -423,11 +413,7 @@ pub fn validate_create_event_predecessor(
             // Ahhh, there is a loop with `m.room.create` events!
             // We remove the predecessor so that we don't process it later.
             let mut event = event.clone();
-
-            match &mut event {
-                SyncStateEvent::Original(event) => event.content.predecessor.take(),
-                SyncStateEvent::Redacted(event) => event.content.predecessor.take(),
-            };
+            event.content.predecessor.take();
 
             raw_event.set_cached_event(event.into());
 
@@ -469,18 +455,21 @@ pub fn is_tombstone_event_valid(
 
     let Some(tombstone) = raw_event
         .deserialize_as(|any_event| as_variant!(any_event, AnySyncStateEvent::RoomTombstone))
-        .and_then(|event| Some(&event.as_original()?.content))
+        .map(|event| &event.content)
     else {
         // `true` means no problem. No successor = no problem here.
         return true;
     };
 
-    let mut successor_room_id = tombstone.replacement_room.clone();
+    let Some(mut successor_room_id) = tombstone.replacement_room.clone() else {
+        // `true` means no problem. No successor = no problem here.
+        return true;
+    };
 
     loop {
         // We must check immediately if the `successor_room_id` is in `already_seen` in
         // case of a room is created and tombstones itself in a single sync.
-        if already_seen.contains(AsRef::<RoomId>::as_ref(&successor_room_id)) {
+        if already_seen.contains(&successor_room_id) {
             // Ahhh, there is a loop with `m.room.tombstone` events!
             error!(?room_id, ?tombstone, "`m.room.tombstone` event is invalid, it creates a loop");
             return false;

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -16,8 +16,7 @@ use matrix_sdk_common::ROOM_VERSION_RULES_FALLBACK;
 use ruma::{
     OwnedUserId, RoomVersionId, assign,
     events::{
-        EmptyStateKey, PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
-        StateEventContent, StateEventType, StaticEventContent,
+        EmptyStateKey, RedactContent, StateEventContent, StateEventType, StaticEventContent,
         macros::EventContent,
         room::create::{PreviousRoom, RoomCreateEventContent},
     },
@@ -132,19 +131,8 @@ impl RoomCreateWithCreatorEventContent {
     }
 }
 
-/// Redacted form of [`RoomCreateWithCreatorEventContent`].
-pub type RedactedRoomCreateWithCreatorEventContent = RoomCreateWithCreatorEventContent;
-
-impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
-    type StateKey = <RoomCreateWithCreatorEventContent as StateEventContent>::StateKey;
-
-    fn event_type(&self) -> StateEventType {
-        RoomCreateWithCreatorEventContent::TYPE.into()
-    }
-}
-
 impl RedactContent for RoomCreateWithCreatorEventContent {
-    type Redacted = RedactedRoomCreateWithCreatorEventContent;
+    type Redacted = Self;
 
     fn redact(self, rules: &RedactionRules) -> Self::Redacted {
         let (content, sender) = self.into_event_content();
@@ -156,12 +144,4 @@ impl RedactContent for RoomCreateWithCreatorEventContent {
 
 fn default_create_room_version_id() -> RoomVersionId {
     RoomVersionId::V1
-}
-
-impl PossiblyRedactedStateEventContent for RoomCreateWithCreatorEventContent {
-    type StateKey = <RoomCreateWithCreatorEventContent as StateEventContent>::StateKey;
-
-    fn event_type(&self) -> StateEventType {
-        RoomCreateWithCreatorEventContent::TYPE.into()
-    }
 }

--- a/crates/matrix-sdk-base/src/room/create.rs
+++ b/crates/matrix-sdk-base/src/room/create.rs
@@ -16,7 +16,7 @@ use matrix_sdk_common::ROOM_VERSION_RULES_FALLBACK;
 use ruma::{
     OwnedUserId, RoomVersionId, assign,
     events::{
-        EmptyStateKey, RedactContent, StateEventContent, StateEventType, StaticEventContent,
+        EmptyStateKey, RedactContent,
         macros::EventContent,
         room::create::{PreviousRoom, RoomCreateEventContent},
     },

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -591,11 +591,9 @@ mod tests {
         events::{
             StateEventType,
             room::{
-                canonical_alias::{
-                    PossiblyRedactedRoomCanonicalAliasEventContent, RoomCanonicalAliasEventContent,
-                },
+                canonical_alias::RoomCanonicalAliasEventContent,
                 member::{MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent},
-                name::{PossiblyRedactedRoomNameEventContent, RoomNameEventContent},
+                name::RoomNameEventContent,
             },
         },
         owned_room_alias_id, owned_user_id, room_alias_id, room_id,
@@ -637,21 +635,21 @@ mod tests {
 
     fn make_canonical_alias_event() -> MinimalStateEvent<RoomCanonicalAliasEventContent> {
         MinimalStateEvent {
-            content: assign!(PossiblyRedactedRoomCanonicalAliasEventContent::new(), {
+            content: assign!(RoomCanonicalAliasEventContent::new(), {
                 alias: Some(owned_room_alias_id!("#test:example.com")),
             }),
             event_id: None,
         }
     }
 
-    fn make_name_event_with(name: &str) -> MinimalStateEvent<PossiblyRedactedRoomNameEventContent> {
+    fn make_name_event_with(name: &str) -> MinimalStateEvent<RoomNameEventContent> {
         MinimalStateEvent {
             content: RoomNameEventContent::new(name.to_owned()).into(),
             event_id: None,
         }
     }
 
-    fn make_name_event() -> MinimalStateEvent<PossiblyRedactedRoomNameEventContent> {
+    fn make_name_event() -> MinimalStateEvent<RoomNameEventContent> {
         make_name_event_with("Test Room")
     }
 

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -19,8 +19,7 @@ use regex::Regex;
 #[cfg(feature = "unstable-msc4426")]
 use ruma::profile::{CallProfileField, StatusProfileField};
 use ruma::{
-    OwnedMxcUri, OwnedUserId, RoomAliasId, UserId,
-    events::{SyncStateEvent, member_hints::MemberHintsEventContent},
+    OwnedMxcUri, OwnedUserId, RoomAliasId, UserId, events::member_hints::MemberHintsEventContent,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
@@ -341,7 +340,7 @@ impl Room {
                     .inspect_err(|e| warn!("Couldn't deserialize the member hints event: {e}"))
                     .ok()
             })
-            .and_then(|event| as_variant!(event, SyncOrStrippedState::Sync(SyncStateEvent::Original(e)) => e.content))
+            .and_then(|event| as_variant!(event, SyncOrStrippedState::Sync(e) => e.content))
             .unwrap_or_default())
     }
 }
@@ -643,10 +642,7 @@ mod tests {
     }
 
     fn make_name_event_with(name: &str) -> MinimalStateEvent<RoomNameEventContent> {
-        MinimalStateEvent {
-            content: RoomNameEventContent::new(name.to_owned()).into(),
-            event_id: None,
-        }
+        MinimalStateEvent { content: RoomNameEventContent::new(name.to_owned()), event_id: None }
     }
 
     fn make_name_event() -> MinimalStateEvent<RoomNameEventContent> {

--- a/crates/matrix-sdk-base/src/room/encryption.rs
+++ b/crates/matrix-sdk-base/src/room/encryption.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::events::room::encryption::PossiblyRedactedRoomEncryptionEventContent;
+use ruma::events::room::encryption::RoomEncryptionEventContent;
 
 use super::Room;
 
@@ -24,7 +24,7 @@ impl Room {
 
     /// Get the `m.room.encryption` content that enabled end to end encryption
     /// in the room.
-    pub fn encryption_settings(&self) -> Option<PossiblyRedactedRoomEncryptionEventContent> {
+    pub fn encryption_settings(&self) -> Option<RoomEncryptionEventContent> {
         self.info.read().base_info.encryption.clone()
     }
 }

--- a/crates/matrix-sdk-base/src/room/knock.rs
+++ b/crates/matrix-sdk-base/src/room/knock.rs
@@ -18,7 +18,7 @@ use eyeball::{AsyncLock, ObservableWriteGuard};
 use ruma::{
     OwnedEventId, OwnedUserId,
     events::{
-        StateEventType, SyncStateEvent,
+        StateEventType,
         room::member::{MembershipState, RoomMemberEventContent},
     },
 };
@@ -47,7 +47,7 @@ impl Room {
         for raw_event in member_raw_events {
             let event = raw_event.cast::<RoomMemberEventContent>().deserialize()?;
             match event {
-                SyncOrStrippedState::Sync(SyncStateEvent::Original(event)) => {
+                SyncOrStrippedState::Sync(event) => {
                     if event.content.membership == MembershipState::Knock {
                         event_to_user_ids.push((event.event_id, event.state_key))
                     } else {

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -606,7 +606,7 @@ impl Room {
     pub fn pinned_event_ids_stream(&self) -> impl Stream<Item = Vec<OwnedEventId>> + use<> {
         self.info
             .subscribe()
-            .map(|i| i.base_info.pinned_events.and_then(|c| c.pinned).unwrap_or_default())
+            .map(|i| i.base_info.pinned_events.map(|c| c.pinned).unwrap_or_default())
     }
 
     /// Returns the current pinned event ids for this room.

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -26,8 +26,8 @@ use ruma::{
     RoomAliasId, RoomId, RoomVersionId,
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
     events::{
-        AnyPossiblyRedactedStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, StateEventType,
+        AnyStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        StateEventType,
         call::member::{
             CallMemberStateKey, MembershipData, PossiblyRedactedCallMemberEventContent,
         },
@@ -257,7 +257,7 @@ impl BaseRoomInfo {
                 // fail to deserialize or that are redacted (i.e. they don't contain the
                 // algorithm used for encryption).
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomEncryption)
+                    as_variant!(any_event, AnyStateEventContent::RoomEncryption)
                 }) && event.content.algorithm.is_some()
                 {
                     self.encryption = Some(event.content);
@@ -268,7 +268,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomAvatar, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomAvatar)
+                    as_variant!(any_event, AnyStateEventContent::RoomAvatar)
                 }) {
                     self.avatar = Some(event);
                     true
@@ -279,7 +279,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomName, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomName)
+                    as_variant!(any_event, AnyStateEventContent::RoomName)
                 }) {
                     self.name = Some(event);
                     true
@@ -291,10 +291,8 @@ impl BaseRoomInfo {
             // `m.room.create` CANNOT be overwritten.
             (StateEventType::RoomCreate, "") if self.create.is_none() => {
                 if let Some(any_event) = raw_event.deserialize()
-                    && let Some(content) = as_variant!(
-                        any_event.get_content(),
-                        AnyPossiblyRedactedStateEventContent::RoomCreate
-                    )
+                    && let Some(content) =
+                        as_variant!(any_event.get_content(), AnyStateEventContent::RoomCreate)
                 {
                     self.create = Some(MinimalStateEvent {
                         content: RoomCreateWithCreatorEventContent::from_event_content(
@@ -310,10 +308,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomHistoryVisibility, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(
-                        any_event,
-                        AnyPossiblyRedactedStateEventContent::RoomHistoryVisibility
-                    )
+                    as_variant!(any_event, AnyStateEventContent::RoomHistoryVisibility)
                 }) {
                     self.history_visibility = Some(event);
                     true
@@ -324,7 +319,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomRetention, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomRetention)
+                    as_variant!(any_event, AnyStateEventContent::RoomRetention)
                 }) {
                     self.retention = Some(event);
                     true
@@ -335,7 +330,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomGuestAccess, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomGuestAccess)
+                    as_variant!(any_event, AnyStateEventContent::RoomGuestAccess)
                 }) {
                     self.guest_access = Some(event);
                     true
@@ -346,7 +341,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::MemberHints, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::MemberHints)
+                    as_variant!(any_event, AnyStateEventContent::MemberHints)
                 }) {
                     self.member_hints = Some(event);
                     true
@@ -357,7 +352,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomJoinRules, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomJoinRules)
+                    as_variant!(any_event, AnyStateEventContent::RoomJoinRules)
                 }) {
                     match &event.content.join_rule {
                         JoinRule::Invite
@@ -382,7 +377,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomCanonicalAlias, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomCanonicalAlias)
+                    as_variant!(any_event, AnyStateEventContent::RoomCanonicalAlias)
                 }) {
                     self.canonical_alias = Some(event);
                     true
@@ -393,7 +388,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomTopic, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomTopic)
+                    as_variant!(any_event, AnyStateEventContent::RoomTopic)
                 }) {
                     self.topic = Some(event);
                     true
@@ -404,7 +399,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomTombstone, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomTombstone)
+                    as_variant!(any_event, AnyStateEventContent::RoomTombstone)
                 }) {
                     self.tombstone = Some(event);
                     true
@@ -415,7 +410,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomPowerLevels, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomPowerLevels)
+                    as_variant!(any_event, AnyStateEventContent::RoomPowerLevels)
                 }) {
                     let new_max = i64::from(
                         event
@@ -444,10 +439,8 @@ impl BaseRoomInfo {
             (StateEventType::CallMember, _) => {
                 if let Ok(call_member_key) = raw_event.state_key.parse::<CallMemberStateKey>() {
                     if let Some(any_event) = raw_event.deserialize()
-                        && let Some(content) = as_variant!(
-                            any_event.get_content(),
-                            AnyPossiblyRedactedStateEventContent::CallMember
-                        )
+                        && let Some(content) =
+                            as_variant!(any_event.get_content(), AnyStateEventContent::CallMember)
                     {
                         let mut event = MinimalStateEvent {
                             content,
@@ -477,7 +470,7 @@ impl BaseRoomInfo {
             }
             (StateEventType::RoomPinnedEvents, "") => {
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
-                    as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomPinnedEvents)
+                    as_variant!(any_event, AnyStateEventContent::RoomPinnedEvents)
                 }) {
                     self.pinned_events = Some(event.content);
                     true

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -832,14 +832,12 @@ impl RoomInfo {
         if raw_event.event_type == StateEventType::MemberHints
             && let Some(AnySyncStateEvent::MemberHints(new_hints)) = raw_event.deserialize()
             // If we have both old and new member hints events
-            && let (Some(current_hints), Some(new)) =
-                (&self.base_info.member_hints, new_hints.as_original())
+            && let Some(current_hints) =
+                &self.base_info.member_hints
             // Then we check if their contents don't match
             && current_hints
                 .content
-                .service_members
-                .as_ref()
-                .is_some_and(|current_members| *current_members != new.content.service_members)
+                .service_members != new_hints.content.service_members
         {
             // And reset the computed value in that case
             self.summary.active_service_members = None;
@@ -1087,7 +1085,7 @@ impl RoomInfo {
     /// Return the service members for this room if the `m.member_hints` event
     /// is available
     pub fn service_members(&self) -> Option<&BTreeSet<OwnedUserId>> {
-        self.base_info.member_hints.as_ref()?.content.service_members.as_ref()
+        Some(&self.base_info.member_hints.as_ref()?.content.service_members)
     }
 
     /// Get the name of this room.
@@ -1268,8 +1266,7 @@ impl RoomInfo {
         self.base_info
             .pinned_events
             .as_ref()
-            .and_then(|content| content.pinned.as_deref())
-            .is_some_and(|pinned| pinned.contains(&event_id.to_owned()))
+            .is_some_and(|content| content.pinned.contains(&event_id.to_owned()))
     }
 
     /// Returns the computed read receipts for this room.
@@ -1562,7 +1559,7 @@ mod tests {
             encryption_state_synced: true,
             latest_event_value: LatestEventValue::None,
             base_info: Box::new(
-                assign!(BaseRoomInfo::new(), { pinned_events: Some(RoomPinnedEventsEventContent::new(vec![owned_event_id!("$a")]).into()) }),
+                assign!(BaseRoomInfo::new(), { pinned_events: Some(RoomPinnedEventsEventContent::new(vec![owned_event_id!("$a")])) }),
             ),
             read_receipts: Default::default(),
             warned_about_unknown_room_version_rules: Arc::new(false.into()),
@@ -1957,7 +1954,7 @@ mod tests {
         });
 
         let info: RoomInfo = serde_json::from_value(info_json.clone()).unwrap();
-        assert_eq!(info.base_info.member_hints.unwrap().content.service_members.unwrap(), expected);
+        assert_eq!(info.base_info.member_hints.unwrap().content.service_members, expected);
         assert_eq!(info.summary.active_service_members, Some(2));
 
         // We receive a new event with the same values as the stored ones
@@ -1973,7 +1970,7 @@ mod tests {
         info.handle_state_event(&mut raw_state_event_with_keys);
 
         // Nothing changed
-        assert_eq!(info.base_info.member_hints.unwrap().content.service_members.unwrap(), expected);
+        assert_eq!(info.base_info.member_hints.unwrap().content.service_members, expected);
         // And the computed value is kept
         assert_eq!(info.summary.active_service_members, Some(2));
 
@@ -1991,10 +1988,7 @@ mod tests {
         info.handle_state_event(&mut raw_state_event_with_keys);
 
         // The new member hints were applied
-        assert_eq!(
-            info.base_info.member_hints.unwrap().content.service_members.unwrap(),
-            new_member_hints
-        );
+        assert_eq!(info.base_info.member_hints.unwrap().content.service_members, new_member_hints);
         // And the computed value is reset
         assert!(info.summary.active_service_members.is_none());
     }

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -28,28 +28,22 @@ use ruma::{
     events::{
         AnyStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         StateEventType,
-        call::member::{
-            CallMemberStateKey, MembershipData, PossiblyRedactedCallMemberEventContent,
-        },
+        call::member::{CallMemberEventContent, CallMemberStateKey, MembershipData},
         direct::OwnedDirectUserIdentifier,
-        member_hints::PossiblyRedactedMemberHintsEventContent,
+        member_hints::MemberHintsEventContent,
         room::{
-            avatar::{self, PossiblyRedactedRoomAvatarEventContent},
-            canonical_alias::PossiblyRedactedRoomCanonicalAliasEventContent,
-            encryption::PossiblyRedactedRoomEncryptionEventContent,
-            guest_access::{GuestAccess, PossiblyRedactedRoomGuestAccessEventContent},
-            history_visibility::{
-                HistoryVisibility, PossiblyRedactedRoomHistoryVisibilityEventContent,
-            },
-            join_rules::{JoinRule, PossiblyRedactedRoomJoinRulesEventContent},
-            name::PossiblyRedactedRoomNameEventContent,
-            pinned_events::{
-                PossiblyRedactedRoomPinnedEventsEventContent, RoomPinnedEventsEventContent,
-            },
+            avatar::{self, RoomAvatarEventContent},
+            canonical_alias::RoomCanonicalAliasEventContent,
+            encryption::RoomEncryptionEventContent,
+            guest_access::{GuestAccess, RoomGuestAccessEventContent},
+            history_visibility::{HistoryVisibility, RoomHistoryVisibilityEventContent},
+            join_rules::{JoinRule, RoomJoinRulesEventContent},
+            name::RoomNameEventContent,
+            pinned_events::RoomPinnedEventsEventContent,
             redaction::SyncRoomRedactionEvent,
             retention::RoomRetentionEventContent,
-            tombstone::PossiblyRedactedRoomTombstoneEventContent,
-            topic::PossiblyRedactedRoomTopicEventContent,
+            tombstone::RoomTombstoneEventContent,
+            topic::RoomTopicEventContent,
         },
         rtc::notification::CallIntent,
         tag::{TagEventContent, TagName, Tags},
@@ -175,42 +169,40 @@ impl Room {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BaseRoomInfo {
     /// The avatar URL of this room.
-    pub(crate) avatar: Option<MinimalStateEvent<PossiblyRedactedRoomAvatarEventContent>>,
+    pub(crate) avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     /// The canonical alias of this room.
-    pub(crate) canonical_alias:
-        Option<MinimalStateEvent<PossiblyRedactedRoomCanonicalAliasEventContent>>,
+    pub(crate) canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
     pub(crate) create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
     pub(crate) dm_targets: HashSet<OwnedDirectUserIdentifier>,
     /// The `m.room.encryption` event content that enabled E2EE in this room.
-    pub(crate) encryption: Option<PossiblyRedactedRoomEncryptionEventContent>,
+    pub(crate) encryption: Option<RoomEncryptionEventContent>,
     /// The guest access policy of this room.
-    pub(crate) guest_access: Option<MinimalStateEvent<PossiblyRedactedRoomGuestAccessEventContent>>,
+    pub(crate) guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     /// The history visibility policy of this room.
-    pub(crate) history_visibility:
-        Option<MinimalStateEvent<PossiblyRedactedRoomHistoryVisibilityEventContent>>,
+    pub(crate) history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
     /// The join rule policy of this room.
-    pub(crate) join_rules: Option<MinimalStateEvent<PossiblyRedactedRoomJoinRulesEventContent>>,
+    pub(crate) join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
     /// The maximal power level that can be found in this room.
     pub(crate) max_power_level: i64,
     /// The member hints for the room as per MSC4171, including service members,
     /// if available.
-    pub(crate) member_hints: Option<MinimalStateEvent<PossiblyRedactedMemberHintsEventContent>>,
+    pub(crate) member_hints: Option<MinimalStateEvent<MemberHintsEventContent>>,
     /// The `m.room.name` of this room.
-    pub(crate) name: Option<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>,
+    pub(crate) name: Option<MinimalStateEvent<RoomNameEventContent>>,
     /// The message retention policy of this room.
     pub(crate) retention: Option<MinimalStateEvent<RoomRetentionEventContent>>,
     /// The `m.room.tombstone` event content of this room.
-    pub(crate) tombstone: Option<MinimalStateEvent<PossiblyRedactedRoomTombstoneEventContent>>,
+    pub(crate) tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
     /// The topic of this room.
-    pub(crate) topic: Option<MinimalStateEvent<PossiblyRedactedRoomTopicEventContent>>,
+    pub(crate) topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
     /// All minimal state events that containing one or more running matrixRTC
     /// memberships.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub(crate) rtc_member_events:
-        BTreeMap<CallMemberStateKey, MinimalStateEvent<PossiblyRedactedCallMemberEventContent>>,
+        BTreeMap<CallMemberStateKey, MinimalStateEvent<CallMemberEventContent>>,
     /// Whether this room has been manually marked as unread.
     #[serde(default)]
     pub(crate) is_marked_unread: bool,
@@ -227,7 +219,7 @@ pub struct BaseRoomInfo {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) fully_read_event_id: Option<OwnedEventId>,
     /// The `m.room.pinned_events` of this room.
-    pub(crate) pinned_events: Option<PossiblyRedactedRoomPinnedEventsEventContent>,
+    pub(crate) pinned_events: Option<RoomPinnedEventsEventContent>,
 }
 
 impl BaseRoomInfo {
@@ -807,10 +799,7 @@ impl RoomInfo {
     }
 
     /// Set the encryption event content in this room.
-    pub fn set_encryption_event(
-        &mut self,
-        event: Option<PossiblyRedactedRoomEncryptionEventContent>,
-    ) {
+    pub fn set_encryption_event(&mut self, event: Option<RoomEncryptionEventContent>) {
         self.base_info.encryption = event;
     }
 
@@ -908,7 +897,7 @@ impl RoomInfo {
     /// Update the room avatar.
     pub fn update_avatar(&mut self, url: Option<OwnedMxcUri>) {
         self.base_info.avatar = url.map(|url| {
-            let mut content = PossiblyRedactedRoomAvatarEventContent::new();
+            let mut content = RoomAvatarEventContent::new();
             content.url = Some(url);
 
             MinimalStateEvent { content, event_id: None }
@@ -1061,7 +1050,7 @@ impl RoomInfo {
         self.base_info
             .guest_access
             .as_ref()
-            .and_then(|event| event.content.guest_access.as_ref())
+            .map(|event| &event.content.guest_access)
             .unwrap_or(&GuestAccess::Forbidden)
     }
 
@@ -1112,7 +1101,7 @@ impl RoomInfo {
     }
 
     /// Get the content of the `m.room.tombstone` event if any.
-    pub fn tombstone(&self) -> Option<&PossiblyRedactedRoomTombstoneEventContent> {
+    pub fn tombstone(&self) -> Option<&RoomTombstoneEventContent> {
         Some(&self.base_info.tombstone.as_ref()?.content)
     }
 
@@ -1261,7 +1250,7 @@ impl RoomInfo {
 
     /// Returns the current pinned event ids for this room.
     pub fn pinned_event_ids(&self) -> Option<Vec<OwnedEventId>> {
-        self.base_info.pinned_events.clone().and_then(|c| c.pinned)
+        self.base_info.pinned_events.clone().map(|c| c.pinned)
     }
 
     /// Returns the event ID of the user's `m.fully_read` marker for this room,

--- a/crates/matrix-sdk-base/src/room/tombstone.rs
+++ b/crates/matrix-sdk-base/src/room/tombstone.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{OwnedRoomId, events::room::tombstone::PossiblyRedactedRoomTombstoneEventContent};
+use ruma::{OwnedRoomId, events::room::tombstone::RoomTombstoneEventContent};
 
 use super::Room;
 
@@ -34,7 +34,7 @@ impl Room {
     /// event has been received. It's faster than using this method.
     ///
     /// [`m.room.tombstone`]: https://spec.matrix.org/v1.14/client-server-api/#mroomtombstone
-    pub fn tombstone_content(&self) -> Option<PossiblyRedactedRoomTombstoneEventContent> {
+    pub fn tombstone_content(&self) -> Option<RoomTombstoneEventContent> {
         self.info.read().tombstone().cloned()
     }
 

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -107,7 +107,7 @@ impl AmbiguityCache {
         // this twice for the same event will result in an incorrect AmbiguityChange
         // overwriting the correct one. In other words, this method is not idempotent so
         // we make it by ignoring duplicate events.
-        if self.changes.get(room_id).is_some_and(|c| c.contains_key(member_event.event_id())) {
+        if self.changes.get(room_id).is_some_and(|c| c.contains_key(&member_event.event_id)) {
             return Ok(());
         }
 
@@ -125,27 +125,26 @@ impl AmbiguityCache {
             return Ok(());
         }
 
-        let disambiguated_member =
-            old_map.as_mut().and_then(|o| o.remove(member_event.state_key()));
+        let disambiguated_member = old_map.as_mut().and_then(|o| o.remove(&member_event.state_key));
         let ambiguated_member =
-            new_map.as_mut().and_then(|n| n.add(member_event.state_key().clone()));
+            new_map.as_mut().and_then(|n| n.add(member_event.state_key.clone()));
         let ambiguous = new_map.as_ref().is_some_and(|n| n.is_ambiguous());
 
         self.update(room_id, old_map, new_map);
 
         let change = AmbiguityChange {
-            member_id: member_event.state_key().clone(),
+            member_id: member_event.state_key.clone(),
             disambiguated_member,
             ambiguated_member,
             member_ambiguous: ambiguous,
         };
 
-        trace!(user_id = ?member_event.state_key(), "Handling display name ambiguity: {change:#?}");
+        trace!(user_id = ?member_event.state_key, "Handling display name ambiguity: {change:#?}");
 
         self.changes
             .entry(room_id.to_owned())
             .or_default()
-            .insert(member_event.event_id().to_owned(), change);
+            .insert(member_event.event_id.clone(), change);
 
         Ok(())
     }
@@ -177,7 +176,7 @@ impl AmbiguityCache {
         room_id: &RoomId,
         new_event: &SyncRoomMemberEvent,
     ) -> Result<Option<String>> {
-        let user_id = new_event.state_key();
+        let user_id = &new_event.state_key;
 
         let old_event = if let Some(member) = changes.member(room_id, user_id) {
             Some(SyncOrStrippedState::Stripped(member))
@@ -250,15 +249,16 @@ impl AmbiguityCache {
             None
         };
 
-        let new_map = if is_member_active(member_event.membership()) {
+        let new_map = if is_member_active(&member_event.content.membership) {
             let new = member_event
-                .as_original()
-                .and_then(|ev| ev.content.displayname.as_deref())
-                .unwrap_or_else(|| member_event.state_key().localpart());
+                .content
+                .displayname
+                .as_deref()
+                .unwrap_or_else(|| member_event.state_key.localpart());
 
             // We don't allow other users to set the display name, so if we have a more
             // trusted version of the display name use that.
-            let new_display_name = if member_event.sender().as_str() == member_event.state_key() {
+            let new_display_name = if member_event.sender == member_event.state_key {
                 new
             } else if let Some(old) = old_display_name.as_deref() {
                 old

--- a/crates/matrix-sdk-base/src/store/avatar_cache.rs
+++ b/crates/matrix-sdk-base/src/store/avatar_cache.rs
@@ -29,19 +29,18 @@ impl AvatarCache {
         room_id: &RoomId,
         member_event: &SyncRoomMemberEvent,
     ) -> Result<(), StoreError> {
-        let user_id = member_event.sender();
+        let user_id = &member_event.sender;
         if self.changes.get(room_id).is_some_and(|user_ids| user_ids.contains_key(user_id)) {
             return Ok(());
         }
-        match member_event {
-            SyncRoomMemberEvent::Original(original_event) => {
-                let avatar_url = original_event.content.avatar_url.clone();
-                self.add_to_changes_if_needed(state_changes, room_id, user_id, avatar_url).await;
-            }
-            SyncRoomMemberEvent::Redacted(_) => {
-                trace!("Redacted event, discarding avatar change for {:?}", user_id);
-            }
+
+        if member_event.is_redacted() {
+            trace!("Redacted event, discarding avatar change for {:?}", user_id);
+        } else {
+            let avatar_url = member_event.content.avatar_url.clone();
+            self.add_to_changes_if_needed(state_changes, room_id, user_id, avatar_url).await;
         }
+
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -20,7 +20,7 @@ use ruma::{
     events::{
         AnyGlobalAccountDataEvent, AnyMessageLikeEventContent, AnyRoomAccountDataEvent,
         AnyStrippedStateEvent, AnySyncStateEvent, GlobalAccountDataEventType,
-        RoomAccountDataEventType, StateEventType, SyncStateEvent,
+        RoomAccountDataEventType, StateEventType,
         presence::PresenceEvent,
         receipt::{ReceiptThread, ReceiptType},
         room::{
@@ -204,9 +204,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         let member_raw: Raw<SyncRoomMemberEvent> =
             f.member(user_id).display_name("example").previous(MembershipState::Invite).into();
         let member_event: SyncRoomMemberEvent = member_raw.deserialize()?;
-        let displayname = DisplayName::new(
-            member_event.as_original().unwrap().content.displayname.as_ref().unwrap(),
-        );
+        let displayname = DisplayName::new(member_event.content.displayname.as_ref().unwrap());
         room_ambiguity_map.insert(displayname.clone(), BTreeSet::from([user_id.to_owned()]));
         room_profiles.insert(user_id.to_owned(), (&member_event).into());
 
@@ -276,11 +274,10 @@ impl StateStoreIntegrationTests for DynStateStore {
                 .expect("can deserialize room topic before redaction")
                 .as_sync()
                 .expect("room topic is a sync state event")
-                .as_original()
-                .expect("room topic is not redacted yet")
                 .content
-                .topic,
-            "😀"
+                .topic
+                .as_deref(),
+            Some("😀")
         );
 
         let mut changes = StateChanges::default();
@@ -299,7 +296,10 @@ impl StateStoreIntegrationTests for DynStateStore {
             .deserialize()
             .expect("can deserialize room topic after redaction");
 
-        assert_matches!(redacted_event.as_sync(), Some(SyncStateEvent::Redacted(_)));
+        assert_matches!(
+            redacted_event.as_sync().expect("room topic is a sync state event").content.topic,
+            None
+        );
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -415,7 +415,7 @@ impl StateStore for MemoryStore {
                             .members
                             .entry(room.clone())
                             .or_default()
-                            .insert(event.state_key().to_owned(), event.membership().clone());
+                            .insert(event.state_key.clone(), event.content.membership.clone());
                     }
                 }
             }

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -22,15 +22,12 @@ use ruma::{
     events::{
         direct::OwnedDirectUserIdentifier,
         room::{
-            avatar::PossiblyRedactedRoomAvatarEventContent,
-            canonical_alias::PossiblyRedactedRoomCanonicalAliasEventContent,
-            create::RoomCreateEventContent, encryption::PossiblyRedactedRoomEncryptionEventContent,
-            guest_access::PossiblyRedactedRoomGuestAccessEventContent,
-            history_visibility::PossiblyRedactedRoomHistoryVisibilityEventContent,
-            join_rules::PossiblyRedactedRoomJoinRulesEventContent,
-            name::PossiblyRedactedRoomNameEventContent,
-            tombstone::PossiblyRedactedRoomTombstoneEventContent,
-            topic::PossiblyRedactedRoomTopicEventContent,
+            avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
+            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
+            guest_access::RoomGuestAccessEventContent,
+            history_visibility::RoomHistoryVisibilityEventContent,
+            join_rules::RoomJoinRulesEventContent, name::RoomNameEventContent,
+            tombstone::RoomTombstoneEventContent, topic::RoomTopicEventContent,
         },
     },
 };
@@ -139,18 +136,17 @@ fn encryption_state_default() -> bool {
 /// [`BaseRoomInfo`] version 1.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct BaseRoomInfoV1 {
-    avatar: Option<MinimalStateEvent<PossiblyRedactedRoomAvatarEventContent>>,
-    canonical_alias: Option<MinimalStateEvent<PossiblyRedactedRoomCanonicalAliasEventContent>>,
+    avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
+    canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     dm_targets: HashSet<OwnedUserId>,
-    encryption: Option<PossiblyRedactedRoomEncryptionEventContent>,
-    guest_access: Option<MinimalStateEvent<PossiblyRedactedRoomGuestAccessEventContent>>,
-    history_visibility:
-        Option<MinimalStateEvent<PossiblyRedactedRoomHistoryVisibilityEventContent>>,
-    join_rules: Option<MinimalStateEvent<PossiblyRedactedRoomJoinRulesEventContent>>,
+    encryption: Option<RoomEncryptionEventContent>,
+    guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
+    history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
+    join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
     max_power_level: i64,
-    name: Option<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>,
-    tombstone: Option<MinimalStateEvent<PossiblyRedactedRoomTombstoneEventContent>>,
-    topic: Option<MinimalStateEvent<PossiblyRedactedRoomTopicEventContent>>,
+    name: Option<MinimalStateEvent<RoomNameEventContent>>,
+    tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
+    topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
 }
 
 impl BaseRoomInfoV1 {

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -50,8 +50,8 @@ use ruma::{
     events::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncStateEvent, EmptyStateKey, EventContentFromType, GlobalAccountDataEventType,
-        RedactContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
-        StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
+        RoomAccountDataEventType, StateEventType, StaticEventContent, StaticStateEventContent,
+        StrippedStateEvent, SyncStateEvent,
         presence::PresenceEvent,
         receipt::ReceiptEventContent,
         room::{
@@ -64,7 +64,6 @@ use ruma::{
     profile::UserProfileUpdate,
     serde::Raw,
 };
-use serde::de::DeserializeOwned;
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tracing::warn;
 pub use traits::compare_thread_subscription_bump_stamps;

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -49,8 +49,8 @@ use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
     events::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, EmptyStateKey, GlobalAccountDataEventType, RedactContent,
-        RedactedStateEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
+        AnySyncStateEvent, EmptyStateKey, EventContentFromType, GlobalAccountDataEventType,
+        RedactContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
         StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
         presence::PresenceEvent,
         receipt::ReceiptEventContent,
@@ -683,10 +683,7 @@ impl StateChanges {
         state_key: &K,
     ) -> Option<&Raw<SyncStateEvent<C>>>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
         K: AsRef<str> + ?Sized,
     {
@@ -704,7 +701,7 @@ impl StateChanges {
         &self,
         room_id: &RoomId,
         state_key: &K,
-    ) -> Option<&Raw<StrippedStateEvent<C::PossiblyRedacted>>>
+    ) -> Option<&Raw<StrippedStateEvent<C>>>
     where
         C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
@@ -725,13 +722,11 @@ impl StateChanges {
         &self,
         room_id: &RoomId,
         state_key: &K,
-    ) -> Option<StrippedStateEvent<C::PossiblyRedacted>>
+    ) -> Option<StrippedStateEvent<C>>
     where
         C: StaticEventContent<IsPrefix = ruma::events::False>
             + StaticStateEventContent
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
-        C::PossiblyRedacted: StaticEventContent + DeserializeOwned,
+            + EventContentFromType,
         C::StateKey: Borrow<K>,
         K: AsRef<str> + ?Sized,
     {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -40,8 +40,8 @@ use ruma::{
     events::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, EmptyStateKey, GlobalAccountDataEvent,
         GlobalAccountDataEventContent, GlobalAccountDataEventType, RedactContent,
-        RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
-        RoomAccountDataEventType, StateEventType, StaticEventContent, StaticStateEventContent,
+        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
+        StateEventType, StaticEventContent, StaticStateEventContent,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
     },
@@ -1968,9 +1968,7 @@ pub trait StateStoreExt: StateStore {
     ) -> Result<Option<RawSyncOrStrippedState<C>>, Self::Error>
     where
         C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent<StateKey = EmptyStateKey>
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+            + StaticStateEventContent<StateKey = EmptyStateKey>,
     {
         Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(|raw| raw.cast()))
     }
@@ -1986,11 +1984,8 @@ pub trait StateStoreExt: StateStore {
         state_key: &K,
     ) -> Result<Option<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
-        C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
     {
         Ok(self
@@ -2009,10 +2004,7 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
     {
         // FIXME: Could be more efficient, if we had streaming store accessor functions
         Ok(self
@@ -2037,11 +2029,8 @@ pub trait StateStoreExt: StateStore {
         state_keys: I,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>, Self::Error>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
-        C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + Sized + Sync + 'a,
         I: IntoIterator<Item = &'a K> + Send,
         I::IntoIter: Send,

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -39,9 +39,9 @@ use ruma::{
     },
     events::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, EmptyStateKey, GlobalAccountDataEvent,
-        GlobalAccountDataEventContent, GlobalAccountDataEventType, RedactContent,
-        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
-        StateEventType, StaticEventContent, StaticStateEventContent,
+        GlobalAccountDataEventContent, GlobalAccountDataEventType, RoomAccountDataEvent,
+        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
+        StaticStateEventContent,
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
     },

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -2,9 +2,8 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, UserId,
     events::{
         AnyStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
-        StateEventType, StaticEventContent, StaticStateEventContent, StrippedStateEvent,
-        SyncStateEvent,
+        RedactContent, StateEventType, StaticEventContent, StaticStateEventContent,
+        StrippedStateEvent, SyncStateEvent,
         room::{
             create::{StrippedRoomCreateEvent, SyncRoomCreateEvent},
             member::PossiblyRedactedRoomMemberEventContent,
@@ -29,7 +28,7 @@ use crate::room::RoomCreateWithCreatorEventContent;
     from = "MinimalStateEventSerdeHelper<C>",
     into = "MinimalStateEventSerdeHelper<C>"
 )]
-pub struct MinimalStateEvent<C: PossiblyRedactedStateEventContent + RedactContent> {
+pub struct MinimalStateEvent<C: StaticStateEventContent + RedactContent> {
     /// The event's content.
     pub content: C,
     /// The event's ID, if known.
@@ -38,7 +37,7 @@ pub struct MinimalStateEvent<C: PossiblyRedactedStateEventContent + RedactConten
 
 impl<C> MinimalStateEvent<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
     C::Redacted: Into<C>,
 {
     /// Redacts this event.
@@ -65,7 +64,7 @@ enum MinimalStateEventSerdeHelper<C> {
 
 impl<C> From<MinimalStateEventSerdeHelper<C>> for MinimalStateEvent<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
     fn from(value: MinimalStateEventSerdeHelper<C>) -> Self {
         match value {
@@ -79,7 +78,7 @@ where
 
 impl<C> From<MinimalStateEvent<C>> for MinimalStateEventSerdeHelper<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
     fn from(value: MinimalStateEvent<C>) -> Self {
         Self::PossiblyRedacted(value.into())
@@ -94,7 +93,7 @@ struct MinimalStateEventSerdeHelperInner<C> {
 
 impl<C> From<MinimalStateEventSerdeHelperInner<C>> for MinimalStateEvent<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
     fn from(value: MinimalStateEventSerdeHelperInner<C>) -> Self {
         let MinimalStateEventSerdeHelperInner { content, event_id } = value;
@@ -104,7 +103,7 @@ where
 
 impl<C> From<MinimalStateEvent<C>> for MinimalStateEventSerdeHelperInner<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
     fn from(value: MinimalStateEvent<C>) -> Self {
         let MinimalStateEvent { content, event_id } = value;
@@ -115,66 +114,39 @@ where
 /// A minimal `m.room.member` event.
 pub type MinimalRoomMemberEvent = MinimalStateEvent<PossiblyRedactedRoomMemberEventContent>;
 
-impl<C1, C2> From<SyncStateEvent<C1>> for MinimalStateEvent<C2>
+impl<C> From<SyncStateEvent<C>> for MinimalStateEvent<C>
 where
-    C1: StaticStateEventContent + RedactContent + Into<C2>,
-    C1::Redacted: RedactedStateEventContent + Into<C2>,
-    C2: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
-    fn from(ev: SyncStateEvent<C1>) -> Self {
-        match ev {
-            SyncStateEvent::Original(ev) => {
-                Self { content: ev.content.into(), event_id: Some(ev.event_id) }
-            }
-            SyncStateEvent::Redacted(ev) => {
-                Self { content: ev.content.into(), event_id: Some(ev.event_id) }
-            }
-        }
+    fn from(ev: SyncStateEvent<C>) -> Self {
+        Self { content: ev.content, event_id: Some(ev.event_id) }
     }
 }
 
-impl<C1, C2> From<&SyncStateEvent<C1>> for MinimalStateEvent<C2>
+impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
 where
-    C1: Clone + StaticStateEventContent + RedactContent + Into<C2>,
-    C1::Redacted: Clone + RedactedStateEventContent + Into<C2>,
-    C2: PossiblyRedactedStateEventContent + RedactContent,
+    C1: Clone + StaticStateEventContent + RedactContent,
 {
-    fn from(ev: &SyncStateEvent<C1>) -> Self {
-        match ev {
-            SyncStateEvent::Original(ev) => {
-                Self { content: ev.content.clone().into(), event_id: Some(ev.event_id.clone()) }
-            }
-            SyncStateEvent::Redacted(ev) => {
-                Self { content: ev.content.clone().into(), event_id: Some(ev.event_id.clone()) }
-            }
-        }
+    fn from(ev: &SyncStateEvent<C>) -> Self {
+        Self { content: ev.content.clone(), event_id: Some(ev.event_id.clone()) }
     }
 }
 
 impl From<&SyncRoomCreateEvent> for MinimalStateEvent<RoomCreateWithCreatorEventContent> {
     fn from(ev: &SyncRoomCreateEvent) -> Self {
-        match ev {
-            SyncStateEvent::Original(ev) => Self {
-                content: RoomCreateWithCreatorEventContent::from_event_content(
-                    ev.content.clone(),
-                    ev.sender.clone(),
-                ),
-                event_id: Some(ev.event_id.clone()),
-            },
-            SyncStateEvent::Redacted(ev) => Self {
-                content: RoomCreateWithCreatorEventContent::from_event_content(
-                    ev.content.clone(),
-                    ev.sender.clone(),
-                ),
-                event_id: Some(ev.event_id.clone()),
-            },
+        Self {
+            content: RoomCreateWithCreatorEventContent::from_event_content(
+                ev.content.clone(),
+                ev.sender.clone(),
+            ),
+            event_id: Some(ev.event_id.clone()),
         }
     }
 }
 
 impl<C> From<StrippedStateEvent<C>> for MinimalStateEvent<C>
 where
-    C: PossiblyRedactedStateEventContent + RedactContent,
+    C: StaticStateEventContent + RedactContent,
 {
     fn from(event: StrippedStateEvent<C>) -> Self {
         Self { content: event.content, event_id: None }
@@ -183,7 +155,7 @@ where
 
 impl<C> From<&StrippedStateEvent<C>> for MinimalStateEvent<C>
 where
-    C: Clone + PossiblyRedactedStateEventContent + RedactContent,
+    C: Clone + StaticStateEventContent + RedactContent,
 {
     fn from(event: &StrippedStateEvent<C>) -> Self {
         Self { content: event.content.clone(), event_id: None }
@@ -281,7 +253,7 @@ impl<T: AnyStateEventEnum> RawStateEventWithKeys<T> {
     ) -> Option<MinimalStateEvent<C>>
     where
         F: FnOnce(AnyStateEventContent) -> Option<C>,
-        C: StaticEventContent + PossiblyRedactedStateEventContent + RedactContent,
+        C: StaticEventContent + StaticStateEventContent + RedactContent,
     {
         let any_event = self.deserialize()?;
         let any_content = any_event.get_content();
@@ -355,8 +327,7 @@ impl RawStateEventWithKeys<AnySyncStateEvent> {
     pub fn deserialize_as<F, C>(&mut self, as_variant_fn: F) -> Option<&SyncStateEvent<C>>
     where
         F: FnOnce(&AnySyncStateEvent) -> Option<&SyncStateEvent<C>>,
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+        C: StaticEventContent + StaticStateEventContent,
     {
         let any_event = self.deserialize()?;
         let event = as_variant_fn(any_event);
@@ -391,7 +362,7 @@ impl RawStateEventWithKeys<AnyStrippedStateEvent> {
     pub fn deserialize_as<F, C>(&mut self, as_variant_fn: F) -> Option<&StrippedStateEvent<C>>
     where
         F: FnOnce(&AnyStrippedStateEvent) -> Option<&StrippedStateEvent<C>>,
-        C: StaticEventContent + PossiblyRedactedStateEventContent,
+        C: StaticEventContent + StaticStateEventContent,
     {
         let any_event = self.deserialize()?;
         let event = as_variant_fn(any_event);

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -125,7 +125,7 @@ where
 
 impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
 where
-    C1: Clone + StaticStateEventContent + RedactContent,
+    C: Clone + StaticStateEventContent + RedactContent,
 {
     fn from(ev: &SyncStateEvent<C>) -> Self {
         Self { content: ev.content.clone(), event_id: Some(ev.event_id.clone()) }

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -6,7 +6,7 @@ use ruma::{
         StrippedStateEvent, SyncStateEvent,
         room::{
             create::{StrippedRoomCreateEvent, SyncRoomCreateEvent},
-            member::PossiblyRedactedRoomMemberEventContent,
+            member::RoomMemberEventContent,
         },
     },
     room_version_rules::RedactionRules,
@@ -112,7 +112,7 @@ where
 }
 
 /// A minimal `m.room.member` event.
-pub type MinimalRoomMemberEvent = MinimalStateEvent<PossiblyRedactedRoomMemberEventContent>;
+pub type MinimalRoomMemberEvent = MinimalStateEvent<RoomMemberEventContent>;
 
 impl<C> From<SyncStateEvent<C>> for MinimalStateEvent<C>
 where
@@ -456,7 +456,7 @@ impl AnyStateEventEnum for AnyStrippedStateEvent {
 
 #[cfg(test)]
 mod tests {
-    use ruma::{event_id, events::room::name::PossiblyRedactedRoomNameEventContent};
+    use ruma::{event_id, events::room::name::RoomNameEventContent};
 
     use super::MinimalStateEvent;
 
@@ -465,36 +465,32 @@ mod tests {
         let event_id = event_id!("$event");
 
         // The old format with `Original` and `Redacted` variants works.
-        let event =
-            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
-                r#"{"Original":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
-            )
-            .unwrap();
+        let event = serde_json::from_str::<MinimalStateEvent<RoomNameEventContent>>(
+            r#"{"Original":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
+        )
+        .unwrap();
         assert_eq!(event.content.name.as_deref(), Some("My Room"));
         assert_eq!(event.event_id.as_deref(), Some(event_id));
 
-        let event =
-            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
-                r#"{"Redacted":{"content":{},"event_id":"$event"}}"#,
-            )
-            .unwrap();
+        let event = serde_json::from_str::<MinimalStateEvent<RoomNameEventContent>>(
+            r#"{"Redacted":{"content":{},"event_id":"$event"}}"#,
+        )
+        .unwrap();
         assert_eq!(event.content.name, None);
         assert_eq!(event.event_id.as_deref(), Some(event_id));
 
         // The new format works.
-        let event =
-            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
-                r#"{"PossiblyRedacted":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
-            )
-            .unwrap();
+        let event = serde_json::from_str::<MinimalStateEvent<RoomNameEventContent>>(
+            r#"{"PossiblyRedacted":{"content":{"name":"My Room"},"event_id":"$event"}}"#,
+        )
+        .unwrap();
         assert_eq!(event.content.name.as_deref(), Some("My Room"));
         assert_eq!(event.event_id.as_deref(), Some(event_id));
 
-        let event =
-            serde_json::from_str::<MinimalStateEvent<PossiblyRedactedRoomNameEventContent>>(
-                r#"{"PossiblyRedacted":{"content":{},"event_id":"$event"}}"#,
-            )
-            .unwrap();
+        let event = serde_json::from_str::<MinimalStateEvent<RoomNameEventContent>>(
+            r#"{"PossiblyRedacted":{"content":{},"event_id":"$event"}}"#,
+        )
+        .unwrap();
         assert_eq!(event.content.name, None);
         assert_eq!(event.event_id.as_deref(), Some(event_id));
     }

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -1,10 +1,10 @@
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, UserId,
     events::{
-        AnyPossiblyRedactedStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, PossiblyRedactedStateEventContent, RedactContent,
-        RedactedStateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
-        StrippedStateEvent, SyncStateEvent,
+        AnyStateEventContent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
+        StateEventType, StaticEventContent, StaticStateEventContent, StrippedStateEvent,
+        SyncStateEvent,
         room::{
             create::{StrippedRoomCreateEvent, SyncRoomCreateEvent},
             member::PossiblyRedactedRoomMemberEventContent,
@@ -263,7 +263,7 @@ impl<T: AnyStateEventEnum> RawStateEventWithKeys<T> {
 
     /// Try to deserialize the raw event and return it as a
     /// [`MinimalStateEvent`] using the selected variant of
-    /// [`AnyPossiblyRedactedStateEventContent`].
+    /// [`AnyStateEventContent`].
     ///
     /// This method should only be called if the variant is already known. It is
     /// considered a developer error for `as_variant_fn` to return `None`, but
@@ -280,7 +280,7 @@ impl<T: AnyStateEventEnum> RawStateEventWithKeys<T> {
         as_variant_fn: F,
     ) -> Option<MinimalStateEvent<C>>
     where
-        F: FnOnce(AnyPossiblyRedactedStateEventContent) -> Option<C>,
+        F: FnOnce(AnyStateEventContent) -> Option<C>,
         C: StaticEventContent + PossiblyRedactedStateEventContent + RedactContent,
     {
         let any_event = self.deserialize()?;
@@ -425,7 +425,7 @@ pub trait AnyStateEventEnum: DeserializeOwned {
     fn get_event_type(&self) -> StateEventType;
 
     /// Get the content of the state event.
-    fn get_content(&self) -> AnyPossiblyRedactedStateEventContent;
+    fn get_content(&self) -> AnyStateEventContent;
 
     /// Get the ID of the state event, if any.
     fn get_event_id(&self) -> Option<&EventId>;
@@ -443,7 +443,7 @@ impl AnyStateEventEnum for AnySyncStateEvent {
         self.event_type()
     }
 
-    fn get_content(&self) -> AnyPossiblyRedactedStateEventContent {
+    fn get_content(&self) -> AnyStateEventContent {
         self.content()
     }
 
@@ -466,7 +466,7 @@ impl AnyStateEventEnum for AnyStrippedStateEvent {
         self.event_type()
     }
 
-    fn get_content(&self) -> AnyPossiblyRedactedStateEventContent {
+    fn get_content(&self) -> AnyStateEventContent {
         self.content()
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 
 use matrix_sdk_common::BoxFuture;
 use ruma::{
     OwnedUserId, UserId,
-    events::{
-        SyncStateEvent,
-        room::member::{MembershipState, SyncRoomMemberEvent},
-    },
+    events::room::member::{MembershipState, SyncRoomMemberEvent},
 };
 
 use super::UserIdentity;
@@ -134,11 +131,11 @@ impl<R: RoomIdentityProvider> RoomIdentityState<R> {
 
     async fn process_membership_change(
         &mut self,
-        sync_room_member_event: Box<SyncRoomMemberEvent>,
+        event: Box<SyncRoomMemberEvent>,
     ) -> Vec<IdentityStatusChange> {
         // Ignore redacted events - memberships should come through as new events, not
         // redactions.
-        if let SyncStateEvent::Original(event) = sync_room_member_event.deref() {
+        if !event.is_redacted() {
             let user_id = &event.state_key;
             // Ignore non-existent users, and changes to our own identity
             if let Some(user_identity @ UserIdentity::Other(_)) =

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -35,7 +35,7 @@ use matrix_sdk_test::{
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::events::{
     StateEvent,
-    room::topic::{OriginalRoomTopicEvent, RoomTopicEventContent},
+    room::topic::{RoomTopicEvent, RoomTopicEventContent},
 };
 use ruma::{
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch, OneTimeKeyAlgorithm,
@@ -960,12 +960,14 @@ async fn test_megolm_state_encryption() {
 
     let decrypted_event = decrypted_event.event.deserialize().unwrap();
 
-    if let AnyTimelineEvent::State(AnyStateEvent::RoomTopic(StateEvent::Original(
-        OriginalRoomTopicEvent { sender, content, .. },
-    ))) = decrypted_event
+    if let AnyTimelineEvent::State(AnyStateEvent::RoomTopic(RoomTopicEvent {
+        sender,
+        content,
+        ..
+    })) = decrypted_event
     {
         assert_eq!(&sender, alice.user_id());
-        assert_eq!(&content.topic, plaintext);
+        assert_eq!(content.topic.as_deref(), Some(plaintext));
     } else {
         panic!("Decrypted room event has the wrong type");
     }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -32,10 +32,7 @@ use ruma::{
     SecondsSinceUnixEpoch, TransactionId, UserId,
     events::{
         AnyMessageLikeEventContent,
-        room::{
-            encryption::{PossiblyRedactedRoomEncryptionEventContent, RoomEncryptionEventContent},
-            history_visibility::HistoryVisibility,
-        },
+        room::{encryption::RoomEncryptionEventContent, history_visibility::HistoryVisibility},
     },
     serde::Raw,
 };
@@ -132,34 +129,10 @@ impl Default for EncryptionSettings {
 impl EncryptionSettings {
     /// Create new encryption settings using an `RoomEncryptionEventContent`,
     /// a history visibility, and key sharing strategy.
-    pub fn new(
-        content: RoomEncryptionEventContent,
-        history_visibility: HistoryVisibility,
-        sharing_strategy: CollectStrategy,
-    ) -> Self {
-        let rotation_period: Duration =
-            content.rotation_period_ms.map_or(ROTATION_PERIOD, |r| Duration::from_millis(r.into()));
-        let rotation_period_msgs: u64 =
-            content.rotation_period_msgs.map_or(ROTATION_MESSAGES, Into::into);
-
-        Self {
-            algorithm: EventEncryptionAlgorithm::from(content.algorithm.as_str()),
-            #[cfg(feature = "experimental-encrypted-state-events")]
-            encrypt_state_events: false,
-            rotation_period,
-            rotation_period_msgs,
-            history_visibility,
-            sharing_strategy,
-        }
-    }
-
-    /// Create new encryption settings using a
-    /// `PossiblyRedactedRoomEncryptionEventContent`, a history visibility,
-    /// and key sharing strategy.
     ///
     /// Returns `None` if the `content` was redacted.
-    pub fn from_possibly_redacted(
-        content: PossiblyRedactedRoomEncryptionEventContent,
+    pub fn new(
+        content: RoomEncryptionEventContent,
         history_visibility: HistoryVisibility,
         sharing_strategy: CollectStrategy,
     ) -> Option<Self> {
@@ -925,7 +898,8 @@ mod tests {
             content.clone(),
             HistoryVisibility::Joined,
             CollectStrategy::AllDevices,
-        );
+        )
+        .expect("content is not redacted");
 
         assert_eq!(settings.rotation_period, ROTATION_PERIOD);
         assert_eq!(settings.rotation_period_msgs, ROTATION_MESSAGES);
@@ -937,7 +911,8 @@ mod tests {
             content,
             HistoryVisibility::Shared,
             CollectStrategy::AllDevices,
-        );
+        )
+        .expect("content is not redacted");
 
         assert_eq!(settings.rotation_period, Duration::from_millis(3600));
         assert_eq!(settings.rotation_period_msgs, 500);

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -72,7 +72,7 @@ impl JsonCastable<EncryptedEvent>
 
 #[cfg(feature = "experimental-encrypted-state-events")]
 impl JsonCastable<EncryptedEvent>
-    for ruma::events::room::encrypted::unstable_state::OriginalSyncStateRoomEncryptedEvent
+    for ruma::events::room::encrypted::unstable_state::SyncStateRoomEncryptedEvent
 {
 }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -614,7 +614,7 @@ async fn migrate_to_v6(db: Database, store_cipher: Option<&StoreCipher>) -> Resu
             let value = result?;
             let member_event = deserialize_value::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?
                 .deserialize()?;
-            let key = encode_key(store_cipher, keys::USER_IDS, (room_id, member_event.state_key()));
+            let key = encode_key(store_cipher, keys::USER_IDS, (room_id, &member_event.state_key));
             let value = serialize_value(store_cipher, &RoomMember::from(&member_event))?;
 
             values.push((key, value));

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -912,7 +912,7 @@ impl_state_store!({
                                 .build()?;
 
                             if let Some(profile) =
-                                profile_changes.and_then(|p| p.get(event.state_key()))
+                                profile_changes.and_then(|p| p.get(&event.state_key))
                             {
                                 profiles
                                     .put(&self.serialize_value(&profile)?)
@@ -2148,7 +2148,7 @@ struct RoomMember {
 
 impl From<&SyncStateEvent<RoomMemberEventContent>> for RoomMember {
     fn from(event: &SyncStateEvent<RoomMemberEventContent>) -> Self {
-        Self { user_id: event.state_key().clone(), membership: event.membership().clone() }
+        Self { user_id: event.state_key.clone(), membership: event.content.membership.clone() }
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1409,7 +1409,7 @@ impl StateStore for SqliteStateStore {
                                 let encoded_room_id = this.encode_key(keys::MEMBER, &room_id);
                                 let user_id = this.encode_key(keys::MEMBER, &state_key);
                                 let membership = this
-                                    .encode_key(keys::MEMBER, member_event.membership().as_str());
+                                    .encode_key(keys::MEMBER, member_event.content.membership.as_str());
                                 let data = this.serialize_value(&state_key)?;
 
                                 txn.set_member(
@@ -1421,7 +1421,7 @@ impl StateStore for SqliteStateStore {
                                 )?;
 
                                 if let Some(profile) =
-                                    profiles.and_then(|p| p.get(member_event.state_key()))
+                                    profiles.and_then(|p| p.get(&member_event.state_key))
                                 {
                                     let room_id = this.encode_key(keys::PROFILE, &room_id);
                                     let user_id = this.encode_key(keys::PROFILE, &state_key);

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -1011,7 +1011,7 @@ impl NotificationItem {
                 if ev.sender() != sender_id {
                     continue;
                 }
-                if let AnyStateEventContentChange::RoomMember(StateEventContentChange::Original {
+                if let AnyStateEventContentChange::RoomMember(StateEventContentChange {
                     content,
                     ..
                 }) = ev.content_change()

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -44,7 +44,7 @@ use matrix_sdk::{
 use ruma::{
     OwnedRoomId, RoomId, SpaceChildOrder,
     events::{
-        self, StateEventType, SyncStateEvent,
+        self, StateEventType,
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
     },
 };
@@ -520,10 +520,9 @@ impl SpaceService {
             if let Ok(parents) = space.get_state_events_static::<SpaceParentEventContent>().await {
                 parents.into_iter()
                 .flat_map(|parent_event| match parent_event.deserialize() {
-                    Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
-                        Some(e.state_key)
+                    Ok(SyncOrStrippedState::Sync(e)) => {
+                        e.content.via.is_some().then_some(e.state_key)
                     }
-                    Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => None,
                     Ok(SyncOrStrippedState::Stripped(e)) => Some(e.state_key),
                     Err(e) => {
                         trace!(room_id = ?space.room_id(), "Could not deserialize m.space.parent: {e}");
@@ -539,7 +538,7 @@ impl SpaceService {
             if let Ok(children) = space.get_state_events_static::<SpaceChildEventContent>().await {
                 children.into_iter()
                 .filter_map(|child_event| match child_event.deserialize() {
-                    Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
+                    Ok(SyncOrStrippedState::Sync(e)) if e.content.via.is_some() => {
                         space_child_states.insert(
                             e.state_key.to_owned(),
                             SpaceRoomChildState {
@@ -550,7 +549,7 @@ impl SpaceService {
 
                         Some(e.state_key)
                     }
-                    Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => None,
+                    Ok(SyncOrStrippedState::Sync(_)) => None,
                     Ok(SyncOrStrippedState::Stripped(e)) => Some(e.state_key),
                     Err(e) => {
                         trace!(room_id = ?space.room_id(), "Could not deserialize m.space.child: {e}");

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -336,8 +336,9 @@ impl SpaceRoomList {
                     let children_state = children_state.clone();
                     async move {
                         let child_state = children_state.get(&room.summary.room_id);
-                        let via =
-                            child_state.map(|state| state.content.via.clone()).unwrap_or_default();
+                        let via = child_state
+                            .and_then(|state| state.content.via.clone())
+                            .unwrap_or_default();
                         let suggested =
                             child_state.map(|state| state.content.suggested).unwrap_or(false);
                         SpaceRoom::new_from_summary(

--- a/crates/matrix-sdk-ui/src/timeline/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_filter.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use ruma::events::{
-    AnySyncStateEvent, AnySyncTimelineEvent, SyncStateEvent, TimelineEventType,
+    AnySyncStateEvent, AnySyncTimelineEvent, TimelineEventType,
     room::member::{MembershipChange, MembershipState},
 };
 
@@ -89,9 +89,9 @@ impl TimelineEventCondition {
         match self {
             Self::EventType(event_type) => event.event_type() == *event_type,
             Self::MembershipChange(filter) => match event {
-                AnySyncTimelineEvent::State(AnySyncStateEvent::RoomMember(
-                    SyncStateEvent::Original(ev),
-                )) => {
+                AnySyncTimelineEvent::State(AnySyncStateEvent::RoomMember(ev))
+                    if !ev.is_redacted() =>
+                {
                     if matches!(ev.membership_change(), MembershipChange::ProfileChanged { .. }) {
                         return false;
                     }
@@ -110,9 +110,9 @@ impl TimelineEventCondition {
                 _ => false,
             },
             Self::ProfileChange => match event {
-                AnySyncTimelineEvent::State(AnySyncStateEvent::RoomMember(
-                    SyncStateEvent::Original(ev),
-                )) => {
+                AnySyncTimelineEvent::State(AnySyncStateEvent::RoomMember(ev))
+                    if !ev.is_redacted() =>
+                {
                     matches!(ev.membership_change(), MembershipChange::ProfileChanged { .. })
                 }
                 _ => false,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -27,7 +27,7 @@ use ruma::{
     events::{
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncStateEvent,
         AnySyncTimelineEvent, MessageLikeEventContent, MessageLikeEventType,
-        StateEventContentChange, StateEventType, SyncStateEvent,
+        StateEventContentChange, StateEventType,
         beacon_info::BeaconInfoEventContent,
         poll::unstable_start::{
             NewUnstablePollStartEventContentWithoutRelation, UnstablePollStartEventContent,
@@ -315,43 +315,35 @@ impl TimelineAction {
             },
 
             AnySyncTimelineEvent::State(ev) => match ev {
-                AnySyncStateEvent::RoomMember(ev) => match ev {
-                    SyncStateEvent::Original(ev) => {
-                        vec![Self::add_item(TimelineItemContent::room_member(
-                            ev.state_key,
-                            StateEventContentChange::Original {
-                                content: ev.content,
-                                prev_content: ev.unsigned.prev_content,
-                            },
-                            ev.sender,
-                        ))]
-                    }
-                    SyncStateEvent::Redacted(ev) => {
-                        vec![Self::add_item(TimelineItemContent::room_member(
-                            ev.state_key,
-                            StateEventContentChange::Redacted(ev.content),
-                            ev.sender,
-                        ))]
-                    }
-                },
-                AnySyncStateEvent::BeaconInfo(ev) => match ev {
-                    SyncStateEvent::Original(ev) => {
-                        // Check the `live` field directly, not `is_live()` which
-                        // considers timeout. We want to create a timeline item for any
-                        // beacon_info that was started as live, regardless of whether
-                        // the timeout has since expired.
-                        if ev.content.live {
-                            let add_item_action =
-                                Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
-                                    kind: MsgLikeKind::LiveLocation(LiveLocationState::new(
-                                        ev.content,
-                                    )),
-                                    reactions: Default::default(),
-                                    thread_root: None,
-                                    in_reply_to: None,
-                                    thread_summary: None,
-                                }));
-                            let handle_aggregation_action = ev.unsigned.prev_content.map(|prev| {
+                AnySyncStateEvent::RoomMember(ev) => {
+                    let is_redacted = ev.is_redacted();
+
+                    vec![Self::add_item(TimelineItemContent::room_member(
+                        ev.state_key,
+                        StateEventContentChange {
+                            content: ev.content,
+                            prev_content: ev.unsigned.prev_content,
+                        },
+                        ev.sender,
+                        is_redacted,
+                    ))]
+                }
+                AnySyncStateEvent::BeaconInfo(ev) => {
+                    // Check the `live` field directly, not `is_live()` which
+                    // considers timeout. We want to create a timeline item for any
+                    // beacon_info that was started as live, regardless of whether
+                    // the timeout has since expired.
+                    if ev.content.live {
+                        let add_item_action =
+                            Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
+                                kind: MsgLikeKind::LiveLocation(LiveLocationState::new(ev.content)),
+                                reactions: Default::default(),
+                                thread_root: None,
+                                in_reply_to: None,
+                                thread_summary: None,
+                            }));
+                        let handle_aggregation_action =
+                            ev.unsigned.prev_content.map(|prev| {
                                 let prev_content = BeaconInfoEventContent::new(
                                     prev.description,
                                     prev.timeout,
@@ -368,31 +360,25 @@ impl TimelineAction {
                                     },
                                 }
                             });
-                            let mut actions = vec![add_item_action];
-                            actions.extend(handle_aggregation_action);
-                            actions
-                        } else {
-                            // A non-live beacon_info is a stop event: it should update the
-                            // existing live item from the same sender rather than creating a
-                            // new timeline item.
-                            let event_id = ev.event_id.clone();
-                            vec![Self::HandleAggregation {
-                                // There is no explicit relates_to on a beacon_info state event;
-                                // the target is identified by sender in handle_beacon_stop.
-                                related_event: event_id.clone(),
-                                kind: HandleAggregationKind::BeaconStop {
-                                    own_id: TimelineEventItemId::EventId(event_id),
-                                    content: ev.content,
-                                },
-                            }]
-                        }
+                        let mut actions = vec![add_item_action];
+                        actions.extend(handle_aggregation_action);
+                        actions
+                    } else {
+                        // A non-live beacon_info is a stop event: it should update the
+                        // existing live item from the same sender rather than creating a
+                        // new timeline item.
+                        let event_id = ev.event_id.clone();
+                        vec![Self::HandleAggregation {
+                            // There is no explicit relates_to on a beacon_info state event;
+                            // the target is identified by sender in handle_beacon_stop.
+                            related_event: event_id.clone(),
+                            kind: HandleAggregationKind::BeaconStop {
+                                own_id: TimelineEventItemId::EventId(event_id),
+                                content: ev.content,
+                            },
+                        }]
                     }
-                    SyncStateEvent::Redacted(_) => {
-                        vec![Self::add_item(TimelineItemContent::MsgLike(
-                            MsgLikeContent::redacted(),
-                        ))]
-                    }
-                },
+                }
                 ev => vec![Self::add_item(TimelineItemContent::OtherState(OtherState {
                     state_key: ev.state_key().to_owned(),
                     content: AnyOtherStateEventContentChange::with_event_content(

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/live_location.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/live_location.rs
@@ -146,7 +146,7 @@ impl LiveLocationState {
     /// `ts + timeout` — see [`LiveLocationState::is_live`] and
     /// [`LiveLocationState::timeout`].
     pub fn ts(&self) -> MilliSecondsSinceUnixEpoch {
-        self.beacon_info.ts
+        self.beacon_info.ts.expect("redacted beacon info should not be a timeline item")
     }
 
     /// An optional human-readable description for this sharing session

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -984,9 +984,7 @@ mod tests {
         assign,
         events::{
             StateEventContentChange,
-            room::member::{
-                MembershipState, PossiblyRedactedRoomMemberEventContent, RoomMemberEventContent,
-            },
+            room::member::{MembershipState, RoomMemberEventContent},
         },
         room_version_rules::RedactionRules,
     };
@@ -1001,9 +999,7 @@ mod tests {
                 content: assign!(RoomMemberEventContent::new(MembershipState::Ban), {
                     reason: Some("🤬".to_owned()),
                 }),
-                prev_content: Some(PossiblyRedactedRoomMemberEventContent::new(
-                    MembershipState::Join,
-                )),
+                prev_content: Some(RoomMemberEventContent::new(MembershipState::Join)),
             },
             change: Some(MembershipChange::Banned),
         });

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -24,7 +24,7 @@ use ruma::{
     OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedUserId, UserId,
     events::{
         AnyMessageLikeEventContent, AnyStateEventContentChange, Mentions, MessageLikeEventType,
-        StateEventContentChange, StateEventType,
+        StateEventContent, StateEventContentChange, StateEventType,
         policy::rule::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
             user::PolicyRuleUserEventContent,
@@ -384,64 +384,66 @@ impl TimelineItemContent {
         user_id: OwnedUserId,
         full_content: StateEventContentChange<RoomMemberEventContent>,
         sender: OwnedUserId,
+        is_redacted: bool,
     ) -> Self {
         use ruma::events::room::member::MembershipChange as MChange;
-        match &full_content {
-            StateEventContentChange::Original { content, prev_content } => {
-                let membership_change = content.membership_change(
-                    prev_content.as_ref().map(|c| c.details()),
-                    &sender,
-                    &user_id,
-                );
 
-                if let MChange::ProfileChanged { displayname_change, avatar_url_change } =
-                    membership_change
-                {
-                    Self::ProfileChange(MemberProfileChange {
-                        user_id,
-                        displayname_change: displayname_change.map(|c| Change {
-                            new: c.new.map(ToOwned::to_owned),
-                            old: c.old.map(ToOwned::to_owned),
-                        }),
-                        avatar_url_change: avatar_url_change.map(|c| Change {
-                            new: c.new.map(ToOwned::to_owned),
-                            old: c.old.map(ToOwned::to_owned),
-                        }),
-                    })
-                } else {
-                    let change = match membership_change {
-                        MChange::None => MembershipChange::None,
-                        MChange::Error => MembershipChange::Error,
-                        MChange::Joined => MembershipChange::Joined,
-                        MChange::Left => MembershipChange::Left,
-                        MChange::Banned => MembershipChange::Banned,
-                        MChange::Unbanned => MembershipChange::Unbanned,
-                        MChange::Kicked => MembershipChange::Kicked,
-                        MChange::Invited => MembershipChange::Invited,
-                        MChange::KickedAndBanned => MembershipChange::KickedAndBanned,
-                        MChange::InvitationAccepted => MembershipChange::InvitationAccepted,
-                        MChange::InvitationRejected => MembershipChange::InvitationRejected,
-                        MChange::InvitationRevoked => MembershipChange::InvitationRevoked,
-                        MChange::Knocked => MembershipChange::Knocked,
-                        MChange::KnockAccepted => MembershipChange::KnockAccepted,
-                        MChange::KnockRetracted => MembershipChange::KnockRetracted,
-                        MChange::KnockDenied => MembershipChange::KnockDenied,
-                        MChange::ProfileChanged { .. } => unreachable!(),
-                        _ => MembershipChange::NotImplemented,
-                    };
-
-                    Self::MembershipChange(RoomMembershipChange {
-                        user_id,
-                        content: full_content,
-                        change: Some(change),
-                    })
-                }
-            }
-            StateEventContentChange::Redacted(_) => Self::MembershipChange(RoomMembershipChange {
+        if is_redacted {
+            Self::MembershipChange(RoomMembershipChange {
                 user_id,
                 content: full_content,
                 change: None,
-            }),
+            })
+        } else {
+            let StateEventContentChange { content, prev_content } = &full_content;
+            let membership_change = content.membership_change(
+                prev_content.as_ref().map(|c| c.details()),
+                &sender,
+                &user_id,
+            );
+
+            if let MChange::ProfileChanged { displayname_change, avatar_url_change } =
+                membership_change
+            {
+                Self::ProfileChange(MemberProfileChange {
+                    user_id,
+                    displayname_change: displayname_change.map(|c| Change {
+                        new: c.new.map(ToOwned::to_owned),
+                        old: c.old.map(ToOwned::to_owned),
+                    }),
+                    avatar_url_change: avatar_url_change.map(|c| Change {
+                        new: c.new.map(ToOwned::to_owned),
+                        old: c.old.map(ToOwned::to_owned),
+                    }),
+                })
+            } else {
+                let change = match membership_change {
+                    MChange::None => MembershipChange::None,
+                    MChange::Error => MembershipChange::Error,
+                    MChange::Joined => MembershipChange::Joined,
+                    MChange::Left => MembershipChange::Left,
+                    MChange::Banned => MembershipChange::Banned,
+                    MChange::Unbanned => MembershipChange::Unbanned,
+                    MChange::Kicked => MembershipChange::Kicked,
+                    MChange::Invited => MembershipChange::Invited,
+                    MChange::KickedAndBanned => MembershipChange::KickedAndBanned,
+                    MChange::InvitationAccepted => MembershipChange::InvitationAccepted,
+                    MChange::InvitationRejected => MembershipChange::InvitationRejected,
+                    MChange::InvitationRevoked => MembershipChange::InvitationRevoked,
+                    MChange::Knocked => MembershipChange::Knocked,
+                    MChange::KnockAccepted => MembershipChange::KnockAccepted,
+                    MChange::KnockRetracted => MembershipChange::KnockRetracted,
+                    MChange::KnockDenied => MembershipChange::KnockDenied,
+                    MChange::ProfileChanged { .. } => unreachable!(),
+                    _ => MembershipChange::NotImplemented,
+                };
+
+                Self::MembershipChange(RoomMembershipChange {
+                    user_id,
+                    content: full_content,
+                    change: Some(change),
+                })
+            }
         }
     }
 
@@ -620,33 +622,27 @@ impl RoomMembershipChange {
     /// Retrieve the member's display name from the current event, or, if
     /// missing, from the one it replaced.
     pub fn display_name(&self) -> Option<String> {
-        if let StateEventContentChange::Original { content, prev_content } = &self.content {
-            content
-                .displayname
-                .as_ref()
-                .or_else(|| {
-                    prev_content.as_ref().and_then(|prev_content| prev_content.displayname.as_ref())
-                })
-                .cloned()
-        } else {
-            None
-        }
+        let StateEventContentChange { content, prev_content } = &self.content;
+        content
+            .displayname
+            .as_ref()
+            .or_else(|| {
+                prev_content.as_ref().and_then(|prev_content| prev_content.displayname.as_ref())
+            })
+            .cloned()
     }
 
     /// Retrieve the avatar URL from the current event, or, if missing, from the
     /// one it replaced.
     pub fn avatar_url(&self) -> Option<OwnedMxcUri> {
-        if let StateEventContentChange::Original { content, prev_content } = &self.content {
-            content
-                .avatar_url
-                .as_ref()
-                .or_else(|| {
-                    prev_content.as_ref().and_then(|prev_content| prev_content.avatar_url.as_ref())
-                })
-                .cloned()
-        } else {
-            None
-        }
+        let StateEventContentChange { content, prev_content } = &self.content;
+        content
+            .avatar_url
+            .as_ref()
+            .or_else(|| {
+                prev_content.as_ref().and_then(|prev_content| prev_content.avatar_url.as_ref())
+            })
+            .cloned()
     }
 
     /// The membership change induced by this event.
@@ -663,7 +659,10 @@ impl RoomMembershipChange {
     fn redact(&self, rules: &RedactionRules) -> Self {
         Self {
             user_id: self.user_id.clone(),
-            content: StateEventContentChange::Redacted(self.content.clone().redact(rules)),
+            content: StateEventContentChange {
+                content: self.content.clone().redact(rules),
+                prev_content: self.content.prev_content.clone(),
+            },
             change: self.change,
         }
     }
@@ -866,88 +865,109 @@ impl AnyOtherStateEventContentChange {
     /// Get the event's type, like `m.room.create`.
     pub fn event_type(&self) -> StateEventType {
         match self {
-            Self::PolicyRuleRoom(c) => c.event_type(),
-            Self::PolicyRuleServer(c) => c.event_type(),
-            Self::PolicyRuleUser(c) => c.event_type(),
-            Self::RoomAvatar(c) => c.event_type(),
-            Self::RoomCanonicalAlias(c) => c.event_type(),
-            Self::RoomCreate(c) => c.event_type(),
-            Self::RoomEncryption(c) => c.event_type(),
-            Self::RoomGuestAccess(c) => c.event_type(),
-            Self::RoomHistoryVisibility(c) => c.event_type(),
-            Self::RoomJoinRules(c) => c.event_type(),
-            Self::RoomName(c) => c.event_type(),
-            Self::RoomPinnedEvents(c) => c.event_type(),
-            Self::RoomPowerLevels(c) => c.event_type(),
-            Self::RoomServerAcl(c) => c.event_type(),
-            Self::RoomThirdPartyInvite(c) => c.event_type(),
-            Self::RoomTombstone(c) => c.event_type(),
-            Self::RoomTopic(c) => c.event_type(),
-            Self::SpaceChild(c) => c.event_type(),
-            Self::SpaceParent(c) => c.event_type(),
+            Self::PolicyRuleRoom(c) => c.content.event_type(),
+            Self::PolicyRuleServer(c) => c.content.event_type(),
+            Self::PolicyRuleUser(c) => c.content.event_type(),
+            Self::RoomAvatar(c) => c.content.event_type(),
+            Self::RoomCanonicalAlias(c) => c.content.event_type(),
+            Self::RoomCreate(c) => c.content.event_type(),
+            Self::RoomEncryption(c) => c.content.event_type(),
+            Self::RoomGuestAccess(c) => c.content.event_type(),
+            Self::RoomHistoryVisibility(c) => c.content.event_type(),
+            Self::RoomJoinRules(c) => c.content.event_type(),
+            Self::RoomName(c) => c.content.event_type(),
+            Self::RoomPinnedEvents(c) => c.content.event_type(),
+            Self::RoomPowerLevels(c) => c.content.event_type(),
+            Self::RoomServerAcl(c) => c.content.event_type(),
+            Self::RoomThirdPartyInvite(c) => c.content.event_type(),
+            Self::RoomTombstone(c) => c.content.event_type(),
+            Self::RoomTopic(c) => c.content.event_type(),
+            Self::SpaceChild(c) => c.content.event_type(),
+            Self::SpaceParent(c) => c.content.event_type(),
             Self::_Custom { event_type } => event_type.as_str().into(),
         }
     }
 
     fn redact(&self, rules: &RedactionRules) -> Self {
         match self {
-            Self::PolicyRuleRoom(c) => {
-                Self::PolicyRuleRoom(StateEventContentChange::Redacted(c.clone().redact(rules)))
+            Self::PolicyRuleRoom(c) => Self::PolicyRuleRoom(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::PolicyRuleServer(c) => Self::PolicyRuleServer(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::PolicyRuleUser(c) => Self::PolicyRuleUser(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomAvatar(c) => Self::RoomAvatar(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomCanonicalAlias(c) => Self::RoomCanonicalAlias(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomCreate(c) => Self::RoomCreate(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomEncryption(c) => Self::RoomEncryption(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomGuestAccess(c) => Self::RoomGuestAccess(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomHistoryVisibility(c) => {
+                Self::RoomHistoryVisibility(StateEventContentChange {
+                    content: c.clone().redact(rules),
+                    prev_content: c.prev_content.clone(),
+                })
             }
-            Self::PolicyRuleServer(c) => {
-                Self::PolicyRuleServer(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::PolicyRuleUser(c) => {
-                Self::PolicyRuleUser(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomAvatar(c) => {
-                Self::RoomAvatar(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomCanonicalAlias(c) => {
-                Self::RoomCanonicalAlias(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomCreate(c) => {
-                Self::RoomCreate(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomEncryption(c) => {
-                Self::RoomEncryption(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomGuestAccess(c) => {
-                Self::RoomGuestAccess(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomHistoryVisibility(c) => Self::RoomHistoryVisibility(
-                StateEventContentChange::Redacted(c.clone().redact(rules)),
-            ),
-            Self::RoomJoinRules(c) => {
-                Self::RoomJoinRules(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomName(c) => {
-                Self::RoomName(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomPinnedEvents(c) => {
-                Self::RoomPinnedEvents(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomPowerLevels(c) => {
-                Self::RoomPowerLevels(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomServerAcl(c) => {
-                Self::RoomServerAcl(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomThirdPartyInvite(c) => Self::RoomThirdPartyInvite(
-                StateEventContentChange::Redacted(c.clone().redact(rules)),
-            ),
-            Self::RoomTombstone(c) => {
-                Self::RoomTombstone(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::RoomTopic(c) => {
-                Self::RoomTopic(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::SpaceChild(c) => {
-                Self::SpaceChild(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
-            Self::SpaceParent(c) => {
-                Self::SpaceParent(StateEventContentChange::Redacted(c.clone().redact(rules)))
-            }
+            Self::RoomJoinRules(c) => Self::RoomJoinRules(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomName(c) => Self::RoomName(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomPinnedEvents(c) => Self::RoomPinnedEvents(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomPowerLevels(c) => Self::RoomPowerLevels(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomServerAcl(c) => Self::RoomServerAcl(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomThirdPartyInvite(c) => Self::RoomThirdPartyInvite(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomTombstone(c) => Self::RoomTombstone(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::RoomTopic(c) => Self::RoomTopic(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::SpaceChild(c) => Self::SpaceChild(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
+            Self::SpaceParent(c) => Self::SpaceParent(StateEventContentChange {
+                content: c.clone().redact(rules),
+                prev_content: c.prev_content.clone(),
+            }),
             Self::_Custom { event_type } => Self::_Custom { event_type: event_type.clone() },
         }
     }
@@ -995,7 +1015,7 @@ mod tests {
     fn redact_membership_change() {
         let content = TimelineItemContent::MembershipChange(RoomMembershipChange {
             user_id: ALICE.to_owned(),
-            content: StateEventContentChange::Original {
+            content: StateEventContentChange {
                 content: assign!(RoomMemberEventContent::new(MembershipState::Ban), {
                     reason: Some("🤬".to_owned()),
                 }),
@@ -1007,7 +1027,11 @@ mod tests {
         let redacted = content.redact(&RedactionRules::V11);
         assert_let!(TimelineItemContent::MembershipChange(inner) = redacted);
         assert_eq!(inner.change, Some(MembershipChange::Banned));
-        assert_let!(StateEventContentChange::Redacted(inner_content_redacted) = inner.content);
+        assert_let!(
+            StateEventContentChange { content: inner_content_redacted, prev_content } =
+                inner.content
+        );
         assert_eq!(inner_content_redacted.membership, MembershipState::Ban);
+        assert_eq!(prev_content.unwrap().membership, MembershipState::Join);
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
@@ -33,42 +33,31 @@ pub enum RoomPinnedEventsChange {
 
 impl From<&StateEventContentChange<RoomPinnedEventsEventContent>> for RoomPinnedEventsChange {
     fn from(value: &StateEventContentChange<RoomPinnedEventsEventContent>) -> Self {
-        match value {
-            StateEventContentChange::Original { content, prev_content } => {
-                if let Some(prev_content) = prev_content {
-                    let mut new_pinned: HashSet<&OwnedEventId> =
-                        HashSet::from_iter(&content.pinned);
-                    if let Some(old_pinned) = &prev_content.pinned {
-                        let mut still_pinned: HashSet<&OwnedEventId> =
-                            HashSet::from_iter(old_pinned);
+        let StateEventContentChange { content, prev_content } = value;
+        if let Some(prev_content) = prev_content {
+            let mut new_pinned: HashSet<&OwnedEventId> = HashSet::from_iter(&content.pinned);
+            let mut still_pinned: HashSet<&OwnedEventId> = HashSet::from_iter(&prev_content.pinned);
 
-                        // Newly added elements will be kept in new_pinned, previous ones in
-                        // still_pinned instead
-                        still_pinned.retain(|item| new_pinned.remove(item));
+            // Newly added elements will be kept in new_pinned, previous ones in
+            // still_pinned instead
+            still_pinned.retain(|item| new_pinned.remove(item));
 
-                        let added = !new_pinned.is_empty();
-                        let removed = still_pinned.len() < old_pinned.len();
-                        if added && removed {
-                            RoomPinnedEventsChange::Changed
-                        } else if added {
-                            RoomPinnedEventsChange::Added
-                        } else if removed {
-                            RoomPinnedEventsChange::Removed
-                        } else {
-                            // Any other case
-                            RoomPinnedEventsChange::Changed
-                        }
-                    } else {
-                        // We don't know the previous state, so let's assume a generic change
-                        RoomPinnedEventsChange::Changed
-                    }
-                } else {
-                    // If there is no previous content we can assume the first pinned event id was
-                    // just added
-                    RoomPinnedEventsChange::Added
-                }
+            let added = !new_pinned.is_empty();
+            let removed = still_pinned.len() < prev_content.pinned.len();
+            if added && removed {
+                RoomPinnedEventsChange::Changed
+            } else if added {
+                RoomPinnedEventsChange::Added
+            } else if removed {
+                RoomPinnedEventsChange::Removed
+            } else {
+                // Any other case
+                RoomPinnedEventsChange::Changed
             }
-            StateEventContentChange::Redacted(_) => RoomPinnedEventsChange::Changed,
+        } else {
+            // If there is no previous content we can assume the first pinned event id was
+            // just added
+            RoomPinnedEventsChange::Added
         }
     }
 }
@@ -77,28 +66,15 @@ impl From<&StateEventContentChange<RoomPinnedEventsEventContent>> for RoomPinned
 mod tests {
     use assert_matches::assert_matches;
     use ruma::{
-        events::{
-            StateEventContentChange,
-            room::pinned_events::{
-                RedactedRoomPinnedEventsEventContent, RoomPinnedEventsEventContent,
-            },
-        },
+        events::{StateEventContentChange, room::pinned_events::RoomPinnedEventsEventContent},
         owned_event_id,
     };
 
     use crate::timeline::event_item::content::pinned_events::RoomPinnedEventsChange;
 
     #[test]
-    fn redacted_pinned_events_content_has_generic_changes() {
-        let content =
-            StateEventContentChange::Redacted(RedactedRoomPinnedEventsEventContent::new());
-        let ret: RoomPinnedEventsChange = (&content).into();
-        assert_matches!(ret, RoomPinnedEventsChange::Changed);
-    }
-
-    #[test]
     fn pinned_events_content_with_no_prev_content_returns_added() {
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(vec![owned_event_id!("$1")]),
             prev_content: None,
         };
@@ -108,7 +84,7 @@ mod tests {
 
     #[test]
     fn pinned_events_content_with_added_ids_returns_added() {
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(vec![owned_event_id!("$1")]),
             prev_content: Some(RoomPinnedEventsEventContent::new(Vec::new()).into()),
         };
@@ -118,7 +94,7 @@ mod tests {
 
     #[test]
     fn pinned_events_content_with_removed_ids_returns_removed() {
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(Vec::new()),
             prev_content: Some(
                 RoomPinnedEventsEventContent::new(vec![owned_event_id!("$1")]).into(),
@@ -130,7 +106,7 @@ mod tests {
 
     #[test]
     fn pinned_events_content_with_added_and_removed_ids_returns_changed() {
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(vec![owned_event_id!("$2")]),
             prev_content: Some(
                 RoomPinnedEventsEventContent::new(vec![owned_event_id!("$1")]).into(),
@@ -142,7 +118,7 @@ mod tests {
 
     #[test]
     fn pinned_events_content_with_changed_order_returns_changed() {
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(vec![
                 owned_event_id!("$2"),
                 owned_event_id!("$1"),
@@ -164,7 +140,7 @@ mod tests {
         // Returning Changed is counter-intuitive, but it makes no sense to display in
         // the timeline 'UserFoo didn't change anything in the pinned events'
 
-        let content = StateEventContentChange::Original {
+        let content = StateEventContentChange {
             content: RoomPinnedEventsEventContent::new(vec![
                 owned_event_id!("$1"),
                 owned_event_id!("$2"),

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -30,9 +30,9 @@ use ruma::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
             ImageInfo,
-            member::{MembershipState, RedactedRoomMemberEventContent},
+            member::{MembershipState, RoomMemberEventContent},
             message::MessageType,
-            topic::RedactedRoomTopicEventContent,
+            topic::RoomTopicEventContent,
         },
     },
     mxc_uri, owned_event_id, owned_mxc_uri, room_id, user_id,
@@ -171,7 +171,6 @@ async fn test_room_member() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert!(item.can_be_replied_to());
     assert_let!(TimelineItemContent::MembershipChange(membership) = item.content());
-    assert_matches!(membership.content(), StateEventContentChange::Original { .. });
     assert_matches!(membership.change(), Some(MembershipChange::Invited));
 
     timeline
@@ -185,7 +184,6 @@ async fn test_room_member() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_let!(TimelineItemContent::MembershipChange(membership) = item.content());
-    assert_matches!(membership.content(), StateEventContentChange::Original { .. });
     assert_matches!(membership.change(), Some(MembershipChange::InvitationAccepted));
 
     timeline
@@ -240,7 +238,6 @@ async fn test_room_member() {
             membership.avatar_url().map(|url| url.to_string()).as_deref(),
             Some("mxc://lolcathost.io/abc")
         );
-        assert_matches!(membership.content(), StateEventContentChange::Original { .. });
         assert_matches!(membership.change(), Some(MembershipChange::Left));
     }
 
@@ -248,13 +245,12 @@ async fn test_room_member() {
         .handle_live_event(f.redacted_state(
             &ALICE,
             ALICE.as_str(),
-            RedactedRoomMemberEventContent::new(MembershipState::Join),
+            RoomMemberEventContent::new(MembershipState::Join),
         ))
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_let!(TimelineItemContent::MembershipChange(membership) = item.content());
-    assert_matches!(membership.content(), StateEventContentChange::Redacted(_));
     assert_matches!(membership.change(), None);
 }
 
@@ -269,21 +265,21 @@ async fn test_other_state() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_let!(TimelineItemContent::OtherState(ev) = item.as_event().unwrap().content());
     assert_let!(AnyOtherStateEventContentChange::RoomName(full_content) = ev.content());
-    assert_let!(StateEventContentChange::Original { content, prev_content } = full_content);
-    assert_eq!(content.name, "Alice's room");
+    assert_let!(StateEventContentChange { content, prev_content } = full_content);
+    assert_eq!(content.name.as_deref(), Some("Alice's room"));
     assert_matches!(prev_content, None);
 
     let date_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
     assert!(date_divider.is_date_divider());
 
-    timeline
-        .handle_live_event(f.redacted_state(&ALICE, "", RedactedRoomTopicEventContent::new()))
-        .await;
+    let mut redacted_topic = RoomTopicEventContent::new(String::new());
+    redacted_topic.topic.take();
+    timeline.handle_live_event(f.redacted_state(&ALICE, "", redacted_topic)).await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_let!(TimelineItemContent::OtherState(ev) = item.as_event().unwrap().content());
     assert_let!(AnyOtherStateEventContentChange::RoomTopic(full_content) = ev.content());
-    assert_matches!(full_content, StateEventContentChange::Redacted(_));
+    assert_matches!(full_content, StateEventContentChange { prev_content: None, .. });
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
@@ -21,8 +21,7 @@ use eyeball_im::VectorDiff;
 use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, event_id,
-    events::beacon_info::{BeaconInfoEventContent, RedactedBeaconInfoEventContent},
-    owned_event_id, uint,
+    events::beacon_info::BeaconInfoEventContent, owned_event_id, uint,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
@@ -730,7 +729,7 @@ async fn test_redacted_beacon_info_produces_redacted_item() {
         .handle_live_event(timeline.factory.redacted_state(
             &ALICE,
             ALICE.as_str(),
-            RedactedBeaconInfoEventContent::new(),
+            BeaconInfoEventContent::new(None, Duration::ZERO, false, None),
         ))
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -19,10 +19,7 @@ use imbl::vector;
 use matrix_sdk_test::{ALICE, BOB, async_test};
 use ruma::{
     event_id,
-    events::{
-        StateEventContentChange, reaction::RedactedReactionEventContent,
-        room::message::OriginalSyncRoomMessageEvent,
-    },
+    events::{reaction::RedactedReactionEventContent, room::message::OriginalSyncRoomMessageEvent},
     owned_event_id,
 };
 use stream_assert::{assert_next_matches, assert_pending};
@@ -44,19 +41,13 @@ async fn test_redact_state_event() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_let!(TimelineItemContent::OtherState(state) = item.content());
-    assert_matches!(
-        state.content,
-        AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Original { .. })
-    );
+    assert_matches!(state.content, AnyOtherStateEventContentChange::RoomName(_));
 
     timeline.handle_live_event(f.redaction(item.event_id().unwrap()).sender(&ALICE)).await;
 
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
     assert_let!(TimelineItemContent::OtherState(state) = item.content());
-    assert_matches!(
-        state.content,
-        AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Redacted(_))
-    );
+    assert_matches!(state.content, AnyOtherStateEventContentChange::RoomName(_));
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -84,12 +84,12 @@ async fn test_back_pagination() {
         assert_let!(TimelineItemContent::OtherState(state) = message.as_event().unwrap().content());
         assert_eq!(state.state_key(), "");
         assert_let!(
-            AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Original {
+            AnyOtherStateEventContentChange::RoomName(StateEventContentChange {
                 content,
                 prev_content
             }) = state.content()
         );
-        assert_eq!(content.name, "New room name");
+        assert_eq!(content.name.as_deref(), Some("New room name"));
         assert_eq!(prev_content.as_ref().unwrap().name.as_ref().unwrap(), "Old room name");
     }
 
@@ -817,12 +817,12 @@ async fn test_empty_chunk() {
         assert_let!(TimelineItemContent::OtherState(state) = message.as_event().unwrap().content());
         assert_eq!(state.state_key(), "");
         assert_let!(
-            AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Original {
+            AnyOtherStateEventContentChange::RoomName(StateEventContentChange {
                 content,
                 prev_content
             }) = state.content()
         );
-        assert_eq!(content.name, "New room name");
+        assert_eq!(content.name.as_deref(), Some("New room name"));
         assert_eq!(prev_content.as_ref().unwrap().name.as_ref().unwrap(), "Old room name");
     }
 
@@ -914,12 +914,12 @@ async fn test_until_num_items_with_empty_chunk() {
         assert_let!(TimelineItemContent::OtherState(state) = message.as_event().unwrap().content());
         assert_eq!(state.state_key(), "");
         assert_let!(
-            AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Original {
+            AnyOtherStateEventContentChange::RoomName(StateEventContentChange {
                 content,
                 prev_content
             }) = state.content()
         );
-        assert_eq!(content.name, "New room name");
+        assert_eq!(content.name.as_deref(), Some("New room name"));
         assert_eq!(prev_content.as_ref().unwrap().name.as_ref().unwrap(), "Old room name");
     }
 

--- a/crates/matrix-sdk/src/automatic_call_status.rs
+++ b/crates/matrix-sdk/src/automatic_call_status.rs
@@ -26,7 +26,7 @@ use std::{
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     OwnedRoomId, SecondsSinceUnixEpoch,
-    events::{OriginalSyncStateEvent, call::member::CallMemberEventContent},
+    events::{SyncStateEvent, call::member::CallMemberEventContent},
 };
 use tracing::warn;
 
@@ -80,7 +80,7 @@ impl AutomaticCallStatus {
         // set until the user clears it manually.
         let rooms: ActiveCallRooms = Arc::new(Mutex::new(HashSet::new()));
         let handle = client.add_event_handler(
-            async move |event: OriginalSyncStateEvent<CallMemberEventContent>,
+            async move |event: SyncStateEvent<CallMemberEventContent>,
                         room: Room,
                         client: Client| {
                 on_event(&rooms, event, room, client);
@@ -101,7 +101,7 @@ impl Drop for AutomaticCallStatus {
 
 fn on_event(
     rooms: &ActiveCallRooms,
-    event: OriginalSyncStateEvent<CallMemberEventContent>,
+    event: SyncStateEvent<CallMemberEventContent>,
     room: Room,
     client: Client,
 ) {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -74,7 +74,7 @@ use ruma::{
         path_builder::PathBuilder,
     },
     assign,
-    events::{beacon_info::OriginalSyncBeaconInfoEvent, direct::DirectUserIdentifier},
+    events::{beacon_info::SyncBeaconInfoEvent, direct::DirectUserIdentifier},
     presence::PresenceState,
     push::Ruleset,
     time::Instant,
@@ -1232,7 +1232,7 @@ impl Client {
     pub fn observe_own_beacon_info_updates(
         &self,
     ) -> Result<impl Stream<Item = BeaconInfoUpdate> + use<>> {
-        let observer = self.observe_events::<OriginalSyncBeaconInfoEvent, Room>();
+        let observer = self.observe_events::<SyncBeaconInfoEvent, Room>();
         let mut stream = observer.subscribe();
         let own_user_id = self.user_id().ok_or(Error::AuthenticationRequired)?.to_owned();
         Ok(async_stream::stream! {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -75,7 +75,7 @@ use ruma::{
     assign,
     events::room::{
         MediaSource, ThumbnailInfo,
-        member::{MembershipChange, OriginalSyncRoomMemberEvent},
+        member::{MembershipChange, SyncRoomMemberEvent},
     },
 };
 #[cfg(feature = "experimental-send-custom-to-device")]
@@ -2131,7 +2131,7 @@ impl Encryption {
     /// [MSC4268]: https://github.com/matrix-org/matrix-spec-proposals/pull/4268
     fn setup_room_membership_session_discard_handler(&self) {
         let client = WeakClient::from_client(&self.client);
-        self.client.add_event_handler(|ev: OriginalSyncRoomMemberEvent, room: Room| async move {
+        self.client.add_event_handler(|ev: SyncRoomMemberEvent, room: Room| async move {
             let Some(client) = client.get() else {
                 // The main client has been dropped.
                 return;

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -751,9 +751,9 @@ mod tests {
             AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
             macros::EventContent,
             room::{
-                member::{MembershipState, OriginalSyncRoomMemberEvent, StrippedRoomMemberEvent},
-                name::OriginalSyncRoomNameEvent,
-                power_levels::OriginalSyncRoomPowerLevelsEvent,
+                member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
+                name::SyncRoomNameEvent,
+                power_levels::SyncRoomPowerLevelsEvent,
             },
             secret_storage::key::SecretStorageKeyEvent,
             typing::SyncTypingEvent,
@@ -793,7 +793,7 @@ mod tests {
 
         client.add_event_handler({
             let member_count = member_count.clone();
-            move |_ev: OriginalSyncRoomMemberEvent, _room: Room| async move {
+            move |_ev: SyncRoomMemberEvent, _room: Room| async move {
                 member_count.fetch_add(1, SeqCst);
             }
         });
@@ -805,7 +805,7 @@ mod tests {
         });
         client.add_event_handler({
             let power_levels_count = power_levels_count.clone();
-            move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: Room| async move {
+            move |_ev: SyncRoomPowerLevelsEvent, _client: Client, _room: Room| async move {
                 power_levels_count.fetch_add(1, SeqCst);
             }
         });
@@ -904,14 +904,14 @@ mod tests {
         // Room event handlers for member events in both rooms
         client.add_room_event_handler(room_id_a, {
             let member_count = member_count.clone();
-            move |_ev: OriginalSyncRoomMemberEvent, _room: Room| {
+            move |_ev: SyncRoomMemberEvent, _room: Room| {
                 member_count.fetch_add(1, SeqCst);
                 future::ready(())
             }
         });
         client.add_room_event_handler(room_id_b, {
             let member_count = member_count.clone();
-            move |_ev: OriginalSyncRoomMemberEvent, _room: Room| {
+            move |_ev: SyncRoomMemberEvent, _room: Room| {
                 member_count.fetch_add(1, SeqCst);
                 future::ready(())
             }
@@ -920,7 +920,7 @@ mod tests {
         // Power levels event handlers for member events in room A
         client.add_room_event_handler(room_id_a, {
             let power_levels_count = power_levels_count.clone();
-            move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: Room| {
+            move |_ev: SyncRoomPowerLevelsEvent, _client: Client, _room: Room| {
                 power_levels_count.fetch_add(1, SeqCst);
                 future::ready(())
             }
@@ -932,9 +932,7 @@ mod tests {
             // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
             // thinks it's useless.
             #[allow(clippy::unused_unit)]
-            async move |_ev: OriginalSyncRoomNameEvent| -> () {
-                unreachable!("No room event in room B")
-            },
+            async move |_ev: SyncRoomNameEvent| -> () { unreachable!("No room event in room B") },
         );
 
         let f = EventFactory::new().sender(user_id!("@example:localhost"));
@@ -963,9 +961,9 @@ mod tests {
     async fn test_add_event_handler_with_tuples() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
-        client.add_event_handler(
-            |_ev: OriginalSyncRoomMemberEvent, (_room, _client): (Room, Client)| future::ready(()),
-        );
+        client.add_event_handler(|_ev: SyncRoomMemberEvent, (_room, _client): (Room, Client)| {
+            future::ready(())
+        });
 
         // If it compiles, it works. No need to assert anything.
 
@@ -980,7 +978,7 @@ mod tests {
 
         client.add_event_handler({
             let member_count = member_count.clone();
-            move |_ev: OriginalSyncRoomMemberEvent| async move {
+            move |_ev: SyncRoomMemberEvent| async move {
                 member_count.fetch_add(1, SeqCst);
             }
         });
@@ -989,7 +987,7 @@ mod tests {
             // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
             // thinks it's useless.
             #[allow(clippy::unused_unit)]
-            async move |_ev: OriginalSyncRoomMemberEvent| -> () {
+            async move |_ev: SyncRoomMemberEvent| -> () {
                 panic!("handler should have been removed");
             },
         );
@@ -999,14 +997,14 @@ mod tests {
             // lint is buggy: rustc wants the explicit conversion from ! to () here, but clippy
             // thinks it's useless.
             #[allow(clippy::unused_unit)]
-            async move |_ev: OriginalSyncRoomMemberEvent| -> () {
+            async move |_ev: SyncRoomMemberEvent| -> () {
                 panic!("handler should have been removed");
             },
         );
 
         client.add_event_handler({
             let member_count = member_count.clone();
-            move |_ev: OriginalSyncRoomMemberEvent| async move {
+            move |_ev: SyncRoomMemberEvent| async move {
                 member_count.fetch_add(1, SeqCst);
             }
         });
@@ -1029,7 +1027,7 @@ mod tests {
     async fn test_event_handler_drop_guard() {
         let client = no_retry_test_client(None).await;
 
-        let handle = client.add_event_handler(|_ev: OriginalSyncRoomMemberEvent| async {});
+        let handle = client.add_event_handler(|_ev: SyncRoomMemberEvent| async {});
         assert_eq!(client.inner.event_handlers.len(), 1);
 
         {
@@ -1048,7 +1046,7 @@ mod tests {
         // I/O aren't.
         let client = no_retry_test_client(None).await;
 
-        client.add_event_handler(|_ev: OriginalSyncRoomMemberEvent, client: Client| async move {
+        client.add_event_handler(|_ev: SyncRoomMemberEvent, client: Client| async move {
             // All of Client's async methods that do network requests (and
             // possibly some that don't) are `!Send` on wasm. We obviously want
             // to be able to use them in event handlers.
@@ -1067,7 +1065,7 @@ mod tests {
         let counter = Arc::new(AtomicU8::new(0));
         client.add_event_handler_context(counter.clone());
         client.add_event_handler(
-            |_ev: Raw<OriginalSyncRoomMemberEvent>, counter: Ctx<Arc<AtomicU8>>| async move {
+            |_ev: Raw<SyncRoomMemberEvent>, counter: Ctx<Arc<AtomicU8>>| async move {
                 counter.fetch_add(1, SeqCst);
             },
         );
@@ -1108,7 +1106,7 @@ mod tests {
         let room_id_0 = room_id!("!r0.matrix.org");
         let room_id_1 = room_id!("!r1.matrix.org");
 
-        let observable = client.observe_events::<OriginalSyncRoomNameEvent, Room>();
+        let observable = client.observe_events::<SyncRoomNameEvent, Room>();
 
         let mut subscriber = observable.subscribe();
 
@@ -1161,7 +1159,7 @@ mod tests {
         let room_id = room_id!("!r0.matrix.org");
 
         let observable_for_room =
-            client.observe_room_events::<OriginalSyncRoomNameEvent, (Room, Client)>(room_id);
+            client.observe_room_events::<SyncRoomNameEvent, (Room, Client)>(room_id);
 
         let mut subscriber_for_room = observable_for_room.subscribe();
 
@@ -1212,7 +1210,7 @@ mod tests {
         let room_id = room_id!("!r0.matrix.org");
 
         let observable_for_room =
-            client.observe_room_events::<OriginalSyncRoomNameEvent, (Room, Client)>(room_id);
+            client.observe_room_events::<SyncRoomNameEvent, (Room, Client)>(room_id);
 
         let mut subscriber_for_room = observable_for_room.subscribe();
 

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -19,10 +19,9 @@ use ruma::{
         self, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
         AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent, False,
-        GlobalAccountDataEventContent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
-        RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
-        RoomAccountDataEventContent, StaticEventContent, StaticStateEventContent,
-        ToDeviceEventContent, presence::PresenceEvent,
+        GlobalAccountDataEventContent, MessageLikeEventContent, RedactContent,
+        RedactedMessageLikeEventContent, RoomAccountDataEventContent, StaticEventContent,
+        StaticStateEventContent, ToDeviceEventContent, presence::PresenceEvent,
     },
     serde::Raw,
 };
@@ -110,35 +109,16 @@ impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
 
 impl<C> SyncEvent for events::SyncStateEvent<C>
 where
-    C: StaticEventContent + StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent,
+    C: StaticEventContent + StaticStateEventContent,
 {
     const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = Some(C::TYPE);
     type IsPrefix = <C as StaticEventContent>::IsPrefix;
 }
 
-impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
-where
-    C: StaticEventContent + StaticStateEventContent,
-{
-    const KIND: HandlerKind = HandlerKind::OriginalState;
-    const TYPE: Option<&'static str> = Some(C::TYPE);
-    type IsPrefix = <C as StaticEventContent>::IsPrefix;
-}
-
-impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
-where
-    C: StaticEventContent + RedactedStateEventContent,
-{
-    const KIND: HandlerKind = HandlerKind::RedactedState;
-    const TYPE: Option<&'static str> = Some(C::TYPE);
-    type IsPrefix = <C as StaticEventContent>::IsPrefix;
-}
-
 impl<C> SyncEvent for events::StrippedStateEvent<C>
 where
-    C: StaticEventContent + PossiblyRedactedStateEventContent,
+    C: StaticEventContent + StaticStateEventContent,
 {
     const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -26,7 +26,7 @@ use matrix_sdk_base::{
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
     events::{
-        AnyMessageLikeEventContent, AnySyncStateEvent, AnySyncTimelineEvent, SyncStateEvent,
+        AnyMessageLikeEventContent, AnySyncStateEvent, AnySyncTimelineEvent,
         relation::Replacement,
         room::{
             member::MembershipChange,
@@ -772,7 +772,7 @@ fn filter_any_sync_state_event(
     power_levels: Option<&RoomPowerLevels>,
 ) -> ControlFlow<(), FilterContinue> {
     match event {
-        AnySyncStateEvent::RoomMember(SyncStateEvent::Original(member)) => {
+        AnySyncStateEvent::RoomMember(member) if !member.is_redacted() => {
             match member.membership_change() {
                 MembershipChange::Knocked => {
                     let can_accept_or_decline_knocks = match power_levels {
@@ -821,7 +821,7 @@ fn filter_any_sync_state_event(
         // Both the start (`is_live() == true`) and stop (`is_live() == false`)
         // events are suitable, so that the item stays visible in the room
         // summary even after the sharing session ends.
-        AnySyncStateEvent::BeaconInfo(SyncStateEvent::Original(_)) => filter_break(),
+        AnySyncStateEvent::BeaconInfo(beacon) if !beacon.is_redacted() => filter_break(),
 
         _ => filter_continue(),
     }

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -679,7 +679,7 @@ mod tests {
         MilliSecondsSinceUnixEpoch, OwnedTransactionId, event_id,
         events::{
             AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
-            room::member::{MembershipState, SyncRoomMemberEvent},
+            room::member::MembershipState,
         },
         owned_event_id, owned_room_id, room_id, user_id,
     };
@@ -1538,7 +1538,7 @@ mod tests {
                         event.deserialize().unwrap(),
                         AnySyncTimelineEvent::State(
                             AnySyncStateEvent::RoomMember(
-                                SyncRoomMemberEvent::Original(event)
+                                event
                             )
                         ) => {
                             assert_eq!(event.event_id, event_id_1);

--- a/crates/matrix-sdk/src/live_locations_observer.rs
+++ b/crates/matrix-sdk/src/live_locations_observer.rs
@@ -26,9 +26,9 @@ use matrix_sdk_common::locks::Mutex;
 use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
     events::{
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncStateEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         beacon::OriginalSyncBeaconEvent,
-        beacon_info::{BeaconInfoEventContent, OriginalSyncBeaconInfoEvent},
+        beacon_info::{BeaconInfoEventContent, SyncBeaconInfoEvent},
         location::LocationContent,
         relation::RelationType,
     },
@@ -105,7 +105,7 @@ impl LiveLocationsObserver {
         let beacon_guard = room.client.event_handler_drop_guard(beacon_handle);
         let beacon_info_handle = room.add_event_handler({
             let shares = shares.clone();
-            async move |event: OriginalSyncBeaconInfoEvent, room: Room| {
+            async move |event: SyncBeaconInfoEvent, room: Room| {
                 Self::handle_beacon_info_event(&shares, &room, event).await;
             }
         });
@@ -159,7 +159,7 @@ impl LiveLocationsObserver {
     fn extract_live_beacon_info(
         event: SyncOrStrippedState<BeaconInfoEventContent>,
     ) -> Option<(OwnedUserId, BeaconInfoEventContent, OwnedEventId)> {
-        let SyncOrStrippedState::Sync(SyncStateEvent::Original(ev)) = event else {
+        let SyncOrStrippedState::Sync(ev) = event else {
             return None;
         };
         if !ev.content.is_live() {
@@ -237,7 +237,7 @@ impl LiveLocationsObserver {
     async fn handle_beacon_info_event(
         shares: &Mutex<ObservableVector<LiveLocationShare>>,
         room: &Room,
-        event: OriginalSyncBeaconInfoEvent,
+        event: SyncBeaconInfoEvent,
     ) {
         {
             let mut shares = shares.lock();

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -191,7 +191,7 @@ fn wrap_room_member_events(
     let (sender, receiver) = mpsc::channel(16);
     let handle =
         room.client.add_room_event_handler(room_id, move |event: SyncRoomMemberEvent| async move {
-            if *event.state_key() == own_user_id {
+            if event.state_key == own_user_id {
                 return;
             }
             let _: Result<_, _> =

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -104,10 +104,9 @@ use ruma::{
     assign,
     events::{
         AnyRoomAccountDataEvent, AnyRoomAccountDataEventContent, AnyTimelineEvent, EmptyStateKey,
-        Mentions, MessageLikeEventContent, OriginalSyncStateEvent, RedactContent,
-        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
-        StateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
-        SyncStateEvent,
+        Mentions, MessageLikeEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
+        RoomAccountDataEventType, StateEventContent, StateEventType, StaticEventContent,
+        StaticStateEventContent, SyncStateEvent,
         beacon::BeaconEventContent,
         beacon_info::BeaconInfoEventContent,
         direct::DirectEventContent,
@@ -146,8 +145,7 @@ use ruma::{
 };
 #[cfg(feature = "experimental-encrypted-state-events")]
 use ruma::{
-    events::room::encrypted::unstable_state::OriginalSyncStateRoomEncryptedEvent,
-    serde::JsonCastable,
+    events::room::encrypted::unstable_state::SyncStateRoomEncryptedEvent, serde::JsonCastable,
 };
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -772,12 +770,12 @@ impl Room {
                     return event;
                 }
             }
-            Ok(AnySyncTimelineEvent::State(AnySyncStateEvent::RoomEncrypted(
-                SyncStateEvent::Original(_),
-            ))) => {
+            Ok(AnySyncTimelineEvent::State(AnySyncStateEvent::RoomEncrypted(ev)))
+                if !ev.is_redacted() =>
+            {
                 if let Ok(event) = self
                     .decrypt_event(
-                        event.cast_ref_unchecked::<OriginalSyncStateRoomEncryptedEvent>(),
+                        event.cast_ref_unchecked::<SyncStateRoomEncryptedEvent>(),
                         push_ctx,
                     )
                     .await
@@ -1264,15 +1262,7 @@ impl Room {
             return Err(Error::InsufficientData);
         };
 
-        let event = raw_event.deserialize()?;
-
-        let mut content = match event {
-            SyncStateEvent::Original(original_event) => original_event.content,
-            SyncStateEvent::Redacted(redacted_event) => {
-                RoomMemberEventContent::new(redacted_event.content.membership)
-            }
-        };
-
+        let mut content = raw_event.deserialize()?.content;
         content.displayname = display_name;
         self.send_state_event_for_key(user_id, content).await
     }
@@ -1451,10 +1441,13 @@ impl Room {
             .into_iter()
             // Extract state key (ie. the parent's id) and sender
             .filter_map(|parent_event| match parent_event.deserialize() {
-                Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
-                    Some((e.state_key.to_owned(), e.sender))
+                Ok(SyncOrStrippedState::Sync(e)) => {
+                    if e.content.via.is_some() {
+                        Some((e.state_key.to_owned(), e.sender))
+                    } else {
+                        None
+                    }
                 }
-                Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => None,
                 Ok(SyncOrStrippedState::Stripped(e)) => Some((e.state_key.to_owned(), e.sender)),
                 Err(e) => {
                     info!(room_id = ?self.room_id(), "Could not deserialize m.space.parent: {e}");
@@ -1475,12 +1468,13 @@ impl Room {
                     .await?
                 {
                     match child_event.deserialize() {
-                        Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(_))) => {
-                            // There is a valid m.space.child in the parent pointing to
-                            // this room
-                            return Ok(ParentSpace::Reciprocal(parent_room));
+                        Ok(SyncOrStrippedState::Sync(e)) => {
+                            if e.content.via.is_some() {
+                                // There is a valid m.space.child in the parent pointing to
+                                // this room
+                                return Ok(ParentSpace::Reciprocal(parent_room));
+                            }
                         }
-                        Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {}
                         Ok(SyncOrStrippedState::Stripped(_)) => {}
                         Err(e) => {
                             info!(
@@ -3420,9 +3414,9 @@ impl Room {
             .get_state_event_static::<RoomServerAclEventContent>()
             .await?
             .and_then(|ev| ev.deserialize().ok());
-        let acl = acl_ev.as_ref().and_then(|ev| match ev {
-            SyncOrStrippedState::Sync(ev) => ev.as_original().map(|ev| &ev.content),
-            SyncOrStrippedState::Stripped(ev) => Some(&ev.content),
+        let acl = acl_ev.as_ref().map(|ev| match ev {
+            SyncOrStrippedState::Sync(ev) => &ev.content,
+            SyncOrStrippedState::Stripped(ev) => &ev.content,
         });
 
         // Filter out server names that:
@@ -3948,15 +3942,20 @@ impl Room {
     pub(crate) async fn get_user_beacon_info(
         &self,
         user_id: &UserId,
-    ) -> Result<OriginalSyncStateEvent<BeaconInfoEventContent>, BeaconError> {
+    ) -> Result<SyncStateEvent<BeaconInfoEventContent>, BeaconError> {
         let raw_event = self
             .get_state_event_static_for_key::<BeaconInfoEventContent, _>(user_id)
             .await?
             .ok_or(BeaconError::NotFound)?;
 
         match raw_event.deserialize()? {
-            SyncOrStrippedState::Sync(SyncStateEvent::Original(beacon_info)) => Ok(beacon_info),
-            SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_)) => Err(BeaconError::Redacted),
+            SyncOrStrippedState::Sync(beacon_info) => {
+                if beacon_info.is_redacted() {
+                    Err(BeaconError::Redacted)
+                } else {
+                    Ok(beacon_info)
+                }
+            }
             SyncOrStrippedState::Stripped(_) => Err(BeaconError::Stripped),
         }
     }
@@ -4172,9 +4171,9 @@ impl Room {
                 // when any of the branches changes
                 tokio::select! {
                     Some((event, _)) = requests_stream.next() => {
-                        if let Some(event) = event.as_original() {
+                        if !event.is_redacted() {
                             // If we can calculate the membership change, try to emit only when needed
-                            let emit = if event.prev_content().is_some() {
+                            let emit = if event.unsigned.prev_content.is_some() {
                                 matches!(event.membership_change(),
                                     MembershipChange::Banned |
                                     MembershipChange::Knocked |

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -105,9 +105,9 @@ use ruma::{
     events::{
         AnyRoomAccountDataEvent, AnyRoomAccountDataEventContent, AnyTimelineEvent, EmptyStateKey,
         Mentions, MessageLikeEventContent, OriginalSyncStateEvent, RedactContent,
-        RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
-        RoomAccountDataEventType, StateEventContent, StateEventType, StaticEventContent,
-        StaticStateEventContent, SyncStateEvent,
+        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
+        StateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
+        SyncStateEvent,
         beacon::BeaconEventContent,
         beacon_info::BeaconInfoEventContent,
         direct::DirectEventContent,
@@ -1308,10 +1308,7 @@ impl Room {
     /// ```
     pub async fn get_state_events_static<C>(&self) -> Result<Vec<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
     {
         Ok(self.client.state_store().get_state_events_static(self.room_id()).await?)
     }
@@ -1354,11 +1351,8 @@ impl Room {
         state_keys: I,
     ) -> Result<Vec<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
-        C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + Sized + Sync + 'a,
         I: IntoIterator<Item = &'a K> + Send,
         I::IntoIter: Send,
@@ -1404,9 +1398,7 @@ impl Room {
     pub async fn get_state_event_static<C>(&self) -> Result<Option<RawSyncOrStrippedState<C>>>
     where
         C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent<StateKey = EmptyStateKey>
-            + RedactContent,
-        C::Redacted: RedactedStateEventContent,
+            + StaticStateEventContent<StateKey = EmptyStateKey>,
     {
         self.get_state_event_static_for_key(&EmptyStateKey).await
     }
@@ -1435,11 +1427,8 @@ impl Room {
         state_key: &K,
     ) -> Result<Option<RawSyncOrStrippedState<C>>>
     where
-        C: StaticEventContent<IsPrefix = ruma::events::False>
-            + StaticStateEventContent
-            + RedactContent,
+        C: StaticEventContent<IsPrefix = ruma::events::False> + StaticStateEventContent,
         C::StateKey: Borrow<K>,
-        C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
     {
         Ok(self

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -117,7 +117,7 @@ use ruma::{
         room::{
             ImageInfo, MediaSource, ThumbnailInfo,
             avatar::{self, RoomAvatarEventContent},
-            encryption::PossiblyRedactedRoomEncryptionEventContent,
+            encryption::RoomEncryptionEventContent,
             history_visibility::HistoryVisibility,
             member::{MembershipChange, RoomMemberEventContent, SyncRoomMemberEvent},
             message::{
@@ -1066,8 +1066,7 @@ impl Room {
                     Ok(response) => Some(
                         response
                             .into_content()
-                            .deserialize_as_unchecked::<PossiblyRedactedRoomEncryptionEventContent>(
-                            )?,
+                            .deserialize_as_unchecked::<RoomEncryptionEventContent>()?,
                     ),
                     Err(err) if err.client_api_error_kind() == Some(&ErrorKind::NotFound) => None,
                     Err(err) => return Err(err.into()),

--- a/crates/matrix-sdk/src/room/power_levels.rs
+++ b/crates/matrix-sdk/src/room/power_levels.rs
@@ -6,10 +6,7 @@ use ruma::{
     OwnedUserId,
     events::{
         MessageLikeEventType, StateEventType,
-        room::power_levels::{
-            PossiblyRedactedRoomPowerLevelsEventContent, RoomPowerLevels,
-            RoomPowerLevelsEventContent,
-        },
+        room::power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
     },
 };
 
@@ -201,7 +198,7 @@ impl From<js_int::TryFromIntError> for crate::error::Error {
 /// event.
 pub fn power_level_user_changes(
     content: &RoomPowerLevelsEventContent,
-    prev_content: &Option<PossiblyRedactedRoomPowerLevelsEventContent>,
+    prev_content: &Option<RoomPowerLevelsEventContent>,
 ) -> HashMap<OwnedUserId, i64> {
     let Some(prev_content) = prev_content.as_ref() else {
         return Default::default();

--- a/crates/matrix-sdk/src/test_utils/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mod.rs
@@ -333,7 +333,7 @@ macro_rules! assert_decrypted_message_eq {
 ///         ruma::events::room::topic::RoomTopicEventContent { topic, .. }
 ///     ) = event
 /// );
-/// assert_eq!(topic, "Encrypted topic!");
+/// assert_eq!(topic.as_deref(), Some("Encrypted topic!"));
 /// # anyhow::Ok(()) };
 /// ```
 #[macro_export]
@@ -350,8 +350,7 @@ macro_rules! assert_let_decrypted_state_event_content {
             .deserialize_as_unchecked::<$crate::ruma::events::AnyStateEvent>()
             .expect("We should be able to deserialize the decrypted event");
 
-        let content =
-            deserialized_event.original_content().expect("The event should not have been redacted");
+        let content = deserialized_event.content();
 
         assert_matches2::assert_let!($pat = content, $($msg)*);
     };

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -202,7 +202,7 @@ async fn test_most_recent_event_in_stream() {
     assert!(beacon_info.is_live());
     assert_eq!(beacon_info.description, Some("Live Share".to_owned()));
     assert_eq!(beacon_info.timeout, Duration::from_millis(3_600_000));
-    assert_eq!(beacon_info.ts, current_time);
+    assert_eq!(beacon_info.ts, Some(current_time));
     assert_eq!(beacon_info.asset.type_, AssetType::Self_);
 }
 
@@ -274,7 +274,7 @@ async fn test_observe_single_live_location_share() {
     assert!(beacon_info.is_live());
     assert_eq!(beacon_info.description, Some("Test Live Share".to_owned()));
     assert_eq!(beacon_info.timeout, Duration::from_millis(3_600_000));
-    assert_eq!(beacon_info.ts, current_time);
+    assert_eq!(beacon_info.ts, Some(current_time));
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon_info/mod.rs
@@ -106,17 +106,17 @@ async fn test_start_live_location_share_for_room() {
         panic!("Expected a BeaconInfo event");
     };
 
-    let content = ev.as_original().unwrap().content.clone();
+    let content = ev.content.clone();
 
-    assert_eq!(ev.sender(), room.own_user_id());
-    assert_eq!(ev.state_key(), "@example:localhost");
-    assert_eq!(ev.event_id(), event_id!("$15139375514XsgmR:localhost"));
+    assert_eq!(ev.sender, room.own_user_id());
+    assert_eq!(ev.state_key, "@example:localhost");
+    assert_eq!(ev.event_id, event_id!("$15139375514XsgmR:localhost"));
     assert_eq!(ev.event_type(), StateEventType::BeaconInfo);
-    assert_eq!(ev.origin_server_ts(), MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
+    assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
 
     assert_eq!(content.description, Some("Live Share".to_owned()));
     assert_eq!(content.timeout, Duration::from_millis(3000));
-    assert_eq!(content.ts, MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
+    assert_eq!(content.ts, Some(MilliSecondsSinceUnixEpoch(uint!(1_636_829_458))));
     assert_eq!(content.asset.type_, AssetType::Self_);
 
     assert!(content.live);
@@ -240,17 +240,17 @@ async fn test_stop_sharing_live_location() {
         panic!("Expected a BeaconInfo event");
     };
 
-    let content = ev.as_original().unwrap().content.clone();
+    let content = ev.content.clone();
 
-    assert_eq!(ev.sender(), room.own_user_id());
-    assert_eq!(ev.state_key(), "@example:localhost");
-    assert_eq!(ev.event_id(), event_id!("$15139375514XsgmR:localhost"));
+    assert_eq!(ev.sender, room.own_user_id());
+    assert_eq!(ev.state_key, "@example:localhost");
+    assert_eq!(ev.event_id, event_id!("$15139375514XsgmR:localhost"));
     assert_eq!(ev.event_type(), StateEventType::BeaconInfo);
-    assert_eq!(ev.origin_server_ts(), MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
+    assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
 
     assert_eq!(content.description, Some("Live Share".to_owned()));
     assert_eq!(content.timeout, Duration::from_millis(3000));
-    assert_eq!(content.ts, MilliSecondsSinceUnixEpoch(uint!(1_636_829_458)));
+    assert_eq!(content.ts, Some(MilliSecondsSinceUnixEpoch(uint!(1_636_829_458))));
     assert_eq!(content.asset.type_, AssetType::Self_);
 
     assert!(!content.live);

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -650,7 +650,7 @@ async fn test_event() {
         AnySyncTimelineEvent::State(AnySyncStateEvent::RoomTombstone(event)) =
             timeline_event.raw().deserialize().unwrap()
     );
-    assert_eq!(event.event_id(), event_id);
+    assert_eq!(event.event_id, event_id);
 
     let push_actions = timeline_event.push_actions().unwrap();
     assert!(push_actions.iter().any(|a| a.is_highlight()));

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -96,10 +96,7 @@ async fn test_receive_room_encryption_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(
-        event.as_original().unwrap().content.algorithm,
-        EventEncryptionAlgorithm::MegolmV1AesSha2
-    );
+    assert_eq!(event.content.algorithm, Some(EventEncryptionAlgorithm::MegolmV1AesSha2));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -238,7 +235,7 @@ async fn test_receive_room_avatar_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.url.as_deref(), Some(avatar_url));
+    assert_eq!(event.content.url.as_deref(), Some(avatar_url));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -371,7 +368,7 @@ async fn test_receive_room_name_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.name, "My room");
+    assert_eq!(event.content.name.as_deref(), Some("My room"));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -503,7 +500,7 @@ async fn test_receive_room_create_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.room_version, RoomVersionId::V12);
+    assert_eq!(event.content.room_version, RoomVersionId::V12);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -681,7 +678,7 @@ async fn test_receive_room_history_visibility_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.history_visibility, HistoryVisibility::Shared);
+    assert_eq!(event.content.history_visibility, HistoryVisibility::Shared);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -813,7 +810,7 @@ async fn test_receive_room_guest_access_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.guest_access, GuestAccess::CanJoin);
+    assert_eq!(event.content.guest_access, GuestAccess::CanJoin);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -946,7 +943,7 @@ async fn test_receive_room_join_rules_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.join_rule, JoinRule::Public);
+    assert_eq!(event.content.join_rule, JoinRule::Public);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -1083,7 +1080,7 @@ async fn test_receive_room_canonical_alias_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.alias.as_deref(), Some(room_alias));
+    assert_eq!(event.content.alias.as_deref(), Some(room_alias));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -1217,7 +1214,7 @@ async fn test_receive_room_topic_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.topic, room_topic);
+    assert_eq!(event.content.topic.as_deref(), Some(room_topic));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -1355,7 +1352,7 @@ async fn test_receive_room_tombstone_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.replacement_room, tombstone_replacement);
+    assert_eq!(event.content.replacement_room.as_deref(), Some(tombstone_replacement));
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -1490,7 +1487,7 @@ async fn test_receive_room_power_levels_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(i64::from(event.as_original().unwrap().content.users_default), -10);
+    assert_eq!(i64::from(event.content.users_default), -10);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.
@@ -1624,7 +1621,7 @@ async fn test_receive_room_pinned_events_event_via_sync() {
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), valid_raw_event.json().get());
     let (event, _) = assert_ready!(event_subscriber);
-    assert_eq!(event.as_original().unwrap().content.pinned, &[pinned_event]);
+    assert_eq!(event.content.pinned, &[pinned_event]);
 
     // Now we receive an event with an invalid content but a valid type
     // and state key.

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
@@ -141,7 +141,7 @@ async fn test_e2ee_state_events() -> Result<()> {
         AnyStateEventContent::RoomName(content) = rename_event
     );
 
-    assert_eq!("Dog Photos", content.name);
+    assert_eq!(Some("Dog Photos"), content.name.as_deref());
 
     Ok(())
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -1,15 +1,13 @@
 use anyhow::Result;
 use assert_matches::assert_matches;
+use assert_matches2::assert_let;
 use assign::assign;
 use matrix_sdk::{
     Client,
     config::SyncSettings,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
-        events::{
-            AnySyncStateEvent, StateEventType,
-            room::name::{RoomNameEventContent, SyncRoomNameEvent},
-        },
+        events::{AnySyncStateEvent, StateEventType, room::name::RoomNameEventContent},
     },
 };
 
@@ -67,12 +65,9 @@ async fn test_redacting_name() -> Result<()> {
         room.get_state_event(StateEventType::RoomName, "").await?.expect("Room Name not found");
     let room_name_event = raw_event.cast::<RoomNameEventContent>().deserialize()?;
     let sync_room_name_event = room_name_event.as_sync().expect("event is sync event");
-    assert_eq!(
-        sync_room_name_event.as_original().expect("event exists").content.name,
-        "Inappropriate text"
-    );
+    assert_eq!(sync_room_name_event.content.name.as_deref(), Some("Inappropriate text"));
 
-    room.redact(sync_room_name_event.event_id(), None, None).await?;
+    room.redact(&sync_room_name_event.event_id, None, None).await?;
     // sync up.
     for _ in 0..=10 {
         // we call sync up to ten times to give the server time to flush other
@@ -88,10 +83,10 @@ async fn test_redacting_name() -> Result<()> {
         room.get_state_event(StateEventType::RoomName, "").await?.expect("Room Name not found");
     let event = raw_event.deserialize()?;
     // Name content has been redacted
-    assert_matches!(
-        event.as_sync().expect("event is sync event"),
-        AnySyncStateEvent::RoomName(SyncRoomNameEvent::Redacted(_))
+    assert_let!(
+        AnySyncStateEvent::RoomName(room_name) = event.as_sync().expect("event is sync event")
     );
+    assert_matches!(room_name.content.name, None);
 
     Ok(())
 }
@@ -140,12 +135,9 @@ async fn test_redacting_name_static() -> Result<()> {
         .expect("Room Name not found")
         .deserialize()?;
     let sync_room_name_event = room_name_event.as_sync().expect("event is sync event");
-    assert_eq!(
-        sync_room_name_event.as_original().expect("event exists").content.name,
-        "Inappropriate text"
-    );
+    assert_eq!(sync_room_name_event.content.name.as_deref(), Some("Inappropriate text"));
 
-    room.redact(sync_room_name_event.event_id(), None, None).await?;
+    room.redact(&sync_room_name_event.event_id, None, None).await?;
     // we sync up.
     for _ in 0..=10 {
         // we call sync up to ten times to give the server time to flush other
@@ -163,7 +155,7 @@ async fn test_redacting_name_static() -> Result<()> {
         .expect("Room Name not found")
         .deserialize()?;
     // Name content has been redacted
-    assert_matches!(event.as_sync().expect("event is sync event"), SyncRoomNameEvent::Redacted(_));
+    assert_matches!(event.as_sync().expect("event is sync event").content.name, None);
 
     Ok(())
 }

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -33,10 +33,10 @@ use ruma::{
         AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
         AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations,
         EphemeralRoomEventContent, EventContentFromType, False, GlobalAccountDataEventContent,
-        Mentions, MessageLikeEvent, MessageLikeEventContent, PossiblyRedactedStateEventContent,
-        RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
-        RoomAccountDataEventContent, StateEvent, StateEventContent, StaticEventContent,
-        StaticStateEventContent, StrippedStateEvent, SyncMessageLikeEvent, SyncStateEvent,
+        Mentions, MessageLikeEvent, MessageLikeEventContent, RedactContent,
+        RedactedMessageLikeEventContent, RoomAccountDataEventContent, StateEvent,
+        StateEventContent, StaticEventContent, StaticStateEventContent, StrippedStateEvent,
+        SyncMessageLikeEvent, SyncStateEvent,
         beacon::BeaconEventContent,
         beacon_info::BeaconInfoEventContent,
         call::{
@@ -677,8 +677,7 @@ impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuil
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
     for Raw<SyncStateEvent<E>>
 where
-    E: StaticStateEventContent + RedactContent,
-    E::Redacted: RedactedStateEventContent,
+    E: StaticStateEventContent,
 {
     fn from(val: EventBuilder<E>) -> Self {
         val.format(EventFormat::SyncTimeline).into_raw()
@@ -688,9 +687,7 @@ where
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
     for SyncStateEvent<E>
 where
-    E: StaticStateEventContent + RedactContent + EventContentFromType,
-    E::Redacted: RedactedStateEventContent<StateKey = <E as StateEventContent>::StateKey>
-        + EventContentFromType,
+    E: StaticStateEventContent + EventContentFromType,
 {
     fn from(val: EventBuilder<E>) -> Self {
         Raw::<SyncStateEvent<E>>::from(val).deserialize().expect("expected sync state")
@@ -716,8 +713,7 @@ impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuil
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
     for Raw<StateEvent<E>>
 where
-    E: StaticStateEventContent + RedactContent,
-    E::Redacted: RedactedStateEventContent,
+    E: StaticStateEventContent,
 {
     fn from(val: EventBuilder<E>) -> Self {
         val.into_raw()
@@ -727,9 +723,7 @@ where
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
     for StateEvent<E>
 where
-    E: StaticStateEventContent + RedactContent + EventContentFromType,
-    E::Redacted: RedactedStateEventContent<StateKey = <E as StateEventContent>::StateKey>
-        + EventContentFromType,
+    E: StaticStateEventContent + EventContentFromType,
 {
     fn from(val: EventBuilder<E>) -> Self {
         Raw::<StateEvent<E>>::from(val).deserialize().expect("expected state")
@@ -753,7 +747,7 @@ impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuil
 }
 
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
-    for Raw<StrippedStateEvent<E::PossiblyRedacted>>
+    for Raw<StrippedStateEvent<E>>
 where
     E: StaticStateEventContent,
 {
@@ -763,15 +757,12 @@ where
 }
 
 impl<E: StaticEventContent<IsPrefix = False> + StateEventContent> From<EventBuilder<E>>
-    for StrippedStateEvent<E::PossiblyRedacted>
+    for StrippedStateEvent<E>
 where
-    E: StaticStateEventContent,
-    E::PossiblyRedacted: PossiblyRedactedStateEventContent + EventContentFromType,
+    E: StaticStateEventContent + EventContentFromType,
 {
     fn from(val: EventBuilder<E>) -> Self {
-        Raw::<StrippedStateEvent<E::PossiblyRedacted>>::from(val)
-            .deserialize()
-            .expect("expected stripped state")
+        Raw::<StrippedStateEvent<E>>::from(val).deserialize().expect("expected stripped state")
     }
 }
 
@@ -1172,7 +1163,7 @@ impl EventFactory {
 
     /// Create a redacted state event, with extra information in the unsigned
     /// section about the redaction itself.
-    pub fn redacted_state<T: StaticEventContent<IsPrefix = False> + RedactedStateEventContent>(
+    pub fn redacted_state<T: StaticEventContent<IsPrefix = False> + StaticStateEventContent>(
         &self,
         redacter: &UserId,
         state_key: impl Into<String>,


### PR DESCRIPTION
Check with CI that this doesn't break anything.

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

