### PR TITLE
crypto: Don't present emoji for a SAS whose negotiated methods exclude emoji

### DIFF
--- a/crates/matrix-sdk-crypto/changelog.d/6945.fixed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6945.fixed.md
@@ -1,0 +1,8 @@
+[**breaking**] `Sas::emoji()` and `Sas::emoji_index()` now return `None` when the emoji method
+was not part of the negotiated short authentication string methods, instead of
+returning an emoji representation the remote side never agreed to display.
+Previously a client that offered only the (mandatory) `decimal` method would
+negotiate `["decimal"]` in the `m.key.verification.accept` event, yet a peer
+built on this crate would still be handed emoji and could show them to its
+user — leaving the two users comparing a decimal string against emoji, two
+incomparable projections of the same SAS bytes.

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -421,6 +421,15 @@ impl InnerSas {
     }
 
     pub fn emoji(&self) -> Option<[Emoji; 7]> {
+        // The emoji representation must only be offered when the emoji method
+        // was part of the negotiated short auth string methods, i.e. it was
+        // listed in the `m.key.verification.accept` event. Otherwise the two
+        // sides may present representations that cannot be compared to each
+        // other.
+        if !self.supports_emoji() {
+            return None;
+        }
+
         match self {
             InnerSas::KeysExchanged(s) => Some(s.get_emoji()),
             InnerSas::MacReceived(s) => Some(s.get_emoji()),
@@ -429,6 +438,10 @@ impl InnerSas {
     }
 
     pub fn emoji_index(&self) -> Option<[u8; 7]> {
+        if !self.supports_emoji() {
+            return None;
+        }
+
         match self {
             InnerSas::KeysExchanged(s) => Some(s.get_emoji_index()),
             InnerSas::MacReceived(s) => Some(s.get_emoji_index()),

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -623,17 +623,21 @@ impl Sas {
 
     /// Get the emoji version of the short auth string.
     ///
-    /// Returns None if we can't yet present the short auth string, otherwise
-    /// seven tuples containing the emoji and description.
+    /// Returns None if we can't yet present the short auth string or if the
+    /// emoji method was not part of the negotiated short auth string methods
+    /// (see [`Sas::supports_emoji()`]), otherwise seven tuples containing the
+    /// emoji and description.
     pub fn emoji(&self) -> Option<[Emoji; 7]> {
         self.inner.read().emoji()
     }
 
     /// Get the index of the emoji representing the short auth string
     ///
-    /// Returns None if we can't yet present the short auth string, otherwise
-    /// seven u8 numbers in the range from 0 to 63 inclusive which can be
-    /// converted to an emoji using the
+    /// Returns None if we can't yet present the short auth string or if the
+    /// emoji method was not part of the negotiated short auth string methods
+    /// (see [`Sas::supports_emoji()`]), otherwise seven u8 numbers in the
+    /// range from 0 to 63 inclusive which can be converted to an emoji using
+    /// the
     /// [relevant spec entry](https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji).
     pub fn emoji_index(&self) -> Option<[u8; 7]> {
         self.inner.read().emoji_index()
@@ -1027,5 +1031,58 @@ mod tests {
 
         assert!(content.short_authentication_string.contains(&ShortAuthenticationString::Decimal));
         assert!(!content.short_authentication_string.contains(&ShortAuthenticationString::Emoji));
+    }
+
+    #[async_test]
+    async fn test_sas_with_restricted_methods_does_not_present_emoji() {
+        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
+        let identities = alice_store.get_identities(bob_device).await.unwrap();
+
+        let short_auth_strings = vec![ShortAuthenticationString::Decimal];
+        let (alice, content) =
+            Sas::start(identities, TransactionId::new(), true, None, Some(short_auth_strings));
+
+        let flow_id = alice.flow_id().to_owned();
+        let content = StartContent::try_from(&content).unwrap();
+
+        let identities = bob_store.get_identities(alice_device).await.unwrap();
+        let bob = Sas::from_start_event(flow_id, &content, identities, None, false).unwrap();
+
+        let request = bob.accept().unwrap();
+
+        let content = OutgoingContent::try_from(request).unwrap();
+        let content = AcceptContent::try_from(&content).unwrap();
+
+        let (content, request_info) =
+            alice.receive_any_event(bob.user_id(), &content.into()).unwrap();
+        alice.mark_request_as_sent(&request_info.unwrap().request_id);
+
+        let content = KeyContent::try_from(&content).unwrap();
+        let (content, request_info) =
+            bob.receive_any_event(alice.user_id(), &content.into()).unwrap();
+        bob.mark_request_as_sent(&request_info.unwrap().request_id);
+
+        let content = KeyContent::try_from(&content).unwrap();
+        alice.receive_any_event(bob.user_id(), &content.into());
+
+        assert_matches!(alice.state(), SasState::KeysExchanged { .. });
+        assert_matches!(bob.state(), SasState::KeysExchanged { .. });
+        assert!(alice.can_be_presented());
+        assert!(bob.can_be_presented());
+
+        // Only the decimal method was negotiated, so neither side supports
+        // emoji and neither side may present an emoji representation: a peer
+        // that displays emoji here shows its user a representation the other
+        // side has no way to compare against.
+        assert!(!alice.supports_emoji());
+        assert!(!bob.supports_emoji());
+
+        assert!(alice.emoji().is_none());
+        assert!(bob.emoji().is_none());
+        assert!(alice.emoji_index().is_none());
+        assert!(bob.emoji_index().is_none());
+
+        // The negotiated decimal representation is presented on both sides.
+        assert_eq!(alice.decimals().unwrap(), bob.decimals().unwrap());
     }
 }


### PR DESCRIPTION

Fixes #6944

`InnerSas::emoji()` and `InnerSas::emoji_index()` returned the emoji representation for any SAS in the `KeysExchanged`/`MacReceived` states, without consulting `supports_emoji()` — i.e. without checking whether the emoji method was actually part of the negotiated `short_authentication_string` set from the `m.key.verification.accept` event.

The gated semantics already exist in the crate: `SasState::KeysExchanged` only populates `emojis` when `supports_emoji()` holds. But consumers using the direct getters (matrix-sdk-crypto-wasm → matrix-js-sdk → Element Web among them) received emoji for a decimal-only negotiation, and Element Web displays emoji whenever it is present — so against a decimal-only peer, both clients agree on `["decimal"]` on the wire and the users are then shown a decimal triplet on one screen and seven emoji on the other. Two incomparable projections of the same (verified-identical) SAS bytes; the ceremony cannot be completed by a human.

This was correct in matrix-js-sdk's legacy crypto (`SAS.ts` generated only the negotiated representations) and regressed in the rust-crypto migration; it is the display-side sibling of #2060.

## Changes

- `InnerSas::emoji()` / `InnerSas::emoji_index()`: return `None` when `supports_emoji()` is false, matching the `SasState` stream semantics.
- Doc comments on `Sas::emoji()` / `Sas::emoji_index()` updated to state the additional condition.
- Regression test `test_sas_with_restricted_methods_does_not_present_emoji`: drives a decimal-only negotiation through the full key exchange and asserts both sides present decimals and neither presents emoji.

`decimals()` is deliberately left ungated in this PR: the accept path already force-includes `Decimal` in `accepted_protocols` (`sas_state.rs`), so a state where decimal is un-negotiated cannot be represented. If you'd prefer a symmetric guard anyway, happy to add it.

- [x] Public API changes documented in changelogs

