### PR TITLE
fix(sqlite): Fix incorrect use of `repeat_vars` by introducing `ChunkFromLargeQuery`

### DIFF
--- a/crates/matrix-sdk-sqlite/changelog.d/6946.fixed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/6946.fixed.md
@@ -1,0 +1,8 @@
+Fix a bug in `SqliteCryptoStore::mark_inbound_group_sessions_as_backed_up`,
+`SqliteStateStore::get_profiles` and `SqliteStateStore::get_global_profiles`,
+where passing a large number of sessions or users were erroring to “too many SQL
+variables” in SQLite. This error is due to a manual misuse of the
+`repeat_vars` function in the `chunk_large_query_over` method. The fix is to
+make misuses impossible by introducing the new `ChunkFromLargeQuery` type,
+replacing the `Vec<Key>` in `chunk_large_query_over`, removing the need to
+manually use `repeat_vars`.

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -58,7 +58,7 @@ use crate::{
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt, repeat_vars,
+        SqliteKeyValueStoreConnExt,
     },
 };
 
@@ -893,13 +893,16 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         }
 
         self.chunk_large_query_over(session_ids, None, move |txn, session_ids| {
-            // Safety: placeholders is not generated using any user input except the number
-            // of session IDs, so it is safe from injection.
-            let sql_params = repeat_vars(session_ids.len());
-            let query = format!("UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({sql_params})");
-            txn.prepare(&query)?.execute(params_from_iter(session_ids.iter()))?;
+            // Safety: host parameters are not generated using any user input except the
+            // number of session IDs, so it is safe from injection.
+            let query = format!(
+                "UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({})",
+                session_ids.host_parameters()
+            );
+            txn.prepare(&query)?.execute(params_from_iter(session_ids))?;
             Ok(Vec::<()>::new())
-        }).await?;
+        })
+        .await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -892,12 +892,10 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
             return Ok(());
         }
 
-        let session_ids_len = session_ids.len();
-
         self.chunk_large_query_over(session_ids, None, move |txn, session_ids| {
             // Safety: placeholders is not generated using any user input except the number
             // of session IDs, so it is safe from injection.
-            let sql_params = repeat_vars(session_ids_len);
+            let sql_params = repeat_vars(session_ids.len());
             let query = format!("UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({sql_params})");
             txn.prepare(&query)?.execute(params_from_iter(session_ids.iter()))?;
             Ok(Vec::<()>::new())

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -58,7 +58,7 @@ use crate::{
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt, SqliteTransactionExt, repeat_vars,
+        SqliteKeyValueStoreConnExt, SqliteTransactionExt, host_parameters,
     },
 };
 
@@ -1548,7 +1548,7 @@ impl EventCacheStore for SqliteEventCacheStore {
 
         // If there's no events for which we want to check duplicates, we can return
         // early. It's not only an optimization to do so: it's required, otherwise the
-        // `repeat_vars` call below will panic.
+        // `host_parameters` call below will panic.
         if event_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1870,7 +1870,7 @@ fn find_event_relations_transaction(
             FROM events \
             LEFT JOIN event_chunks ON events.event_id = event_chunks.event_id AND event_chunks.linked_chunk_id = ? \
             WHERE events.relates_to = ? AND events.room_id = ? AND events.rel_type IN ({})",
-            repeat_vars(filters.len())
+            host_parameters(filters.len())
         );
 
         // First the filters need to be stringified; because `.to_sql()` will borrow

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -1584,7 +1584,7 @@ impl EventCacheStore for SqliteEventCacheStore {
                             FROM event_chunks \
                             WHERE linked_chunk_id = ? AND event_id IN ({}) \
                             ORDER BY chunk_id ASC, position ASC",
-                            repeat_vars(event_ids_and_hashed_event_ids.len()),
+                            event_ids_and_hashed_event_ids.host_parameters(),
                         );
 
                         let parameters = params_from_iter(

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -48,7 +48,7 @@ use crate::{
     error::{Error, Result},
     utils::{
         EncryptableStore, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt, SqliteTransactionExt, repeat_vars, time_to_timestamp,
+        SqliteKeyValueStoreConnExt, SqliteTransactionExt, time_to_timestamp,
     },
 };
 
@@ -671,7 +671,7 @@ impl MediaStoreInner for SqliteMediaStore {
                         }
 
                         txn.chunk_large_query_over(rows_to_remove, None, |txn, row_ids| {
-                            let sql_params = repeat_vars(row_ids.len());
+                            let sql_params = row_ids.host_parameters();
                             let query = format!("DELETE FROM media WHERE rowid IN ({sql_params})");
                             txn.prepare(&query)?.execute(params_from_iter(row_ids))?;
                             Ok(Vec::<()>::new())

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -51,7 +51,7 @@ use crate::{
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
-        SqliteKeyValueStoreConnExt, repeat_vars,
+        SqliteKeyValueStoreConnExt,
     },
 };
 
@@ -931,8 +931,8 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let keys_length = keys.len();
 
         self.chunk_large_query_over(keys, Some(keys_length), |txn, keys| {
-            let sql_params = repeat_vars(keys.len());
-            let sql = format!("SELECT value FROM kv_blob WHERE key IN ({sql_params})");
+            let sql =
+                format!("SELECT value FROM kv_blob WHERE key IN ({})", keys.host_parameters());
 
             let params = rusqlite::params_from_iter(keys);
 
@@ -976,11 +976,11 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         event_type: Key,
         state_keys: Vec<Key>,
     ) -> Result<Vec<(bool, Vec<u8>)>> {
-        self.chunk_large_query_over(state_keys, None, move |txn, state_keys: Vec<Key>| {
-            let sql_params = repeat_vars(state_keys.len());
+        self.chunk_large_query_over(state_keys, None, move |txn, state_keys| {
             let sql = format!(
                 "SELECT stripped, data FROM state_event
-                 WHERE room_id = ? AND event_type = ? AND state_key IN ({sql_params})"
+                 WHERE room_id = ? AND event_type = ? AND state_key IN ({})",
+                state_keys.host_parameters()
             );
 
             let params = rusqlite::params_from_iter(
@@ -1022,9 +1022,9 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let user_ids_length = user_ids.len();
 
         self.chunk_large_query_over(user_ids, Some(user_ids_length), move |txn, user_ids| {
-            let sql_params = repeat_vars(user_ids.len());
             let sql = format!(
-                "SELECT user_id, data FROM profile WHERE room_id = ? AND user_id IN ({sql_params})"
+                "SELECT user_id, data FROM profile WHERE room_id = ? AND user_id IN ({})",
+                user_ids.host_parameters(),
             );
 
             let params = rusqlite::params_from_iter(iter::once(room_id.clone()).chain(user_ids));
@@ -1042,9 +1042,9 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let user_ids_length = user_ids.len();
 
         self.chunk_large_query_over(user_ids, Some(user_ids_length), move |txn, user_ids| {
-            let sql_params = repeat_vars(user_ids.len());
             let sql = format!(
-                "SELECT user_id, profile_data FROM global_profiles WHERE user_id IN ({sql_params})"
+                "SELECT user_id, profile_data FROM global_profiles WHERE user_id IN ({})",
+                user_ids.host_parameters(),
             );
 
             let params = rusqlite::params_from_iter(user_ids);
@@ -1066,9 +1066,9 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
             .await?
         } else {
             self.chunk_large_query_over(memberships, None, move |txn, memberships| {
-                let sql_params = repeat_vars(memberships.len());
                 let sql = format!(
-                    "SELECT data FROM member WHERE room_id = ? AND membership IN ({sql_params})"
+                    "SELECT data FROM member WHERE room_id = ? AND membership IN ({})",
+                    memberships.host_parameters(),
                 );
 
                 let params =
@@ -1120,9 +1120,9 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let names_length = names.len();
 
         self.chunk_large_query_over(names, Some(names_length), move |txn, names| {
-            let sql_params = repeat_vars(names.len());
             let sql = format!(
-                "SELECT name, data FROM display_name WHERE room_id = ? AND name IN ({sql_params})"
+                "SELECT name, data FROM display_name WHERE room_id = ? AND name IN ({})",
+                names.host_parameters()
             );
 
             let params = rusqlite::params_from_iter(iter::once(room_id.clone()).chain(names));

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1022,7 +1022,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let user_ids_length = user_ids.len();
 
         self.chunk_large_query_over(user_ids, Some(user_ids_length), move |txn, user_ids| {
-            let sql_params = repeat_vars(user_ids_length);
+            let sql_params = repeat_vars(user_ids.len());
             let sql = format!(
                 "SELECT user_id, data FROM profile WHERE room_id = ? AND user_id IN ({sql_params})"
             );
@@ -1042,7 +1042,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
         let user_ids_length = user_ids.len();
 
         self.chunk_large_query_over(user_ids, Some(user_ids_length), move |txn, user_ids| {
-            let sql_params = repeat_vars(user_ids_length);
+            let sql_params = repeat_vars(user_ids.len());
             let sql = format!(
                 "SELECT user_id, profile_data FROM global_profiles WHERE user_id IN ({sql_params})"
             );

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -125,6 +125,12 @@ pub(crate) trait SqliteAsyncConnExt {
         E: From<rusqlite::Error> + Send + 'static,
         F: FnOnce(&Transaction<'_>) -> Result<T, E> + Send + 'static;
 
+    /// Chunk a large query over some keys.
+    ///
+    /// Imagine there is a _dynamic_ query that runs potentially large number of
+    /// parameters, so much that the maximum number of parameters can be hit.
+    /// Then, this helper is for you. It will execute the query on chunks of
+    /// parameters.
     async fn chunk_large_query_over<Query, Res>(
         &self,
         mut keys_to_chunk: Vec<Key>,
@@ -133,7 +139,7 @@ pub(crate) trait SqliteAsyncConnExt {
     ) -> Result<Vec<Res>>
     where
         Res: Send + 'static,
-        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static;
+        Query: Fn(&Transaction<'_>, ChunkFromLargeQuery<Key>) -> Result<Vec<Res>> + Send + 'static;
 
     /// Apply the [`RuntimeConfig`].
     ///
@@ -352,12 +358,6 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
         .map_err(E::from)?
     }
 
-    /// Chunk a large query over some keys.
-    ///
-    /// Imagine there is a _dynamic_ query that runs potentially large number of
-    /// parameters, so much that the maximum number of parameters can be hit.
-    /// Then, this helper is for you. It will execute the query on chunks of
-    /// parameters.
     async fn chunk_large_query_over<Query, Res>(
         &self,
         keys_to_chunk: Vec<Key>,
@@ -366,7 +366,7 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
     ) -> Result<Vec<Res>>
     where
         Res: Send + 'static,
-        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static,
+        Query: Fn(&Transaction<'_>, ChunkFromLargeQuery<Key>) -> Result<Vec<Res>> + Send + 'static,
     {
         self.with_transaction(move |txn| {
             txn.chunk_large_query_over(keys_to_chunk, result_capacity, do_query)
@@ -391,6 +391,7 @@ fn map_interact_err(error: InteractError) -> rusqlite::Error {
 }
 
 pub(crate) trait SqliteTransactionExt {
+    /// See [`SqliteAsyncConnExt::chunk_large_query_over`].
     fn chunk_large_query_over<Key, Query, Res>(
         &self,
         keys_to_chunk: Vec<Key>,
@@ -399,7 +400,37 @@ pub(crate) trait SqliteTransactionExt {
     ) -> Result<Vec<Res>>
     where
         Res: Send + 'static,
-        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static;
+        Query: Fn(&Transaction<'_>, ChunkFromLargeQuery<Key>) -> Result<Vec<Res>> + Send + 'static;
+}
+
+/// Represent the new chunk prepared by
+/// [`SqliteAsyncConnExt::chunk_large_query_over`] or
+/// [`SqliteTransactionExt::chunk_large_query_over`].
+#[repr(transparent)]
+pub(crate) struct ChunkFromLargeQuery<Key>(Vec<Key>);
+
+impl<Key> IntoIterator for ChunkFromLargeQuery<Key> {
+    type Item = Key;
+    type IntoIter = std::vec::IntoIter<Key>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<Key> ChunkFromLargeQuery<Key> {
+    /// Return the correct number of host parameters (the `?` variable in an SQL
+    /// query) equals to the size of the chunk.
+    pub fn host_parameters(&self) -> impl fmt::Display + use<Key> {
+        repeat_vars(self.0.len())
+    }
+
+    /// Iterate over the keys in the chunk, by reference.
+    ///
+    /// To get an owned iterator, see the `IntoIterator` implementation.
+    pub fn iter(&self) -> std::slice::Iter<'_, Key> {
+        self.0.iter()
+    }
 }
 
 impl SqliteTransactionExt for Transaction<'_> {
@@ -411,7 +442,7 @@ impl SqliteTransactionExt for Transaction<'_> {
     ) -> Result<Vec<Res>>
     where
         Res: Send + 'static,
-        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static,
+        Query: Fn(&Transaction<'_>, ChunkFromLargeQuery<Key>) -> Result<Vec<Res>> + Send + 'static,
     {
         // Divide by 2 to allow space for more static parameters (not part of
         // `keys_to_chunk`).
@@ -424,7 +455,7 @@ impl SqliteTransactionExt for Transaction<'_> {
             // Chunking isn't necessary.
             let chunk = keys_to_chunk;
 
-            Ok(do_query(self, chunk)?)
+            Ok(do_query(self, ChunkFromLargeQuery(chunk))?)
         } else {
             // Chunking _is_ necessary.
 
@@ -438,7 +469,7 @@ impl SqliteTransactionExt for Transaction<'_> {
                 let chunk = keys_to_chunk;
                 keys_to_chunk = tail;
 
-                all_results.extend(do_query(self, chunk)?);
+                all_results.extend(do_query(self, ChunkFromLargeQuery(chunk))?);
             }
 
             Ok(all_results)

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -422,7 +422,7 @@ impl<Key> ChunkFromLargeQuery<Key> {
     /// Return the correct number of host parameters (the `?` variable in an SQL
     /// query) equals to the size of the chunk.
     pub fn host_parameters(&self) -> impl fmt::Display + use<Key> {
-        repeat_vars(self.0.len())
+        host_parameters(self.0.len())
     }
 
     /// Iterate over the keys in the chunk, by reference.
@@ -656,8 +656,8 @@ impl SqliteKeyValueStoreAsyncConnExt for SqliteAsyncConn {
 }
 
 /// Repeat `?` n times, where n is defined by `count`. `?` are comma-separated.
-pub(crate) fn repeat_vars(count: usize) -> impl fmt::Display {
-    assert_ne!(count, 0, "Can't generate zero repeated vars");
+pub(crate) fn host_parameters(count: usize) -> impl fmt::Display {
+    assert_ne!(count, 0, "Can't generate zero host parameters");
 
     iter::repeat_n("?", count).format(",")
 }
@@ -774,16 +774,16 @@ mod unit_tests {
     use super::*;
 
     #[test]
-    fn can_generate_repeated_vars() {
-        assert_eq!(repeat_vars(1).to_string(), "?");
-        assert_eq!(repeat_vars(2).to_string(), "?,?");
-        assert_eq!(repeat_vars(5).to_string(), "?,?,?,?,?");
+    fn test_can_generate_host_parameters() {
+        assert_eq!(host_parameters(1).to_string(), "?");
+        assert_eq!(host_parameters(2).to_string(), "?,?");
+        assert_eq!(host_parameters(5).to_string(), "?,?,?,?,?");
     }
 
     #[test]
-    #[should_panic(expected = "Can't generate zero repeated vars")]
-    fn generating_zero_vars_panics() {
-        repeat_vars(0);
+    #[should_panic(expected = "Can't generate zero host parameters")]
+    fn test_generating_zero_host_parameters_panics() {
+        host_parameters(0);
     }
 
     #[test]


### PR DESCRIPTION
This patch introduces a new `ChunkFromLargeQuery` type, which replaces the `Vec<Key>` in the query passed to `chunk_large_query_over`. This new type introduces the `host_parameters` method, which calls `repeat_vars` with the size of the chunk, removing a bug of misusing the `repeat_vars` function.

`ChunkFromLargeQuery` also implements `IntoIterator` to make it transparent to use in most situations.

Then, `repeat_vars` is renamed to `host_parameters` because it is how [SQLite names this thing](https://sqlite.org/limits.html).

The first patch has been written by @poljar, I've added him as a co-author.

Finally, `host_parameters` (ex-`repeat_vars`) should ideally be removed, but we are using it in two last places. Should we do something about?

---

- Fixes https://github.com/element-hq/element-x-ios-rageshakes/issues/7611#issuecomment-5474982154 where `SqliteStateStore::get_profiles` was called for 99'737 profiles (!). https://github.com/matrix-org/matrix-rust-sdk/pull/2231/ was supposed to fix the problem but the API was misused. This new patch here aims at making a misuse impossible.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
