### PR TITLE
fix(xtask): Fix the matcher for logs in `sync`

### DIFF
--- a/xtask/src/log/sync.rs
+++ b/xtask/src/log/sync.rs
@@ -41,6 +41,7 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
 
             # Let's capture some data about `send()`!
             \s>\ssend\{
+                .*
                 request_id="REQ-(?<request_id>\d+)"
                 \smethod=(?<method>\S+)
                 \suri="(?<uri>[^"]+)"


### PR DESCRIPTION
The `config` field has been added recently on the `send` method, breaking this command. This is an attempt to fix it.

For the sake of archeology: https://github.com/matrix-org/matrix-rust-sdk/pull/6762 broke the tool.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
