### PR TITLE
Don't assume a known room is joined just because it has no invite state

### DIFF
--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -224,8 +224,11 @@ pub async fn update_any_room(
 /// Look through the sliding sync data for this room, find/create it in the
 /// store, and process any invite information.
 ///
-/// If there is any invite state events, the room can be considered an invited
+/// If there are any invite state events, the room can be considered an invited
 /// or knocked room, depending of the membership event (if any).
+///
+/// Otherwise, we assume that a new unknown room is joined. But a known room
+/// keeps the state it already has (with no assumption about it being joined).
 fn membership(
     context: &mut Context,
     state_events: &mut [RawStateEventWithKeys<AnySyncStateEvent>],
@@ -286,17 +289,13 @@ fn membership(
             }
         }
     }
-    // No invite state events. We assume this is a joined room for the moment. See this block to
-    // learn more.
+    // No invite state events.
     else {
+        // A new unknown room is assumed to be joined, but not a known room.
+        // The homeserver only sends the invite state once, so just because
+        // we don't have any invite state does *not* mean that the room is joined.
         let room = store.get_or_create_room(room_id, RoomState::Joined);
         let mut room_info = room.clone_info();
-
-        // We default to considering this room joined if it's not an invite. If it's
-        // actually left (and we remembered to request membership events in our sync
-        // request), then we can find this out from the events in required_state by
-        // calling handle_own_room_membership.
-        room_info.mark_as_joined();
 
         // We don't need to do this in a v2 sync, because the membership of a room can
         // be figured out by whether the room is in the `join`, `leave` etc. property.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1414,6 +1414,100 @@ mod tests {
     }
 
     #[async_test]
+    async fn test_invited_room_stays_invited_when_a_later_response_has_no_invite_state() {
+        // Given a logged-in client that knows about an invited room…
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!r:e.uk");
+        let user_id = user_id!("@u:e.uk");
+
+        let mut room = http::response::Room::new();
+        set_room_invited(&mut room, user_id, user_id);
+        let response = response_with_room(room_id, room);
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // (sanity: state is invite)
+        assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Invited);
+
+        // When a later response mentions the room again, but has no `invite_state` and
+        // no membership event…
+        let response = response_with_room(room_id, http::response::Room::new());
+        let sync_resp = client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // … the room is still invited, and still reported as such.
+        assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Invited);
+        assert!(sync_resp.rooms.invited.contains_key(room_id));
+        assert!(!sync_resp.rooms.joined.contains_key(room_id));
+    }
+
+    #[async_test]
+    async fn test_invited_room_becomes_joined_from_required_state_event() {
+        // Given a logged-in client that knows about an invited room…
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!r:e.uk");
+        let user_id = user_id!("@u:e.uk");
+
+        let mut room = http::response::Room::new();
+        set_room_invited(&mut room, user_id, user_id);
+        let response = response_with_room(room_id, room);
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // (sanity: state is invite)
+        assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Invited);
+
+        let mut room_info_notable_update = client.room_info_notable_update_receiver();
+
+        // When the invite is accepted, the server sends the new membership event in
+        // `required_state`…
+        let mut room = http::response::Room::new();
+        set_room_joined(&mut room, user_id);
+        let response = response_with_room(room_id, room);
+        let sync_resp = client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        // … and the room becomes joined.
+        assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
+
+        assert!(sync_resp.rooms.joined.contains_key(room_id));
+        assert!(!sync_resp.rooms.invited.contains_key(room_id));
+
+        // The membership change is notable.
+        assert_matches!(
+            room_info_notable_update.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(reasons.contains(RoomInfoNotableUpdateReasons::MEMBERSHIP));
+            }
+        );
+    }
+
+    #[async_test]
     async fn test_avatar_is_found_in_invitation_room_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -94,6 +94,10 @@ pub trait StateStoreIntegrationTests {
     async fn test_custom_storage(&self) -> TestResult;
     /// Test stripped and non-stripped room member saving.
     async fn test_stripped_non_stripped(&self) -> TestResult;
+    /// Test that a stripped room keeps its stripped state across saves.
+    async fn test_stripped_state_is_kept_across_saves(&self) -> TestResult;
+    /// Test that a room info only save doesn't drop the room's data.
+    async fn test_room_info_only_save_keeps_room_data(&self) -> TestResult;
     /// Test room removal.
     async fn test_room_removal(&self) -> TestResult;
     /// Test profile removal.
@@ -1095,6 +1099,127 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await?;
         assert_eq!(members, vec![user_id.to_owned()]);
+
+        Ok(())
+    }
+
+    async fn test_stripped_state_is_kept_across_saves(&self) -> TestResult {
+        // The server sends `invite_state`/`knock_state` once, so it must survive any
+        // later save.
+        for (room_id, room_state) in [
+            (room_id!("!test_stripped_state_invited:localhost"), RoomState::Invited),
+            (room_id!("!test_stripped_state_knocked:localhost"), RoomState::Knocked),
+        ] {
+            let user_id = user_id();
+
+            let mut changes = StateChanges::default();
+            changes.add_stripped_member(
+                room_id,
+                user_id,
+                custom_stripped_membership_event(user_id),
+            );
+
+            let f = EventFactory::new().sender(user_id).room(room_id);
+            let stripped_name_raw: Raw<AnyStrippedStateEvent> = f.room_name("room name").into();
+            let stripped_name_event =
+                RawStateEventWithKeys::try_from_raw_state_event(stripped_name_raw).unwrap();
+            changes
+                .stripped_state
+                .entry(room_id.to_owned())
+                .or_default()
+                .entry(stripped_name_event.event_type)
+                .or_default()
+                .insert(stripped_name_event.state_key, stripped_name_event.raw);
+
+            changes.add_room(RoomInfo::new(room_id, room_state));
+            self.save_changes(&changes).await?;
+
+            assert!(
+                self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_some(),
+                "{room_state:?}: the stripped room name must be saved"
+            );
+            let member_event =
+                self.get_member_event(room_id, user_id).await?.unwrap().deserialize()?;
+            assert_matches!(member_event, MemberEvent::Stripped(_));
+
+            // A later sync only carries the room info.
+            let mut changes = StateChanges::default();
+            changes.add_room(RoomInfo::new(room_id, room_state));
+            self.save_changes(&changes).await?;
+
+            assert!(
+                self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_some(),
+                "{room_state:?}: the stripped room name must survive a room info save"
+            );
+            assert!(
+                self.get_member_event(room_id, user_id).await?.is_some(),
+                "{room_state:?}: the stripped member must survive a room info save"
+            );
+            assert_eq!(
+                self.get_user_ids(room_id, RoomMemberships::empty()).await?,
+                vec![user_id.to_owned()],
+                "{room_state:?}: the stripped member must still be listed"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn test_room_info_only_save_keeps_room_data(&self) -> TestResult {
+        // A `StateChanges` carrying nothing but a `RoomInfo`, as
+        // `BaseClient::room_knocked` saves, has nothing to put in place of what it
+        // would delete, so it must delete nothing.
+        for (room_id, new_state) in [
+            (room_id!("!test_room_info_only_save_knocked:localhost"), RoomState::Knocked),
+            (room_id!("!test_room_info_only_save_invited:localhost"), RoomState::Invited),
+        ] {
+            let user_id = user_id();
+
+            let mut changes = StateChanges::default();
+            changes
+                .state
+                .entry(room_id.to_owned())
+                .or_default()
+                .entry(StateEventType::RoomMember)
+                .or_default()
+                .insert(user_id.into(), membership_event().cast());
+
+            let f = EventFactory::new().sender(user_id).room(room_id);
+            let name_raw: Raw<AnySyncStateEvent> = f.room_name("room name").into();
+            let name_event = name_raw.deserialize()?;
+            changes.add_state_event(room_id, name_event, name_raw);
+
+            changes.add_room(RoomInfo::new(room_id, RoomState::Left));
+            self.save_changes(&changes).await?;
+
+            let member_event =
+                self.get_member_event(room_id, user_id).await?.unwrap().deserialize()?;
+            assert_matches!(member_event, MemberEvent::Sync(_));
+            assert!(self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_some());
+
+            // Knocking on (or being invited back to) the room.
+            let mut changes = StateChanges::default();
+            changes.add_room(RoomInfo::new(room_id, new_state));
+            self.save_changes(&changes).await?;
+
+            let member_event = self
+                .get_member_event(room_id, user_id)
+                .await?
+                .unwrap_or_else(|| {
+                    panic!("{new_state:?}: the member event must survive a room info only save")
+                })
+                .deserialize()?;
+            assert_matches!(member_event, MemberEvent::Sync(_));
+            assert!(
+                self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_some(),
+                "{new_state:?}: the room name must survive a room info only save"
+            );
+            assert_eq!(
+                self.get_user_ids(room_id, RoomMemberships::empty()).await?,
+                vec![user_id.to_owned()],
+                "{new_state:?}: the member must still be listed"
+            );
+        }
 
         Ok(())
     }
@@ -2360,6 +2485,18 @@ macro_rules! statestore_integration_tests {
             async fn test_stripped_non_stripped() -> TestResult {
                 let store = get_store().await?.into_state_store();
                 store.test_stripped_non_stripped().await
+            }
+
+            #[async_test]
+            async fn test_stripped_state_is_kept_across_saves() -> TestResult {
+                let store = get_store().await?.into_state_store();
+                store.test_stripped_state_is_kept_across_saves().await
+            }
+
+            #[async_test]
+            async fn test_room_info_only_save_keeps_room_data() -> TestResult {
+                let store = get_store().await?.into_state_store();
+                store.test_room_info_only_save_keeps_room_data().await
             }
 
             #[async_test]

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1350,9 +1350,17 @@ impl StateStore for SqliteStateStore {
                 }
 
                 for (room_id, room_info) in room_infos {
-                    let stripped = room_info.state() == RoomState::Invited;
-                    // Remove non-stripped data for stripped rooms and vice-versa.
-                    this.remove_maybe_stripped_room_data(txn, &room_id, !stripped)?;
+                    // Invited and knocked rooms only have stripped state.
+                    let stripped = matches!(room_info.state(), RoomState::Invited | RoomState::Knocked);
+
+                    // Once the room state isn't invited or knocking, we can drop its stripped state.
+                    // If we haven't joined it but we do have real state, we can replace it
+                    // with the stripped state (only if said stripped state is available).
+                    // Otherwise, we would end up deleting the room's state events and members,
+                    // which is obviously bad and undesirable.
+                    if !stripped || stripped_state.contains_key(&room_id) {
+                        this.remove_maybe_stripped_room_data(txn, &room_id, !stripped)?;
+                    }
 
                     let room_id = this.encode_key(keys::ROOM_INFO, room_id);
                     let state = this
@@ -2560,6 +2568,68 @@ mod tests {
         tracing::info!("using store @ {}", tmpdir_path.to_str().unwrap());
 
         Ok(SqliteStateStore::open(tmpdir_path.to_str().unwrap(), None).await.unwrap())
+    }
+
+    /// Specific to this store, which keys stripped storage off the room state,
+    /// so it can't live in `statestore_integration_tests!`.
+    #[matrix_sdk_test::async_test]
+    async fn test_stripped_data_is_dropped_once_the_room_is_joined() {
+        use matrix_sdk_base::{
+            RoomInfo, RoomMemberships, RoomState, StateChanges, store::StateStoreExt,
+        };
+        use ruma::{
+            events::{
+                StateEventType,
+                room::member::{MembershipState, RoomMemberEventContent},
+            },
+            room_id,
+            serde::Raw,
+            user_id,
+        };
+
+        let store = get_store().await.unwrap();
+        let room_id = room_id!("!test_stripped_data_is_dropped:localhost");
+        let user_id = user_id!("@u:localhost");
+
+        // Invited: all we know about the room is its stripped state.
+        let member: Raw<ruma::events::room::member::StrippedRoomMemberEvent> =
+            Raw::new(&serde_json::json!({
+                "type": "m.room.member",
+                "content": RoomMemberEventContent::new(MembershipState::Invite),
+                "sender": "@inviter:localhost",
+                "state_key": user_id,
+            }))
+            .unwrap()
+            .cast_unchecked();
+
+        let mut changes = StateChanges::default();
+        changes.add_stripped_member(room_id, user_id, member);
+        changes.add_room(RoomInfo::new(room_id, RoomState::Invited));
+        store.save_changes(&changes).await.unwrap();
+
+        assert!(store.get_member_event(room_id, user_id).await.unwrap().is_some());
+
+        // Accepting the invite: `BaseClient::room_joined` saves the room info and
+        // nothing else.
+        let mut changes = StateChanges::default();
+        changes.add_room(RoomInfo::new(room_id, RoomState::Joined));
+        store.save_changes(&changes).await.unwrap();
+
+        assert!(
+            store.get_member_event(room_id, user_id).await.unwrap().is_none(),
+            "the stripped member event must be dropped once the room is joined"
+        );
+        assert!(
+            store.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap().is_empty(),
+            "the stripped member must no longer be listed"
+        );
+        assert!(
+            store
+                .get_state_event(room_id, StateEventType::RoomMember, user_id.as_str())
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     statestore_integration_tests!();


### PR DESCRIPTION
If a sync response didn't include the `invite_state` for a room, the sdk previously marked it as joined, unconditionally.

That's not really correct, because the homeserver only sends a room's `invite_state` the very first time that it syncs the room info,
so all future sync responses might result in an invited room being improperly converted to a joined room.

There's a few tricky issues surrounding this for knocked rooms too, especially how the state store will update a room entry. I added more detail in the commit messages.

**This is pretty confusing but it does fix my issues with knocked rooms, nevertheless i'd appreciate a deep review**  to make sure i didn't screw anything up. 

AFAICT, stripped state is basically a preview of a room that you're not in yet (not joined/invited/knocked or anything), so we don't want a "stripped state event" to take the place of a room's existing "real" room info state. Previously, a sync response that includes some updated info about a knocked room would result in accidental deletion of the invite state (really the knocked state) in the state store for it, which means that the other code (which i also fixed in this PR) would treat that room as joined. Definitely wrong, IIUC.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
   * no public API changes
- [x] This PR was made with the help of AI.
   * yes, claude Opus 5 and i worked through the solution together, but i made heavy edits

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
