### PR TITLE
feat(send queue): stop writing the reason-less redact variant

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6931.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6931.added.md
@@ -1,1 +1,1 @@
-Add `DependentQueuedRequestKind::RedactEventWithReason`, which carries the reason that a raced abort applies to the redaction materializing it. `RedactEvent` is unchanged, so pending requests persisted by older versions load as before.
+Add `DependentQueuedRequestKind::RedactEventWithReason`, which carries the reason for send queue led redaction. The old variant is kept unchanged so existing request can drain and will be simply deleted later.

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -237,8 +237,9 @@ pub enum DependentQueuedRequestKind {
     /// the redaction if the event was sent by the time the abort was processed
     /// and must be redacted server-side.
     RedactEventWithReason {
-        /// Reason for the redaction.
-        reason: String,
+        /// Reason for the redaction, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
     },
 
     /// The event should be reacted to, with the given key.
@@ -547,17 +548,27 @@ mod tests {
     use super::DependentQueuedRequestKind;
 
     #[test]
-    fn test_deserialize_redact_event_variants() {
-        // `RedactEvent` is a unit variant, and must stay one: requests persisted
-        // before `RedactEventWithReason` existed are serialized as a plain string.
+    fn test_deserialize_legacy_redact_event() {
+        // `RedactEvent` is a unit variant, and must stay one for as long as it exists:
+        // requests persisted before `RedactEventWithReason` are serialized as a plain
+        // string, and this is the only thing that still reads them.
         let deserialized: DependentQueuedRequestKind =
             serde_json::from_str("\"RedactEvent\"").unwrap();
         assert_matches!(deserialized, DependentQueuedRequestKind::RedactEvent);
+    }
 
-        let kind = DependentQueuedRequestKind::RedactEventWithReason { reason: "spam".to_owned() };
-        let serialized = serde_json::to_string(&kind).unwrap();
-        let deserialized: DependentQueuedRequestKind = serde_json::from_str(&serialized).unwrap();
-        assert_let!(DependentQueuedRequestKind::RedactEventWithReason { reason } = deserialized);
-        assert_eq!(reason, "spam");
+    #[test]
+    fn test_redact_event_with_reason_round_trip() {
+        for reason in [None, Some("spam".to_owned())] {
+            let kind = DependentQueuedRequestKind::RedactEventWithReason { reason: reason.clone() };
+            let serialized = serde_json::to_string(&kind).unwrap();
+            let deserialized: DependentQueuedRequestKind =
+                serde_json::from_str(&serialized).unwrap();
+            assert_let!(
+                DependentQueuedRequestKind::RedactEventWithReason { reason: deserialized } =
+                    deserialized
+            );
+            assert_eq!(deserialized, reason);
+        }
     }
 }

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -1624,12 +1624,7 @@ impl QueueStorage {
                     transaction_id,
                     ChildTransactionId::new(),
                     MilliSecondsSinceUnixEpoch::now(),
-                    match reason {
-                        Some(reason) => {
-                            DependentQueuedRequestKind::RedactEventWithReason { reason }
-                        }
-                        None => DependentQueuedRequestKind::RedactEvent,
-                    },
+                    DependentQueuedRequestKind::RedactEventWithReason { reason },
                 )
                 .await?;
 
@@ -2288,7 +2283,8 @@ impl QueueStorage {
             kind @ (DependentQueuedRequestKind::RedactEvent
             | DependentQueuedRequestKind::RedactEventWithReason { .. }) => {
                 let reason = match kind {
-                    DependentQueuedRequestKind::RedactEventWithReason { reason } => Some(reason),
+                    DependentQueuedRequestKind::RedactEventWithReason { reason } => reason,
+                    // The legacy variant carries no reason.
                     _ => None,
                 };
 
@@ -3354,7 +3350,7 @@ mod tests {
         let redact = DependentQueuedRequest {
             own_transaction_id: ChildTransactionId::new(),
             parent_transaction_id: txn.clone(),
-            kind: DependentQueuedRequestKind::RedactEvent,
+            kind: DependentQueuedRequestKind::RedactEventWithReason { reason: None },
             parent_key: None,
             created_at: MilliSecondsSinceUnixEpoch::now(),
         };
@@ -3389,7 +3385,7 @@ mod tests {
         let res = canonicalize_dependent_requests(&inputs);
 
         assert_eq!(res.len(), 1);
-        assert_matches!(&res[0].kind, DependentQueuedRequestKind::RedactEvent);
+        assert_matches!(&res[0].kind, DependentQueuedRequestKind::RedactEventWithReason { .. });
         assert_eq!(res[0].parent_transaction_id, txn);
     }
 
@@ -3438,7 +3434,7 @@ mod tests {
             // This one pertains to txn1.
             DependentQueuedRequest {
                 own_transaction_id: child1.clone(),
-                kind: DependentQueuedRequestKind::RedactEvent,
+                kind: DependentQueuedRequestKind::RedactEventWithReason { reason: None },
                 parent_transaction_id: txn1.clone(),
                 parent_key: None,
                 created_at: MilliSecondsSinceUnixEpoch::now(),
@@ -3466,7 +3462,10 @@ mod tests {
         for dependent in res {
             if dependent.own_transaction_id == child1 {
                 assert_eq!(dependent.parent_transaction_id, txn1);
-                assert_matches!(dependent.kind, DependentQueuedRequestKind::RedactEvent);
+                assert_matches!(
+                    dependent.kind,
+                    DependentQueuedRequestKind::RedactEventWithReason { .. }
+                );
             } else {
                 assert_eq!(dependent.parent_transaction_id, txn2);
                 assert_matches!(dependent.kind, DependentQueuedRequestKind::EditEvent { .. });


### PR DESCRIPTION
Every new dependent redaction now uses `RedactEventWithReason`, whose reason is optional, rather than picking between it and the unit `RedactEvent`.

`RedactEvent` stays for the sole purpose of reading requests persisted before the reason existed and it can be removed once none can plausibly remain.