### PR TITLE
feat(send queue): remove the reason-less redact variant

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/6959.removed.md
+++ b/crates/matrix-sdk-base/changelog.d/6959.removed.md
@@ -1,0 +1,1 @@
+Remove `DependentQueuedRequestKind::RedactEvent`, which nothing has written since `RedactEventWithReason` was introduced.

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1127,7 +1127,7 @@ impl StateStoreIntegrationTests for DynStateStore {
                 &txn,
                 ChildTransactionId::new(),
                 MilliSecondsSinceUnixEpoch::now(),
-                DependentQueuedRequestKind::RedactEvent,
+                DependentQueuedRequestKind::RedactEventWithReason { reason: None },
             )
             .await?;
         }
@@ -1670,7 +1670,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             &txn0,
             child_txn.clone(),
             MilliSecondsSinceUnixEpoch::now(),
-            DependentQueuedRequestKind::RedactEvent,
+            DependentQueuedRequestKind::RedactEventWithReason { reason: None },
         )
         .await?;
 
@@ -1680,7 +1680,10 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(dependents[0].parent_transaction_id, txn0);
         assert_eq!(dependents[0].own_transaction_id, child_txn);
         assert!(dependents[0].parent_key.is_none());
-        assert_matches!(dependents[0].kind, DependentQueuedRequestKind::RedactEvent);
+        assert_matches!(
+            dependents[0].kind,
+            DependentQueuedRequestKind::RedactEventWithReason { .. }
+        );
 
         // Update the event id.
         let (event, event_type) = event0.raw();
@@ -1715,7 +1718,10 @@ impl StateStoreIntegrationTests for DynStateStore {
                 assert_eq!(received_event_type.as_str(), event_type);
             }
         );
-        assert_matches!(dependents[0].kind, DependentQueuedRequestKind::RedactEvent);
+        assert_matches!(
+            dependents[0].kind,
+            DependentQueuedRequestKind::RedactEventWithReason { .. }
+        );
 
         // Now remove it.
         let removed = self
@@ -1745,7 +1751,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             &txn0,
             ChildTransactionId::new(),
             MilliSecondsSinceUnixEpoch::now(),
-            DependentQueuedRequestKind::RedactEvent,
+            DependentQueuedRequestKind::RedactEventWithReason { reason: None },
         )
         .await?;
         assert_eq!(self.load_dependent_queued_requests(room_id).await?.len(), 1);
@@ -1788,7 +1794,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             &txn,
             child_txn.clone(),
             MilliSecondsSinceUnixEpoch::now(),
-            DependentQueuedRequestKind::RedactEvent,
+            DependentQueuedRequestKind::RedactEventWithReason { reason: None },
         )
         .await?;
 
@@ -1798,7 +1804,10 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(dependents[0].parent_transaction_id, txn);
         assert_eq!(dependents[0].own_transaction_id, child_txn);
         assert!(dependents[0].parent_key.is_none());
-        assert_matches!(dependents[0].kind, DependentQueuedRequestKind::RedactEvent);
+        assert_matches!(
+            dependents[0].kind,
+            DependentQueuedRequestKind::RedactEventWithReason { .. }
+        );
 
         // Make it a reaction, instead of a redaction.
         self.update_dependent_queued_request(

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -230,9 +230,6 @@ pub enum DependentQueuedRequestKind {
         new_content: SerializableEventContent,
     },
 
-    /// The event should be redacted/aborted/removed.
-    RedactEvent,
-
     /// The event should be redacted/aborted/removed, with a reason applied to
     /// the redaction if the event was sent by the time the abort was processed
     /// and must be redacted server-side.
@@ -509,7 +506,6 @@ impl DependentQueuedRequest {
     pub fn is_own_event(&self) -> bool {
         match self.kind {
             DependentQueuedRequestKind::EditEvent { .. }
-            | DependentQueuedRequestKind::RedactEvent
             | DependentQueuedRequestKind::RedactEventWithReason { .. }
             | DependentQueuedRequestKind::ReactEvent { .. }
             | DependentQueuedRequestKind::UploadFileOrThumbnail { .. } => {
@@ -543,19 +539,9 @@ impl fmt::Debug for QueuedRequest {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::{assert_let, assert_matches};
+    use assert_matches2::assert_let;
 
     use super::DependentQueuedRequestKind;
-
-    #[test]
-    fn test_deserialize_legacy_redact_event() {
-        // `RedactEvent` is a unit variant, and must stay one for as long as it exists:
-        // requests persisted before `RedactEventWithReason` are serialized as a plain
-        // string, and this is the only thing that still reads them.
-        let deserialized: DependentQueuedRequestKind =
-            serde_json::from_str("\"RedactEvent\"").unwrap();
-        assert_matches!(deserialized, DependentQueuedRequestKind::RedactEvent);
-    }
 
     #[test]
     fn test_redact_event_with_reason_round_trip() {

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -2969,7 +2969,7 @@ mod migration_tests {
                     room_id,
                     &local_tx,
                     ChildTransactionId::new(),
-                    DependentQueuedRequestKind::RedactEvent,
+                    DependentQueuedRequestKind::RedactEventWithReason { reason: None },
                 )?;
                 add_send_queue_event_v7(&db, txn, &wedge_tx, room_id, true)?;
                 add_send_queue_event_v7(&db, txn, &local_tx, room_id, false)?;

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -2061,7 +2061,6 @@ impl QueueStorage {
         let reactions_and_medias =
             dependent_requests.into_iter().filter_map(|dep| match dep.kind {
                 DependentQueuedRequestKind::EditEvent { .. }
-                | DependentQueuedRequestKind::RedactEvent
                 | DependentQueuedRequestKind::RedactEventWithReason { .. } => {
                     // TODO: reflect local edits/redacts too?
                     None
@@ -2280,14 +2279,7 @@ impl QueueStorage {
                 }
             }
 
-            kind @ (DependentQueuedRequestKind::RedactEvent
-            | DependentQueuedRequestKind::RedactEventWithReason { .. }) => {
-                let reason = match kind {
-                    DependentQueuedRequestKind::RedactEventWithReason { reason } => reason,
-                    // The legacy variant carries no reason.
-                    _ => None,
-                };
-
+            DependentQueuedRequestKind::RedactEventWithReason { reason } => {
                 if let Some(parent_key) = parent_key {
                     let Some(event_id) = parent_key.into_event_id() else {
                         return Err(RoomSendQueueError::StorageError(
@@ -3171,11 +3163,7 @@ fn canonicalize_dependent_requests(
         let prevs = by_txn.entry(d.parent_transaction_id.clone()).or_default();
 
         if prevs.iter().any(|prev| {
-            matches!(
-                prev.kind,
-                DependentQueuedRequestKind::RedactEvent
-                    | DependentQueuedRequestKind::RedactEventWithReason { .. }
-            )
+            matches!(prev.kind, DependentQueuedRequestKind::RedactEventWithReason { .. })
         }) {
             // The parent event has already been flagged for redaction, don't consider the
             // other dependent events.
@@ -3208,8 +3196,7 @@ fn canonicalize_dependent_requests(
                 prevs.push(d);
             }
 
-            DependentQueuedRequestKind::RedactEvent
-            | DependentQueuedRequestKind::RedactEventWithReason { .. } => {
+            DependentQueuedRequestKind::RedactEventWithReason { .. } => {
                 // Remove every other dependent action.
                 prevs.clear();
                 prevs.push(d);


### PR DESCRIPTION
Remove `DependentQueuedRequestKind::RedactEvent`, which nothing has written since `RedactEventWithReason` was introduced.


**Reviewer note: leave this alone until stalebot reminds us about it. By then it will be safe to merge as (almost) all users would have drained their existing send queues.**


- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.