### PR TITLE
Performance improvements to `RelationalLinkedChunk`

### DIFF
--- a/benchmarks/benches/event_cache.rs
+++ b/benchmarks/benches/event_cache.rs
@@ -104,12 +104,6 @@ fn handle_room_updates(c: &mut Criterion) {
         });
 
         for (store_name, store_builder) in &store_builders {
-            // TODO: Remove this conditional block when memory store performance
-            // is improved. At the moment, it takes too long and is causing CI to
-            // timeout.
-            if *store_name == "memory" && num_rooms == 100 {
-                continue;
-            }
             let client = runtime.block_on(async {
                 let event_cache_store = store_builder().await;
 

--- a/benchmarks/benches/event_cache.rs
+++ b/benchmarks/benches/event_cache.rs
@@ -104,6 +104,12 @@ fn handle_room_updates(c: &mut Criterion) {
         });
 
         for (store_name, store_builder) in &store_builders {
+            // TODO: Remove this conditional block when memory store performance
+            // is improved. At the moment, it takes too long and is causing CI to
+            // timeout.
+            if *store_name == "memory" && num_rooms == 100 {
+                continue;
+            }
             let client = runtime.block_on(async {
                 let event_cache_store = store_builder().await;
 

--- a/crates/matrix-sdk-base/changelog.d/6872.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/6872.fixed.md
@@ -1,0 +1,9 @@
+`EventCacheStoreIntegrationTests` were updated to ensure that implementations
+of `EventCacheStore` adhere to the following three properties.
+
+1. An `Event` should not exist within a `LinkedChunk` more than once - i.e., it
+   should occupy only a single `Position`.
+2. Each `Position` within a `LinkedChunk` should only be occupied by a single `Event`.
+3. When changes are made to the content of an `Event` in one `LinkedChunk`, these
+   changes should be reflected in all `LinkedChunk`s which contain an instance of
+   that `Event`.

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -1150,42 +1150,81 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
     async fn test_linked_chunk_replace_item(&self) {
         let room_id = &DEFAULT_TEST_ROOM_ID;
-        let linked_chunk_id = LinkedChunkId::Room(room_id);
+
+        // Create every kind of linked chunk id in the room, as well
+        // as one in a different room.
+        let linked_chunk_ids = [
+            LinkedChunkId::Room(room_id),
+            LinkedChunkId::Thread(room_id, event_id!("$thread_root")),
+            LinkedChunkId::PinnedEvents(room_id),
+            LinkedChunkId::EventFocused(room_id, event_id!("$focus_root")),
+            LinkedChunkId::Room(room_id!("!other_room")),
+        ];
+
+        // The event id of the event that will be replaced
         let event_id = event_id!("$world");
 
+        // Add the same two events to every linked chunk id in the list
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![
+                    Update::NewItemsChunk { previous: None, new: CId::new(42), next: None },
+                    Update::PushItems {
+                        at: Position::new(CId::new(42), 0),
+                        items: vec![
+                            make_test_event(room_id, "hello"),
+                            make_test_event_with_event_id(room_id, "world", Some(event_id)),
+                        ],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+
+            assert_eq!(chunks.len(), 1);
+
+            let c = chunks.remove(0);
+            assert_eq!(c.identifier, CId::new(42));
+            assert_eq!(c.previous, None);
+            assert_eq!(c.next, None);
+            assert_matches!(c.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "hello");
+                check_test_event(&events[1], "world");
+            });
+        }
+
+        // In one of the linked chunks, replace the second event with different
+        // content, but keep the event id the same.
         self.handle_linked_chunk_updates(
-            linked_chunk_id,
-            vec![
-                Update::NewItemsChunk { previous: None, new: CId::new(42), next: None },
-                Update::PushItems {
-                    at: Position::new(CId::new(42), 0),
-                    items: vec![
-                        make_test_event(room_id, "hello"),
-                        make_test_event_with_event_id(room_id, "world", Some(event_id)),
-                    ],
-                },
-                Update::ReplaceItem {
-                    at: Position::new(CId::new(42), 1),
-                    item: make_test_event_with_event_id(room_id, "yolo", Some(event_id)),
-                },
-            ],
+            linked_chunk_ids[0],
+            vec![Update::ReplaceItem {
+                at: Position::new(CId::new(42), 1),
+                item: make_test_event_with_event_id(room_id, "yolo", Some(event_id)),
+            }],
         )
         .await
         .unwrap();
 
-        let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+        // Ensure that the event content has been updated in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
 
-        assert_eq!(chunks.len(), 1);
+            assert_eq!(chunks.len(), 1);
 
-        let c = chunks.remove(0);
-        assert_eq!(c.identifier, CId::new(42));
-        assert_eq!(c.previous, None);
-        assert_eq!(c.next, None);
-        assert_matches!(c.content, ChunkContent::Items(events) => {
-            assert_eq!(events.len(), 2);
-            check_test_event(&events[0], "hello");
-            check_test_event(&events[1], "yolo");
-        });
+            let c = chunks.remove(0);
+            assert_eq!(c.identifier, CId::new(42));
+            assert_eq!(c.previous, None);
+            assert_eq!(c.next, None);
+            assert_matches!(c.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "hello");
+                check_test_event(&events[1], "yolo");
+            });
+        }
     }
 
     async fn test_linked_chunk_remove_item(&self) {

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -165,6 +165,9 @@ pub trait EventCacheStoreIntegrationTests {
     /// Test removing a chunk.
     async fn test_linked_chunk_remove_chunk(&self);
 
+    /// Test pushing items onto a linked chunk.
+    async fn test_linked_chunk_push_items(&self);
+
     /// Test replacing an item in a linked chunk.
     async fn test_linked_chunk_replace_item(&self);
 
@@ -947,6 +950,202 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_matches!(c.content, ChunkContent::Gap(gap) => {
             assert_eq!(gap.token, "tartiflette");
         });
+    }
+
+    async fn test_linked_chunk_push_items(&self) {
+        let room_id = *DEFAULT_TEST_ROOM_ID;
+
+        // Create every kind of linked chunk id in the room.
+        let linked_chunk_ids = [
+            LinkedChunkId::Room(room_id),
+            LinkedChunkId::Thread(room_id, event_id!("$thread_root")),
+            LinkedChunkId::PinnedEvents(room_id),
+            LinkedChunkId::EventFocused(room_id, event_id!("$focus_root")),
+        ];
+
+        // Add the same event to every linked chunk
+        let event_id_a = event_id!("$a");
+        let event_a = make_test_event_with_event_id(room_id, "a", Some(event_id_a));
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![
+                    Update::NewItemsChunk { previous: None, new: CId::new(0), next: None },
+                    Update::PushItems {
+                        at: Position::new(CId::new(0), 0),
+                        items: vec![event_a.clone()],
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 1);
+                check_test_event(&events[0], "a");
+            });
+        }
+
+        let event_b = make_test_event_with_event_id(room_id, "b", Some(event_id!("$b")));
+        // Pushing an event to an occupied position should fail in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec![event_b.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event to an occupied position");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 1);
+                check_test_event(&events[0], "a");
+            });
+        }
+
+        // Pushing an event to an unoccupied position should succeed in every linked
+        // chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 1),
+                    items: vec![event_b.clone()],
+                }],
+            )
+            .await
+            .unwrap();
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Create an updated version of event a
+        let updated_event_a = make_test_event_with_event_id(room_id, "updated_a", Some(event_id_a));
+
+        // Pushing an updated event to a position occupied by the same event should
+        // fail in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 0),
+                    items: vec![updated_event_a.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event to an occupied position");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Pushing an updated event to a position occupied by a different event should
+        // fail in every linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 1),
+                    items: vec![updated_event_a.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event to an occupied position");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Pushing an updated event to an unoccupied position in a linked chunk should
+        // fail if the event already exists in the linked chunk.
+        for linked_chunk_id in linked_chunk_ids {
+            self.handle_linked_chunk_updates(
+                linked_chunk_id,
+                vec![Update::PushItems {
+                    at: Position::new(CId::new(0), 2),
+                    items: vec![updated_event_a.clone()],
+                }],
+            )
+            .await
+            .expect_err("should fail to push an event that already exists in the linked chunk");
+
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "a");
+                check_test_event(&events[1], "b");
+            });
+        }
+
+        // Create a new linked chunk in a new room that does not contain event a
+        let other_linked_chunk_id = LinkedChunkId::Room(room_id!("!other_room:localhost"));
+        self.handle_linked_chunk_updates(
+            other_linked_chunk_id,
+            vec![Update::NewItemsChunk { previous: None, new: CId::new(0), next: None }],
+        )
+        .await
+        .unwrap();
+
+        // Pushing an updated version of event a to an unoccupied position in the new
+        // linked chunk should succeed and also update the event content across all
+        // linked chunks in all rooms.
+        self.handle_linked_chunk_updates(
+            other_linked_chunk_id,
+            vec![Update::PushItems {
+                at: Position::new(CId::new(0), 0),
+                items: vec![updated_event_a.clone()],
+            }],
+        )
+        .await
+        .unwrap();
+
+        let mut chunks = self.load_all_chunks(other_linked_chunk_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk = chunks.remove(0);
+        assert_matches!(chunk.content, ChunkContent::Items(events) => {
+            assert_eq!(events.len(), 1);
+            check_test_event(&events[0], "updated_a");
+        });
+
+        for linked_chunk_id in linked_chunk_ids {
+            let mut chunks = self.load_all_chunks(linked_chunk_id).await.unwrap();
+            assert_eq!(chunks.len(), 1);
+            let chunk = chunks.remove(0);
+            assert_matches!(chunk.content, ChunkContent::Items(events) => {
+                assert_eq!(events.len(), 2);
+                check_test_event(&events[0], "updated_a");
+                check_test_event(&events[1], "b");
+            });
+        }
     }
 
     async fn test_linked_chunk_replace_item(&self) {
@@ -2464,6 +2663,13 @@ macro_rules! event_cache_store_integration_tests {
                 let event_cache_store =
                     get_event_cache_store().await.unwrap().into_event_cache_store();
                 event_cache_store.test_linked_chunk_remove_chunk().await;
+            }
+
+            #[async_test]
+            async fn test_linked_chunk_push_items() {
+                let event_cache_store =
+                    get_event_cache_store().await.unwrap().into_event_cache_store();
+                event_cache_store.test_linked_chunk_push_items().await;
             }
 
             #[async_test]

--- a/crates/matrix-sdk-common/changelog.d/6872.fixed.md
+++ b/crates/matrix-sdk-common/changelog.d/6872.fixed.md
@@ -1,0 +1,8 @@
+Update `RelationalLinkedChunk` to ensure it adheres to the following three properties.
+
+1. An `Event` should not exist within a `LinkedChunk` more than once - i.e., it
+   should occupy only a single `Position`.
+2. Each `Position` within a `LinkedChunk` should only be occupied by a single `Event`.
+3. When changes are made to the content of an `Event` in one `LinkedChunk`, these
+   changes should be reflected in all `LinkedChunk`s which contain an instance of
+   that `Event`.

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -1233,7 +1233,7 @@ impl PartialEq<u64> for ChunkIdentifier {
 /// The position of something inside a [`Chunk`].
 ///
 /// It's a pair of a chunk position and an item index.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Position(ChunkIdentifier, usize);
 
 impl Position {

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -98,6 +98,14 @@ pub enum RelationalLinkedChunkError {
         /// The chunk identifier.
         identifier: ChunkIdentifier,
     },
+    /// The provided item is already present in the linked chunk
+    /// to which it is being added.
+    #[error("item already in linked chunk")]
+    ItemAlreadyInLinkedChunk,
+    /// A position in a linked chunk is already occupied by
+    /// an event
+    #[error("position already occupied")]
+    PositionAlreadyOccupied,
 }
 
 /// The [`IndexableItem`] trait is used to mark items that can be indexed into a
@@ -121,7 +129,7 @@ impl IndexableItem for TimelineEvent {
 
 impl<ItemId, Item, Gap> RelationalLinkedChunk<ItemId, Item, Gap>
 where
-    Item: IndexableItem<ItemId = ItemId>,
+    Item: IndexableItem<ItemId = ItemId> + Clone,
     ItemId: Hash + PartialEq + Eq + Clone + Ord,
 {
     /// Create a new relational linked chunk.
@@ -198,15 +206,51 @@ where
                 Update::PushItems { mut at, items } => {
                     for item in items {
                         let item_id = item.id();
-                        self.items
-                            .entry(linked_chunk_id.to_owned())
-                            .or_default()
-                            .insert(item_id.clone(), (item, Some(at)));
+                        let linked_chunk_items =
+                            self.items.entry(linked_chunk_id.to_owned()).or_default();
+
+                        // Ensure item does not already exist in another position
+                        // in this linked chunk
+                        if let Some((_, position)) = linked_chunk_items.get(&item_id)
+                            && position.is_some()
+                        {
+                            return Err(RelationalLinkedChunkError::ItemAlreadyInLinkedChunk);
+                        }
+                        for row in &self.items_chunks {
+                            if row.linked_chunk_id == linked_chunk_id
+                                && let Either::Item(id) = &row.item
+                                && id == &item_id
+                            {
+                                return Err(RelationalLinkedChunkError::ItemAlreadyInLinkedChunk);
+                            }
+                        }
+
+                        // Ensure position is not occupied by another item
+                        for (_, position) in linked_chunk_items.values() {
+                            if let Some(position) = position
+                                && *position == at
+                            {
+                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
+                            }
+                        }
+                        for row in &self.items_chunks {
+                            if row.linked_chunk_id == linked_chunk_id && row.position == at {
+                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
+                            }
+                        }
+
+                        linked_chunk_items.insert(item_id.clone(), (item.clone(), Some(at)));
                         self.items_chunks.push(ItemRow {
                             linked_chunk_id: linked_chunk_id.to_owned(),
                             position: at,
                             item: Either::Item(item_id),
                         });
+
+                        // Ensure item is updated if it exists anywhere else in the store
+                        for items in &mut self.items.values_mut() {
+                            items.entry(item.id()).and_modify(|e| e.0 = item.clone());
+                        }
+
                         at.increment_index();
                     }
                 }
@@ -258,7 +302,21 @@ where
                     }
 
                     self.items_chunks.remove(entry_to_remove.expect("Remove an unknown item"));
+
                     // We deliberately keep the item in the items collection.
+                    self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                        for (_, opt) in items.values_mut() {
+                            if let Some(position) = opt
+                                && position.chunk_identifier() == at.chunk_identifier()
+                            {
+                                if position.index() == at.index() {
+                                    opt.take();
+                                } else if position.index() > at.index() {
+                                    position.decrement_index();
+                                }
+                            }
+                        }
+                    });
                 }
 
                 Update::DetachLastItems { at } => {
@@ -285,6 +343,11 @@ where
 
                     for index_to_remove in indices_to_remove.into_iter().rev() {
                         self.items_chunks.remove(index_to_remove);
+                        self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                            for (_, pos) in items.values_mut() {
+                                pos.take();
+                            }
+                        });
                     }
                 }
 
@@ -293,7 +356,12 @@ where
                 Update::Clear => {
                     self.chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
                     self.items_chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
-                    // We deliberately leave the items intact.
+                    // We deliberately leave the items in the items collection.
+                    self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                        for (_, pos) in items.values_mut() {
+                            pos.take();
+                        }
+                    });
                 }
             }
         }
@@ -575,7 +643,7 @@ where
 
 impl<ItemId, Item, Gap> Default for RelationalLinkedChunk<ItemId, Item, Gap>
 where
-    Item: IndexableItem<ItemId = ItemId>,
+    Item: IndexableItem<ItemId = ItemId> + Clone,
     ItemId: Hash + PartialEq + Eq + Clone + Ord,
 {
     fn default() -> Self {

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -348,12 +348,16 @@ where
 
                     for index_to_remove in indices_to_remove.into_iter().rev() {
                         self.items_chunks.remove(index_to_remove);
-                        self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
-                            for (_, pos) in items.values_mut() {
-                                pos.take();
-                            }
-                        });
                     }
+
+                    self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
+                        for (_, pos) in items.values_mut() {
+                            pos.take_if(|pos| {
+                                pos.chunk_identifier() == at.chunk_identifier()
+                                    && pos.index() >= at.index()
+                            });
+                        }
+                    });
                 }
 
                 Update::StartReattachItems | Update::EndReattachItems => { /* nothing */ }

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -84,6 +84,9 @@ pub struct RelationalLinkedChunk<ItemId, Item, Gap> {
     /// Items chunks.
     items_chunks: Vec<ItemRow<ItemId, Gap>>,
 
+    /// Occupied positions.
+    items_positions: HashSet<(OwnedLinkedChunkId, Position)>,
+
     /// The items' content themselves.
     items: HashMap<OwnedLinkedChunkId, BTreeMap<ItemId, (Item, Option<Position>)>>,
 }
@@ -134,7 +137,12 @@ where
 {
     /// Create a new relational linked chunk.
     pub fn new() -> Self {
-        Self { chunks: Vec::new(), items_chunks: Vec::new(), items: HashMap::new() }
+        Self {
+            chunks: Vec::new(),
+            items_chunks: Vec::new(),
+            items_positions: HashSet::new(),
+            items: HashMap::new(),
+        }
     }
 
     /// Remove all the chunks and items for a particular room for this
@@ -143,6 +151,7 @@ where
         self.chunks.retain(|ChunkRow { linked_chunk_id, .. }| linked_chunk_id.room_id() != room_id);
         self.items_chunks
             .retain(|ItemRow { linked_chunk_id, .. }| linked_chunk_id.room_id() != room_id);
+        self.items_positions.retain(|(linked_chunk_id, _)| linked_chunk_id.room_id() != room_id);
         self.items.retain(|key, _| key.room_id() != room_id);
     }
 
@@ -150,6 +159,7 @@ where
     pub fn clear(&mut self) {
         self.chunks.clear();
         self.items_chunks.clear();
+        self.items_positions.clear();
         self.items.clear();
     }
 
@@ -225,18 +235,14 @@ where
                             }
                         }
 
-                        // Ensure position is not occupied by another item
-                        for (_, position) in linked_chunk_items.values() {
-                            if let Some(position) = position
-                                && *position == at
-                            {
-                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
-                            }
-                        }
-                        for row in &self.items_chunks {
-                            if row.linked_chunk_id == linked_chunk_id && row.position == at {
-                                return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
-                            }
+                        // Ensure position is not occupied by another item. If position
+                        // is already occupied, return an error. Otherwise, record given
+                        // position as occupied.
+                        let items_positions_key = (linked_chunk_id.to_owned(), at);
+                        if self.items_positions.contains(&items_positions_key) {
+                            return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
+                        } else {
+                            self.items_positions.insert(items_positions_key);
                         }
 
                         linked_chunk_items.insert(item_id.clone(), (item.clone(), Some(at)));
@@ -280,6 +286,7 @@ where
 
                 Update::RemoveItem { at } => {
                     let mut entry_to_remove = None;
+                    let mut position_to_remove = Option::<Position>::None;
 
                     for (
                         nth,
@@ -289,6 +296,14 @@ where
                         // Filter by linked chunk id.
                         if linked_chunk_id != &*linked_chunk_id_candidate {
                             continue;
+                        }
+
+                        // Track the largest index in the chunk to remove.
+                        if position.chunk_identifier() == at.chunk_identifier()
+                            && position_to_remove
+                                .is_none_or(|inner| inner.index() < position.index())
+                        {
+                            position_to_remove.replace(*position);
                         }
 
                         // Find the item to remove.
@@ -307,6 +322,10 @@ where
                     }
 
                     self.items_chunks.remove(entry_to_remove.expect("Remove an unknown item"));
+                    self.items_positions.remove(&(
+                        linked_chunk_id.to_owned(),
+                        position_to_remove.expect("Remove an unknown item"),
+                    ));
 
                     // We deliberately keep the item in the items collection.
                     self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
@@ -341,12 +360,13 @@ where
                                 (linked_chunk_id == linked_chunk_id_candidate
                                     && position.chunk_identifier() == at.chunk_identifier()
                                     && position.index() >= at.index())
-                                .then_some(nth)
+                                .then_some((nth, *position))
                             },
                         )
                         .collect::<Vec<_>>();
 
-                    for index_to_remove in indices_to_remove.into_iter().rev() {
+                    for (index_to_remove, position) in indices_to_remove.into_iter().rev() {
+                        self.items_positions.remove(&(linked_chunk_id.to_owned(), position));
                         self.items_chunks.remove(index_to_remove);
                     }
 
@@ -365,6 +385,7 @@ where
                 Update::Clear => {
                     self.chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
                     self.items_chunks.retain(|chunk| chunk.linked_chunk_id != linked_chunk_id);
+                    self.items_positions.retain(|(id, _)| id.as_ref() != linked_chunk_id);
                     // We deliberately leave the items in the items collection.
                     self.items.entry(linked_chunk_id.to_owned()).and_modify(|items| {
                         for (_, pos) in items.values_mut() {

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -269,8 +269,13 @@ where
                     self.items
                         .entry(linked_chunk_id.to_owned())
                         .or_default()
-                        .insert(item_id.clone(), (item, Some(at)));
-                    existing.item = Either::Item(item_id);
+                        .insert(item_id.clone(), (item.clone(), Some(at)));
+                    existing.item = Either::Item(item_id.clone());
+
+                    // Ensure item is updated if it exists anywhere else in the store
+                    for items in &mut self.items.values_mut() {
+                        items.entry(item_id.clone()).and_modify(|e| e.0 = item.clone());
+                    }
                 }
 
                 Update::RemoveItem { at } => {

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -220,19 +220,16 @@ where
                             self.items.entry(linked_chunk_id.to_owned()).or_default();
 
                         // Ensure item does not already exist in another position
-                        // in this linked chunk
+                        // in this linked chunk.
+                        //
+                        // Note that we do not check `items_chunks`, going through each
+                        // `ItemRow` is very slow. So, it is imperative that `items` is
+                        // kept in sync with `items_chunks` in order for the check below
+                        // to be sufficient.
                         if let Some((_, position)) = linked_chunk_items.get(&item_id)
                             && position.is_some()
                         {
                             return Err(RelationalLinkedChunkError::ItemAlreadyInLinkedChunk);
-                        }
-                        for row in &self.items_chunks {
-                            if row.linked_chunk_id == linked_chunk_id
-                                && let Either::Item(id) = &row.item
-                                && id == &item_id
-                            {
-                                return Err(RelationalLinkedChunkError::ItemAlreadyInLinkedChunk);
-                            }
                         }
 
                         // Ensure position is not occupied by another item. If position

--- a/crates/matrix-sdk-indexeddb/changelog.d/6872.fixed.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/6872.fixed.md
@@ -1,0 +1,5 @@
+Ensure that every instance of an `Event` across all `LinkedChunk`s is
+updated when one instance of that `Event` is updated. For efficiency,
+a new index was added to the `EVENTS` object store that tracks the
+`EventId` of an `Event`, so that all instances of an `Event` across
+all `LinkedChunk`s could be retrieved with a single query.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v7};
+    use super::{Version, v8};
 
-    pub const VERSION: Version = Version::V7;
-    pub use v7::keys;
+    pub const VERSION: Version = Version::V8;
+    pub use v8::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -66,6 +66,8 @@ pub enum Version {
     V6 = 6,
     /// Version 7 of the database, for details see [`v7`].
     V7 = 7,
+    /// Version 8 of the database, for details see [`v8`].
+    V8 = 8,
 }
 
 impl Version {
@@ -79,7 +81,8 @@ impl Version {
             Self::V4 => v4::upgrade(transaction).map(Some),
             Self::V5 => v5::upgrade(transaction).map(Some),
             Self::V6 => v6::upgrade(transaction).map(Some),
-            Self::V7 => Ok(None),
+            Self::V7 => v7::upgrade(transaction).map(Some),
+            Self::V8 => Ok(None),
         }
     }
 }
@@ -101,6 +104,7 @@ impl TryFrom<u32> for Version {
             5 => Ok(Version::V5),
             6 => Ok(Version::V6),
             7 => Ok(Version::V7),
+            8 => Ok(Version::V8),
             v => Err(UnknownVersionError(v)),
         }
     }
@@ -443,7 +447,45 @@ mod v7 {
     pub fn empty_threads(transaction: &Transaction<'_>) -> Result<(), Error> {
         let threads = transaction.object_store(keys::THREADS)?;
         threads.clear()?;
+        Ok(())
+    }
 
+    /// Upgrade database from `v7` to `v8`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v8::add_event_id_index_to_events_object_store(transaction)?;
+        Ok(Version::V8)
+    }
+}
+
+pub mod v8 {
+    use indexed_db_futures::Build;
+
+    use super::*;
+
+    pub mod keys {
+        // Re-use all the same keys from `v6`.
+        pub use super::v6::keys::*;
+
+        pub const EVENTS_EVENT_ID: &str = "events_event_id";
+        pub const EVENTS_EVENT_ID_KEY_PATH: &str = "event_id";
+    }
+
+    /// Add a new index to the events object store which tracks the event id of
+    /// an event.
+    ///
+    /// The primary key of the store tracks both the linked chunk id and the
+    /// event id of the event. This makes finding the same event across linked
+    /// chunks difficult.
+    ///
+    /// The new index, therefore, allows a single lookup to find all of these
+    /// events at once.
+    pub fn add_event_id_index_to_events_object_store(
+        transaction: &Transaction<'_>,
+    ) -> Result<(), Error> {
+        let events = transaction.object_store(keys::EVENTS)?;
+        let _ = events
+            .create_index(keys::EVENTS_EVENT_ID, keys::EVENTS_EVENT_ID_KEY_PATH.into())
+            .build()?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -453,6 +453,7 @@ mod v7 {
     /// Upgrade database from `v7` to `v8`
     pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
         v8::add_event_id_index_to_events_object_store(transaction)?;
+        v8::empty_event_cache(transaction)?;
         Ok(Version::V8)
     }
 }
@@ -486,6 +487,24 @@ pub mod v8 {
         let _ = events
             .create_index(keys::EVENTS_EVENT_ID, keys::EVENTS_EVENT_ID_KEY_PATH.into())
             .build()?;
+        Ok(())
+    }
+
+    /// Empty the entire store, as the logic for adding events has been updated
+    /// to ensure that event content is consistent across linked chunks.
+    pub fn empty_event_cache(transaction: &Transaction<'_>) -> Result<(), Error> {
+        let linked_chunks = transaction.object_store(keys::LINKED_CHUNKS)?;
+        linked_chunks.clear()?;
+
+        let gaps = transaction.object_store(keys::GAPS)?;
+        gaps.clear()?;
+
+        let events = transaction.object_store(keys::EVENTS)?;
+        events.clear()?;
+
+        let threads = transaction.object_store(keys::THREADS)?;
+        threads.clear()?;
+
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -319,6 +319,9 @@ impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, LinkedChunkId<'a>> for Index
 pub struct IndexedEvent {
     /// The primary key of the object store.
     pub id: IndexedEventIdKey,
+    /// An indexed key on the object store, which represent the event id of
+    /// the event.
+    pub event_id: IndexedEventEventIdKey,
     /// An indexed key on the object store, which represents the room in which
     /// the event exists
     pub room: IndexedEventRoomKey,
@@ -364,6 +367,7 @@ impl Indexed for Event {
         });
         Ok(IndexedEvent {
             id,
+            event_id: IndexedEventEventIdKey::encode(event_id, serializer),
             room,
             position,
             relation,
@@ -420,6 +424,26 @@ impl IndexedPrefixKeyBounds<Event, LinkedChunkId<'_>> for IndexedEventIdKey {
         let linked_chunk_id =
             serializer.hash_key(keys::LINKED_CHUNK_IDS, linked_chunk_id.storage_key());
         Self(linked_chunk_id, (*INDEXED_KEY_UPPER_STRING).clone())
+    }
+}
+
+/// The value associated with the [`event_id`](IndexedEvent::event_id) index of
+/// the [`EVENTS`][1] object store, which is constructed from:
+///
+/// - The (possibly) hashed Event ID.
+///
+/// [1]: crate::event_cache_store::migrations::v7::add_event_id_index_to_events_object_store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IndexedEventEventIdKey(IndexedEventId);
+
+impl IndexedKey<Event> for IndexedEventEventIdKey {
+    const INDEX: Option<&'static str> = Some(keys::EVENTS_EVENT_ID);
+
+    type KeyComponents<'a> = &'a EventId;
+
+    fn encode(event_id: Self::KeyComponents<'_>, serializer: &SafeEncodeSerializer) -> Self {
+        let event_id = serializer.encode_key_as_string(keys::EVENTS, event_id);
+        Self(event_id)
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,10 +26,10 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventIdKey,
-            IndexedEventPositionKey, IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey,
-            IndexedLease, IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread,
-            IndexedThreadIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventEventIdKey,
+            IndexedEventIdKey, IndexedEventPositionKey, IndexedEventRelationKey,
+            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
+            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -338,6 +338,16 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<Option<Event>, TransactionError> {
         let key = self.serializer().encode_key((linked_chunk_id, event_id));
         self.get_item_by_key::<Event, IndexedEventIdKey>(key).await
+    }
+
+    /// Query IndexedDB for events that match the given event id across all
+    /// linked chunks.
+    pub async fn get_events_by_event_id(
+        &self,
+        event_id: &EventId,
+    ) -> Result<Vec<Event>, TransactionError> {
+        let key = self.serializer().encode_key::<_, IndexedEventEventIdKey>(event_id);
+        self.get_items_by_key::<Event, IndexedEventEventIdKey>(key).await
     }
 
     /// Query IndexedDB for events that match the given event id in the given

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -26,10 +26,10 @@ use crate::{
     error::AsyncErrorDeps,
     event_cache_store::{
         serializer::indexed_types::{
-            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventEventIdKey,
-            IndexedEventIdKey, IndexedEventPositionKey, IndexedEventRelationKey,
-            IndexedEventRoomKey, IndexedGapIdKey, IndexedLease, IndexedLeaseIdKey,
-            IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
+            IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventError,
+            IndexedEventEventIdKey, IndexedEventIdKey, IndexedEventPositionKey,
+            IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey, IndexedLease,
+            IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -444,17 +444,31 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     /// This functionality allows events to be promoted from
     /// out-of-band events to in-band events, but not vice versa.
     ///
+    /// Additionally, if an event with the same ID already exists anywhere
+    /// in the store, every instance is updated with the provided content, i.e.,
+    /// across all linked chunks.
+    ///
     /// When the event is successfully added, the function returns
     /// the intermediary type [`IndexedEvent`] in case inspection
     /// is needed.
     pub async fn add_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
-        let existing =
-            self.get_event_by_id(event.linked_chunk_id(), event.event_id().unwrap()).await?;
-        if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
-            self.put_event(event).await
-        } else {
-            self.add_item(event).await
+        let linked_chunk_id = event.linked_chunk_id();
+        let Some(event_id) = event.event_id() else {
+            return Err(TransactionError::Serialization(Box::new(IndexedEventError::NoEventId)));
+        };
+
+        let existing = self.get_event_by_id(linked_chunk_id, event_id).await?;
+        let indexed =
+            if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
+                self.put_event(event).await?
+            } else {
+                self.add_item(event).await?
+            };
+
+        for existing in self.get_events_by_event_id(event_id).await? {
+            self.put_event(&existing.with_content(event.content().clone())).await?;
         }
+        Ok(indexed)
     }
 
     /// Puts an event in IndexedDB. If an event with the same key already

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -458,25 +458,57 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
         };
 
         let existing = self.get_event_by_id(linked_chunk_id, event_id).await?;
+
         let indexed =
             if matches!(event, Event::InBand(_)) && matches!(existing, Some(Event::OutOfBand(_))) {
-                self.put_event(event).await?
+                self.put_item(event).await?
             } else {
                 self.add_item(event).await?
             };
 
-        for existing in self.get_events_by_event_id(event_id).await? {
-            self.put_event(&existing.with_content(event.content().clone())).await?;
-        }
+        self.update_events_by_event_id(event_id, |existing| {
+            existing.with_content(event.content().clone())
+        })
+        .await?;
+
         Ok(indexed)
     }
 
     /// Puts an event in IndexedDB. If an event with the same key already
-    /// exists, it will be overwritten. When the item is successfully put, the
-    /// function returns the intermediary type [`IndexedEvent`] in case
-    /// inspection is needed.
+    /// exists in it will be overwritten.
+    ///
+    /// Additionally, if an event with the same ID exists in any other linked
+    /// chunk, every instance is updated with the provided content.
+    ///
+    /// When the item is successfully put, the function returns the intermediary
+    /// type [`IndexedEvent`] in case inspection is needed.
     pub async fn put_event(&self, event: &Event) -> Result<IndexedEvent, TransactionError> {
-        self.put_item(event).await
+        let Some(event_id) = event.event_id() else {
+            return Err(TransactionError::Serialization(Box::new(IndexedEventError::NoEventId)));
+        };
+
+        let indexed = self.put_item(event).await?;
+
+        self.update_events_by_event_id(event_id, |existing| {
+            existing.with_content(event.content().clone())
+        })
+        .await?;
+
+        Ok(indexed)
+    }
+
+    /// Update all events in the store matching the given event ID by reading
+    /// them, applying the function `F`, and then writing them back to
+    /// IndexedDB.
+    ///
+    /// Note that this is a potentially expensive operation, as IndexedDB
+    /// does not provide modification utilities.
+    pub async fn update_events_by_event_id<F: Fn(Event) -> Event>(
+        &self,
+        event_id: &EventId,
+        f: F,
+    ) -> Result<(), TransactionError> {
+        self.update_items_by_key_components::<Event, IndexedEventEventIdKey, F>(event_id, f).await
     }
 
     /// Update events in the given position range matching the given linked

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/types.rs
@@ -127,6 +127,14 @@ impl Event {
         }
     }
 
+    /// A reference to the underlying event.
+    pub fn content(&self) -> &TimelineEvent {
+        match self {
+            Event::InBand(e) => &e.content,
+            Event::OutOfBand(e) => &e.content,
+        }
+    }
+
     /// Sets the content of the underlying [`GenericEvent`] and returns
     /// the mutated [`Event`]
     pub fn with_content(mut self, content: TimelineEvent) -> Self {

--- a/crates/matrix-sdk-sqlite/changelog.d/6872.fixed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/6872.fixed.md
@@ -1,0 +1,2 @@
+Add a uniqueness constraint on `event_chunks` table that ensures
+an `Event` cannot be in a `LinkedChunk` more than once.

--- a/crates/matrix-sdk-sqlite/migrations/event_cache_store/018_event_chunks_unique_linked_chunk_id_event_id.sql
+++ b/crates/matrix-sdk-sqlite/migrations/event_cache_store/018_event_chunks_unique_linked_chunk_id_event_id.sql
@@ -1,0 +1,39 @@
+-- Introduce uniqueness constraint on (linked_chunk_id, event_id)
+-- Empties event cache of all data.
+
+DELETE FROM linked_chunks;
+DELETE FROM event_chunks;  -- should be done by cascading
+DELETE FROM gap_chunks;    -- should be done by cascading
+DELETE FROM threads;
+
+DROP TABLE event_chunks;
+
+-- Recreate event_chunks with new PRIMARY KEY
+CREATE TABLE "event_chunks" (
+    -- Which linked chunk does this event belong to? (hashed key shared with linked_chunks)
+    "linked_chunk_id" BLOB NOT NULL,
+    -- Which chunk does this event refer to? Corresponds to a `ChunkIdentifier`.
+    "chunk_id" INTEGER NOT NULL,
+
+    -- `OwnedEventId` for events.
+    "event_id" BLOB NOT NULL,
+    -- Position (index) in the chunk.
+    "position" INTEGER NOT NULL,
+
+    -- We need a uniqueness constraint over the `linked_chunk_id`, `chunk_id` and
+    -- `position` tuple because (i) they must be unique, (ii) it dramatically
+    -- improves the performance. Also, we don't have a ROWID, so we must use a PRIMARY KEY, hence
+    -- we use this composite key as the primary key.
+    PRIMARY KEY (linked_chunk_id, chunk_id, position),
+
+    -- We need a uniqueness constraint over `linked_chunk_id` and `event_id` so that
+    -- events cannot be stored in the same linked chunk multiple times.
+    UNIQUE (linked_chunk_id, event_id),
+
+    -- If the owning chunk gets deleted, delete the entry too.
+    FOREIGN KEY (linked_chunk_id, chunk_id) REFERENCES linked_chunks(linked_chunk_id, id) ON DELETE CASCADE
+)
+WITHOUT ROWID;
+
+-- Create a non-unique index on `event_id` for query performance.
+CREATE INDEX "event_chunks_event_id_idx" ON "event_chunks" ("event_id");

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -662,6 +662,15 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         .await?;
     }
 
+    if version < 18 {
+        debug!("Upgrading database to version 18");
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!("../migrations/event_cache_store/018_event_chunks_unique_linked_chunk_id_event_id.sql"))?;
+            txn.set_db_version(18)
+        })
+        .await?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This pull request is stacked on top of matrix-org/matrix-rust-sdk#6872. It provides some basic performance improvements in order to ensure that benchmarks do not time out during a CI run.

### Changes

1. **Add a `HashSet` for tracking the `Position`s of `Item`s in `RelationalLinkedChunk`.** This serves as the "source of truth" for whether a `Position` is occupied and prevents us from having to loop over many entries in `items` and `items_chunks` when processing `Update::PushItems`.
2. **Remove a redundant check for a unique `ItemId` when processing `Update::PushItems`.** Instead of checking whether an `ItemId` exists in both `items` and `items_chunks`, we treat `items` as the "source of truth" and only check whether an `ItemId` exists there. This provides prevents us from having to loop over all entries in `items_chunks`.
3. **Revert [`3fa8dc2`](3fa8dc2b381564657ab459044f557cefc8fe501d)**. The reverted commit bypassed benchmarks with large inputs for the in-memory implementation of `EventCacheStore`. This is no longer bypassed.


---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Michael Goldenberg <m@mgoldenberg.net>

