### PR TITLE
chore(sdk): Do call `save_catchup_tokens ` if necessary

### DIFF
--- a/crates/matrix-sdk/src/client/thread_subscriptions.rs
+++ b/crates/matrix-sdk/src/client/thread_subscriptions.rs
@@ -77,20 +77,14 @@ impl GuardedStoreAccess {
     }
 
     /// Saves the tokens in the database.
-    ///
-    /// Returns whether the list of tokens is empty or not.
     #[instrument(skip_all, fields(num_tokens = tokens.len()))]
-    async fn save_catchup_tokens(
-        &self,
-        tokens: Vec<ThreadSubscriptionCatchupToken>,
-    ) -> Result<bool> {
+    async fn save_catchup_tokens(&self, tokens: Vec<ThreadSubscriptionCatchupToken>) -> Result<()> {
         let store = self.client.state_store();
-        let is_empty = if tokens.is_empty() {
+        if tokens.is_empty() {
             store.remove_kv_data(StateStoreDataKey::ThreadSubscriptionsCatchupTokens).await?;
 
             trace!("Marking thread subscriptions as not outdated \\o/");
             self.is_outdated.store(false, atomic::Ordering::SeqCst);
-            true
         } else {
             store
                 .set_kv_data(
@@ -101,9 +95,9 @@ impl GuardedStoreAccess {
 
             trace!("Marking thread subscriptions as outdated.");
             self.is_outdated.store(true, atomic::Ordering::SeqCst);
-            false
-        };
-        Ok(is_empty)
+        }
+
+        Ok(())
     }
 }
 
@@ -234,16 +228,14 @@ impl ThreadSubscriptionCatchup {
             } else {
                 trace!(?token, "Saving catchup token");
                 tokens.push(token);
+
+                guard.save_catchup_tokens(tokens).await?;
+
+                // Wake up the catchup task, in case it's waiting.
+                self.ping.notify_one();
             }
         } else {
             trace!("No catchup token to save");
-        }
-
-        let is_token_list_empty = guard.save_catchup_tokens(tokens).await?;
-
-        // Wake up the catchup task, in case it's waiting.
-        if !is_token_list_empty {
-            self.ping.notify_one();
         }
 
         Ok(())


### PR DESCRIPTION
Follow up of #6955.

This patch calls `save_catchup_tokens` if and only if the list of tokens has changed. In other way, it avoids calling it if there is no reason to.

`save_catchup_tokens` no longer returns a `bool`, it makes no particular sense and was used in a single place, which is now removed.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
