### PR TITLE
feat(crypto): Allow X.509-verified identities to confer device trust

### DIFF
--- a/crates/matrix-sdk-crypto/changelog.d/6962.changed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6962.changed.md
@@ -1,0 +1,11 @@
+A user identity whose master key carries a valid X.509 signature
+chaining to one of the configured trust anchors now confers trust
+on that user's devices.
+
+Previously, such an identity was reported as verified by
+`UserIdentity::is_verified()`, but its devices would still be
+reported as unverified by `Device::is_verified()`, and the room key
+sharing strategies withheld room keys from them.
+
+Requires the `experimental-x509-identity-verification` feature and a
+configured X.509 verifier.

--- a/crates/matrix-sdk-crypto/changelog.d/6962.removed.md
+++ b/crates/matrix-sdk-crypto/changelog.d/6962.removed.md
@@ -1,0 +1,9 @@
+[**breaking**] Removed `OwnUserIdentityData::is_identity_verified()`.
+
+This method asked whether we had verified another user's identity from
+the perspective of our own identity, and so only ever considered
+cross-signing.
+
+Use `UserIdentity::is_verified()` or `OtherUserIdentity::is_verified()`
+instead, which account for every root of trust we have in that identity,
+including an X.509 signature on its master key.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -37,6 +37,8 @@ use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, olm::SessionConfig};
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
 #[cfg(any(test, feature = "testing", doc))]
 use crate::OlmMachine;
+#[cfg(feature = "experimental-x509-identity-verification")]
+use crate::x509::X509Verifier;
 use crate::{
     Account, Sas, VerificationRequest,
     error::{MismatchedIdentityKeysError, OlmError, OlmResult, SignatureError},
@@ -127,6 +129,8 @@ pub struct Device {
     pub(crate) verification_machine: VerificationMachine,
     pub(crate) own_identity: Option<OwnUserIdentityData>,
     pub(crate) device_owner_identity: Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) x509_verifier: Option<X509Verifier>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -300,9 +304,11 @@ impl Device {
     pub fn is_device_owner_verified(&self) -> bool {
         self.device_owner_identity.as_ref().is_some_and(|id| match id {
             UserIdentityData::Own(own_identity) => own_identity.is_verified(),
-            UserIdentityData::Other(other_identity) => {
-                other_identity.is_verified(self.own_identity.as_ref())
-            }
+            UserIdentityData::Other(other_identity) => other_identity.is_verified(
+                self.own_identity.as_ref(),
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                self.x509_verifier.as_ref(),
+            ),
         })
     }
 
@@ -353,12 +359,22 @@ impl Device {
     /// [`is_locally_trusted()`]: #method.is_locally_trusted
     /// [`is_cross_signing_trusted()`]: #method.is_cross_signing_trusted
     pub fn is_verified(&self) -> bool {
-        self.inner.is_verified(&self.own_identity, &self.device_owner_identity)
+        self.inner.is_verified(
+            &self.own_identity,
+            &self.device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            self.x509_verifier.as_ref(),
+        )
     }
 
     /// Is this device considered to be verified using cross signing.
     pub fn is_cross_signing_trusted(&self) -> bool {
-        self.inner.is_cross_signing_trusted(&self.own_identity, &self.device_owner_identity)
+        self.inner.is_cross_signing_trusted(
+            &self.own_identity,
+            &self.device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            self.x509_verifier.as_ref(),
+        )
     }
 
     /// Manually verify this device.
@@ -493,6 +509,8 @@ impl Device {
             share_strategy,
             &self.own_identity,
             &self.device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            self.x509_verifier.as_ref(),
         )
         .await?
         {
@@ -523,6 +541,8 @@ pub struct UserDevices {
     pub(crate) verification_machine: VerificationMachine,
     pub(crate) own_identity: Option<OwnUserIdentityData>,
     pub(crate) device_owner_identity: Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    pub(crate) x509_verifier: Option<X509Verifier>,
 }
 
 impl UserDevices {
@@ -533,6 +553,8 @@ impl UserDevices {
             verification_machine: self.verification_machine.clone(),
             own_identity: self.own_identity.clone(),
             device_owner_identity: self.device_owner_identity.clone(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: self.x509_verifier.clone(),
         })
     }
 
@@ -555,7 +577,14 @@ impl UserDevices {
             .filter(|d| {
                 !(d.user_id() == self.own_user_id() && d.device_id() == self.own_device_id())
             })
-            .any(|d| d.is_verified(&self.own_identity, &self.device_owner_identity))
+            .any(|d| {
+                d.is_verified(
+                    &self.own_identity,
+                    &self.device_owner_identity,
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    self.x509_verifier.as_ref(),
+                )
+            })
     }
 
     /// Iterator over all the device ids of the user devices.
@@ -570,6 +599,8 @@ impl UserDevices {
             verification_machine: self.verification_machine.clone(),
             own_identity: self.own_identity.clone(),
             device_owner_identity: self.device_owner_identity.clone(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: self.x509_verifier.clone(),
         })
     }
 }
@@ -758,14 +789,26 @@ impl DeviceData {
         &self,
         own_identity: &Option<OwnUserIdentityData>,
         device_owner: &Option<UserIdentityData>,
+        #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+            &X509Verifier,
+        >,
     ) -> bool {
-        self.is_locally_trusted() || self.is_cross_signing_trusted(own_identity, device_owner)
+        self.is_locally_trusted()
+            || self.is_cross_signing_trusted(
+                own_identity,
+                device_owner,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
+            )
     }
 
     pub(crate) fn is_cross_signing_trusted(
         &self,
         own_identity: &Option<OwnUserIdentityData>,
         device_owner: &Option<UserIdentityData>,
+        #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+            &X509Verifier,
+        >,
     ) -> bool {
         device_owner.as_ref().is_some_and(|device_identity| match device_identity {
             UserIdentityData::Own(_) => own_identity.as_ref().is_some_and(|own_identity| {
@@ -773,11 +816,15 @@ impl DeviceData {
             }),
 
             // If it's a device from someone else, first check that our user
-            // has verified the other user and then check if the other user
-            // has signed this device.
+            // has verified the other user (either by cross-signing their
+            // identity, or via a valid X.509 signature on their master key)
+            // and then check if the other user has signed this device.
             UserIdentityData::Other(device_identity) => {
-                device_identity.is_verified(own_identity.as_ref())
-                    && device_identity.is_device_signed(self)
+                device_identity.is_verified(
+                    own_identity.as_ref(),
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    x509_verifier,
+                ) && device_identity.is_device_signed(self)
             }
         })
     }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -1213,4 +1213,61 @@ pub(crate) mod tests {
             Ed25519PublicKey::from_base64("2/5LWJMow5zhJqakV88SIc7q/1pa8fmkfgAzx72w9G4").unwrap(),
         );
     }
+
+    /// A device signed by its owner's self-signing key becomes trusted when
+    /// the owner's identity is verified via X.509, even though we never
+    /// cross-signed the identity ourselves.
+    #[cfg(feature = "experimental-x509-identity-verification")]
+    #[matrix_sdk_test::async_test]
+    async fn test_x509_verified_owner_confers_device_trust() {
+        use std::sync::Arc;
+
+        use ruma::device_id;
+
+        use crate::{
+            machine::test_helpers::create_signed_device_of_unverified_user,
+            olm::{Account, PrivateCrossSigningIdentity},
+            x509::{
+                RustRawX509Signer, RustRawX509Verifier, X509Signer, X509Verifier,
+                tests::{ca_cert, cert_and_key_with_email_signed_by},
+            },
+        };
+
+        // Given Alice's identity is signed with an X.509 certificate chaining
+        // to a CA...
+        let (ca_certificate, ca_signing_key) = ca_cert();
+        let (certificate, signing_key) =
+            cert_and_key_with_email_signed_by("alice@hs.co", &ca_certificate, &ca_signing_key);
+        let x509_signer = X509Signer::new(Arc::new(
+            RustRawX509Signer::new_from_pem_data(&certificate.pem(), &signing_key.serialize_pem())
+                .unwrap(),
+        ));
+        let account = Account::with_device_id(user_id!("@alice:hs.co"), device_id!("ALICEDEV"));
+        let alice_private_identity =
+            PrivateCrossSigningIdentity::for_account(&account, Some(&x509_signer)).await.unwrap();
+
+        // ...and her device is signed by her self-signing key, but we have not
+        // cross-signed her identity ourselves.
+        let mut device =
+            create_signed_device_of_unverified_user(account.device_keys(), &alice_private_identity)
+                .await;
+        assert!(device.is_cross_signed_by_owner());
+
+        // Without a verifier for the CA, the device is not trusted.
+        assert!(!device.is_cross_signing_trusted());
+
+        // With a verifier trusting the CA, the device is trusted.
+        device.x509_verifier = Some(X509Verifier::new(Arc::new(
+            RustRawX509Verifier::new_from_pem_data(&ca_certificate.pem()).unwrap(),
+        )));
+        assert!(device.is_cross_signing_trusted());
+        assert!(device.is_verified());
+
+        // A verifier trusting a *different* CA does not trust the device.
+        let (wrong_ca_certificate, _) = ca_cert();
+        device.x509_verifier = Some(X509Verifier::new(Arc::new(
+            RustRawX509Verifier::new_from_pem_data(&wrong_ca_certificate.pem()).unwrap(),
+        )));
+        assert!(!device.is_cross_signing_trusted());
+    }
 }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -301,7 +301,7 @@ impl Device {
         self.device_owner_identity.as_ref().is_some_and(|id| match id {
             UserIdentityData::Own(own_identity) => own_identity.is_verified(),
             UserIdentityData::Other(other_identity) => {
-                self.own_identity.as_ref().is_some_and(|oi| oi.is_identity_verified(other_identity))
+                other_identity.is_verified(self.own_identity.as_ref())
             }
         })
     }
@@ -767,23 +767,19 @@ impl DeviceData {
         own_identity: &Option<OwnUserIdentityData>,
         device_owner: &Option<UserIdentityData>,
     ) -> bool {
-        own_identity.as_ref().zip(device_owner.as_ref()).is_some_and(
-            |(own_identity, device_identity)| {
-                match device_identity {
-                    UserIdentityData::Own(_) => {
-                        own_identity.is_verified() && own_identity.is_device_signed(self)
-                    }
+        device_owner.as_ref().is_some_and(|device_identity| match device_identity {
+            UserIdentityData::Own(_) => own_identity.as_ref().is_some_and(|own_identity| {
+                own_identity.is_verified() && own_identity.is_device_signed(self)
+            }),
 
-                    // If it's a device from someone else, first check
-                    // that our user has verified the other user and then
-                    // check if the other user has signed this device.
-                    UserIdentityData::Other(device_identity) => {
-                        own_identity.is_identity_verified(device_identity)
-                            && device_identity.is_device_signed(self)
-                    }
-                }
-            },
-        )
+            // If it's a device from someone else, first check that our user
+            // has verified the other user and then check if the other user
+            // has signed this device.
+            UserIdentityData::Other(device_identity) => {
+                device_identity.is_verified(own_identity.as_ref())
+                    && device_identity.is_device_signed(self)
+            }
+        })
     }
 
     pub(crate) fn is_cross_signed_by_owner(

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -115,6 +115,12 @@ impl UserIdentity {
     /// For another user's identity, it means that we have verified our own
     /// identity as above, *and* that the other user's identity has been signed
     /// by our own user-signing key.
+    ///
+    /// Alternatively, if experimental X.509 identity verification is enabled,
+    /// an X.509 verifier is configured, and this is another user's identity,
+    /// we consider this identity verified if it carries a valid X.509
+    /// signature chaining to one of our trusted CAs, regardless of whether
+    /// our own identity is verified or even present.
     pub fn is_verified(&self) -> bool {
         match self {
             UserIdentity::Own(u) => u.is_verified(),
@@ -370,22 +376,11 @@ impl DerefMut for OtherUserIdentity {
 impl OtherUserIdentity {
     /// Is this user identity verified?
     pub fn is_verified(&self) -> bool {
-        let is_cross_signed = self.inner.is_verified(self.own_identity.as_ref());
-
-        // If we have an X.509 verifier, we can use that to verify the user
-        #[cfg(feature = "experimental-x509-identity-verification")]
-        {
-            let is_x509_signed = || {
-                self.x509_verifier.as_ref().is_some_and(|verifier| {
-                    verifier.verify_signed_object(&self.user_id, self.inner.master_key().as_ref())
-                })
-            };
-
-            is_cross_signed || is_x509_signed()
-        }
-
-        #[cfg(not(feature = "experimental-x509-identity-verification"))]
-        is_cross_signed
+        self.inner.is_verified(
+            self.own_identity.as_ref(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            self.x509_verifier.as_ref(),
+        )
     }
 
     /// Manually verify this user.
@@ -808,13 +803,37 @@ impl OtherUserIdentityData {
     /// The identity of another user is verified if our own identity is
     /// verified and has signed this identity with our user-signing key.
     ///
+    /// Alternatively, if experimental X.509 identity verification is enabled
+    /// and an X.509 verifier is configured, we consider this identity verified
+    /// if it carries a valid X.509 signature chaining to one of our trusted
+    /// CAs, regardless of whether our own identity is verified or even
+    /// present.
+    ///
     /// User verification, device trust and the room key sharing strategies
     /// should all go through this method, such that their answers cannot
     /// disagree.
-    pub(crate) fn is_verified(&self, own_identity: Option<&OwnUserIdentityData>) -> bool {
-        own_identity.is_some_and(|own_identity| {
+    pub(crate) fn is_verified(
+        &self,
+        own_identity: Option<&OwnUserIdentityData>,
+        #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+            &X509Verifier,
+        >,
+    ) -> bool {
+        let is_cross_signed = own_identity.is_some_and(|own_identity| {
             own_identity.is_verified() && own_identity.is_identity_signed(self)
-        })
+        });
+
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        {
+            is_cross_signed
+                // Check X.509 signature without a let binding so we short-circuit if we are cross-signed
+                || x509_verifier.is_some_and(|verifier| {
+                    verifier.verify_signed_object(self.user_id(), self.master_key().as_ref())
+                })
+        }
+
+        #[cfg(not(feature = "experimental-x509-identity-verification"))]
+        is_cross_signed
     }
 
     #[cfg(test)]
@@ -1722,6 +1741,8 @@ pub(crate) mod tests {
             verification_machine: verification_machine.clone(),
             own_identity: Some(identity.clone()),
             device_owner_identity: Some(UserIdentityData::Own(identity.clone())),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: None,
         };
 
         let second = Device {
@@ -1729,6 +1750,8 @@ pub(crate) mod tests {
             verification_machine,
             own_identity: Some(identity.clone()),
             device_owner_identity: Some(UserIdentityData::Own(identity.clone())),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: None,
         };
 
         assert!(!second.is_locally_trusted());
@@ -1756,6 +1779,8 @@ pub(crate) mod tests {
             verification_machine: verification_machine.clone(),
             own_identity: Some(public_identity.clone()),
             device_owner_identity: Some(public_identity.clone().into()),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: None,
         };
 
         assert!(!device.is_verified());

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -370,10 +370,7 @@ impl DerefMut for OtherUserIdentity {
 impl OtherUserIdentity {
     /// Is this user identity verified?
     pub fn is_verified(&self) -> bool {
-        let is_cross_signed = self
-            .own_identity
-            .as_ref()
-            .is_some_and(|own_identity| own_identity.is_identity_verified(&self.inner));
+        let is_cross_signed = self.inner.is_verified(self.own_identity.as_ref());
 
         // If we have an X.509 verifier, we can use that to verify the user
         #[cfg(feature = "experimental-x509-identity-verification")]
@@ -806,6 +803,20 @@ impl OtherUserIdentityData {
         })
     }
 
+    /// Check if this identity is verified from our point of view.
+    ///
+    /// The identity of another user is verified if our own identity is
+    /// verified and has signed this identity with our user-signing key.
+    ///
+    /// User verification, device trust and the room key sharing strategies
+    /// should all go through this method, such that their answers cannot
+    /// disagree.
+    pub(crate) fn is_verified(&self, own_identity: Option<&OwnUserIdentityData>) -> bool {
+        own_identity.is_some_and(|own_identity| {
+            own_identity.is_verified() && own_identity.is_identity_signed(self)
+        })
+    }
+
     #[cfg(test)]
     pub(crate) async fn from_private(identity: &crate::olm::PrivateCrossSigningIdentity) -> Self {
         let master_key = identity.master_key.lock().await.as_ref().unwrap().public_key().clone();
@@ -1085,25 +1096,11 @@ impl OwnUserIdentityData {
         &self.user_signing_key
     }
 
-    /// Check if the given user identity has been verified.
-    ///
-    /// The identity of another user is verified iff our own identity is
-    /// verified and if our own identity has signed the other user's
-    /// identity.
-    ///
-    /// # Arguments
-    ///
-    /// * `identity` - The identity of another user which we want to check has
-    ///   been verified.
-    pub fn is_identity_verified(&self, identity: &OtherUserIdentityData) -> bool {
-        self.is_verified() && self.is_identity_signed(identity)
-    }
-
     /// Check if the given identity has been signed by this identity.
     ///
     /// Note that, normally, you'll also want to check that the
     /// `OwnUserIdentityData` has been verified; for that,
-    /// [`Self::is_identity_verified`] is more appropriate.
+    /// [`OtherUserIdentityData::is_verified`] is more appropriate.
     ///
     /// # Arguments
     ///

--- a/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
+++ b/crates/matrix-sdk-crypto/src/machine/test_helpers.rs
@@ -424,6 +424,8 @@ pub fn create_unsigned_device(device_keys: DeviceKeys) -> Device {
         verification_machine: dummy_verification_machine(),
         own_identity: None,
         device_owner_identity: None,
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        x509_verifier: None,
     }
 }
 
@@ -446,6 +448,8 @@ pub async fn create_signed_device_of_unverified_user(
         verification_machine: dummy_verification_machine(),
         own_identity: None,
         device_owner_identity: Some(public_identity.into()),
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        x509_verifier: None,
     };
     assert!(device.is_cross_signed_by_owner());
     device
@@ -475,6 +479,8 @@ pub async fn create_signed_device_of_verified_user(
         verification_machine: dummy_verification_machine(),
         own_identity: Some(own_identity.to_public_identity().await.unwrap()),
         device_owner_identity: Some(public_identity.into()),
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        x509_verifier: None,
     };
     assert!(device.is_cross_signed_by_owner());
     assert!(device.is_cross_signing_trusted());

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -1047,9 +1047,7 @@ fn is_user_verified(
 ) -> bool {
     match user_identity {
         UserIdentityData::Own(own_identity) => own_identity.is_verified(),
-        UserIdentityData::Other(other_identity) => {
-            own_identity.is_some_and(|oi| oi.is_identity_verified(other_identity))
-        }
+        UserIdentityData::Other(other_identity) => other_identity.is_verified(own_identity),
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument, trace};
 
 use super::OutboundGroupSession;
+#[cfg(feature = "experimental-x509-identity-verification")]
+use crate::x509::X509Verifier;
 #[cfg(doc)]
 use crate::{Device, UserIdentity};
 use crate::{
@@ -265,6 +267,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                     user_devices,
                     &own_identity,
                     &device_owner_identity,
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 );
                 update_recipients_for_user(&mut result, outbound, user_id, recipient_devices);
             }
@@ -285,6 +289,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                 if has_identity_verification_violation(
                     own_identity.as_ref(),
                     device_owner_identity.as_ref(),
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 ) {
                     verified_users_with_new_identities.push(user_id.to_owned());
                     // No point considering the individual devices of this user.
@@ -296,6 +302,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                         user_devices,
                         &own_identity,
                         &device_owner_identity,
+                        #[cfg(feature = "experimental-x509-identity-verification")]
+                        store.x509_verifier(),
                     );
 
                 match recipient_devices {
@@ -353,6 +361,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                 if has_identity_verification_violation(
                     own_identity.as_ref(),
                     device_owner_identity.as_ref(),
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 ) {
                     verified_users_with_new_identities.push(user_id.to_owned());
                     // No point considering the individual devices of this user.
@@ -381,6 +391,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
                     user_devices,
                     &own_identity,
                     &device_owner_identity,
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 );
 
                 update_recipients_for_user(&mut result, outbound, user_id, recipient_devices);
@@ -516,6 +528,8 @@ pub(crate) async fn split_devices_for_share_strategy(
                     device,
                     &own_identity,
                     &device_owner_identity,
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 ) {
                     blocked_devices.push((device.clone(), withheld_code));
                 } else {
@@ -548,6 +562,8 @@ pub(crate) async fn split_devices_for_share_strategy(
                 if has_identity_verification_violation(
                     own_identity.as_ref(),
                     device_owner_identity.as_ref(),
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 ) {
                     verified_users_with_new_identities.insert(user_id.to_owned());
                 } else {
@@ -555,6 +571,8 @@ pub(crate) async fn split_devices_for_share_strategy(
                         device,
                         own_identity.as_ref(),
                         device_owner_identity.as_ref(),
+                        #[cfg(feature = "experimental-x509-identity-verification")]
+                        store.x509_verifier(),
                     ) {
                         ErrorOnVerifiedUserProblemDeviceDecision::Ok => {
                             allowed_devices.push(device.clone())
@@ -602,6 +620,8 @@ pub(crate) async fn split_devices_for_share_strategy(
                 if has_identity_verification_violation(
                     own_identity.as_ref(),
                     device_owner_identity.as_ref(),
+                    #[cfg(feature = "experimental-x509-identity-verification")]
+                    store.x509_verifier(),
                 ) {
                     verified_users_with_new_identities.insert(user_id.to_owned());
                 } else if let Some(device_owner_identity) = device_owner_identity {
@@ -633,6 +653,8 @@ pub(crate) async fn split_devices_for_share_strategy(
                         device,
                         &own_identity,
                         &device_owner_identity,
+                        #[cfg(feature = "experimental-x509-identity-verification")]
+                        store.x509_verifier(),
                     )
                 {
                     blocked_devices.push((device.clone(), withheld_code));
@@ -659,17 +681,24 @@ pub(crate) async fn withheld_code_for_device_for_share_strategy(
     share_strategy: CollectStrategy,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> OlmResult<Option<WithheldCode>> {
     match share_strategy {
         CollectStrategy::AllDevices => Ok(withheld_code_for_device_for_all_devices_strategy(
             device,
             own_identity,
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
         )),
         CollectStrategy::ErrorOnVerifiedUserProblem => {
             if has_identity_verification_violation(
                 own_identity.as_ref(),
                 device_owner_identity.as_ref(),
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
             ) {
                 return Err(OlmError::SessionRecipientCollectionError(
                     SessionRecipientCollectionError::VerifiedUserChangedIdentity(vec![
@@ -681,6 +710,8 @@ pub(crate) async fn withheld_code_for_device_for_share_strategy(
                 device,
                 own_identity.as_ref(),
                 device_owner_identity.as_ref(),
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
             ) {
                 ErrorOnVerifiedUserProblemDeviceDecision::Ok => Ok(None),
                 ErrorOnVerifiedUserProblemDeviceDecision::Withhold(code) => Ok(Some(code)),
@@ -716,6 +747,8 @@ pub(crate) async fn withheld_code_for_device_for_share_strategy(
             if has_identity_verification_violation(
                 own_identity.as_ref(),
                 device_owner_identity.as_ref(),
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
             ) {
                 Err(OlmError::SessionRecipientCollectionError(
                     SessionRecipientCollectionError::VerifiedUserChangedIdentity(vec![
@@ -738,6 +771,8 @@ pub(crate) async fn withheld_code_for_device_for_share_strategy(
                 device,
                 own_identity,
                 device_owner_identity,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
             ))
         }
     }
@@ -775,12 +810,17 @@ fn split_devices_for_user_for_all_devices_strategy(
     user_devices: HashMap<OwnedDeviceId, DeviceData>,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> RecipientDevicesForUser {
     let (left, right) = user_devices.into_values().partition_map(|d| {
         if let Some(withheld_code) = withheld_code_for_device_for_all_devices_strategy(
             &d,
             own_identity,
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
         ) {
             Either::Right((d, withheld_code))
         } else {
@@ -798,6 +838,9 @@ fn withheld_code_for_device_for_all_devices_strategy(
     device_data: &DeviceData,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> Option<WithheldCode> {
     if device_data.is_blacklisted() {
         Some(WithheldCode::Blacklisted)
@@ -806,6 +849,8 @@ fn withheld_code_for_device_for_all_devices_strategy(
             device_data,
             own_identity.as_ref(),
             device_owner_identity.as_ref(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
         )
     {
         Some(WithheldCode::Unverified)
@@ -826,13 +871,21 @@ fn should_withhold_to_dehydrated_device(
     device: &DeviceData,
     own_identity: Option<&OwnUserIdentityData>,
     device_owner_identity: Option<&UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> bool {
     device_owner_identity.is_none_or(|owner_id| {
         // Dehydrated devices must be signed by their owners
         !device.is_cross_signed_by_owner(owner_id) ||
 
         // If the user has changed identity since we verified them, withhold the message
-        (owner_id.was_previously_verified() && !is_user_verified(own_identity, owner_id))
+        (owner_id.was_previously_verified() && !is_user_verified(
+            own_identity,
+            owner_id,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
+        ))
     })
 }
 
@@ -852,6 +905,9 @@ fn split_devices_for_user_for_error_on_verified_user_problem_strategy(
     user_devices: HashMap<OwnedDeviceId, DeviceData>,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> ErrorOnVerifiedUserProblemResult {
     let mut recipient_devices = RecipientDevicesForUser::default();
 
@@ -864,6 +920,8 @@ fn split_devices_for_user_for_error_on_verified_user_problem_strategy(
             &d,
             own_identity.as_ref(),
             device_owner_identity.as_ref(),
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
         ) {
             ErrorOnVerifiedUserProblemDeviceDecision::Ok => {
                 recipient_devices.allowed_devices.push(d)
@@ -898,13 +956,22 @@ fn handle_device_for_user_for_error_on_verified_user_problem_strategy(
     device: &DeviceData,
     own_identity: Option<&OwnUserIdentityData>,
     device_owner_identity: Option<&UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> ErrorOnVerifiedUserProblemDeviceDecision {
     if device.is_blacklisted() {
         ErrorOnVerifiedUserProblemDeviceDecision::Withhold(WithheldCode::Blacklisted)
     } else if device.local_trust_state() == LocalTrust::Ignored {
         // Ignore the trust state of that device and share
         ErrorOnVerifiedUserProblemDeviceDecision::Ok
-    } else if is_unsigned_device_of_verified_user(own_identity, device_owner_identity, device) {
+    } else if is_unsigned_device_of_verified_user(
+        own_identity,
+        device_owner_identity,
+        device,
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        x509_verifier,
+    ) {
         ErrorOnVerifiedUserProblemDeviceDecision::UnsignedOfVerified
     } else if device.is_dehydrated()
         && device_owner_identity.is_none_or(|owner_id| {
@@ -980,12 +1047,17 @@ fn split_devices_for_user_for_only_trusted_devices(
     user_devices: HashMap<OwnedDeviceId, DeviceData>,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> RecipientDevicesForUser {
     let (left, right) = user_devices.into_values().partition_map(|d| {
         if let Some(withheld_code) = withheld_code_for_device_for_only_trusted_devices_strategy(
             &d,
             own_identity,
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
         ) {
             Either::Right((d, withheld_code))
         } else {
@@ -1002,10 +1074,18 @@ fn withheld_code_for_device_for_only_trusted_devices_strategy(
     device_data: &DeviceData,
     own_identity: &Option<OwnUserIdentityData>,
     device_owner_identity: &Option<UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> Option<WithheldCode> {
     match (
         device_data.local_trust_state(),
-        device_data.is_cross_signing_trusted(own_identity, device_owner_identity),
+        device_data.is_cross_signing_trusted(
+            own_identity,
+            device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
+        ),
     ) {
         (LocalTrust::BlackListed, _) => Some(WithheldCode::Blacklisted),
         (LocalTrust::Ignored | LocalTrust::Verified, _) => None,
@@ -1018,10 +1098,17 @@ fn is_unsigned_device_of_verified_user(
     own_identity: Option<&OwnUserIdentityData>,
     device_owner_identity: Option<&UserIdentityData>,
     device_data: &DeviceData,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> bool {
     device_owner_identity.is_some_and(|device_owner_identity| {
-        is_user_verified(own_identity, device_owner_identity)
-            && !device_data.is_cross_signed_by_owner(device_owner_identity)
+        is_user_verified(
+            own_identity,
+            device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
+        ) && !device_data.is_cross_signed_by_owner(device_owner_identity)
     })
 }
 
@@ -1034,20 +1121,35 @@ fn is_unsigned_device_of_verified_user(
 fn has_identity_verification_violation(
     own_identity: Option<&OwnUserIdentityData>,
     device_owner_identity: Option<&UserIdentityData>,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> bool {
     device_owner_identity.is_some_and(|device_owner_identity| {
         device_owner_identity.was_previously_verified()
-            && !is_user_verified(own_identity, device_owner_identity)
+            && !is_user_verified(
+                own_identity,
+                device_owner_identity,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier,
+            )
     })
 }
 
 fn is_user_verified(
     own_identity: Option<&OwnUserIdentityData>,
     user_identity: &UserIdentityData,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<
+        &X509Verifier,
+    >,
 ) -> bool {
     match user_identity {
         UserIdentityData::Own(own_identity) => own_identity.is_verified(),
-        UserIdentityData::Other(other_identity) => other_identity.is_verified(own_identity),
+        UserIdentityData::Other(other_identity) => other_identity.is_verified(
+            own_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier,
+        ),
     }
 }
 
@@ -1306,6 +1408,8 @@ mod tests {
                 CollectStrategy::AllDevices,
                 &own_identity_data,
                 &dan_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1456,6 +1560,8 @@ mod tests {
                 CollectStrategy::OnlyTrustedDevices,
                 &own_identity_data,
                 &dan_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1472,6 +1578,8 @@ mod tests {
                 CollectStrategy::OnlyTrustedDevices,
                 &own_identity_data,
                 &dan_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1488,6 +1596,8 @@ mod tests {
                 CollectStrategy::OnlyTrustedDevices,
                 &own_identity_data,
                 &dave_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1599,6 +1709,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &carol_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1617,6 +1729,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &carol_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
         );
@@ -1685,6 +1799,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1764,6 +1880,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -1861,6 +1979,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &own_user_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
         );
@@ -1943,6 +2063,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -2022,6 +2144,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -2098,6 +2222,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
         );
@@ -2139,6 +2265,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &bob_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
             .unwrap(),
@@ -2214,6 +2342,8 @@ mod tests {
                 CollectStrategy::ErrorOnVerifiedUserProblem,
                 &own_identity_data,
                 &own_user_identity_data,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                None,
             )
             .await
         );
@@ -2252,6 +2382,8 @@ mod tests {
             CollectStrategy::ErrorOnVerifiedUserProblem,
             &own_identity_data,
             &own_user_identity_data,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            None,
         )
         .await
         .unwrap();

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -376,6 +376,7 @@ fn collect_device_updates(
     own_identity: Option<OwnUserIdentityData>,
     identities: IdentityChanges,
     devices: DeviceChanges,
+    #[cfg(feature = "experimental-x509-identity-verification")] x509_verifier: Option<X509Verifier>,
 ) -> DeviceUpdates {
     let mut new: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
     let mut changed: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
@@ -394,6 +395,8 @@ fn collect_device_updates(
             verification_machine: verification_machine.to_owned(),
             own_identity: own_identity.to_owned(),
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: x509_verifier.to_owned(),
         }
     };
 
@@ -890,6 +893,8 @@ impl Store {
             verification_machine: self.inner.verification_machine.clone(),
             own_identity,
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: self.x509_verifier().cloned(),
         })
     }
 
@@ -934,6 +939,8 @@ impl Store {
             verification_machine: self.inner.verification_machine.clone(),
             own_identity,
             device_owner_identity,
+            #[cfg(feature = "experimental-x509-identity-verification")]
+            x509_verifier: self.x509_verifier().cloned(),
         })
     }
 
@@ -1362,6 +1369,8 @@ impl Store {
     /// ```
     pub fn devices_stream(&self) -> impl Stream<Item = DeviceUpdates> + use<> {
         let verification_machine = self.inner.verification_machine.to_owned();
+        #[cfg(feature = "experimental-x509-identity-verification")]
+        let x509_verifier = self.x509_verifier().cloned();
 
         self.inner.store.identities_stream().map(move |(own_identity, identities, devices)| {
             collect_device_updates(
@@ -1369,6 +1378,8 @@ impl Store {
                 own_identity,
                 identities,
                 devices,
+                #[cfg(feature = "experimental-x509-identity-verification")]
+                x509_verifier.to_owned(),
             )
         })
     }

--- a/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
@@ -52,6 +52,11 @@ impl X509Verifier {
     /// Verify that the given object is signed with a certificate issued by a
     /// trusted CA, and that the certificate was issued to the given user
     /// ID.
+    ///
+    /// Note that, unlike verifying an Ed25519 signature, the result here is
+    /// derived from the configured trust anchors at the time of the call, and
+    /// so this method may give a different answer in the future, e.g. once the
+    /// certificate chain expires.
     pub(crate) fn verify_signed_object(
         &self,
         user_id: &UserId,


### PR DESCRIPTION
<!-- description of the changes in this PR -->

When a user's identity is verified via an `io.element.x509` signature (with the `experimental-x509-identity-verification` feature enabled), `OtherUserIdentity::is_verified()` correctly returns `true`. However, every one of said user's devices still reports `is_cross_signing_trusted() == false`, since the current user has not signed the user's MSK themselves.

To fix this, I have folded the common identity checks between device trust, user identity verification, and share strategy into a single `OtherUserIdentityData::is_verified` method that confers trust in a user via an X.509 signature to their devices. 

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/6964

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Skye Elliot <skyee@element.io>
