### PR TITLE
fix(sync-service): restart the syncs when the ignore user list changes

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6966.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6966.fixed.md
@@ -1,0 +1,1 @@
+The `SyncService` now restarts the room list sliding sync session when the ignore user list changes. Ignoring or unignoring a user clears the event cache, and without a fresh session the server never resends the timelines, so the room list lost its latest events and its ordering until the cache was cleared by hand.

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -24,7 +24,7 @@
 //! sync, if that is not desirable, the offline support for the [`SyncService`]
 //! may be enabled using the [`SyncServiceBuilder::with_offline_mode`] setting.
 
-use std::{sync::Arc, time::Duration};
+use std::{future::pending, sync::Arc, time::Duration};
 
 use eyeball::{SharedObservable, Subscriber};
 use futures_util::{
@@ -173,7 +173,10 @@ impl SyncTaskSupervisor {
                     receiver.recv().await.unwrap_or_else(TerminationReport::supervisor_error);
 
                 match report.origin {
-                    TerminationOrigin::EncryptionSync | TerminationOrigin::RoomList => {}
+                    // An `IgnoreUserListChange` never reaches this channel.
+                    TerminationOrigin::EncryptionSync
+                    | TerminationOrigin::RoomList
+                    | TerminationOrigin::IgnoreUserListChange => {}
                     // Since the sync service aren't running anymore, we can only receive a report
                     // from the supervisor. It would have probably made sense to have separate
                     // channels for reports the sync services send and the user can send using the
@@ -249,6 +252,9 @@ impl SyncTaskSupervisor {
         let offline_mode = inner.with_offline_mode;
         let parent_span = inner.parent_span.clone();
 
+        let mut ignore_user_list_stream =
+            room_list_service.client().subscribe_to_ignore_user_list_changes();
+
         let future = async move {
             loop {
                 let (room_list_task, encryption_sync_task) = Self::spawn_child_tasks(
@@ -262,20 +268,19 @@ impl SyncTaskSupervisor {
 
                 sync_permit_guard = MaybeAcquiredPermit::Unacquired(encryption_sync_permit.clone());
 
-                let report = if let Some(report) = receiver.recv().await {
-                    report
-                } else {
-                    info!("internal channel has been closed?");
-                    // We should still stop the child tasks in the unlikely scenario that our
-                    // receiver died.
-                    TerminationReport::supervisor_error()
-                };
+                let report =
+                    Self::wait_for_termination(&mut receiver, &mut ignore_user_list_stream).await;
+
+                let ignore_user_list_changed =
+                    matches!(report.origin, TerminationOrigin::IgnoreUserListChange);
 
                 // If one service failed, make sure to request stopping the other one.
                 let (stop_room_list, stop_encryption) = match &report.origin {
                     TerminationOrigin::EncryptionSync => (true, false),
                     TerminationOrigin::RoomList => (false, true),
-                    TerminationOrigin::Supervisor => (true, true),
+                    TerminationOrigin::Supervisor | TerminationOrigin::IgnoreUserListChange => {
+                        (true, true)
+                    }
                 };
 
                 // Stop both services, and wait for the streams to properly finish: at some
@@ -287,7 +292,8 @@ impl SyncTaskSupervisor {
                         warn!(?report, "unable to stop room list service: {err:#}");
                     }
 
-                    if report.has_expired() {
+                    // A cleared event cache refills only from a fresh session.
+                    if report.has_expired() || ignore_user_list_changed {
                         room_list_service.expire_sync_session().await;
                     }
                 }
@@ -309,6 +315,18 @@ impl SyncTaskSupervisor {
                 if let Err(err) = encryption_sync_task.await {
                     error!("when awaiting encryption sync: {err:#}");
                 }
+
+                let report = if ignore_user_list_changed {
+                    match Self::drain_child_reports(&mut receiver) {
+                        Some(report) => report,
+                        None => {
+                            info!("Restarting the syncs after an ignore user list change");
+                            continue;
+                        }
+                    }
+                } else {
+                    report
+                };
 
                 if let Some(error) = report.error {
                     if offline_mode {
@@ -344,6 +362,52 @@ impl SyncTaskSupervisor {
         let task = spawn(future);
 
         (task, termination_sender)
+    }
+
+    /// Wait for a [`TerminationReport`], or an ignore user list change.
+    async fn wait_for_termination(
+        receiver: &mut Receiver<TerminationReport>,
+        ignore_user_list_stream: &mut Subscriber<Vec<String>>,
+    ) -> TerminationReport {
+        let wait_for_report = async {
+            receiver.recv().await.unwrap_or_else(|| {
+                // A dead receiver must still stop the child tasks.
+                info!("internal channel has been closed?");
+                TerminationReport::supervisor_error()
+            })
+        };
+
+        let wait_for_ignore_user_list_change = async {
+            match ignore_user_list_stream.next().await {
+                Some(_) => TerminationReport::ignore_user_list_change(),
+                None => {
+                    info!("Ignore user list stream has closed");
+                    pending().await
+                }
+            }
+        };
+
+        pin_mut!(wait_for_report);
+        pin_mut!(wait_for_ignore_user_list_change);
+
+        match select(wait_for_report, wait_for_ignore_user_list_change).await {
+            Either::Left((report, _)) | Either::Right((report, _)) => report,
+        }
+    }
+
+    /// Drop the reports of the stopped child tasks, keeping a racing stop.
+    fn drain_child_reports(
+        receiver: &mut Receiver<TerminationReport>,
+    ) -> Option<TerminationReport> {
+        let mut supervisor_report = None;
+
+        while let Ok(report) = receiver.try_recv() {
+            if matches!(report.origin, TerminationOrigin::Supervisor) {
+                supervisor_report = Some(report);
+            }
+        }
+
+        supervisor_report
     }
 
     async fn spawn_child_tasks(
@@ -701,6 +765,7 @@ enum TerminationOrigin {
     EncryptionSync,
     RoomList,
     Supervisor,
+    IgnoreUserListChange,
 }
 
 #[derive(Debug)]
@@ -737,6 +802,11 @@ impl TerminationReport {
     /// [`TerminationOrigin::Supervisor`] and `error` set to `None`.
     fn supervisor() -> Self {
         Self { origin: TerminationOrigin::Supervisor, error: None }
+    }
+
+    /// Report that the ignore user list changed, which is not an error.
+    fn ignore_user_list_change() -> Self {
+        Self { origin: TerminationOrigin::IgnoreUserListChange, error: None }
     }
 
     /// Check whether the termination is due to an expired sliding sync session.

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -252,6 +252,91 @@ async fn test_sync_service_client_sync_presence_is_used_by_both_syncs() -> anyho
 }
 
 #[async_test]
+async fn test_sync_service_restarts_when_ignore_user_list_changes() -> anyhow::Result<()> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_pos = Arc::new(Mutex::new(0));
+
+    // A room list request without a `pos` starts a fresh sliding sync session.
+    let session_starts = Arc::new(Mutex::new(0));
+    let observed_session_starts = session_starts.clone();
+
+    let _guard = Mock::given(SlidingSyncMatcher)
+        .respond_with(move |request: &Request| {
+            let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
+
+            if partial_request.conn_id.as_deref() != Some("room-list") {
+                return ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "txn_id": partial_request.txn_id,
+                        "pos": "0"
+                    }))
+                    .set_delay(Duration::from_millis(50));
+            }
+
+            if !request.url.query_pairs().any(|(key, _)| key == "pos") {
+                *session_starts.lock().unwrap() += 1;
+            }
+
+            let mut pos = room_pos.lock().unwrap();
+            *pos += 1;
+
+            // Ignore Bob only after a few responses carried a valid `pos`.
+            let extensions = if *pos >= 3 {
+                json!({
+                    "account_data": {
+                        "global": [{
+                            "type": "m.ignored_user_list",
+                            "content": { "ignored_users": { "@bob:localhost": {} } }
+                        }]
+                    }
+                })
+            } else {
+                json!({})
+            };
+
+            ResponseTemplate::new(200)
+                .set_body_json(json!({
+                    "txn_id": partial_request.txn_id,
+                    "pos": (*pos).to_string(),
+                    "extensions": extensions,
+                }))
+                .set_delay(Duration::from_millis(50))
+        })
+        .mount_as_scoped(&server)
+        .await;
+
+    let sync_service = SyncService::builder(client).build().await.unwrap();
+    let mut state_stream = sync_service.state();
+
+    sync_service.start().await;
+    assert_next_matches!(state_stream, State::Running);
+
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        if *observed_session_starts.lock().unwrap() > 1 {
+            break;
+        }
+    }
+
+    // Let the syncs run some more, so a restart loop would show up as well.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // No client ever sees the restart in the state.
+    assert_pending!(state_stream);
+
+    sync_service.stop().await;
+    assert_next_matches!(state_stream, State::Idle);
+
+    // The initial session, and the one restarted for the ignore user list.
+    assert_eq!(*observed_session_starts.lock().unwrap(), 2);
+
+    Ok(())
+}
+
+#[async_test]
 async fn test_sync_service_offline_mode() {
     let mock_server = MatrixMockServer::new().await;
     let client = mock_server.client_builder().build().await;


### PR DESCRIPTION
Ignoring or unignoring a user clears the event cache. The room list sliding sync session keeps its `pos`, so the server never resends the timelines: the room list stays without its latest events, and with a broken ordering, until the user clears the cache by hand. Unignoring the user does not repair it either.

`SyncTaskSupervisor` now waits on the ignore user list too, through `Client::subscribe_to_ignore_user_list_changes`. A change becomes a `TerminationReport` with the new `TerminationOrigin::IgnoreUserListChange` origin, which stops both syncs, expires the room list sliding sync session, and restarts them. The encryption sync session keeps its `pos`, because the event cache holds none of its data. The `SyncService` state stays `Running` across the restart, so no client sees a spurious `Terminated` or `Idle` state.

The new integration test `test_sync_service_restarts_when_ignore_user_list_changes` injects an `m.ignored_user_list` event in a sliding sync response, then asserts that exactly one room list request without a `pos` follows a request with one. The exact count also proves that the restart does not loop.

Closes #5983

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

Signed-off-by: Gabriel Cruz <gabe@gmelodie.com>