### PR TITLE
feat(ui): Allow filtering out custom events in the timeline

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6969.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/6969.added.md
@@ -1,0 +1,2 @@
+Allow filtering out or only including custom message-like and state events using 
+`TimelineEventCondition::AnyCustomMessageLikeEvent` and `TimelineEventCondition::AnyCustomStateEvent`.

--- a/crates/matrix-sdk-ui/src/timeline/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_filter.rs
@@ -55,6 +55,10 @@ pub enum TimelineEventCondition {
     /// The event is an `m.room.member` event that represents a profile
     /// change (displayname or avatar URL).
     ProfileChange,
+    /// The event is a custom message-like event type.
+    AnyCustomMessageLikeEvent,
+    /// The event is a custom state event type.
+    AnyCustomStateEvent,
 }
 
 /// The membership states that should be included/excluded from the timeline
@@ -116,6 +120,18 @@ impl TimelineEventCondition {
                     matches!(ev.membership_change(), MembershipChange::ProfileChanged { .. })
                 }
                 _ => false,
+            },
+            Self::AnyCustomMessageLikeEvent => match event {
+                AnySyncTimelineEvent::MessageLike(_) => {
+                    matches!(event.event_type(), TimelineEventType::_Custom(_))
+                }
+                AnySyncTimelineEvent::State(_) => false,
+            },
+            Self::AnyCustomStateEvent => match event {
+                AnySyncTimelineEvent::State(_) => {
+                    matches!(event.event_type(), TimelineEventType::_Custom(_))
+                }
+                AnySyncTimelineEvent::MessageLike(_) => false,
             },
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -21,7 +21,7 @@ use matrix_sdk::deserialized_responses::TimelineEvent;
 use matrix_sdk_test::{ALICE, BOB, async_test, sync_timeline_event};
 use ruma::{
     events::{
-        AnySyncTimelineEvent, TimelineEventType,
+        AnySyncTimelineEvent, MessageLikeEventType, StateEventType, TimelineEventType,
         room::{
             member::MembershipState,
             message::{MessageType, RedactedRoomMessageEventContent},
@@ -663,6 +663,79 @@ async fn test_event_filter_can_exclude_only_join_and_leave_membership_changes() 
     assert_eq!(num_profile_change_items, 2);
 }
 
+#[async_test]
+async fn test_event_filter_exclude_any_custom_message_like_event_type() {
+    // Don't return any custom message-like events
+    let event_filter =
+        TimelineEventFilter::Exclude(vec![TimelineEventCondition::AnyCustomMessageLikeEvent]);
+
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(move |event, _| event_filter.filter(event)),
+            ..Default::default()
+        })
+        .build()
+        .await;
+    let f = &timeline.factory;
+
+    // Add a normal message event that will be kept
+    timeline.handle_live_event(f.text_msg("Hey").sender(&ALICE)).await;
+    // And a custom message event that will be filtered out
+    timeline.handle_live_event(f.custom_message_like_event().sender(&ALICE)).await;
+    // Add a couple of room name state events
+    timeline.handle_live_event(f.room_name("A new room name").sender(&ALICE)).await;
+    timeline.handle_live_event(f.room_name("A new room name (again)").sender(&ALICE)).await;
+    // And a different state event
+    timeline.handle_live_event(f.room_topic("A new room topic").sender(&ALICE)).await;
+
+    // The timeline should contain everything except for the message event.
+    let event_items: Vec<Arc<TimelineItem>> = timeline.get_event_items().await;
+    let num_normal_text_message_items = event_items.iter().filter(is_text_message_item).count();
+    let num_custom_text_message_items =
+        event_items.iter().filter(is_custom_text_message_item).count();
+    let num_room_name_items = event_items.iter().filter(is_room_name_item).count();
+    let num_room_topic_items = event_items.iter().filter(is_room_topic_item).count();
+    assert_eq!(event_items.len(), 4);
+    assert_eq!(num_normal_text_message_items, 1);
+    assert_eq!(num_custom_text_message_items, 0);
+    assert_eq!(num_room_name_items, 2);
+    assert_eq!(num_room_topic_items, 1);
+}
+
+#[async_test]
+async fn test_event_filter_exclude_any_custom_state_event_type() {
+    // Don't return any custom state events
+    let event_filter =
+        TimelineEventFilter::Exclude(vec![TimelineEventCondition::AnyCustomStateEvent]);
+
+    let timeline = TestTimelineBuilder::new()
+        .settings(TimelineSettings {
+            event_filter: Arc::new(move |event, _| event_filter.filter(event)),
+            ..Default::default()
+        })
+        .build()
+        .await;
+    let f = &timeline.factory;
+
+    // Add customs state event that will be filtered out
+    timeline.handle_live_event(f.custom_state_event().sender(&ALICE)).await;
+    // Add a couple of room name state events
+    timeline.handle_live_event(f.room_name("A new room name").sender(&ALICE)).await;
+    timeline.handle_live_event(f.room_name("A new room name (again)").sender(&ALICE)).await;
+    // And a different state event
+    timeline.handle_live_event(f.room_topic("A new room topic").sender(&ALICE)).await;
+
+    // The timeline should contain everything except for the message event.
+    let event_items: Vec<Arc<TimelineItem>> = timeline.get_event_items().await;
+    let num_custom_state_items = event_items.iter().filter(is_custom_state_item).count();
+    let num_room_name_items = event_items.iter().filter(is_room_name_item).count();
+    let num_room_topic_items = event_items.iter().filter(is_room_topic_item).count();
+    assert_eq!(event_items.len(), 3);
+    assert_eq!(num_custom_state_items, 0);
+    assert_eq!(num_room_name_items, 2);
+    assert_eq!(num_room_topic_items, 1);
+}
+
 impl TestTimeline {
     async fn get_event_items(&self) -> Vec<Arc<TimelineItem>> {
         self.controller
@@ -687,6 +760,27 @@ fn is_text_message_item(item: &&Arc<TimelineItem>) -> bool {
         },
         _ => false,
     }
+}
+
+fn is_custom_text_message_item(item: &&Arc<TimelineItem>) -> bool {
+    let msg_like = item.as_event().and_then(|e| e.content.as_msglike()).map(|e| e.kind.clone());
+    match msg_like {
+        Some(MsgLikeKind::Other(other)) => {
+            matches!(other.event_type, MessageLikeEventType::_Custom(_))
+        }
+        _ => false,
+    }
+}
+
+fn is_custom_state_item(item: &&Arc<TimelineItem>) -> bool {
+    let event_type = item
+        .as_event()
+        .and_then(|e| match e.content() {
+            TimelineItemContent::OtherState(state) => Some(state.content()),
+            _ => None,
+        })
+        .map(|e| e.event_type());
+    matches!(event_type, Some(StateEventType::_Custom(_)))
 }
 
 fn is_room_name_item(item: &&Arc<TimelineItem>) -> bool {

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -110,7 +110,7 @@ use ruma::{
     serde::Raw,
     server_name,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::base64_sha256_hash;
@@ -1560,6 +1560,11 @@ impl EventFactory {
         self.event(CustomMessageLikeEventContent)
     }
 
+    /// Create a new `rs.matrix-sdk.custom.test` custom event
+    pub fn custom_state_event(&self) -> EventBuilder<CustomStateEventContent> {
+        self.event(CustomStateEventContent).state_key("test")
+    }
+
     /// Set the next server timestamp.
     ///
     /// Timestamps will continue to increase by 1 (millisecond) from that value.
@@ -1929,3 +1934,7 @@ impl From<MembershipState> for PreviousMembership {
 #[derive(Clone, Default, Debug, Serialize, EventContent)]
 #[ruma_event(type = "rs.matrix-sdk.custom.test", kind = MessageLike)]
 pub struct CustomMessageLikeEventContent;
+
+#[derive(Clone, Default, Debug, Serialize, Deserialize, EventContent)]
+#[ruma_event(type = "rs.matrix-sdk.custom-state.test", kind = State, state_key_type = String)]
+pub struct CustomStateEventContent;


### PR DESCRIPTION
With this we can hide custom message-like events, state events, or both.

Previously there was no way to do this other than another filter pass in the clients

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
