### PR TITLE
fix(ui): Fix possible panic in `compute_event_receipts`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -353,7 +353,10 @@ impl ReadReceiptsState {
         // Include receipts from the following events that are hidden or can't show
         // read receipts until the next event that is visible and can show read
         // receipts.
-        let next_events_iter = timeline_items.all_remote_events().range(current_event_index + 1..);
+
+        // Start by creating an iterator from the following event, if possible.
+        let next_events_iter =
+            timeline_items.all_remote_events().range(current_event_index..).skip(1);
         let mut hidden = Vec::new();
         for hidden_receipt_event_meta in
             next_events_iter.take_while(|meta| !meta.visible || !meta.can_show_read_receipts)


### PR DESCRIPTION
The `next_events_iter` could panic if `current_event_index + 1` was out of bounds.

With `skip(1)`, this should just return an empty iterator instead.

Follow-up PR for https://github.com/matrix-org/matrix-rust-sdk/pull/6963

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
