### PR TITLE
feat(crypto-ffi): Add per-level log methods to Logger callback interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,6 +3772,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tracing-core",
  "tracing-subscriber",
  "uniffi",
  "vergen-gitcl",

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -44,6 +44,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-core.workspace = true
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
 uniffi = { workspace = true, features = ["cli"] }
 vodozemac.workspace = true

--- a/bindings/matrix-sdk-crypto-ffi/changelog.d/6972.changed.md
+++ b/bindings/matrix-sdk-crypto-ffi/changelog.d/6972.changed.md
@@ -1,0 +1,1 @@
+Changed the Logger callback interface to support per-level log methods, replacing its single catch-all log method

--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -3,22 +3,37 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use tracing_core::{Level, Metadata};
 use tracing_subscriber::{EnvFilter, fmt::MakeWriter};
 
 /// Trait that can be used to forward Rust logs over FFI to a language specific
 /// logger.
 #[matrix_sdk_ffi_macros::export(callback_interface)]
 pub trait Logger: Send {
-    /// Called every time the Rust side wants to post a log line.
-    fn log(&self, log_line: String);
-    // TODO add support for different log levels, do this by adding more methods
-    // to the trait.
+    /// Called every time the Rust side wants to post a debug log line.
+    fn log_debug(&self, log_line: String);
+    /// Called every time the Rust side wants to post an error log line.
+    fn log_error(&self, log_line: String);
+    /// Called every time the Rust side wants to post an info log line.
+    fn log_info(&self, log_line: String);
+    /// Called every time the Rust side wants to post a trace log line.
+    fn log_trace(&self, log_line: String);
+    /// Called every time the Rust side wants to post a warn log line.
+    fn log_warn(&self, log_line: String);
 }
 
 impl Write for LoggerWrapper {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         let data = String::from_utf8_lossy(buf).to_string();
-        self.inner.lock().unwrap().log(data);
+        let lock = self.inner.lock().unwrap();
+
+        match self.level {
+            Level::DEBUG => lock.log_debug(data),
+            Level::ERROR => lock.log_error(data),
+            Level::INFO => lock.log_info(data),
+            Level::TRACE => lock.log_trace(data),
+            Level::WARN => lock.log_warn(data),
+        }
 
         Ok(buf.len())
     }
@@ -34,17 +49,22 @@ impl MakeWriter<'_> for LoggerWrapper {
     fn make_writer(&self) -> Self::Writer {
         self.clone()
     }
+
+    fn make_writer_for(&self, meta: &Metadata<'_>) -> Self::Writer {
+        LoggerWrapper { inner: self.inner.clone(), level: *meta.level() }
+    }
 }
 
 #[derive(Clone)]
 pub struct LoggerWrapper {
     inner: Arc<Mutex<Box<dyn Logger>>>,
+    level: Level,
 }
 
 /// Set the logger that should be used to forward Rust logs over FFI.
 #[matrix_sdk_ffi_macros::export]
 pub fn set_logger(logger: Box<dyn Logger>) {
-    let logger = LoggerWrapper { inner: Arc::new(Mutex::new(logger)) };
+    let logger = LoggerWrapper { inner: Arc::new(Mutex::new(logger)), level: Level::DEBUG };
 
     let filter = EnvFilter::from_default_env()
         .add_directive(


### PR DESCRIPTION
Closes #1759 

<!-- description of the changes in this PR -->
The `Logger` trait previously only supported one catch-all `log` method which discarded the log level of tracing events. This adds dedicated per-level log methods to the trait.

`LoggerWrapper` has a new internal `level` field that tracks the log level, it's instantiated with `Level::DEBUG` as a default.

**_NOTE: This is a breaking change to the crate's public bindings API contract._** I did not find any special instructions for cases like this but I wanted to note it prominently.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
