### PR TITLE
Add support for delayed event (MSC4140)

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6973.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6973.added.md
@@ -1,0 +1,3 @@
+Added `Room::sendDelayedEvent`, `Room::sendDelayedStateEvent` and `Room::updateDelayedEvent` for delayed events 
+([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)). 
+They fail if the homeserver does not advertise support for delayed events.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -12,7 +12,7 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, fs, path::PathBuf, pin::pin, sync::Arc};
+use std::{collections::HashMap, fs, path::PathBuf, pin::pin, sync::Arc, time::Duration};
 
 use anyhow::{Context, Result};
 use futures_util::{StreamExt, pin_mut};
@@ -36,7 +36,9 @@ use matrix_sdk_ui::{
 use mime::Mime;
 use ruma::{
     EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
-    ServerName, UserId, assign,
+    ServerName, UserId,
+    api::client::delayed_events::{DelayParameters, update_delayed_event::UpdateAction},
+    assign,
     events::{
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
         receipt::ReceiptThread as RumaReceiptThread,
@@ -497,6 +499,115 @@ impl Room {
             self.inner.send_state_event_raw(&event_type, &state_key, content_json).await?;
 
         Ok(response.event_id.to_string())
+    }
+
+    /// Send a delayed message-like event to the room ([MSC4140]).
+    ///
+    /// The homeserver holds on to the event and only distributes it to the room
+    /// once `delay_ms` has elapsed, unless the delayed event is updated
+    /// beforehand with [`Room::update_delayed_event`].
+    ///
+    /// If the room is encrypted, the content is encrypted when the event is
+    /// scheduled, like [`Room::send_raw`] does. A member joining the room
+    /// before the delay elapses won't be able to decrypt it.
+    ///
+    /// # Arguments
+    ///
+    /// * `delay_ms` - How long, in milliseconds, the homeserver should hold on
+    ///   to the event.
+    ///
+    /// * `event_type` - The type of the event to send.
+    ///
+    /// * `content` - The content of the event to send encoded as a JSON string.
+    ///
+    /// Returns the `delay_id` identifying the scheduled event.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    pub async fn send_delayed_event(
+        &self,
+        delay_ms: u64,
+        event_type: String,
+        content: String,
+    ) -> Result<String, ClientError> {
+        let content_json: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| ClientError::Generic {
+                msg: format!("Failed to parse JSON: {e}"),
+                details: Some(format!("{e:?}")),
+            })?;
+
+        let response = self
+            .inner
+            .send_raw(&event_type, content_json)
+            .with_delay(DelayParameters::Timeout { timeout: Duration::from_millis(delay_ms) })
+            .await?;
+
+        Ok(response.delay_id)
+    }
+
+    /// Send a delayed state event to the room ([MSC4140]).
+    ///
+    /// See [`Room::send_delayed_event`] for the semantics of delayed events.
+    ///
+    /// # Arguments
+    ///
+    /// * `delay_ms` - How long, in milliseconds, the homeserver should hold on
+    ///   to the event.
+    ///
+    /// * `event_type` - The type of the state event to send.
+    ///
+    /// * `state_key` - A unique key which defines the overwriting semantics for
+    ///   this piece of room state. This is often an empty string.
+    ///
+    /// * `content` - The content of the event to send encoded as a JSON string.
+    ///
+    /// Returns the `delay_id` identifying the scheduled event.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    pub async fn send_delayed_state_event(
+        &self,
+        delay_ms: u64,
+        event_type: String,
+        state_key: String,
+        content: String,
+    ) -> Result<String, ClientError> {
+        let content_json: serde_json::Value =
+            serde_json::from_str(&content).map_err(|e| ClientError::Generic {
+                msg: format!("Failed to parse JSON: {e}"),
+                details: Some(format!("{e:?}")),
+            })?;
+
+        let response = self
+            .inner
+            .send_delayed_state_event_raw(
+                &event_type,
+                &state_key,
+                content_json,
+                DelayParameters::Timeout { timeout: Duration::from_millis(delay_ms) },
+            )
+            .await?;
+
+        Ok(response.delay_id)
+    }
+
+    /// Cancel, restart or immediately send a previously scheduled delayed
+    /// event ([MSC4140]).
+    ///
+    /// # Arguments
+    ///
+    /// * `delay_id` - The identifier returned by [`Room::send_delayed_event`]
+    ///   or [`Room::send_delayed_state_event`].
+    ///
+    /// * `action` - What should happen to the delayed event.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    pub async fn update_delayed_event(
+        &self,
+        delay_id: String,
+        action: DelayedEventUpdateAction,
+    ) -> Result<(), ClientError> {
+        self.inner.update_delayed_event(delay_id, action.into()).await?;
+
+        Ok(())
     }
 
     /// Redacts an event from the room.
@@ -1415,6 +1526,30 @@ pub struct EventWithRelations {
     /// The events related to it, directly or (recursively) through other
     /// related events.
     pub related_events: Vec<Arc<TimelineEvent>>,
+}
+
+/// What to do with a delayed event that hasn't been distributed to the room
+/// yet ([MSC4140]).
+///
+/// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum DelayedEventUpdateAction {
+    /// Cancel the delayed event: it will never be sent to the room.
+    Cancel,
+    /// Restart the delay timeout, keeping the event scheduled.
+    Restart,
+    /// Send the event to the room right away.
+    Send,
+}
+
+impl From<DelayedEventUpdateAction> for UpdateAction {
+    fn from(value: DelayedEventUpdateAction) -> Self {
+        match value {
+            DelayedEventUpdateAction::Cancel => Self::Cancel,
+            DelayedEventUpdateAction::Restart => Self::Restart,
+            DelayedEventUpdateAction::Send => Self::Send,
+        }
+    }
 }
 
 /// A listener for receiving call decline events in a room.

--- a/crates/matrix-sdk/changelog.d/6973.added.md
+++ b/crates/matrix-sdk/changelog.d/6973.added.md
@@ -1,0 +1,5 @@
+Added a public API for delayed events ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)),
+previously only reachable through the widget driver: `SendRawMessageLikeEvent::with_delay` turns a `Room::send_raw` 
+call into a delayed send, and `Room::send_delayed_state_event_raw` and `Room::update_delayed_event` cover state events
+and cancelling / restarting / sending a scheduled event.
+All three fail with the new `Error::UnsupportedHomeserverFeature` when the homeserver does not advertise `org.matrix.msc4140`.

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -46,7 +46,7 @@ use matrix_sdk_sqlite::SqliteStoreConfig;
 use reqwest::Certificate;
 use ruma::{
     OwnedServerName, ServerName,
-    api::{MatrixVersion, SupportedVersions, error::FromHttpResponseError},
+    api::{FeatureFlag, MatrixVersion, SupportedVersions, error::FromHttpResponseError},
     presence::PresenceState,
 };
 use thiserror::Error;
@@ -125,6 +125,7 @@ pub struct ClientBuilder {
     respect_login_well_known: bool,
     well_known_lookup_disabled: bool,
     server_versions: Option<BTreeSet<MatrixVersion>>,
+    unstable_features: BTreeSet<FeatureFlag>,
     handle_refresh_tokens: bool,
     base_client: Option<BaseClient>,
     #[cfg(feature = "e2e-encryption")]
@@ -165,6 +166,7 @@ impl ClientBuilder {
             respect_login_well_known: true,
             well_known_lookup_disabled: false,
             server_versions: None,
+            unstable_features: Default::default(),
             handle_refresh_tokens: false,
             base_client: None,
             #[cfg(feature = "e2e-encryption")]
@@ -505,6 +507,20 @@ impl ClientBuilder {
         self
     }
 
+    /// Specify the unstable features advertised by the homeserver manually,
+    /// alongside the versions given to
+    /// [`server_versions()`][Self::server_versions].
+    ///
+    /// This is only used if `server_versions()` is called too, and is helpful
+    /// for test code that doesn't care to mock the `/versions` endpoint.
+    pub(crate) fn unstable_features(
+        mut self,
+        value: impl IntoIterator<Item = FeatureFlag>,
+    ) -> Self {
+        self.unstable_features = value.into_iter().collect();
+        self
+    }
+
     #[cfg(not(target_family = "wasm"))]
     fn http_settings(&mut self) -> &mut HttpSettings {
         self.http_cfg.get_or_insert_with(Default::default).settings()
@@ -726,7 +742,7 @@ impl ClientBuilder {
         let supported_versions = match self.server_versions {
             Some(versions) => Cached(TtlValue::without_expiry(SupportedVersions {
                 versions,
-                features: Default::default(),
+                features: self.unstable_features,
             })),
             None => NotSet,
         };

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -513,6 +513,7 @@ impl ClientBuilder {
     ///
     /// This is only used if `server_versions()` is called too, and is helpful
     /// for test code that doesn't care to mock the `/versions` endpoint.
+    #[cfg(any(test, feature = "testing"))]
     pub(crate) fn unstable_features(
         mut self,
         value: impl IntoIterator<Item = FeatureFlag>,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2937,6 +2937,41 @@ impl Client {
         Ok(self.unstable_features().await?.contains(&FeatureFlag::from("org.matrix.msc4028")))
     }
 
+    /// Check whether the homeserver supports delayed events ([MSC4140]), i.e.
+    /// whether it advertises `org.matrix.msc4140` in the `unstable_features` of
+    /// its `/versions` response.
+    ///
+    /// The delayed-event APIs ([`SendRawMessageLikeEvent::with_delay`],
+    /// [`Room::send_delayed_state_event_raw`] and
+    /// [`Room::update_delayed_event`]) check this themselves and fail with
+    /// [`Error::UnsupportedHomeserverFeature`] otherwise, so this is mostly
+    /// useful to decide up front whether a feature relying on delayed events
+    /// can be offered at all.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    /// [`SendRawMessageLikeEvent::with_delay`]: crate::room::futures::SendRawMessageLikeEvent::with_delay
+    pub async fn can_homeserver_send_delayed_events(&self) -> HttpResult<bool> {
+        Ok(self.unstable_features().await?.contains(&FeatureFlag::Msc4140))
+    }
+
+    /// Fail with [`Error::UnsupportedHomeserverFeature`] unless the homeserver
+    /// supports delayed events ([MSC4140]).
+    ///
+    /// This must be checked before scheduling a delayed event: the delayed
+    /// variants of `/send` and `/state` only differ from the regular ones by
+    /// the unstable `org.matrix.msc4140.delay` query parameter, which a
+    /// homeserver without support silently ignores, sending the event right
+    /// away instead of holding on to it.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    pub(crate) async fn ensure_delayed_events_supported(&self) -> Result<()> {
+        if self.can_homeserver_send_delayed_events().await? {
+            Ok(())
+        } else {
+            Err(Error::UnsupportedHomeserverFeature(FeatureFlag::Msc4140))
+        }
+    }
+
     /// Get information of all our own devices.
     ///
     /// # Examples

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -34,6 +34,7 @@ use reqwest::Error as ReqwestError;
 use ruma::{
     IdParseError,
     api::{
+        FeatureFlag,
         client::uiaa::{UiaaInfo, UiaaResponse},
         error::{ErrorKind, FromHttpResponseError, IntoHttpError, RetryAfter},
     },
@@ -347,6 +348,12 @@ pub enum Error {
     /// different.
     #[error("wrong room state: {0}")]
     WrongRoomState(Box<WrongRoomState>),
+
+    /// The homeserver does not advertise support for an unstable feature this
+    /// operation depends on, in the `unstable_features` of its `/versions`
+    /// response.
+    #[error("the homeserver does not support the `{0}` unstable feature")]
+    UnsupportedHomeserverFeature(FeatureFlag),
 
     /// Session callbacks have been set multiple times.
     #[error("session callbacks have been set multiple times")]

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -28,7 +28,10 @@ use mime::Mime;
 use ruma::events::{MessageLikeUnsigned, SyncMessageLikeEvent};
 use ruma::{
     OwnedTransactionId, TransactionId,
-    api::client::message::send_message_event,
+    api::client::{
+        delayed_events::{DelayParameters, delayed_message_event},
+        message::send_message_event,
+    },
     assign,
     events::{AnyMessageLikeEventContent, MessageLikeEventContent},
     serde::Raw,
@@ -170,6 +173,35 @@ impl<'a> SendRawMessageLikeEvent<'a> {
         self.request_config = Some(request_config);
         self
     }
+
+    /// Send the event as a delayed event ([MSC4140]) instead of sending it
+    /// right away.
+    ///
+    /// The homeserver holds on to the event and only distributes it to the room
+    /// once the delay elapses. Until then the event can be cancelled, restarted
+    /// or sent immediately with [`Room::update_delayed_event`], using the
+    /// `delay_id` from the response.
+    ///
+    /// The event is prepared exactly like an immediate one: in particular it
+    /// is encrypted if the room is encrypted. Note that this happens when the
+    /// event is *scheduled*: the room key is shared with the members of the
+    /// room at that point, so a member joining before the delay elapses won't
+    /// be able to decrypt the event, and restarting the delay does not
+    /// re-encrypt it.
+    ///
+    /// # Errors
+    ///
+    /// Fails with [`Error::UnsupportedHomeserverFeature`] if the homeserver
+    /// does not advertise support for delayed events, see
+    /// [`Client::can_homeserver_send_delayed_events`]. Without that check the
+    /// homeserver would ignore the delay and send the event right away.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    /// [`Error::UnsupportedHomeserverFeature`]: crate::Error::UnsupportedHomeserverFeature
+    /// [`Client::can_homeserver_send_delayed_events`]: crate::Client::can_homeserver_send_delayed_events
+    pub fn with_delay(self, delay: DelayParameters) -> SendDelayedRawMessageLikeEvent<'a> {
+        SendDelayedRawMessageLikeEvent { inner: self, delay }
+    }
 }
 
 impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
@@ -177,58 +209,11 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
     boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
-        #[cfg_attr(not(feature = "e2e-encryption"), allow(unused_mut))]
-        let Self {
-            room,
-            mut event_type,
-            mut content,
-            tracing_span,
-            transaction_id,
-            request_config,
-        } = self;
+        let Self { room, event_type, content, tracing_span, transaction_id, request_config } = self;
 
         let fut = async move {
-            room.ensure_room_joined()?;
-
-            let txn_id = transaction_id.unwrap_or_else(TransactionId::new);
-            Span::current().record("transaction_id", tracing::field::debug(&txn_id));
-
-            #[cfg(not(feature = "e2e-encryption"))]
-            trace!("Sending plaintext event to room because we don't have encryption support.");
-
-            #[cfg(feature = "e2e-encryption")]
-            let mut encryption_info: Option<EncryptionInfo> = None;
-            #[cfg(not(feature = "e2e-encryption"))]
-            let encryption_info: Option<EncryptionInfo> = None;
-
-            #[cfg(feature = "e2e-encryption")]
-            if room.latest_encryption_state().await?.is_encrypted() {
-                Span::current().record("is_room_encrypted", true);
-                // Reactions are currently famously not encrypted, skip encrypting
-                // them until they are.
-                if event_type == "m.reaction" {
-                    trace!("Sending plaintext event because of the event type.");
-                } else {
-                    trace!(
-                        room_id = ?room.room_id(),
-                        "Sending encrypted event because the room is encrypted.",
-                    );
-
-                    ensure_room_encryption_ready(room).await?;
-
-                    let olm = room.client.olm_machine().await;
-                    let olm = olm.as_ref().expect("Olm machine wasn't started");
-
-                    let result =
-                        olm.encrypt_room_event_raw(room.room_id(), event_type, &content).await?;
-                    content = result.content.cast();
-                    encryption_info = Some(result.encryption_info);
-                    event_type = "m.room.encrypted";
-                }
-            } else {
-                Span::current().record("is_room_encrypted", false);
-                trace!("Sending plaintext event because the room is NOT encrypted.");
-            }
+            let PreparedMessageLikeEvent { txn_id, event_type, content, encryption_info } =
+                prepare_message_like_event(room, event_type, content, transaction_id).await?;
 
             let request = send_message_event::v3::Request::new_raw(
                 room.room_id().to_owned(),
@@ -247,6 +232,139 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
 
         Box::pin(fut.instrument(tracing_span))
     }
+}
+
+/// Future returned by [`SendRawMessageLikeEvent::with_delay`].
+#[allow(missing_debug_implementations)]
+pub struct SendDelayedRawMessageLikeEvent<'a> {
+    inner: SendRawMessageLikeEvent<'a>,
+    delay: DelayParameters,
+}
+
+impl<'a> SendDelayedRawMessageLikeEvent<'a> {
+    /// Set a transaction ID for this event.
+    ///
+    /// See [`SendRawMessageLikeEvent::with_transaction_id`].
+    pub fn with_transaction_id(mut self, txn_id: &TransactionId) -> Self {
+        self.inner = self.inner.with_transaction_id(txn_id);
+        self
+    }
+
+    /// Assign a given [`RequestConfig`] to configure how this request should
+    /// behave with respect to the network.
+    pub fn with_request_config(mut self, request_config: RequestConfig) -> Self {
+        self.inner = self.inner.with_request_config(request_config);
+        self
+    }
+}
+
+impl<'a> IntoFuture for SendDelayedRawMessageLikeEvent<'a> {
+    type Output = Result<delayed_message_event::unstable::Response>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self {
+            inner:
+                SendRawMessageLikeEvent {
+                    room,
+                    event_type,
+                    content,
+                    tracing_span,
+                    transaction_id,
+                    request_config,
+                },
+            delay,
+        } = self;
+
+        let fut = async move {
+            // Check this first: it is pointless to share a room key for an event we
+            // are not going to send.
+            room.client.ensure_delayed_events_supported().await?;
+
+            let PreparedMessageLikeEvent { txn_id, event_type, content, encryption_info: _ } =
+                prepare_message_like_event(room, event_type, content, transaction_id).await?;
+
+            let request = delayed_message_event::unstable::Request::new_raw(
+                room.room_id().to_owned(),
+                txn_id,
+                event_type.into(),
+                delay,
+                content,
+            );
+
+            let response = room.client.send(request).with_request_config(request_config).await?;
+
+            info!(delay_id = response.delay_id, "Scheduled delayed event in room");
+
+            Ok(response)
+        };
+
+        Box::pin(fut.instrument(tracing_span))
+    }
+}
+
+/// A message-like event that is ready to be handed to the homeserver.
+struct PreparedMessageLikeEvent<'a> {
+    txn_id: OwnedTransactionId,
+    /// The type to send, `m.room.encrypted` if the content was encrypted.
+    event_type: &'a str,
+    content: Raw<AnyMessageLikeEventContent>,
+    /// The encryption info, if the content was encrypted.
+    encryption_info: Option<EncryptionInfo>,
+}
+
+/// The steps shared by every way of sending a message-like event: check that
+/// the room is joined, pick a transaction ID, and encrypt the content if the
+/// room is encrypted.
+#[cfg_attr(not(feature = "e2e-encryption"), allow(unused_mut))]
+async fn prepare_message_like_event<'a>(
+    room: &Room,
+    mut event_type: &'a str,
+    mut content: Raw<AnyMessageLikeEventContent>,
+    transaction_id: Option<OwnedTransactionId>,
+) -> Result<PreparedMessageLikeEvent<'a>> {
+    room.ensure_room_joined()?;
+
+    let txn_id = transaction_id.unwrap_or_else(TransactionId::new);
+    Span::current().record("transaction_id", tracing::field::debug(&txn_id));
+
+    #[cfg(not(feature = "e2e-encryption"))]
+    trace!("Sending plaintext event to room because we don't have encryption support.");
+
+    #[cfg(feature = "e2e-encryption")]
+    let mut encryption_info: Option<EncryptionInfo> = None;
+    #[cfg(not(feature = "e2e-encryption"))]
+    let encryption_info: Option<EncryptionInfo> = None;
+
+    #[cfg(feature = "e2e-encryption")]
+    if room.latest_encryption_state().await?.is_encrypted() {
+        Span::current().record("is_room_encrypted", true);
+        // Reactions are currently famously not encrypted, skip encrypting
+        // them until they are.
+        if event_type == "m.reaction" {
+            trace!("Sending plaintext event because of the event type.");
+        } else {
+            trace!(
+                room_id = ?room.room_id(),
+                "Sending encrypted event because the room is encrypted.",
+            );
+
+            ensure_room_encryption_ready(room).await?;
+
+            let olm = room.client.olm_machine().await;
+            let olm = olm.as_ref().expect("Olm machine wasn't started");
+
+            let result = olm.encrypt_room_event_raw(room.room_id(), event_type, &content).await?;
+            content = result.content.cast();
+            encryption_info = Some(result.encryption_info);
+            event_type = "m.room.encrypted";
+        }
+    } else {
+        Span::current().record("is_room_encrypted", false);
+        trace!("Sending plaintext event because the room is NOT encrypted.");
+    }
+
+    Ok(PreparedMessageLikeEvent { txn_id, event_type, content, encryption_info })
 }
 
 /// Future returned by [`Room::send_attachment`].

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -316,7 +316,7 @@ struct PreparedMessageLikeEvent<'a> {
 /// The steps shared by every way of sending a message-like event: check that
 /// the room is joined, pick a transaction ID, and encrypt the content if the
 /// room is encrypted.
-#[cfg_attr(not(feature = "e2e-encryption"), allow(unused_mut))]
+#[cfg_attr(not(feature = "e2e-encryption"), allow(unused_mut, clippy::unused_async))]
 async fn prepare_message_like_event<'a>(
     room: &Room,
     mut event_type: &'a str,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -77,6 +77,7 @@ use ruma::{
         client::{
             config::{set_global_account_data, set_room_account_data},
             context,
+            delayed_events::{DelayParameters, delayed_state_event, update_delayed_event},
             filter::LazyLoadOptions,
             membership::{
                 Invite3pid, ban_user, forget_room, get_member_events,
@@ -2579,7 +2580,9 @@ impl Room {
     ///
     /// If you want to set a transaction ID for the event, use
     /// [`.with_transaction_id()`][SendRawMessageLikeEvent::with_transaction_id]
-    /// on the returned value before `.await`ing it.
+    /// on the returned value before `.await`ing it. To schedule the event as a
+    /// delayed event ([MSC4140]), use
+    /// [`.with_delay()`][SendRawMessageLikeEvent::with_delay].
     ///
     /// # Arguments
     ///
@@ -2589,6 +2592,8 @@ impl Room {
     ///   type can be `serde_json::Value`, but also other raw JSON types; for
     ///   the full list check the documentation of
     ///   [`IntoRawMessageLikeEventContent`].
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
     ///
     /// # Examples
     ///
@@ -2617,6 +2622,96 @@ impl Room {
         // Note: the recorded instrument fields are saved in
         // `SendRawMessageLikeEvent::into_future`.
         SendRawMessageLikeEvent::new(self, event_type, content)
+    }
+
+    /// Send a delayed state event with custom JSON content to this room
+    /// ([MSC4140]).
+    ///
+    /// A delayed event is handed to the homeserver right away, but only
+    /// distributed to the room once its delay elapses. Until then it can be
+    /// cancelled, restarted or sent immediately with
+    /// [`update_delayed_event()`][Self::update_delayed_event], using the
+    /// `delay_id` from the returned response.
+    ///
+    /// To send a delayed *message-like* event, use
+    /// [`SendRawMessageLikeEvent::with_delay`] on the future returned by
+    /// [`send_raw()`][Self::send_raw].
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of the event that we're sending out.
+    ///
+    /// * `state_key` - A unique key which defines the overwriting semantics for
+    ///   this piece of room state. This value is often a zero-length string.
+    ///
+    /// * `content` - The content of the event as a raw JSON value. The argument
+    ///   type can be `serde_json::Value`, but also other raw JSON types; for
+    ///   the full list check the documentation of [`IntoRawStateEventContent`].
+    ///
+    /// * `delay` - How long the homeserver should hold on to the event.
+    ///
+    /// # Errors
+    ///
+    /// Fails with [`Error::UnsupportedHomeserverFeature`] if the homeserver
+    /// does not advertise support for delayed events, see
+    /// [`Client::can_homeserver_send_delayed_events`]. Without that check the
+    /// homeserver would ignore the delay and send the event right away.
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    #[instrument(skip_all)]
+    pub async fn send_delayed_state_event_raw(
+        &self,
+        event_type: &str,
+        state_key: &str,
+        content: impl IntoRawStateEventContent,
+        delay: DelayParameters,
+    ) -> Result<delayed_state_event::unstable::Response> {
+        self.client.ensure_delayed_events_supported().await?;
+
+        let request = delayed_state_event::unstable::Request::new_raw(
+            self.room_id().to_owned(),
+            state_key.to_owned(),
+            event_type.into(),
+            delay,
+            content.into_raw_state_event_content(),
+        );
+
+        Ok(self.client.send(request).await?)
+    }
+
+    /// Update a delayed event that was previously scheduled with
+    /// [`SendRawMessageLikeEvent::with_delay`] or
+    /// [`send_delayed_state_event_raw()`][Self::send_delayed_state_event_raw]
+    /// ([MSC4140]).
+    ///
+    /// Depending on the `action` this cancels the delayed event, restarts its
+    /// timeout, or sends it to the room right away.
+    ///
+    /// # Arguments
+    ///
+    /// * `delay_id` - The identifier of the delayed event, as returned by the
+    ///   homeserver when the event was scheduled.
+    ///
+    /// * `action` - What to do with the delayed event.
+    ///
+    /// # Errors
+    ///
+    /// Fails with [`Error::UnsupportedHomeserverFeature`] if the homeserver
+    /// does not advertise support for delayed events, see
+    /// [`Client::can_homeserver_send_delayed_events`].
+    ///
+    /// [MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+    #[instrument(skip_all)]
+    pub async fn update_delayed_event(
+        &self,
+        delay_id: String,
+        action: update_delayed_event::UpdateAction,
+    ) -> Result<update_delayed_event::unstable_v1::Response> {
+        self.client.ensure_delayed_events_supported().await?;
+
+        let request = update_delayed_event::unstable_v1::Request::new(delay_id, action);
+
+        Ok(self.client.send(request).await?)
     }
 
     /// Send an attachment to this room.

--- a/crates/matrix-sdk/src/test_utils/client.rs
+++ b/crates/matrix-sdk/src/test_utils/client.rs
@@ -14,8 +14,14 @@
 
 //! Augmented [`ClientBuilder`] that can set up an already logged-in user.
 
+use std::collections::BTreeSet;
+
 use matrix_sdk_base::{SessionMeta, store::RoomLoadSettings};
-use ruma::{OwnedDeviceId, OwnedUserId, api::MatrixVersion, owned_device_id, owned_user_id};
+use ruma::{
+    OwnedDeviceId, OwnedUserId,
+    api::{FeatureFlag, MatrixVersion},
+    owned_device_id, owned_user_id,
+};
 
 use crate::{
     Client, ClientBuilder, SessionTokens, authentication::matrix::MatrixSession,
@@ -28,6 +34,7 @@ pub struct MockClientBuilder {
     builder: ClientBuilder,
     auth_state: AuthState,
     server_versions: ServerVersions,
+    unstable_features: BTreeSet<FeatureFlag>,
 }
 
 impl MockClientBuilder {
@@ -51,6 +58,7 @@ impl MockClientBuilder {
                 device_id: None,
             },
             server_versions: ServerVersions::Default,
+            unstable_features: Default::default(),
         }
     }
 
@@ -63,6 +71,17 @@ impl MockClientBuilder {
     /// Set the cached server versions in the client.
     pub fn server_versions(mut self, versions: Vec<MatrixVersion>) -> Self {
         self.server_versions = ServerVersions::Custom(versions);
+        self
+    }
+
+    /// Set the unstable features the homeserver advertises, alongside the
+    /// cached server versions.
+    ///
+    /// This has no effect if [`no_server_versions()`][Self::no_server_versions]
+    /// is called: the features are then discovered from the (mocked)
+    /// `/versions` endpoint like the versions.
+    pub fn unstable_features(mut self, features: impl IntoIterator<Item = FeatureFlag>) -> Self {
+        self.unstable_features = features.into_iter().collect();
         self
     }
 
@@ -129,7 +148,7 @@ impl MockClientBuilder {
         let mut builder = self.builder;
 
         if let Some(versions) = self.server_versions.into_vec() {
-            builder = builder.server_versions(versions);
+            builder = builder.server_versions(versions).unstable_features(self.unstable_features);
         }
 
         let client = builder.build().await.expect("building client failed");

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -34,9 +34,8 @@ use ruma::{
     },
     assign,
     events::{
-        AnyMessageLikeEventContent, AnyStateEvent, AnyStateEventContent, AnySyncStateEvent,
-        AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent, AnyToDeviceEventContent,
-        MessageLikeEventType, StateEventType, TimelineEventType, ToDeviceEventType,
+        AnyStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, AnyToDeviceEvent,
+        AnyToDeviceEventContent, StateEventType, TimelineEventType, ToDeviceEventType,
         room::MediaSource,
     },
     serde::{Base64, Raw, from_raw_json_value},
@@ -215,27 +214,18 @@ impl MatrixDriver {
                 self.room.send_state_event_raw(&type_str, &key, content).await?.event_id,
             ),
 
-            (None, Some(delayed_event_parameters)) => {
-                let r = delayed_events::delayed_message_event::unstable::Request::new_raw(
-                    self.room.room_id().to_owned(),
-                    TransactionId::new(),
-                    MessageLikeEventType::from(type_str),
-                    delayed_event_parameters,
-                    Raw::<AnyMessageLikeEventContent>::from_json(content),
-                );
-                self.room.client.send(r).await.map(|r| r.into())?
-            }
+            (None, Some(delayed_event_parameters)) => self
+                .room
+                .send_raw(&type_str, content)
+                .with_delay(delayed_event_parameters)
+                .await?
+                .into(),
 
-            (Some(key), Some(delayed_event_parameters)) => {
-                let r = delayed_events::delayed_state_event::unstable::Request::new_raw(
-                    self.room.room_id().to_owned(),
-                    key,
-                    StateEventType::from(type_str),
-                    delayed_event_parameters,
-                    Raw::<AnyStateEventContent>::from_json(content),
-                );
-                self.room.client.send(r).await.map(|r| r.into())?
-            }
+            (Some(key), Some(delayed_event_parameters)) => self
+                .room
+                .send_delayed_state_event_raw(&type_str, &key, content, delayed_event_parameters)
+                .await?
+                .into(),
         })
     }
 
@@ -248,8 +238,7 @@ impl MatrixDriver {
         delay_id: String,
         action: UpdateAction,
     ) -> Result<delayed_events::update_delayed_event::unstable_v1::Response> {
-        let r = delayed_events::update_delayed_event::unstable_v1::Request::new(delay_id, action);
-        self.room.client.send(r).await.map_err(|error| Error::Http(Box::new(error)))
+        self.room.update_delayed_event(delay_id, action).await
     }
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`

--- a/crates/matrix-sdk/tests/integration/room/delayed_events.rs
+++ b/crates/matrix-sdk/tests/integration/room/delayed_events.rs
@@ -1,0 +1,224 @@
+//! Tests for the MSC4140 delayed-event API: `send_raw(..).with_delay(..)`,
+//! `Room::send_delayed_state_event_raw` and `Room::update_delayed_event`.
+
+use assert_matches2::assert_matches;
+use matrix_sdk::{
+    Error,
+    ruma::{
+        api::{
+            FeatureFlag,
+            client::delayed_events::{DelayParameters, update_delayed_event::UpdateAction},
+        },
+        events::{MessageLikeEventType, StateEventType},
+    },
+    test_utils::mocks::MatrixMockServer,
+};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use ruma::{RoomVersionId, device_id, room_id, time::Duration, user_id};
+use serde_json::json;
+use wiremock::{
+    Mock, ResponseTemplate,
+    matchers::{body_json, method, path_regex},
+};
+
+#[async_test]
+async fn test_can_homeserver_send_delayed_events() {
+    let server = MatrixMockServer::new().await;
+
+    let client = server.client_builder().unstable_features([FeatureFlag::Msc4140]).build().await;
+    assert!(client.can_homeserver_send_delayed_events().await.unwrap());
+
+    let client = server.client_builder().build().await;
+    assert!(!client.can_homeserver_send_delayed_events().await.unwrap());
+}
+
+#[async_test]
+async fn test_send_raw_with_delay() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().unstable_features([FeatureFlag::Msc4140]).build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id!("!a:b.c")).await;
+
+    server
+        .mock_room_send()
+        .match_delayed_event(Duration::from_millis(1000))
+        .for_type(MessageLikeEventType::RoomMessage)
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "delay_id": "1234" })))
+        .mock_once()
+        .mount()
+        .await;
+
+    let response = room
+        .send_raw("m.room.message", json!({ "msgtype": "m.text", "body": "hello" }))
+        .with_delay(DelayParameters::Timeout { timeout: Duration::from_millis(1000) })
+        .await
+        .unwrap();
+
+    assert_eq!(response.delay_id, "1234");
+}
+
+/// A delayed event goes through the same preparation as an immediate one, so
+/// it must be encrypted when the room is encrypted rather than handed to the
+/// homeserver in the clear.
+#[cfg(feature = "e2e-encryption")]
+#[async_test]
+async fn test_send_raw_with_delay_in_encrypted_room() {
+    let room_id = room_id!("!test:localhost");
+    let alice_user_id = user_id!("@alice:localhost");
+    let alice_device_id = device_id!("ALICEDEVICE");
+
+    let server = MatrixMockServer::new().await;
+    server.mock_crypto_endpoints_preset().await;
+    server.mock_room_state_encryption().encrypted().mount().await;
+
+    let alice = server
+        .client_builder_for_crypto_end_to_end(alice_user_id, alice_device_id)
+        .unstable_features([FeatureFlag::Msc4140])
+        .build()
+        .await;
+
+    let f = EventFactory::new().sender(alice_user_id).room(room_id);
+
+    server
+        .mock_sync()
+        .ok_and_run(&alice, |builder| {
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(room_id)
+                    .add_state_event(f.create(alice_user_id, RoomVersionId::V1))
+                    .add_state_event(f.room_encryption()),
+            );
+        })
+        .await;
+
+    // Sharing the room key requires the member list.
+    server
+        .mock_get_members()
+        .ok(vec![f.member(alice_user_id).into_raw()])
+        .mock_once()
+        .mount()
+        .await;
+
+    // The delayed event must reach the homeserver as `m.room.encrypted`, with
+    // the plaintext type and content nowhere in the body.
+    server
+        .mock_room_send()
+        .match_delayed_event(Duration::from_millis(1000))
+        .for_type(MessageLikeEventType::RoomEncrypted)
+        .body_matches_partial_json(json!({
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "device_id": "ALICEDEVICE",
+        }))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "delay_id": "1234" })))
+        .mock_once()
+        .mount()
+        .await;
+
+    let room = alice.get_room(room_id).expect("Alice should have access to the room");
+
+    let response = room
+        .send_raw("m.room.message", json!({ "msgtype": "m.text", "body": "hello" }))
+        .with_delay(DelayParameters::Timeout { timeout: Duration::from_millis(1000) })
+        .await
+        .unwrap();
+
+    assert_eq!(response.delay_id, "1234");
+}
+
+#[async_test]
+async fn test_send_delayed_state_event_raw() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().unstable_features([FeatureFlag::Msc4140]).build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id!("!a:b.c")).await;
+
+    server
+        .mock_room_send_state()
+        .match_delayed_event(Duration::from_millis(1000))
+        .for_type(StateEventType::RoomTopic)
+        .for_key("".to_owned())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "delay_id": "1234" })))
+        .mock_once()
+        .mount()
+        .await;
+
+    let response = room
+        .send_delayed_state_event_raw(
+            "m.room.topic",
+            "",
+            json!({ "topic": "hello" }),
+            DelayParameters::Timeout { timeout: Duration::from_millis(1000) },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.delay_id, "1234");
+}
+
+#[async_test]
+async fn test_update_delayed_event() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().unstable_features([FeatureFlag::Msc4140]).build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id!("!a:b.c")).await;
+
+    for (action, serialized) in [
+        (UpdateAction::Cancel, "cancel"),
+        (UpdateAction::Restart, "restart"),
+        (UpdateAction::Send, "send"),
+    ] {
+        let _guard = Mock::given(method("POST"))
+            .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4140/delayed_events/1234$"))
+            .and(body_json(json!({ "action": serialized })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount_as_scoped(server.server())
+            .await;
+
+        room.update_delayed_event("1234".to_owned(), action).await.unwrap();
+    }
+}
+
+/// A homeserver without MSC4140 support ignores the unstable delay query
+/// parameter and sends the event right away, so the SDK must refuse to
+/// schedule anything on such a homeserver rather than let that happen.
+#[async_test]
+async fn test_delayed_events_require_homeserver_support() {
+    let server = MatrixMockServer::new().await;
+    // No unstable features advertised.
+    let client = server.client_builder().build().await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+    let room = server.sync_joined_room(&client, room_id!("!a:b.c")).await;
+
+    // Nothing must reach the room endpoints.
+    server.mock_room_send().ok(ruma::event_id!("$1")).never().mount().await;
+    server.mock_room_send_state().ok(ruma::event_id!("$1")).never().mount().await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4140/delayed_events/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(0)
+        .mount(server.server())
+        .await;
+
+    let delay = DelayParameters::Timeout { timeout: Duration::from_millis(1000) };
+
+    let error = room
+        .send_raw("m.room.message", json!({ "msgtype": "m.text", "body": "hello" }))
+        .with_delay(delay.clone())
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::UnsupportedHomeserverFeature(FeatureFlag::Msc4140));
+
+    let error = room
+        .send_delayed_state_event_raw("m.room.topic", "", json!({ "topic": "hello" }), delay)
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::UnsupportedHomeserverFeature(FeatureFlag::Msc4140));
+
+    let error =
+        room.update_delayed_event("1234".to_owned(), UpdateAction::Cancel).await.unwrap_err();
+    assert_matches!(error, Error::UnsupportedHomeserverFeature(FeatureFlag::Msc4140));
+}

--- a/crates/matrix-sdk/tests/integration/room/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/mod.rs
@@ -3,6 +3,7 @@ mod beacon;
 mod beacon_info;
 mod calls;
 mod common;
+mod delayed_events;
 mod joined;
 mod left;
 mod notification_mode;

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -38,7 +38,7 @@ use matrix_sdk_common::{
 use matrix_sdk_test::{ALICE, BOB, JoinedRoomBuilder, async_test, event_factory::EventFactory};
 use ruma::{
     OwnedRoomId,
-    api::client::to_device::send_event_to_device::v3::Messages,
+    api::{FeatureFlag, client::to_device::send_event_to_device::v3::Messages},
     device_id, event_id,
     events::{
         AnySyncStateEvent, AnyToDeviceEvent, MessageLikeEventType, StateEventType,
@@ -84,7 +84,11 @@ async fn run_test_driver(
     is_room_e2ee: bool,
 ) -> (Client, MatrixMockServer, WidgetDriverHandle) {
     let mock_server = MatrixMockServer::new().await;
-    let client = mock_server.client_builder().build().await;
+
+    // Delayed events are only sent to a homeserver that advertises support for
+    // them.
+    let client =
+        mock_server.client_builder().unstable_features([FeatureFlag::Msc4140]).build().await;
 
     let room = mock_server.sync_joined_room(&client, &ROOM_ID).await;
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

**Motivation:** I am working on a rust rtc stack https://github.com/BillCarsonFr/matrix-rust-rtc. , and some of the needed primitive are missing in rust-sdk.

I am starting with support of delayed event (state events and room event). 
Currently the widget driver had some support for it (by using raw ruma requests), and I am moving it so it became part of the API.

While doing so I noticed that the driver implementation was faulty:

- It was not encrypting delayed events in encrypted rooms 🥶
- It was not checking for delayed event support before processing. This is annoying because delaying an event is just adding a query param to the send request, so if the homeserver ignores it there is a risk of sending the delayed event immediatly. Hopefully recent synapse detects that and errors with `M_FORBIDDEN: MatrixError: [403] Sending delayed events has been disallowed`


A note on the send event future, I cannot just add an optional parameter to `SendRawMessageLikeEvent` because delayed event returns a delayed_id, and the send event future returns a `OwnedEventId`
In order to share the encryption code, I created an intermediate future `PreparedMessageLikeEvent` that handles the common part before the ruma request.
I added a `SendRawMessageLikeEvent::with_delay` that converts to the new `SendDelayedRawMessageLikeEvent` future


- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
