### PR TITLE
Add `serde_bytes` attribute to make media uploads faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,6 +3995,7 @@ dependencies = [
  "rand 0.10.2",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -11,7 +11,9 @@ rust-version.workspace = true
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.cargo-machete]
-ignored = ["getrandom", "getrandom_0_2"] # We manually enable a feature for each.
+# getrandom: we manually enable a feature for each.
+# serde_bytes: we only use it in a `#[serde(with = "...")]` attribute.
+ignored = ["getrandom", "getrandom_0_2", "serde_bytes"]
 
 [features]
 js = ["dep:getrandom", "getrandom?/wasm_js"]
@@ -27,6 +29,7 @@ pbkdf2.workspace = true
 rand = { workspace = true, features = ["thread_rng"] }
 rmp-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_bytes = "0.11"
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -679,6 +679,7 @@ impl MacKey {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EncryptedValue {
     version: u8,
+    #[serde(with = "serde_bytes")]
     ciphertext: Vec<u8>,
     nonce: [u8; XNONCE_SIZE],
 }


### PR DESCRIPTION
The `EncryptedValue` struct's `ciphertext` field was being serialized as an array of integers (one integer for every byte), not as a single binary blob/chunk.
This made stored values quite a bit larger than necessary, and also did per-byte processing instead of just reading it out of memory, both of which made file/media uploads via the matrix SDK a lot slower.

With the `serde_bytes` attribute, it gets properly treated as a binary chunk, so its way faster to read from the store and upload.

It's not only uploads too, but that's where it was most obvious. Any other value that goes through the encrypted store is faster to access as well.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
   * no public API changes, just an internal improvement
- [x] This PR was made with the help of AI.
    * yep, discovered and fixed by Claude Opus 5 when i was investigating why media uploads in Robrix were so slow

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kevin Boos <kevinaboos@gmail.com>
