### PR TITLE
feat(state): Add bindings to listen and read any state event

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6979.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6979.added.md
@@ -1,0 +1,2 @@
+Added `Room::stateEvents` to read the current state events of a given type,
+and `Room::subscribeToStateEvents` to be notified with the full list of state events of that type.

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
     DraftAttachment as SdkDraftAttachment, DraftAttachmentContent, DraftThumbnail, EncryptionState,
     PredecessorRoom as SdkPredecessorRoom, RoomHeroWithProfile as SdkRoomHeroWithProfile,
     RoomMemberships, RoomState, SuccessorRoom as SdkSuccessorRoom,
-    deserialized_responses::TimelineEvent as SdkTimelineEvent,
+    deserialized_responses::{RawAnySyncOrStrippedState, TimelineEvent as SdkTimelineEvent},
     encryption::LocalTrust,
     room::{
         Room as SdkRoom, RoomMemberRole, edit::EditedContent, power_levels::RoomPowerLevelChanges,
@@ -38,7 +38,7 @@ use ruma::{
     EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
     ServerName, UserId, assign,
     events::{
-        AnyMessageLikeEventContent, AnySyncTimelineEvent,
+        AnyMessageLikeEventContent, AnySyncTimelineEvent, StateEventType,
         receipt::ReceiptThread as RumaReceiptThread,
         relation::RelationType as RumaRelationType,
         room::{
@@ -48,7 +48,9 @@ use ruma::{
         },
     },
 };
-use tracing::error;
+use serde::Deserialize;
+use serde_json::value::RawValue as RawJsonValue;
+use tracing::{error, warn};
 
 use self::{power_levels::RoomPowerLevels, room_info::RoomInfo};
 use crate::{
@@ -497,6 +499,54 @@ impl Room {
             self.inner.send_state_event_raw(&event_type, &state_key, content_json).await?;
 
         Ok(response.event_id.to_string())
+    }
+
+    /// The current room state events of the given type, one per state key.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The type of the state events to read (e.g.
+    ///   `"m.room.name"` or a custom type).
+    ///
+    /// Only the state the sync asked for is stored locally, so for a custom
+    /// event type this is empty unless that type is part of the sliding sync
+    /// `required_state`.
+    pub async fn state_events(
+        &self,
+        event_type: String,
+    ) -> Result<Vec<RoomStateEvent>, ClientError> {
+        let events = self.inner.get_state_events(StateEventType::from(event_type)).await?;
+
+        Ok(to_state_events(events))
+    }
+
+    /// Subscribe to the room state events of the given type.
+    ///
+    /// The listener is called with the full current list of state events of
+    /// that type, one per state key, immediately and then after every sync
+    /// that changed any of them. All the changes of one sync are reported as a
+    /// single snapshot.
+    ///
+    /// Use the returned [`TaskHandle`] to cancel the subscription.
+    pub fn subscribe_to_state_events(
+        self: Arc<Self>,
+        event_type: String,
+        listener: Box<dyn RoomStateEventsListener>,
+    ) -> Arc<TaskHandle> {
+        let event_type = StateEventType::from(event_type);
+
+        let snapshots = self.inner.subscribe_to_state_events(event_type);
+
+        Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
+            pin_mut!(snapshots);
+
+            while let Some(snapshot) = snapshots.next().await {
+                match snapshot {
+                    Ok(events) => listener.on_update(to_state_events(events)),
+                    Err(error) => error!("Failed to read the room state: {error}"),
+                }
+            }
+        })))
     }
 
     /// Redacts an event from the room.
@@ -1415,6 +1465,80 @@ pub struct EventWithRelations {
     /// The events related to it, directly or (recursively) through other
     /// related events.
     pub related_events: Vec<Arc<TimelineEvent>>,
+}
+
+/// A room state event, as exposed over FFI.
+#[derive(uniffi::Record)]
+pub struct RoomStateEvent {
+    /// The event type, e.g. `m.room.name`.
+    pub event_type: String,
+    /// The state key this event is stored under.
+    pub state_key: String,
+    /// The event sender.
+    pub sender: String,
+    /// The `content` of the event, as a JSON string.
+    pub content_json: String,
+    /// The event id, or `None` for the stripped state of a room we are only
+    /// invited to.
+    pub event_id: Option<String>,
+    /// When the event was sent, in milliseconds since the Unix epoch, or `None`
+    /// for the stripped state of a room we are only invited to.
+    pub timestamp: Option<u64>,
+}
+
+impl RoomStateEvent {
+    fn from_raw(raw: &RawAnySyncOrStrippedState) -> Result<Self, serde_json::Error> {
+        /// The subset of a state event that is exposed over FFI. Both the sync
+        /// and the stripped shape deserialize into this.
+        #[derive(Deserialize)]
+        struct RoomStateEventHelper<'a> {
+            #[serde(rename = "type")]
+            event_type: String,
+            state_key: String,
+            sender: String,
+            #[serde(borrow)]
+            content: &'a RawJsonValue,
+            event_id: Option<String>,
+            origin_server_ts: Option<u64>,
+        }
+
+        let json = match raw {
+            RawAnySyncOrStrippedState::Sync(raw) => raw.json(),
+            RawAnySyncOrStrippedState::Stripped(raw) => raw.json(),
+        };
+        let helper: RoomStateEventHelper<'_> = serde_json::from_str(json.get())?;
+
+        Ok(Self {
+            event_type: helper.event_type,
+            state_key: helper.state_key,
+            sender: helper.sender,
+            content_json: helper.content.get().to_owned(),
+            event_id: helper.event_id,
+            timestamp: helper.origin_server_ts,
+        })
+    }
+}
+
+/// Converts the raw state of a room, skipping (and logging) any event that
+/// can't be parsed.
+fn to_state_events(raw_events: Vec<RawAnySyncOrStrippedState>) -> Vec<RoomStateEvent> {
+    raw_events
+        .iter()
+        .filter_map(|raw| match RoomStateEvent::from_raw(raw) {
+            Ok(event) => Some(event),
+            Err(error) => {
+                warn!("Skipping malformed state event: {error}");
+                None
+            }
+        })
+        .collect()
+}
+
+/// A listener for the room state events of a single type, registered with
+/// [`Room::subscribe_to_state_events`].
+#[matrix_sdk_ffi_macros::export(callback_interface)]
+pub trait RoomStateEventsListener: SyncOutsideWasm + SendOutsideWasm {
+    fn on_update(&self, events: Vec<RoomStateEvent>);
 }
 
 /// A listener for receiving call decline events in a room.

--- a/crates/matrix-sdk/changelog.d/6979.added.md
+++ b/crates/matrix-sdk/changelog.d/6979.added.md
@@ -1,0 +1,2 @@
+Added `Room::subscribe_to_state_events`, a stream that yields the full current list of state
+events of a given type in this room.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -186,7 +186,7 @@ use crate::{
         power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt},
         privacy_settings::RoomPrivacySettings,
     },
-    sync::RoomUpdate,
+    sync::{RoomUpdate, State},
     utils::{IntoRawMessageLikeEventContent, IntoRawStateEventContent},
 };
 
@@ -678,6 +678,47 @@ impl Room {
         });
         let drop_guard = self.client().event_handler_drop_guard(typing_event_handler_handle);
         (drop_guard, receiver)
+    }
+
+    /// Subscribe to the state events of a given type in this room.
+    ///
+    /// The returned stream yields the full list of state events of that type,
+    /// one per state key, as [`get_state_events()`][Self::get_state_events]
+    /// would return it: first as it currently is, then after every sync
+    /// response that reported state changes of that type for this room.
+    ///
+    /// Reading the state can fail, in which case the error is yielded and the
+    /// stream carries on with the next sync. The stream ends when the
+    /// [`Client`] is dropped.
+    pub fn subscribe_to_state_events(
+        &self,
+        event_type: StateEventType,
+    ) -> impl Stream<Item = Result<Vec<RawAnySyncOrStrippedState>>> + use<> {
+        let room = self.clone();
+        let mut room_updates = self.subscribe_to_updates();
+
+        stream! {
+            // Emit the current state first. We subscribed to the room updates before
+            // reading it, so a change happening in between isn't missed; it may be
+            // reported twice instead, which is harmless for a snapshot.
+            yield room.get_state_events(event_type.clone()).await;
+
+            loop {
+                match room_updates.recv().await {
+                    Ok(update) => {
+                        if !has_state_events_of_type(&update, &event_type) {
+                            continue;
+                        }
+                    }
+                    // Sync responses were missed because they weren't consumed fast
+                    // enough; a fresh snapshot catches up on all of them at once.
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+
+                yield room.get_state_events(event_type.clone()).await;
+            }
+        }
     }
 
     /// Subscribe to updates about users who are in "pin violation" i.e. their
@@ -4923,6 +4964,25 @@ pub struct RoomMemberWithSenderInfo {
     /// The info of the sender of the event `room_member` is based on, if
     /// available.
     pub sender_info: Option<RoomMember>,
+}
+
+/// Whether a room update reports state events of the given type, in the state
+/// section of the sync response (state events found in the timeline are not
+/// considered).
+fn has_state_events_of_type(update: &RoomUpdate, event_type: &StateEventType) -> bool {
+    // We only care about the state of rooms we are in.
+    let RoomUpdate::Joined { updates, .. } = update else {
+        return false;
+    };
+
+    let (State::Before(state_events) | State::After(state_events)) = &updates.state;
+
+    state_events.iter().any(|raw| {
+        raw.get_field::<StateEventType>("type")
+            .ok()
+            .flatten()
+            .is_some_and(|received_type| received_type == *event_type)
+    })
 }
 
 #[cfg(all(test, not(target_family = "wasm")))]

--- a/crates/matrix-sdk/tests/integration/room/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/mod.rs
@@ -8,5 +8,6 @@ mod left;
 mod notification_mode;
 mod pinned_events;
 mod spaces;
+mod state_events;
 mod tags;
 mod thread;

--- a/crates/matrix-sdk/tests/integration/room/state_events.rs
+++ b/crates/matrix-sdk/tests/integration/room/state_events.rs
@@ -1,0 +1,202 @@
+//! Tests for [`matrix_sdk::Room::subscribe_to_state_events`].
+//!
+//! They follow MatrixRTC call memberships, the use case this API exists for,
+//! and a fully custom state event type.
+
+use std::collections::BTreeSet;
+
+use assert_matches2::assert_let;
+use futures_util::pin_mut;
+use matrix_sdk::{
+    assert_next_with_timeout, deserialized_responses::RawAnySyncOrStrippedState,
+    test_utils::mocks::MatrixMockServer,
+};
+use matrix_sdk_test::{JoinedRoomBuilder, async_test, event_factory::EventFactory};
+use ruma::{events::StateEventType, owned_user_id, room_id, user_id};
+use stream_assert::assert_pending;
+
+/// The `(type, sender)` pairs of a state snapshot of a joined room.
+fn types_and_senders(state: &[RawAnySyncOrStrippedState]) -> BTreeSet<(String, String)> {
+    state
+        .iter()
+        .map(|raw| {
+            assert_let!(RawAnySyncOrStrippedState::Sync(raw) = raw);
+            (
+                raw.get_field::<String>("type").unwrap().unwrap(),
+                raw.get_field::<String>("sender").unwrap().unwrap(),
+            )
+        })
+        .collect()
+}
+
+const CALL_MEMBER: &str = "org.matrix.msc3401.call.member";
+
+#[async_test]
+async fn test_subscribe_to_state_events() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!test:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let stream = room.subscribe_to_state_events(StateEventType::CallMember);
+    pin_mut!(stream);
+
+    // The current state comes first: nobody is in the call yet.
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert!(state.is_empty());
+
+    let alice = owned_user_id!("@alice:localhost");
+    let bob = owned_user_id!("@bob:localhost");
+    let f = EventFactory::new().room(room_id);
+
+    // Alice joins the call. The sync also carries a state event of another type,
+    // which is not part of the snapshot.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_state_event(f.call_membership_state(alice.clone(), "ALICEDEVICE".to_owned()))
+                .add_state_event(f.custom_state_event().sender(&alice)),
+        )
+        .await;
+
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert_eq!(
+        types_and_senders(&state),
+        BTreeSet::from([(CALL_MEMBER.to_owned(), alice.to_string())])
+    );
+
+    // Bob joins too, reported through `state_after`. The snapshot is the full
+    // membership, not just the change.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .use_state_after()
+                .add_state_event(f.call_membership_state(bob.clone(), "BOBDEVICE".to_owned())),
+        )
+        .await;
+
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert_eq!(
+        types_and_senders(&state),
+        BTreeSet::from([
+            (CALL_MEMBER.to_owned(), alice.to_string()),
+            (CALL_MEMBER.to_owned(), bob.to_string())
+        ])
+    );
+
+    // A sync without any call membership change yields nothing.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_state_event(f.custom_state_event().sender(&alice)),
+        )
+        .await;
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_subscribe_to_state_events_yields_one_snapshot_per_sync() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!test:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let stream = room.subscribe_to_state_events(StateEventType::CallMember);
+    pin_mut!(stream);
+
+    // Skip the current state.
+    assert_next_with_timeout!(stream).unwrap();
+
+    let alice = owned_user_id!("@alice:localhost");
+    let f = EventFactory::new().room(room_id);
+
+    // Alice joins the call from two devices in the same sync: a single snapshot,
+    // with both memberships.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_state_event(f.call_membership_state(alice.clone(), "PHONE".to_owned()))
+                .add_state_event(f.call_membership_state(alice.clone(), "LAPTOP".to_owned())),
+        )
+        .await;
+
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert_eq!(state.len(), 2);
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_subscribe_to_state_events_ignores_the_timeline() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!test:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    let stream = room.subscribe_to_state_events(StateEventType::CallMember);
+    pin_mut!(stream);
+
+    // Skip the current state.
+    assert_next_with_timeout!(stream).unwrap();
+
+    let f = EventFactory::new().room(room_id);
+
+    // A call membership that only appears in the timeline updates the room state,
+    // but is not what this subscription reports.
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id).add_timeline_event(
+                f.call_membership_state(owned_user_id!("@alice:localhost"), "DEVICE".to_owned()),
+            ),
+        )
+        .await;
+
+    assert_eq!(room.get_state_events(StateEventType::CallMember).await.unwrap().len(), 1);
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn test_subscribe_to_custom_state_events() {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let room_id = room_id!("!test:example.org");
+    let room = server.sync_joined_room(&client, room_id).await;
+
+    // A type the SDK knows nothing about works the same way.
+    let event_type = StateEventType::from("rs.matrix-sdk.custom-state.test");
+    let stream = room.subscribe_to_state_events(event_type);
+    pin_mut!(stream);
+
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert!(state.is_empty());
+
+    let alice = user_id!("@alice:localhost");
+    let f = EventFactory::new().room(room_id).sender(alice);
+
+    server
+        .sync_room(
+            &client,
+            JoinedRoomBuilder::new(room_id)
+                .add_state_event(f.custom_state_event().state_key("first"))
+                .add_state_event(f.custom_state_event().state_key("second")),
+        )
+        .await;
+
+    let state = assert_next_with_timeout!(stream).unwrap();
+    assert_eq!(state.len(), 2);
+    assert_eq!(
+        types_and_senders(&state),
+        BTreeSet::from([("rs.matrix-sdk.custom-state.test".to_owned(), alice.to_string())])
+    );
+
+    assert_pending!(stream);
+}


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Motivation: I am working on a rust rtc stack https://github.com/BillCarsonFr/matrix-rust-rtc. , and some of the needed primitive are missing in rust-sdk.

Some API I needed are not available via the mobile bindings.
I need to subscribe and read custom state events.

I am using the existing `Room::subscribe_to_updates()` as the trigger point

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
