### PR TITLE
fix(notifications): Stop the notification decryption retry as soon as the key arrives

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6982.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6982.changed.md
@@ -1,0 +1,6 @@
+When an event in a notification can't be decrypted, the encryption sync run to
+obtain the missing room key now attempts decryption after every iteration and
+stops as soon as it succeeds, instead of always running two iterations before
+trying once. Two iterations are still run at least, and further ones only while
+a deadline of two poll timeouts has not passed, so the time spent when the key
+never arrives is unchanged.

--- a/crates/matrix-sdk-ui/changelog.d/6982.removed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6982.removed.md
@@ -1,0 +1,3 @@
+[**breaking**] `EncryptionSyncService::run_fixed_iterations` has been replaced
+by `EncryptionSyncService::run_iterations`, which returns a stream yielding once
+per iteration; take as many items from it as iterations you want to run.

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -149,9 +149,6 @@ impl EncryptionSyncService {
                 // do so).
 
                 if lock_guard.is_none() {
-                    // If we can't acquire the cross-process lock on the first attempt,
-                    // that means the main process is running, or its lease hasn't expired
-                    // yet. In case it's the latter, wait a bit and retry.
                     tracing::debug!(
                         "Lock was already taken, and we're not the main loop; retrying in {}ms...",
                         LEASE_DURATION_MS

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -113,96 +113,111 @@ impl EncryptionSyncService {
         Ok(Self { client, sliding_sync })
     }
 
-    /// Runs an `EncryptionSyncService` loop for a fixed number of iterations.
+    /// Runs an `EncryptionSyncService` loop, one iteration at a time.
     ///
-    /// This runs for the given number of iterations, or less than that, if it
-    /// stops earlier or could not acquire a cross-process lock (if configured
-    /// with it).
+    /// The returned stream yields `Ok(())` after each iteration of the sliding
+    /// sync loop, so that the caller can decide after each of them whether to
+    /// keep going (e.g. because an event still can't be decrypted) or to stop
+    /// by dropping the stream.
+    ///
+    /// If the cross-process lock is configured but could not be acquired, the
+    /// stream ends without yielding anything. Another process is expected to
+    /// run the encryption sync in this case.
     ///
     /// Note: the [`EncryptionSyncPermit`] parameter ensures that there's at
     /// most one encryption sync running at any time. See its documentation
     /// for more details.
-    #[instrument(skip_all)]
-    pub async fn run_fixed_iterations(
+    pub fn run_iterations(
         self,
-        num_iterations: u8,
-        _permit: OwnedMutexGuard<EncryptionSyncPermit>,
-    ) -> Result<(), Error> {
-        let sync = self.sliding_sync.sync();
+        permit: OwnedMutexGuard<EncryptionSyncPermit>,
+    ) -> impl Stream<Item = Result<(), Error>> {
+        stream!({
+            // Move the permit into the stream, so that it's held for as long as the stream
+            // is alive.
+            let _permit = permit;
 
-        pin_mut!(sync);
+            let _lock_guard = if let CrossProcessLockConfig::MultiProcess { .. } =
+                self.client.cross_process_lock_config()
+            {
+                let mut lock_guard = match self.client.encryption().try_lock_store_once().await {
+                    Ok(lock_guard) => lock_guard,
+                    Err(err) => {
+                        yield Err(Error::LockError(err));
+                        return;
+                    }
+                };
 
-        let _lock_guard = if let CrossProcessLockConfig::MultiProcess { .. } =
-            self.client.cross_process_lock_config()
-        {
-            let mut lock_guard =
-                self.client.encryption().try_lock_store_once().await.map_err(Error::LockError)?;
-
-            // Try to take the lock at the beginning; if it's busy, that means that another
-            // process already holds onto it, and as such we won't try to run the
-            // encryption sync loop at all (because we expect the other process to
-            // do so).
-
-            if lock_guard.is_none() {
-                // If we can't acquire the cross-process lock on the first attempt,
-                // that means the main process is running, or its lease hasn't expired
-                // yet. In case it's the latter, wait a bit and retry.
-                tracing::debug!(
-                    "Lock was already taken, and we're not the main loop; retrying in {}ms...",
-                    LEASE_DURATION_MS
-                );
-
-                sleep(Duration::from_millis(LEASE_DURATION_MS.into())).await;
-
-                lock_guard = self
-                    .client
-                    .encryption()
-                    .try_lock_store_once()
-                    .await
-                    .map_err(Error::LockError)?;
+                // Try to take the lock at the beginning; if it's busy, that means that another
+                // process already holds onto it, and as such we won't try to run the
+                // encryption sync loop at all (because we expect the other process to
+                // do so).
 
                 if lock_guard.is_none() {
+                    // If we can't acquire the cross-process lock on the first attempt,
+                    // that means the main process is running, or its lease hasn't expired
+                    // yet. In case it's the latter, wait a bit and retry.
                     tracing::debug!(
-                        "Second attempt at locking outside the main app failed, aborting."
+                        "Lock was already taken, and we're not the main loop; retrying in {}ms...",
+                        LEASE_DURATION_MS
                     );
-                    return Ok(());
+
+                    sleep(Duration::from_millis(LEASE_DURATION_MS.into())).await;
+
+                    lock_guard = match self.client.encryption().try_lock_store_once().await {
+                        Ok(lock_guard) => lock_guard,
+                        Err(err) => {
+                            yield Err(Error::LockError(err));
+                            return;
+                        }
+                    };
+
+                    if lock_guard.is_none() {
+                        tracing::debug!(
+                            "Second attempt at locking outside the main app failed, aborting."
+                        );
+                        return;
+                    }
+                }
+
+                lock_guard
+            } else {
+                None
+            };
+
+            let sync = self.sliding_sync.sync();
+
+            pin_mut!(sync);
+
+            loop {
+                match sync.next().await {
+                    Some(Ok(update_summary)) => {
+                        // This API is only concerned with the e2ee and to-device extensions.
+                        // Warn if anything weird has been received from the homeserver.
+                        if !update_summary.lists.is_empty() {
+                            debug!(?update_summary.lists, "unexpected non-empty list of lists in encryption sync API");
+                        }
+                        if !update_summary.rooms.is_empty() {
+                            debug!(?update_summary.rooms, "unexpected non-empty list of rooms in encryption sync API");
+                        }
+
+                        // Cool cool, let's do it again.
+                        trace!("Encryption sync received an update!");
+                        yield Ok(());
+                    }
+
+                    Some(Err(err)) => {
+                        trace!("Encryption sync stopped because of an error: {err:#}");
+                        yield Err(Error::SlidingSync(err));
+                        break;
+                    }
+
+                    None => {
+                        trace!("Encryption sync properly terminated.");
+                        break;
+                    }
                 }
             }
-
-            lock_guard
-        } else {
-            None
-        };
-
-        for _ in 0..num_iterations {
-            match sync.next().await {
-                Some(Ok(update_summary)) => {
-                    // This API is only concerned with the e2ee and to-device extensions.
-                    // Warn if anything weird has been received from the homeserver.
-                    if !update_summary.lists.is_empty() {
-                        debug!(?update_summary.lists, "unexpected non-empty list of lists in encryption sync API");
-                    }
-                    if !update_summary.rooms.is_empty() {
-                        debug!(?update_summary.rooms, "unexpected non-empty list of rooms in encryption sync API");
-                    }
-
-                    // Cool cool, let's do it again.
-                    trace!("Encryption sync received an update!");
-                }
-
-                Some(Err(err)) => {
-                    trace!("Encryption sync stopped because of an error: {err:#}");
-                    return Err(Error::SlidingSync(err));
-                }
-
-                None => {
-                    trace!("Encryption sync properly terminated.");
-                    break;
-                }
-            }
-        }
-
-        Ok(())
+        })
     }
 
     /// Start synchronization.

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -113,16 +113,12 @@ impl EncryptionSyncService {
         Ok(Self { client, sliding_sync })
     }
 
-    /// Runs an `EncryptionSyncService` loop, one iteration at a time.
+    /// Runs an `EncryptionSyncService` loop, yielding `Ok(())` after each
+    /// iteration so the caller can decide whether to continue or stop by
+    /// dropping the stream.
     ///
-    /// The returned stream yields `Ok(())` after each iteration of the sliding
-    /// sync loop, so that the caller can decide after each of them whether to
-    /// keep going (e.g. because an event still can't be decrypted) or to stop
-    /// by dropping the stream.
-    ///
-    /// If the cross-process lock is configured but could not be acquired, the
-    /// stream ends without yielding anything. Another process is expected to
-    /// run the encryption sync in this case.
+    /// Ends without yielding if the cross-process lock is configured but
+    /// can't be acquired (another process is expected to run the sync).
     ///
     /// Note: the [`EncryptionSyncPermit`] parameter ensures that there's at
     /// most one encryption sync running at any time. See its documentation

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -307,17 +307,12 @@ impl NotificationClient {
             }
         };
 
-        // Run an `EncryptionSync` loop, attempting to decrypt the event after each
-        // iteration:
-        // - the first iteration allows to get SS events as well as send e2ee requests,
-        // - the following ones let the SS homeserver forward events triggered by the
-        //   sending of e2ee requests, such as the room key we're missing.
+        // Run an `EncryptionSync` loop, trying to decrypt the event after each
+        // iteration. The first one fetches SS events and sends e2ee requests; the
+        // rest let the homeserver forward events those requests triggered.
         //
-        // Stop as soon as the event could be decrypted, or once the minimum number of
-        // iterations has been run and the deadline has passed.
-        //
-        // Just log out errors, but don't have them abort the notification processing:
-        // an undecrypted notification is still better than no notifications.
+        // Stop once the event is decrypted, or once the minimum number of
+        // iterations has run and the deadline has passed.
 
         let encryption_sync = match EncryptionSyncService::new(
             self.client.clone(),

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -116,15 +116,52 @@ impl NotificationClient {
     const CONNECTION_ID: &'static str = "notifications";
     const LOCK_ID: &'static str = "notifications";
 
-    /// Maximum time to wait for the main encryption sync to receive a
-    /// missing room key, in a [`NotificationProcessSetup::SingleProcess`]
-    /// setup where that sync is already running.
+    /// Maximum time spent waiting for a missing room key, when an event in a
+    /// notification can't be decrypted. Kept small, since we might be short on
+    /// time.
     ///
-    /// The value matches the time budget of the other path, where no encryption
-    /// sync is running and the notification client runs one itself, using two
-    /// sync iterations of the sync, each of which long-polls for up to
-    /// 3 seconds.
-    const RUNNING_SYNC_DECRYPTION_DEADLINE: Duration = Duration::from_secs(6);
+    /// This applies to both ways of obtaining the key, so that they give up
+    /// after the same amount of time:
+    ///
+    /// - When the notification client runs the encryption sync itself, this
+    ///   bounds the time spent running it, once at least
+    ///   [`Self::MIN_DECRYPTION_ITERATIONS`] have been run. Decryption is
+    ///   attempted after each iteration, so this only bounds the unsuccessful
+    ///   case: once the deadline has passed, no new iteration is started.
+    /// - In a [`NotificationProcessSetup::SingleProcess`] setup where the main
+    ///   encryption sync is already running, the notification client must not
+    ///   run a second one and waits for the running one to receive the key
+    ///   instead. The wait ends as soon as a key for the room is received, so
+    ///   this only bounds the case where the key doesn't arrive.
+    ///
+    /// In both cases, the event is returned undecrypted once the deadline has
+    /// passed.
+    const DECRYPTION_DEADLINE: Duration = Duration::from_secs(6);
+
+    /// Minimum number of encryption sync iterations to run when an event in a
+    /// notification can't be decrypted, before [`Self::DECRYPTION_DEADLINE`]
+    /// is considered.
+    ///
+    /// The first iteration sends the e2ee requests and receives pending
+    /// to-device messages; the second lets the homeserver forward what those
+    /// requests triggered.
+    const MIN_DECRYPTION_ITERATIONS: usize = 2;
+
+    /// Long-poll timeout of each request of the encryption sync run to obtain
+    /// a missing room key, i.e. how long the homeserver waits for a to-device
+    /// message to arrive before answering.
+    ///
+    /// Set so that [`Self::MIN_DECRYPTION_ITERATIONS`] full-length polls fit
+    /// exactly in [`Self::DECRYPTION_DEADLINE`]: when the homeserver has
+    /// nothing to return, the minimum iterations use up the whole deadline and
+    /// no further iteration is started.
+    const ENCRYPTION_SYNC_POLL_TIMEOUT: Duration =
+        Self::DECRYPTION_DEADLINE.checked_div(Self::MIN_DECRYPTION_ITERATIONS as u32).unwrap();
+
+    /// Extra time allowed for the network round trip of each request of the
+    /// encryption sync, on top of [`Self::ENCRYPTION_SYNC_POLL_TIMEOUT`].
+    /// This is an upper bound on how long a request may take.
+    const ENCRYPTION_SYNC_NETWORK_TIMEOUT: Duration = Duration::from_secs(4);
 
     /// Create a new notification client.
     pub async fn new(
@@ -245,17 +282,8 @@ impl NotificationClient {
         // Serialize calls to this function.
         let _guard = self.encryption_sync_mutex.lock().await;
 
-        // The message is still encrypted, and the client is configured to retry
-        // decryption.
-        //
-        // Spawn an `EncryptionSync` that runs two iterations of the sliding sync loop:
-        // - the first iteration allows to get SS events as well as send e2ee requests.
-        // - the second one let the SS homeserver forward events triggered by the
-        //   sending of e2ee requests.
-        //
-        // Keep timeouts small for both, since we might be short on time.
-
         let push_ctx = room.push_context().await?;
+
         let sync_permit_guard = match &self.process_setup {
             NotificationProcessSetup::MultipleProcesses => {
                 // We're running on our own process, dedicated for notifications. In that case,
@@ -279,50 +307,81 @@ impl NotificationClient {
             }
         };
 
-        let encryption_sync = EncryptionSyncService::new(
-            self.client.clone(),
-            Some((Duration::from_secs(3), Duration::from_secs(4))),
-        )
-        .await;
-
+        // Run an `EncryptionSync` loop, attempting to decrypt the event after each
+        // iteration:
+        // - the first iteration allows to get SS events as well as send e2ee requests,
+        // - the following ones let the SS homeserver forward events triggered by the
+        //   sending of e2ee requests, such as the room key we're missing.
+        //
+        // Stop as soon as the event could be decrypted, or once the minimum number of
+        // iterations has been run and the deadline has passed.
+        //
         // Just log out errors, but don't have them abort the notification processing:
-        // an undecrypted notification is still better than no
-        // notifications.
+        // an undecrypted notification is still better than no notifications.
 
-        match encryption_sync {
-            Ok(sync) => match sync.run_fixed_iterations(2, sync_permit_guard).await {
-                // Note: We specify the cast type in case the
-                // `experimental-encrypted-state-events` feature is enabled, which provides
-                // multiple cast implementations.
-                Ok(()) => match room.decrypt_event(raw_event.cast_ref_unchecked::<OriginalSyncRoomEncryptedEvent>(), push_ctx.as_ref()).await {
-                    Ok(new_event) => match new_event.kind {
-                        matrix_sdk::deserialized_responses::TimelineEventKind::UnableToDecrypt {
-                            utd_info, ..
-                        } => {
-                            trace!(
-                                "Encryption sync failed to decrypt the event: {:?}",
-                                utd_info.reason
-                            );
-                            Ok(None)
-                        }
-                        _ => {
-                            trace!("Encryption sync managed to decrypt the event.");
-                            Ok(Some(new_event))
-                        }
-                    },
-                    Err(err) => {
-                        trace!("Encryption sync failed to decrypt the event: {err}");
-                        Ok(None)
-                    }
-                },
-                Err(err) => {
-                    warn!("Encryption sync error: {err:#}");
-                    Ok(None)
-                }
-            },
+        let encryption_sync = match EncryptionSyncService::new(
+            self.client.clone(),
+            Some((Self::ENCRYPTION_SYNC_POLL_TIMEOUT, Self::ENCRYPTION_SYNC_NETWORK_TIMEOUT)),
+        )
+        .await
+        {
+            Ok(encryption_sync) => encryption_sync,
             Err(err) => {
-                warn!("Encryption sync build error: {err:#}",);
-                Ok(None)
+                warn!("Encryption sync build error: {err:#}");
+                return Ok(None);
+            }
+        };
+
+        let deadline = Instant::now() + Self::DECRYPTION_DEADLINE;
+        let iterations = encryption_sync.run_iterations(sync_permit_guard);
+        pin_mut!(iterations);
+
+        let mut num_iterations = 0;
+
+        loop {
+            let sync_ended = match iterations.next().await {
+                Some(Ok(())) => {
+                    num_iterations += 1;
+                    false
+                }
+
+                Some(Err(err)) => {
+                    warn!("Encryption sync error: {err:#}");
+                    return Ok(None);
+                }
+
+                None => {
+                    // The sync terminated, or the cross-process lock is held by the main app,
+                    // which may well have fetched the room key itself in the meantime: attempt
+                    // to decrypt one last time.
+                    trace!("Encryption sync ended, attempting to decrypt one last time");
+                    true
+                }
+            };
+
+            match try_decrypt(room, raw_event, push_ctx.as_ref()).await {
+                Ok(DecryptionAttempt::Decrypted(new_event)) => {
+                    trace!("Encryption sync managed to decrypt the event.");
+                    return Ok(Some(new_event));
+                }
+                Ok(DecryptionAttempt::MissingRoomKey) => {
+                    if sync_ended {
+                        debug!("Encryption sync ended and the room key is still missing.");
+                        return Ok(None);
+                    }
+                    if num_iterations >= Self::MIN_DECRYPTION_ITERATIONS
+                        && Instant::now() >= deadline
+                    {
+                        debug!("Deadline reached while waiting for the room key, giving up.");
+                        return Ok(None);
+                    }
+                    trace!("Still missing the room key, running another encryption sync iteration");
+                }
+                Ok(DecryptionAttempt::Unrecoverable) => return Ok(None),
+                Err(err) => {
+                    trace!("Encryption sync failed to decrypt the event: {err}");
+                    return Ok(None);
+                }
             }
         }
     }
@@ -335,7 +394,7 @@ impl NotificationClient {
     /// must not run a second one.
     ///
     /// Returns `Ok(None)` if no key for the room has been received within
-    /// [`Self::RUNNING_SYNC_DECRYPTION_DEADLINE`], or if the event can't be
+    /// [`Self::DECRYPTION_DEADLINE`], or if the event can't be
     /// decrypted for another reason.
     async fn wait_for_room_key(
         &self,
@@ -358,7 +417,7 @@ impl NotificationClient {
         };
         pin_mut!(room_keys);
 
-        let deadline = Instant::now() + Self::RUNNING_SYNC_DECRYPTION_DEADLINE;
+        let deadline = Instant::now() + Self::DECRYPTION_DEADLINE;
 
         loop {
             match try_decrypt(room, raw_event, push_ctx).await? {

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -341,8 +341,10 @@ impl NotificationClient {
                 }
 
                 Some(Err(err)) => {
-                    warn!("Encryption sync error: {err:#}");
-                    return Ok(None);
+                    // The room key might have been persisted before this error was raised.
+                    // Don't exit directly so that redrycption is attempted one last time.
+                    warn!("Encryption sync error, attempting to decrypt one last time: {err:#}");
+                    true
                 }
 
                 None => {

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -14,7 +14,7 @@ use matrix_sdk_test::async_test;
 use matrix_sdk_ui::encryption_sync_service::{EncryptionSyncPermit, EncryptionSyncService};
 use serde::Deserialize;
 use serde_json::json;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 use tracing::{error, info, trace, warn};
 use wiremock::{
     Mock, MockGuard, MockServer, Request, ResponseTemplate,
@@ -28,6 +28,27 @@ use crate::{
     },
     sliding_sync_then_assert_request_and_fake_response,
 };
+
+/// Runs exactly `num_iterations` iterations of the given encryption sync,
+/// failing if it errors or ends before that.
+async fn run_iterations(
+    encryption_sync: EncryptionSyncService,
+    num_iterations: usize,
+    sync_permit_guard: OwnedMutexGuard<EncryptionSyncPermit>,
+) -> anyhow::Result<()> {
+    let iterations = encryption_sync.run_iterations(sync_permit_guard);
+    pin_mut!(iterations);
+
+    for i in 0..num_iterations {
+        match iterations.next().await {
+            Some(Ok(())) => {}
+            Some(Err(err)) => return Err(err.into()),
+            None => anyhow::bail!("encryption sync ended after {i} of {num_iterations} iterations"),
+        }
+    }
+
+    Ok(())
+}
 
 #[async_test]
 async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
@@ -174,6 +195,33 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
 }
 
 #[async_test]
+async fn test_run_iterations_holds_the_permit_while_the_stream_is_alive() -> anyhow::Result<()> {
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+
+    let _guard = setup_mocking_sliding_sync_server(&server).await;
+
+    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
+    let sync_permit_guard = sync_permit.clone().lock_owned().await;
+    let encryption_sync = EncryptionSyncService::new(client, None).await?;
+
+    let mut iterations = Box::pin(encryption_sync.run_iterations(sync_permit_guard));
+
+    // The permit is held before the stream is first polled…
+    assert!(sync_permit.try_lock().is_err());
+
+    // …and while it's being consumed.
+    assert!(matches!(iterations.next().await, Some(Ok(()))));
+    assert!(sync_permit.try_lock().is_err());
+
+    // Dropping the stream releases it.
+    drop(iterations);
+    assert!(sync_permit.try_lock().is_ok());
+
+    Ok(())
+}
+
+#[async_test]
 async fn test_sync_holds_the_permit_while_the_stream_is_alive() -> anyhow::Result<()> {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
@@ -211,7 +259,7 @@ async fn test_encryption_sync_default_sync_presence_is_online() -> anyhow::Resul
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync = EncryptionSyncService::new(client, None).await?;
 
-    encryption_sync.run_fixed_iterations(1, sync_permit_guard).await?;
+    run_iterations(encryption_sync, 1, sync_permit_guard).await?;
 
     assert_sliding_sync_presence_for_conn_ids(&server, None, &["encryption"]).await;
 
@@ -219,7 +267,7 @@ async fn test_encryption_sync_default_sync_presence_is_online() -> anyhow::Resul
 }
 
 #[async_test]
-async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
+async fn test_encryption_sync_one_iteration() -> anyhow::Result<()> {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
@@ -229,10 +277,11 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync = EncryptionSyncService::new(client, None).await?;
 
-    // Run all the iterations.
-    encryption_sync.run_fixed_iterations(1, sync_permit_guard).await?;
+    // Take a single iteration from the stream, then drop it.
+    run_iterations(encryption_sync, 1, sync_permit_guard).await?;
 
-    // Check the requests are the ones we've expected.
+    // Exactly one request must have been made, with the extensions enabled: the
+    // stream must not run ahead of the iterations taken from it.
     let expected_requests = [json!({
         "conn_id": "encryption",
         "extensions": {
@@ -251,7 +300,7 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
 }
 
 #[async_test]
-async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
+async fn test_encryption_sync_two_iterations() -> anyhow::Result<()> {
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 
@@ -261,8 +310,10 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync = EncryptionSyncService::new(client, None).await?;
 
-    encryption_sync.run_fixed_iterations(2, sync_permit_guard).await?;
+    // Take two iterations from the stream, then drop it.
+    run_iterations(encryption_sync, 2, sync_permit_guard).await?;
 
+    // Exactly two requests must have been made, one per iteration.
     let expected_requests = [
         json!({
             "conn_id": "encryption",


### PR DESCRIPTION
When an event in a notification couldn't be decrypted, the notification client ran exactly two iterations of an encryption sync and only then attempted decryption. If the room key arrived during the first iteration, which is the, the second one had nothing to return and blocked for the full poll timeout before the event was decrypted.

This change instead attempts decryption after every iteration, and stop as soon as it succeeds. At least the two iterations that used to run are still run, so slow networks get the same number of attempts as before, and further iterations are only started while a deadline of two poll timeouts has not passed, which is the time two full-length polls used to take. The unsuccessful case therefore costs what it did, while the successful one no longer waits for an empty second poll.

Note that I have extracted some of the timing values into constants for the purpose of documenting them and because I plan to make them configurable by callers in a follow-up PR.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
