### PR TITLE
fix(ui): `TimelineStateTransaction::clear` removes remote events too

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/6983.fixed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6983.fixed.md
@@ -1,0 +1,5 @@
+When the Timeline received an update from the Event Cache about an event
+removal, if the Timeline contained a local timeline item, it could have resulted
+in a broken mapping between the timeline items and the remote events. The
+consequences to that are numerous, but for instance, some timeline items could
+have been wrongly removed, or not removed when expected.

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -2031,14 +2031,15 @@ impl AllRemoteEvents {
     /// `new_timeline_item_index`.
     fn timeline_item_has_been_removed_at(&mut self, timeline_item_index_to_remove: usize) {
         for event_meta in self.0.iter_mut() {
-            let mut remove_timeline_item_index = false;
-
             // A `timeline_item_index` is removed. Let's shift all indexes that come
             // after the removed one.
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 match (*timeline_item_index).cmp(&timeline_item_index_to_remove) {
                     Ordering::Equal => {
-                        remove_timeline_item_index = true;
+                        // This is the `event_meta` that holds the
+                        // `timeline_item_index` that is being
+                        // removed. So let's clean it.
+                        event_meta.timeline_item_index = None;
                     }
 
                     Ordering::Greater => {
@@ -2047,12 +2048,6 @@ impl AllRemoteEvents {
 
                     Ordering::Less => {}
                 }
-            }
-
-            // This is the `event_meta` that holds the `timeline_item_index` that is being
-            // removed. So let's clean it.
-            if remove_timeline_item_index {
-                event_meta.timeline_item_index = None;
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -686,12 +686,17 @@ pub struct ObservableItemsTransactionEntry<'observable_transaction_items, 'obser
 }
 
 impl ObservableItemsTransactionEntry<'_, '_> {
-    /// Remove this timeline item.
-    pub fn remove(this: Self) {
-        let entry_index = ObservableVectorTransactionEntry::index(&this.entry);
+    /// Remove this timeline item, and its associated remote event if any.
+    pub fn remove_timeline_index_and_remote_event(this: Self) {
+        let timeline_item_index = ObservableVectorTransactionEntry::index(&this.entry);
 
         ObservableVectorTransactionEntry::remove(this.entry);
-        this.all_remote_events.timeline_item_has_been_removed_at(entry_index);
+
+        if let Some(event_index) =
+            this.all_remote_events.timeline_item_has_been_removed_at(timeline_item_index)
+        {
+            this.all_remote_events.remove(event_index);
+        }
     }
 }
 
@@ -1492,7 +1497,7 @@ mod observable_items_tests {
     }
 
     #[test]
-    fn test_transaction_for_each_remove() {
+    fn test_transaction_for_each_remove_timeline_item_and_remote_event() {
         let mut items = ObservableItems::new();
 
         // Push events to iterate on.
@@ -1520,7 +1525,7 @@ mod observable_items_tests {
         // Iterate over events, and remove one.
         transaction.for_each(|entry| {
             if entry.as_event().unwrap().event_id().unwrap().as_str() == "$ev1" {
-                ObservableItemsTransactionEntry::remove(entry);
+                ObservableItemsTransactionEntry::remove_timeline_index_and_remote_event(entry);
             }
         });
 
@@ -1530,10 +1535,10 @@ mod observable_items_tests {
             | event_id | event_index | timeline_item_index |
             |----------|-------------|---------------------|
             | "$ev0"   | 0           | 0                   |
-            | "$ev2"   | 2           | 1                   | // has shifted
+            | "$ev2"   | 1           | 1                   | // has shifted
         }
 
-        assert_eq!(transaction.all_remote_events().0.len(), 3);
+        assert_eq!(transaction.all_remote_events().0.len(), 2);
         assert_eq!(transaction.len(), 2);
     }
 
@@ -2029,10 +2034,18 @@ impl AllRemoteEvents {
 
     /// Notify that a timeline item has been removed at
     /// `new_timeline_item_index`.
-    fn timeline_item_has_been_removed_at(&mut self, timeline_item_index_to_remove: usize) {
-        for event_meta in self.0.iter_mut() {
-            // A `timeline_item_index` is removed. Let's shift all indexes that come
-            // after the removed one.
+    ///
+    /// It returns the position of the remote event, so the `event_index`, if
+    /// any.
+    fn timeline_item_has_been_removed_at(
+        &mut self,
+        timeline_item_index_to_remove: usize,
+    ) -> Option<usize> {
+        let mut found_event_index = None;
+
+        for (event_index, event_meta) in self.0.iter_mut().enumerate().rev() {
+            // A `timeline_item_index` is removed. Let's shift all indexes that
+            // come after the removed one.
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 match (*timeline_item_index).cmp(&timeline_item_index_to_remove) {
                     Ordering::Equal => {
@@ -2040,16 +2053,25 @@ impl AllRemoteEvents {
                         // `timeline_item_index` that is being
                         // removed. So let's clean it.
                         event_meta.timeline_item_index = None;
+                        found_event_index = Some(event_index);
                     }
 
                     Ordering::Greater => {
                         *timeline_item_index -= 1;
                     }
 
-                    Ordering::Less => {}
+                    Ordering::Less => {
+                        // Let's break here. It's safer than in
+                        // `Ordering::Equal` in case it's never matched, i.e. if
+                        // no remote event matches the
+                        // `timeline_item_index_to_remove`.
+                        break;
+                    }
                 }
             }
         }
+
+        found_event_index
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -1032,11 +1032,11 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                         }
                     })
                 {
-                    ObservableItemsTransactionEntry::remove(entry);
+                    ObservableItemsTransactionEntry::remove_timeline_index_and_remote_event(entry);
                 }
             });
 
-            // Remove stray date dividers
+            // Remove adjacent date dividers.
             let mut idx = 0;
             while idx < self.items.len() {
                 if self.items[idx].is_date_divider()

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -373,3 +373,53 @@ async fn test_no_reuse_of_counters() {
     // The remote id still isn't the same as the local id.
     assert_ne!(local_id, remote_id);
 }
+
+#[async_test]
+async fn test_clear_does_not_break_mapping_between_timeline_items_and_remote_events() {
+    let timeline = TestTimeline::new().await;
+
+    // Add a local event so that `VectorDiff::Clear` cherry-pick events to
+    // remove instead of clearing everything.
+    //
+    // This is essential to test a bug where this cherry-picking was previously
+    // breaking the mapping between the timeline items and the remote events.
+    timeline
+        .handle_local_event(AnyMessageLikeEventContent::RoomMessage(
+            RoomMessageEventContent::text_plain("echo"),
+        ))
+        .await;
+
+    let f = &timeline.factory;
+    timeline
+        .handle_event_update(
+            vec![
+                VectorDiff::Append {
+                    values: [
+                        f.text_msg("foo").sender(&ALICE).event_id(event_id!("$0")).into_event(),
+                        f.text_msg("bar").sender(&ALICE).event_id(event_id!("$1")).into_event(),
+                    ]
+                    .into(),
+                },
+                VectorDiff::Clear,
+                VectorDiff::Append {
+                    values: [f
+                        .text_msg("baz")
+                        .sender(&ALICE)
+                        .event_id(event_id!("$2"))
+                        .into_event()]
+                    .into(),
+                },
+                VectorDiff::Remove { index: 0 },
+            ],
+            RemoteEventOrigin::Sync,
+        )
+        .await;
+
+    let items = timeline.controller.items().await;
+
+    assert!(!items.iter().any(|item| {
+        item.as_event()
+            .and_then(|event| event.event_id())
+            .is_some_and(|event_id| event_id.as_str() == "$2")
+    }));
+}

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -1028,7 +1028,7 @@ async fn test_backpaginate_replace_empty_gap() {
             JoinedRoomBuilder::new(room_id)
                 .add_timeline_event(f.text_msg("world").event_id(event_id!("$2")))
                 .set_timeline_limited()
-                .set_timeline_prev_batch("prev-batch".to_owned()),
+                .set_timeline_prev_batch("prev_batch".to_owned()),
         )
         .await;
 
@@ -1040,6 +1040,7 @@ async fn test_backpaginate_replace_empty_gap() {
     // The first back-pagination will return a previous-batch token, but no events.
     server
         .mock_room_messages()
+        .match_from("prev_batch")
         .ok(RoomMessagesResponseTemplate::default().end_token("prev_batch"))
         .mock_once()
         .mount()


### PR DESCRIPTION
This patch fixes a bug in `TimelineStateTransaction::clear` where selectively removing timeline items forgot to remove their associated remote events if any, resulting in a mismatch in the timeline item <-> remote event mapping.

To achieve so, `ObservableItemsTransactionEntry::remove` is renamed to `remove_timeline_index_and_remote_event`. Why doing both operations here? Because this type is used inside a closure passed to `ObservableItemsTransaction::for_each`. The access to the items and the remote events are hidden behind this type: the caller cannot pick the value to use whether it is the items or the remote events. We need an operation to work on both here.

Then, `AllRemoteEvents::timeline_item_has_been_removed_at` needs to return the index of the remote event, aka `event_index`.

At the same time, `timeline_item_has_been_removed_at` has been updated to scan events in reverse order and stop as soon as possible, avoiding useless scan.

---

This is derived from https://gist.github.com/ara4n/d9462cca5c758c5b8f6a9536a1278c85. The patch about the code is… well… entirely wrong at all levels. A single test about `Timeline` turned to be somehow useful. It was pretty convoluted, but investigating it has revealed a bug — fixed by this patch!

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
