### PR TITLE
Profiles: Update the store when changing profile fields to act as a local echo.

### DIFF
--- a/bindings/matrix-sdk-ffi/changelog.d/6984.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/6984.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] The Profiles sliding sync extension (MSC4262) is now always enabled like the other extensions. `SyncServiceBuilder::with_profiles_extension` has been removed.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -80,7 +80,6 @@ use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedMxcUri, OwnedServerName, RoomAliasId,
     RoomOrAliasId, ServerName,
     api::{
-        FeatureFlag,
         client::{
             alias::get_alias,
             discovery::get_authorization_server_metadata::v1::{
@@ -2201,7 +2200,7 @@ impl Client {
 
     /// Checks if the server supports the Profiles sliding sync extension.
     pub async fn is_profiles_sliding_sync_extension_supported(&self) -> Result<bool, ClientError> {
-        Ok(self.inner.unstable_features().await?.contains(&FeatureFlag::from("org.matrix.msc4262")))
+        Ok(self.inner.is_global_profile_sync_enabled().await?)
     }
 
     /// Checks if the server supports user status.

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -127,16 +127,6 @@ impl SyncServiceBuilder {
         Arc::new(Self { builder, ..this })
     }
 
-    /// Enable the Profiles sliding sync extension for the room list service.
-    ///
-    /// Required to merge the global `m.status` and `m.call` fields into the
-    /// room members and profiles read from the SDK.
-    pub fn with_profiles_extension(self: Arc<Self>) -> Arc<Self> {
-        let this = unwrap_or_clone_arc(self);
-        let builder = this.builder.with_profiles_extension();
-        Arc::new(Self { builder, ..this })
-    }
-
     /// Set a custom Sliding Sync connection ID for the room list service.
     ///
     /// By default [`matrix_sdk_ui::room_list_service::DEFAULT_CONNECTION_ID`]

--- a/crates/matrix-sdk-base/changelog.d/6984.added.md
+++ b/crates/matrix-sdk-base/changelog.d/6984.added.md
@@ -1,0 +1,1 @@
+Add `BaseClient::own_profile_updated`, to manually merge a change to the user's own global profile into the store and notify subscribers.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -49,7 +49,7 @@ use ruma::{
     push::Ruleset,
     time::Instant,
 };
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, MutexGuard, broadcast};
 #[cfg(feature = "e2e-encryption")]
 use tokio::sync::{RwLock, RwLockReadGuard};
 use tracing::{Level, debug, enabled, info, instrument, warn};
@@ -1158,6 +1158,37 @@ impl BaseClient {
         &self,
     ) -> broadcast::Receiver<BTreeSet<OwnedUserId>> {
         self.global_profile_updates_sender.subscribe()
+    }
+
+    /// Notify the rest of the SDK that the global profiles of the given users
+    /// changed in the store.
+    ///
+    /// Broadcasts the changed user IDs, and nudges the `RoomInfo` of any room
+    /// where one of them is a hero so the hero fields are re-read.
+    pub(crate) fn notify_global_profile_updates(
+        &self,
+        user_ids: BTreeSet<OwnedUserId>,
+        #[cfg_attr(not(feature = "unstable-msc4426"), allow(unused_variables))]
+        state_store_guard: &MutexGuard<'_, ()>,
+    ) -> Result<()> {
+        if user_ids.is_empty() {
+            return Ok(());
+        }
+
+        // Nudge `RoomInfo` so hero status/call fields are re-read.
+        #[cfg(feature = "unstable-msc4426")]
+        for room in self.state_store.rooms() {
+            if room.hero_user_ids().iter().any(|hero| user_ids.contains(hero)) {
+                room.update_room_info_with_store_guard(state_store_guard, |room_info| {
+                    (room_info, RoomInfoNotableUpdateReasons::HEROES)
+                })
+                .map_err(crate::StoreError::from)?;
+            }
+        }
+
+        let _ = self.global_profile_updates_sender.send(user_ids);
+
+        Ok(())
     }
 
     /// Checks whether the provided `user_id` belongs to an ignored user.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -46,6 +46,7 @@ use ruma::{
         push_rules::{PushRulesEvent, PushRulesEventContent},
         room::member::SyncRoomMemberEvent,
     },
+    profile::UserProfileUpdate,
     push::Ruleset,
     time::Instant,
 };
@@ -1158,6 +1159,21 @@ impl BaseClient {
         &self,
     ) -> broadcast::Receiver<BTreeSet<OwnedUserId>> {
         self.global_profile_updates_sender.subscribe()
+    }
+
+    /// Our own global profile has been updated.
+    ///
+    /// Updates the internal and cached state accordingly, so the change is
+    /// observable before the next sync reflects it.
+    pub async fn own_profile_updated(&self, update: UserProfileUpdate) -> Result<()> {
+        let own_user_id = self.session_meta().ok_or(Error::InsufficientData)?.user_id.clone();
+        let state_store_guard = self.state_store_lock().lock().await;
+
+        let mut changes = StateChanges::default();
+        changes.global_profiles.insert(own_user_id.clone(), update);
+        self.state_store.save_changes_with_guard(&state_store_guard, &changes).await?;
+
+        self.notify_global_profile_updates(BTreeSet::from([own_user_id]), &state_store_guard)
     }
 
     /// Notify the rest of the SDK that the global profiles of the given users

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1165,6 +1165,9 @@ impl BaseClient {
     ///
     /// Updates the internal and cached state accordingly, so the change is
     /// observable before the next sync reflects it.
+    ///
+    /// **Note:** This method should only be called when global profile syncing
+    /// is enabled
     pub async fn own_profile_updated(&self, update: UserProfileUpdate) -> Result<()> {
         let own_user_id = self.session_meta().ok_or(Error::InsufficientData)?.user_id.clone();
         let state_store_guard = self.state_store_lock().lock().await;

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -221,26 +221,10 @@ impl BaseClient {
 
         // Profile-only updates don't modify any rooms, so nothing else broadcasts
         // them. Surface the change so subscribers can react accordingly.
-        if !extensions.profiles.is_empty() {
-            let _ = self
-                .global_profile_updates_sender
-                .send(extensions.profiles.users.keys().cloned().collect());
-
-            // Nudge `RoomInfo` so hero status/call fields are re-read.
-            #[cfg(feature = "unstable-msc4426")]
-            for room in self.state_store.rooms() {
-                if room
-                    .hero_user_ids()
-                    .iter()
-                    .any(|user_id| extensions.profiles.users.contains_key(user_id))
-                {
-                    room.update_room_info_with_store_guard(state_store_guard, |room_info| {
-                        (room_info, crate::RoomInfoNotableUpdateReasons::HEROES)
-                    })
-                    .map_err(crate::StoreError::from)?;
-                }
-            }
-        }
+        self.notify_global_profile_updates(
+            extensions.profiles.users.keys().cloned().collect(),
+            state_store_guard,
+        )?;
 
         let mut context = processors::Context::default();
 

--- a/crates/matrix-sdk-ui/changelog.d/6984.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/6984.changed.md
@@ -1,0 +1,1 @@
+[**breaking**] The Profiles sliding sync extension (MSC4262) is now always enabled like the other extensions. `SyncServiceBuilder::with_profiles_extension` has been removed.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -144,8 +144,7 @@ impl RoomListService {
     /// to create one in this case using
     /// [`EncryptionSyncService`][crate::encryption_sync_service::EncryptionSyncService].
     pub async fn new(client: Client) -> Result<Self, Error> {
-        Self::new_with(client, true, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT, false)
-            .await
+        Self::new_with(client, true, DEFAULT_CONNECTION_ID, DEFAULT_LIST_TIMELINE_LIMIT).await
     }
 
     /// Like [`RoomListService::new`] but with additional configuration options.
@@ -154,9 +153,6 @@ impl RoomListService {
     ///   cross-process position sharing.
     /// - `connection_id`: the Sliding Sync connection ID
     /// - `timeline_limit`: the timeline limit
-    /// - `profiles_extension`: enables the Profiles extension, required to
-    ///   merge the global `m.status` and `m.call` fields into room members and
-    ///   profiles
     ///
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub async fn new_with(
@@ -164,7 +160,6 @@ impl RoomListService {
         share_pos: bool,
         connection_id: &str,
         timeline_limit: u32,
-        profiles_extension: bool,
     ) -> Result<Self, Error> {
         let mut builder = client
             .sliding_sync(connection_id)
@@ -177,6 +172,9 @@ impl RoomListService {
                 rooms: Some(vec![http::request::ExtensionRoomConfig::AllSubscribed])
             }))
             .with_typing_extension(assign!(http::request::Typing::default(), {
+                enabled: Some(true),
+            }))
+            .with_profiles_extension(assign!(http::request::Profiles::default(), {
                 enabled: Some(true),
             }));
 
@@ -204,14 +202,6 @@ impl RoomListService {
                     "Failed to check whether the client requested thread subscriptions extension: not enabling."
                 );
             }
-        }
-
-        if profiles_extension {
-            debug!("Enabling the profiles extension for the room list sliding sync");
-            builder = builder.with_profiles_extension(assign!(
-                http::request::Profiles::default(),
-                { enabled: Some(true) }
-            ));
         }
 
         if share_pos {

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -775,13 +775,6 @@ pub struct SyncServiceBuilder {
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     with_share_pos: bool,
 
-    /// Whether to enable the Profiles sliding sync extension for the room list
-    /// service.
-    ///
-    /// Required to merge the global `m.status` and `m.call` fields into the
-    /// room members and profiles read from this crate.
-    with_profiles_extension: bool,
-
     /// Custom connection ID for the room list service.
     /// Defaults to [`room_list_service::DEFAULT_CONNECTION_ID`]. Use a
     /// different value for secondary processes such as iOS share extensions
@@ -806,7 +799,6 @@ impl SyncServiceBuilder {
             client,
             with_offline_mode: false,
             with_share_pos: true,
-            with_profiles_extension: false,
             room_list_conn_id: DEFAULT_CONNECTION_ID.to_owned(),
             room_list_timeline_limit: DEFAULT_LIST_TIMELINE_LIMIT,
             parent_span: Span::none(),
@@ -827,15 +819,6 @@ impl SyncServiceBuilder {
     /// [`SlidingSyncBuilder::share_pos`]: matrix_sdk::sliding_sync::SlidingSyncBuilder::share_pos
     pub fn with_share_pos(mut self, enable: bool) -> Self {
         self.with_share_pos = enable;
-        self
-    }
-
-    /// Enable the Profiles sliding sync extension for the room list service.
-    ///
-    /// Required to merge the global `m.status` and `m.call` fields into the
-    /// room members and profiles read from this crate.
-    pub fn with_profiles_extension(mut self) -> Self {
-        self.with_profiles_extension = true;
         self
     }
 
@@ -868,7 +851,6 @@ impl SyncServiceBuilder {
             client,
             with_offline_mode,
             with_share_pos,
-            with_profiles_extension,
             room_list_conn_id,
             room_list_timeline_limit,
             parent_span,
@@ -881,7 +863,6 @@ impl SyncServiceBuilder {
             with_share_pos,
             &room_list_conn_id,
             room_list_timeline_limit,
-            with_profiles_extension,
         )
         .await?;
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -380,6 +380,9 @@ async fn test_sync_all_states() -> Result<(), Error> {
                 "typing": {
                     "enabled": true,
                 },
+                "org.matrix.msc4262.profiles": {
+                    "enabled": true,
+                },
             },
         },
         respond with = {
@@ -2407,6 +2410,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                 "account_data": { "enabled": true },
                 "receipts": { "enabled": true, "rooms": [ "*" ] },
                 "typing": { "enabled": true },
+                "org.matrix.msc4262.profiles": { "enabled": true },
             },
         },
         respond with = {
@@ -2506,6 +2510,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                 "account_data": { "enabled": true },
                 "receipts": { "enabled": true, "rooms": [ "*" ] },
                 "typing": { "enabled": true },
+                "org.matrix.msc4262.profiles": { "enabled": true },
             },
         },
         respond with = {
@@ -2641,6 +2646,7 @@ async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
                 "account_data": { "enabled": true },
                 "receipts": { "enabled": true, "rooms": [ "*" ] },
                 "typing": { "enabled": true },
+                "org.matrix.msc4262.profiles": { "enabled": true },
             },
         },
         respond with = {
@@ -2747,6 +2753,7 @@ async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
                 "account_data": { "enabled": true },
                 "receipts": { "enabled": true, "rooms": [ "*" ] },
                 "typing": { "enabled": true },
+                "org.matrix.msc4262.profiles": { "enabled": true },
             },
         },
         respond with = {
@@ -3300,6 +3307,9 @@ async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_i
                     "typing": {
                         "enabled": true,
                     },
+                    "org.matrix.msc4262.profiles": {
+                        "enabled": true,
+                    },
                 },
                 "lists": {
                     "all_rooms": {
@@ -3398,6 +3408,9 @@ async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_i
                 "io.element.msc4308.thread_subscriptions": {
                     "enabled": true,
                     "limit": 10,
+                },
+                "org.matrix.msc4262.profiles": {
+                    "enabled": true,
                 },
             },
             "lists": {

--- a/crates/matrix-sdk/changelog.d/6984.changed.md
+++ b/crates/matrix-sdk/changelog.d/6984.changed.md
@@ -1,0 +1,1 @@
+`Account` automatically updates the local copy of the user's global profile after updating (to act as a local echo). Requires support for global profile syncing.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -65,13 +65,13 @@ use ruma::{
         push_rules::PushRulesEventContent,
         room::MediaSource,
     },
-    profile::{ProfileFieldName, ProfileFieldValue},
+    profile::{ProfileFieldName, ProfileFieldValue, UserProfileChanges, UserProfileUpdate},
     push::Ruleset,
     serde::Raw,
     thirdparty::Medium,
 };
 use serde::Deserialize;
-use tracing::error;
+use tracing::{debug, error, warn};
 
 use crate::{Client, Error, Result, config::RequestConfig};
 
@@ -506,8 +506,12 @@ impl Account {
     /// Returns an error if the request fails.
     pub async fn set_profile_field(&self, value: ProfileFieldValue) -> Result<()> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = set_profile_field::v3::Request::new(user_id.to_owned(), value);
+        let request = set_profile_field::v3::Request::new(user_id.to_owned(), value.clone());
         self.client.send(request).await?;
+
+        let mut changes = UserProfileChanges::new();
+        changes.insert_updated_value(value);
+        self.own_profile_updated(changes).await;
 
         Ok(())
     }
@@ -527,10 +531,40 @@ impl Account {
     /// of if the request fails in some other way.
     pub async fn delete_profile_field(&self, field: ProfileFieldName) -> Result<()> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = delete_profile_field::v3::Request::new(user_id.to_owned(), field);
+        let request = delete_profile_field::v3::Request::new(user_id.to_owned(), field.clone());
         self.client.send(request).await?;
 
+        let mut changes = UserProfileChanges::new();
+        changes.removed.push(field);
+        self.own_profile_updated(changes).await;
+
         Ok(())
+    }
+
+    /// Apply the given changes to the locally stored copy of our own profile,
+    /// so they are observable before the next sync reflects them.
+    async fn own_profile_updated(&self, changes: UserProfileChanges) {
+        match self.client.is_global_profile_sync_enabled().await {
+            Ok(true) => {}
+
+            Ok(false) => {
+                debug!("Server doesn't support global profile sync: skip the local echo.");
+                return;
+            }
+
+            Err(error) => {
+                warn!(?error, "Unknown support for global profile sync: skipping the local echo.");
+                return;
+            }
+        }
+
+        if let Err(error) =
+            self.client.base_client().own_profile_updated(UserProfileUpdate::Updated(changes)).await
+        {
+            // The homeserver has already accepted the changes at this point, so we
+            // only need to log the failure.
+            warn!(?error, "Failed to update the locally stored copy of our own profile");
+        }
     }
 
     /// Change the password of the account.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3744,6 +3744,22 @@ impl Client {
         Ok(server_enabled)
     }
 
+    /// Whether global user profiles are included in the sync response.
+    ///
+    /// Requires [MSC4262](https://github.com/matrix-org/matrix-spec-proposals/pull/4262)
+    /// for sliding sync. Not implemented for sync v2.
+    pub async fn is_global_profile_sync_enabled(&self) -> Result<bool> {
+        if matches!(self.sliding_sync_version(), SlidingSyncVersion::None) {
+            return Ok(false);
+        }
+
+        Ok(self
+            .supported_versions()
+            .await?
+            .features
+            .contains(&FeatureFlag::from("org.matrix.msc4262")))
+    }
+
     /// Fetch thread subscriptions changes between `from` and up to `to`.
     ///
     /// The `limit` optional parameter can be used to limit the number of

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -3681,6 +3681,11 @@ impl<'a> MockEndpoint<'a, VersionsEndpoint> {
         self.with_feature("org.matrix.simplified_msc3575", true)
     }
 
+    /// Indicate that global profile sync is supported by this homeserver.
+    pub fn with_profiles_sliding_sync_extension(self) -> Self {
+        self.with_feature("org.matrix.msc4262", true)
+    }
+
     /// Set the supported versions in the response of this endpoint.
     pub fn with_versions(mut self, versions: Vec<&'static str>) -> Self {
         self.endpoint.versions = versions;

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -326,11 +326,23 @@ async fn test_get_cached_avatar_url() {
 #[cfg(feature = "unstable-msc4426")]
 #[async_test]
 async fn test_set_status() {
-    use ruma::profile::StatusProfileField;
+    use std::collections::BTreeSet;
 
+    use ruma::profile::{Status, StatusProfileField};
+
+    // Given an account without a status.
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    server
+        .mock_versions()
+        .with_versions(vec!["v1.16"])
+        .with_profiles_sliding_sync_extension()
+        .ok()
+        .named("versions")
+        .mount()
+        .await;
+    let client = server.client_builder().no_server_versions().build().await;
     let user_id = client.user_id().unwrap();
+    let mut profile_updates = client.subscribe_to_global_profile_updates();
 
     server
         .mock_set_profile_field(user_id, ProfileFieldName::Status)
@@ -344,17 +356,56 @@ async fn test_set_status() {
         .mount()
         .await;
 
+    // When setting a status.
     let account = client.account();
-    account.set_status("🌴".to_owned(), "Away".to_owned()).await.unwrap();
+    let result = account.set_status("🌴".to_owned(), "Away".to_owned()).await;
+
+    // Then the status should be sent and stored as a local echo, with any
+    // subscribers being notified.
+    assert!(result.is_ok());
+    let profile = client
+        .state_store()
+        .get_global_profile(user_id)
+        .await
+        .unwrap()
+        .expect("the local echo should be stored");
+    let status = profile
+        .get_static::<Status>()
+        .expect("the status should deserialize")
+        .expect("the status should be set");
+    assert_eq!(status.text, "Away");
+    assert_eq!(status.emoji, "🌴");
+    assert_eq!(profile_updates.recv().await.unwrap(), BTreeSet::from([user_id.to_owned()]));
 }
 
 #[cfg(feature = "unstable-msc4426")]
 #[async_test]
 async fn test_clear_status() {
+    use std::collections::BTreeSet;
+
+    use ruma::profile::Status;
+
+    // Given an account that already has a status (locally echoed into the store for
+    // this test).
     let server = MatrixMockServer::new().await;
-    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    server
+        .mock_versions()
+        .with_versions(vec!["v1.16"])
+        .with_profiles_sliding_sync_extension()
+        .ok()
+        .named("versions")
+        .mount()
+        .await;
+    let client = server.client_builder().no_server_versions().build().await;
     let user_id = client.user_id().unwrap();
 
+    server
+        .mock_set_profile_field(user_id, ProfileFieldName::Status)
+        .ok()
+        .mock_once()
+        .named("set org.matrix.msc4426.status profile field")
+        .mount()
+        .await;
     server
         .mock_delete_profile_field(user_id, ProfileFieldName::Status)
         .ok()
@@ -364,7 +415,49 @@ async fn test_clear_status() {
         .await;
 
     let account = client.account();
-    account.clear_status().await.unwrap();
+    account.set_status("🌴".to_owned(), "Away".to_owned()).await.unwrap();
+    let mut profile_updates = client.subscribe_to_global_profile_updates();
+
+    // When the status is cleared.
+    let result = account.clear_status().await;
+
+    // Then the clear should be sent and stored as a local echo, with any
+    // subscribers being notified.
+    assert!(result.is_ok());
+    let profile = client
+        .state_store()
+        .get_global_profile(user_id)
+        .await
+        .unwrap()
+        .expect("the profile should still be stored");
+    assert_matches!(profile.get_static::<Status>(), Ok(None));
+    assert_eq!(profile_updates.recv().await.unwrap(), BTreeSet::from([user_id.to_owned()]));
+}
+
+#[cfg(feature = "unstable-msc4426")]
+#[async_test]
+async fn test_set_status_without_profile_sync() {
+    // Given an account on a server that doesn't support the profiles sliding sync
+    // extension.
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
+    let user_id = client.user_id().unwrap();
+
+    server
+        .mock_set_profile_field(user_id, ProfileFieldName::Status)
+        .ok()
+        .mock_once()
+        .named("set org.matrix.msc4426.status profile field")
+        .mount()
+        .await;
+
+    // When setting a status.
+    let account = client.account();
+    let result = account.set_status("🌴".to_owned(), "Away".to_owned()).await;
+
+    // Then it should be sent, but not stored locally.
+    assert!(result.is_ok());
+    assert_matches!(client.state_store().get_global_profile(user_id).await, Ok(None));
 }
 
 #[cfg(feature = "unstable-msc4426")]


### PR DESCRIPTION
This works similarly to joining/leaving a room where the store is manually updated immediately after the request succeeds so that a slow /sync response isn't visible to the user.

I've also removed the flag to enable profile sync, matching read-receipts/typing indicators etc to help simplify the checks as `Account` should only store the update if we're actually syncing profiles (this wasn't an issue before as the sync processing can only receive profiles when syncing is enabled).

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
