### PR TITLE
chore(base): Use `serde_bytes` with attachment content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,7 @@ dependencies = [
  "regex",
  "ruma",
  "serde",
+ "serde_bytes",
  "serde_json",
  "similar-asserts",
  "stream_assert",

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -15,6 +15,10 @@ version = "0.18.0"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
+[package.metadata.cargo-machete]
+# serde_bytes is only used in `#[serde(with = "...")]` attributes.
+ignored = ["serde_bytes"]
+
 [features]
 default = []
 e2e-encryption = ["dep:matrix-sdk-crypto"]
@@ -99,6 +103,7 @@ ruma = { workspace = true, features = [
     "rand",
 ] }
 serde = { workspace = true, features = ["rc"] }
+serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -2292,6 +2292,7 @@ pub enum DraftAttachmentContent {
     /// Image attachment.
     Image {
         /// The image file data.
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
         /// MIME type.
         mimetype: Option<String>,
@@ -2309,6 +2310,7 @@ pub enum DraftAttachmentContent {
     /// Video attachment.
     Video {
         /// The video file data.
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
         /// MIME type.
         mimetype: Option<String>,
@@ -2328,6 +2330,7 @@ pub enum DraftAttachmentContent {
     /// Audio attachment.
     Audio {
         /// The audio file data.
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
         /// MIME type.
         mimetype: Option<String>,
@@ -2339,6 +2342,7 @@ pub enum DraftAttachmentContent {
     /// Generic file attachment.
     File {
         /// The file data.
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
         /// MIME type.
         mimetype: Option<String>,
@@ -2353,6 +2357,7 @@ pub struct DraftThumbnail {
     /// The filename of the thumbnail.
     pub filename: String,
     /// The thumbnail image data.
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
     /// MIME type of the thumbnail.
     pub mimetype: Option<String>,


### PR DESCRIPTION
This optimizes the serialization and deserialization of `DraftAttachmentContent` variants and  `DraftThumbnail`.

This PR was inspired by https://github.com/matrix-org/matrix-rust-sdk/pull/6976.

<!-- description of the changes in this PR -->

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
