### PR TITLE
feat(sdk): Add `ThreadEventCache::subscribe_to_thread_info`

### DIFF
--- a/crates/matrix-sdk/changelog.d/6993.added.md
+++ b/crates/matrix-sdk/changelog.d/6993.added.md
@@ -1,0 +1,2 @@
+`ThreadEventCache` gains a new method: `subscribe_to_thread_info` to subscribe
+to updates of the `ThreadInfo`. This is very similar to `Room::subscribe_info`.

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -20,7 +20,12 @@ mod updates;
 
 use std::{fmt, sync::Arc};
 
-use matrix_sdk_base::{event_cache::Event, read_receipts::ReadReceipts, sync::Timeline};
+use eyeball::AsyncLock;
+use matrix_sdk_base::{
+    event_cache::{Event, thread::ThreadInfo},
+    read_receipts::ReadReceipts,
+    sync::Timeline,
+};
 use ruma::{
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, events::relation::RelationType,
     room_version_rules::RoomVersionRules,
@@ -160,7 +165,7 @@ impl ThreadEventCache {
     /// To get multiple information about the read receipts, use
     /// [`Self::read_receipts`] as it involves a single lock.
     pub async fn num_unread_messages(&self) -> Result<u64> {
-        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_unread)
+        Ok(self.inner.state.read().await?.thread_info.read().await.read_receipts.num_unread)
     }
 
     /// Get the number of unread notifications.
@@ -168,7 +173,7 @@ impl ThreadEventCache {
     /// To get multiple information about the read receipts, use
     /// [`Self::read_receipts`] as it involves a single lock.
     pub async fn num_unread_notifications(&self) -> Result<u64> {
-        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_notifications)
+        Ok(self.inner.state.read().await?.thread_info.read().await.read_receipts.num_notifications)
     }
 
     /// Get the number of unread mentions, that is, messages causing a highlight
@@ -177,12 +182,19 @@ impl ThreadEventCache {
     /// To get multiple information about the read receipts, use
     /// [`Self::read_receipts`] as it involves a single lock.
     pub async fn num_unread_mentions(&self) -> Result<u64> {
-        Ok(self.inner.state.read().await?.thread_info.read_receipts.num_mentions)
+        Ok(self.inner.state.read().await?.thread_info.read().await.read_receipts.num_mentions)
     }
 
     /// Get the detailed information about read receipts for this thread.
     pub async fn read_receipts(&self) -> Result<ReadReceipts> {
-        Ok(self.inner.state.read().await?.thread_info.read_receipts.clone())
+        Ok(self.inner.state.read().await?.thread_info.read().await.read_receipts.clone())
+    }
+
+    /// Subscribe to update of the [`ThreadInfo`].
+    pub async fn subscribe_to_thread_info(
+        &self,
+    ) -> Result<eyeball::Subscriber<ThreadInfo, AsyncLock>> {
+        Ok(self.inner.state.read().await?.thread_info.subscribe().await)
     }
 
     /// Subscribe to this thread updates, after getting the initial list of

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -14,6 +14,7 @@
 
 use std::iter::empty;
 
+use eyeball::{AsyncLock, ObservableWriteGuard, SharedObservable};
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
     apply_redaction, check_validity_of_replacement_events,
@@ -83,7 +84,7 @@ pub struct ThreadEventCacheState {
     thread_linked_chunk: EventLinkedChunk,
 
     /// The information related to this thread, [`ThreadInfo`].
-    pub thread_info: ThreadInfo,
+    pub thread_info: SharedObservable<ThreadInfo, AsyncLock>,
 
     /// A clone of [`super::ThreadEventCacheInner::update_sender`].
     ///
@@ -188,7 +189,7 @@ impl ThreadEventCacheState {
                 linked_chunk,
                 full_linked_chunk_metadata,
             ),
-            thread_info,
+            thread_info: SharedObservable::new_async(thread_info),
             update_sender,
             linked_chunk_update_sender,
             waited_for_initial_prev_token: false,
@@ -563,7 +564,7 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             return Ok(());
         };
 
-        let prev_read_receipts = &self.state.thread_info.read_receipts;
+        let prev_read_receipts = self.state.thread_info.read().await.read_receipts.clone();
         let mut read_receipts = prev_read_receipts.clone();
 
         let client = room.client();
@@ -579,16 +580,20 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         )
         .await;
 
-        if prev_read_receipts != &read_receipts {
-            // The read receipt has changed! Do a little dance to update the `ThreadInfo` in
-            // the store.
-            self.state.thread_info.read_receipts = read_receipts;
+        if prev_read_receipts != read_receipts {
+            // The read receipt has changed! Do a little dance to update the
+            // `ThreadInfo` in the store.
+            let mut thread_info = self.state.thread_info.write().await;
+
+            ObservableWriteGuard::update(&mut thread_info, |thread_info| {
+                thread_info.read_receipts = read_receipts;
+            });
 
             let room_id = &self.state.room_id;
             let thread_id = &self.state.thread_id;
 
             if let Err(error) =
-                self.store.update_thread_info(room_id, thread_id, &self.state.thread_info).await
+                self.store.update_thread_info(room_id, thread_id, &thread_info).await
             {
                 error!(?room_id, ?thread_id, ?error, "Failed to update the `ThreadInfo`");
             }

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
@@ -56,6 +56,7 @@ async fn test_unread_count_new_message_no_receipt() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
 
     assert!(thread_updates.is_empty());
 
@@ -76,6 +77,9 @@ async fn test_unread_count_new_message_no_receipt() {
 
     // Both messages from Alice count as unread since there is no read receipt.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that the unread count only includes messages after the last known read
@@ -96,6 +100,8 @@ async fn test_unread_count_new_message_with_known_receipt() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     server
@@ -129,6 +135,9 @@ async fn test_unread_count_new_message_with_known_receipt() {
 
     // Only ev3 (after the receipt) is unread.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that a message sent by the current user creates an implicit read
@@ -149,6 +158,8 @@ async fn test_unread_count_implicit_receipt_own_message() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     server
@@ -184,6 +195,9 @@ async fn test_unread_count_implicit_receipt_own_message() {
     let read_receipts = thread.read_receipts().await.unwrap();
     assert_eq!(read_receipts.num_unread, 2);
     assert_eq!(read_receipts.latest_active.unwrap().event_id, event_id!("$3"));
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that receiving only a new read receipt event (with no new messages)
@@ -204,6 +218,8 @@ async fn test_unread_count_receipt_only_no_new_message() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     // First sync: three messages from Alice, no receipt.
@@ -248,6 +264,9 @@ async fn test_unread_count_receipt_only_no_new_message() {
 
     // Only ev3 (after the receipt) is unread now.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that a read receipt for an unknown event is stored as pending, and
@@ -268,6 +287,8 @@ async fn test_unread_count_pending_receipt() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     // First sync: three messages from Alice plus a receipt for a future event.
@@ -307,6 +328,9 @@ async fn test_unread_count_pending_receipt() {
     assert!(read_receipts.pending.iter().any(|id| id == event_id!("$future")));
     assert_eq!(read_receipts.pending.len(), 1);
 
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
+
     // Second sync: $future arrives along with another message.
     server
         .sync_room(
@@ -332,6 +356,9 @@ async fn test_unread_count_pending_receipt() {
     let read_receipts = thread.read_receipts().await.unwrap();
     assert_eq!(read_receipts.num_unread, 1);
     assert!(read_receipts.pending.is_empty());
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that unread counts accumulate across multiple syncs when no read
@@ -351,6 +378,8 @@ async fn test_unread_count_accumulates_across_syncs() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     // First sync: two messages.
@@ -370,6 +399,9 @@ async fn test_unread_count_accumulates_across_syncs() {
     assert_let_timeout!(Ok(_) = thread_updates.recv());
     assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
 
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
+
     // Second sync: one more message, still no receipt.
     server
         .sync_room(
@@ -384,6 +416,9 @@ async fn test_unread_count_accumulates_across_syncs() {
 
     // Three messages are now unread in total.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 3);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that state events (e.g. a membership change) in the timeline do not
@@ -436,6 +471,8 @@ async fn test_reaction_does_not_increment_unread() {
     server.sync_joined_room(&client, room_id).await;
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     server
@@ -455,6 +492,9 @@ async fn test_reaction_does_not_increment_unread() {
 
     // Only the text message counts as unread, the reaction doesn't.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that messages with mentions increment the number of mentions.
@@ -482,6 +522,8 @@ async fn test_mentions_increments_unread_mentions() {
         .membership(MembershipState::Join)
         .event_id(event_id!("$member"));
 
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     server
         .sync_room(
             &client,
@@ -501,6 +543,9 @@ async fn test_mentions_increments_unread_mentions() {
     // The message counts as unread and also increments the mentions count.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
     assert_eq!(thread.num_unread_mentions().await.unwrap(), 1);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that the unread count computation doesn't skip a more-recent active
@@ -522,6 +567,8 @@ async fn test_compute_unread_counts_considers_active_receipt() {
 
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     // Starting with a room with 1 implicit receipt, then two messages from Alice,
@@ -563,6 +610,9 @@ async fn test_compute_unread_counts_considers_active_receipt() {
     // The message counts are properly updated (one new message unread after $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
 
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
+
     // Provided a sync with one new message from Alice in the same room.
     server
         .sync_room(
@@ -580,6 +630,9 @@ async fn test_compute_unread_counts_considers_active_receipt() {
 
     // The message counts are properly updated (two messages after $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 2);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that the unread count gets updated when the sync update only contains
@@ -623,6 +676,8 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
     // We receive the thread update for the two new messages.
     assert_let_timeout!(Ok(_) = thread_updates.recv());
 
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     // Then, provided a sync with a single duplicated message sent by somebody else,
     // but a read receipt for the existing message $2,
     server
@@ -649,6 +704,9 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
 
     // The message counts are properly updated (zero new message unread after $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 0);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }
 
 /// Test that a read receipt saved in the state store but not marked as active
@@ -687,6 +745,8 @@ async fn test_read_receipt_from_store_used_as_latest_active() {
 
     let (thread, _drop_handles) = event_cache.thread(room_id, thread_id).await.unwrap();
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
+    let mut thread_info_updates = thread.subscribe_to_thread_info().await.unwrap();
+
     assert!(thread_updates.is_empty());
 
     server
@@ -713,4 +773,7 @@ async fn test_read_receipt_from_store_used_as_latest_active() {
 
     // Only ev3 (after the receipt) is unread.
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
+
+    // Asserting the `ThreadInfo` has received an update too.
+    assert!(thread_info_updates.next().await.is_some());
 }


### PR DESCRIPTION
This patch updates `ThreadEventCacheState::thread_info` to become a `SharedObservable<_, AsyncLock>`.

This patch also adds `ThreadEventCache::subscribe_to_thread_info`.

---

- Stacked on top of https://github.com/matrix-org/matrix-rust-sdk/pull/6938.

---

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
