### PR TITLE
chore: `rustfmt` the whole project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
-          toolchain: nightly-2026-07-18
+          toolchain: nightly-2026-09-07
           components: clippy, rustfmt
 
       - name: Load cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
-          toolchain: nightly-2026-07-18
+          toolchain: nightly-2026-09-07
 
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/benchmarks/benches/event_cache.rs
+++ b/benchmarks/benches/event_cache.rs
@@ -34,18 +34,20 @@ fn handle_room_updates(c: &mut Criterion) {
     const NUM_EVENTS: usize = 1000;
 
     for num_rooms in [1, 10, 100] {
-        // Add some joined rooms, each with NUM_EVENTS in it, to the sync response.
+        // Add some joined rooms, each with NUM_EVENTS in it, to the sync
+        // response.
         let mut room_updates = RoomUpdates::default();
 
         let mut changes = matrix_sdk::StateChanges::default();
 
         for i in 0..num_rooms {
-            // Synapse's room IDs for rooms v1 to v11 have an 18 characters localpart.
+            // Synapse's room IDs for rooms v1 to v11 have an 18 characters
+            // localpart.
             let raw_room_id = format!("!firstbatchroom{i:04}:example.com");
 
             let room_id = if i % 10 == 9 {
-                // Make 1 in 10 rooms use a room v12 ID, which is a base64 hash similar to an
-                // event ID.
+                // Make 1 in 10 rooms use a room v12 ID, which is a base64 hash
+                // similar to an event ID.
                 RoomId::new_v2(&base64_sha256_hash(raw_room_id.as_bytes())).unwrap()
             } else {
                 OwnedRoomId::try_from(raw_room_id).unwrap()
@@ -75,7 +77,8 @@ fn handle_room_updates(c: &mut Criterion) {
                 Box::new(move || {
                     let temp_dir = temp_dir.clone();
                     Box::pin(async move {
-                        // Remove all the files in the temp_dir, to reset the event cache state.
+                        // Remove all the files in the temp_dir, to reset the
+                        // event cache state.
                         for entry in temp_dir.path().read_dir().unwrap() {
                             let entry = entry.unwrap();
                             let path = entry.path();
@@ -162,8 +165,8 @@ fn handle_room_updates(c: &mut Criterion) {
 }
 
 fn find_event_relations(c: &mut Criterion) {
-    // Number of other events to saturate the DB, but that will not be affected by
-    // the benchmark. A small multiple of this number will be added.
+    // Number of other events to saturate the DB, but that will not be affected
+    // by the benchmark. A small multiple of this number will be added.
     // When running locally, run with more events than in Codespeed CI.
     #[cfg(feature = "codspeed")]
     const NUM_OTHER_EVENTS: usize = 100;

--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -170,7 +170,8 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
             assert!(!pinned_event_ids.is_empty());
             assert_eq!(pinned_event_ids.len(), PINNED_EVENTS_COUNT);
 
-            // Reset cache so it always loads the events from the mocked endpoint
+            // Reset cache so it always loads the events from the mocked
+            // endpoint
             client
                 .event_cache_store()
                 .lock()

--- a/benchmarks/benches/room_list.rs
+++ b/benchmarks/benches/room_list.rs
@@ -30,12 +30,13 @@ pub fn create(c: &mut Criterion) {
     let server_ts_range = Uniform::try_from(100..1000).unwrap();
 
     for room_nth in 0..NUMBER_OF_ROOMS {
-        // Synapse's room IDs for rooms v1 to v11 have an 18 characters localpart.
+        // Synapse's room IDs for rooms v1 to v11 have an 18 characters
+        // localpart.
         let raw_room_id = format!("!arsgratiaartis{room_nth:04}:example.com");
 
         let room_id = if room_nth % 10 == 9 {
-            // Make 1 in 10 rooms use a room v12 ID, which is a base64 hash similar to an
-            // event ID.
+            // Make 1 in 10 rooms use a room v12 ID, which is a base64 hash
+            // similar to an event ID.
             RoomId::new_v2(&base64_sha256_hash(raw_room_id.as_bytes())).unwrap()
         } else {
             OwnedRoomId::try_from(raw_room_id).unwrap()
@@ -77,7 +78,8 @@ pub fn create(c: &mut Criterion) {
                 let (entries_stream, entries_controller) =
                     room_list.entries_with_dynamic_adapters(20);
 
-                // Setting the filter will trigger the entries stream computation.
+                // Setting the filter will trigger the entries stream
+                // computation.
                 entries_controller.set_filter(Box::new(new_filter_non_left()));
 
                 pin_mut!(entries_stream);

--- a/benchmarks/benches/store_bench.rs
+++ b/benchmarks/benches/store_bench.rs
@@ -25,12 +25,13 @@ pub fn restore_session(c: &mut Criterion) {
     let mut changes = StateChanges::default();
 
     for i in 0..NUM_JOINED_ROOMS {
-        // Synapse's room IDs for rooms v1 to v11 have an 18 characters localpart.
+        // Synapse's room IDs for rooms v1 to v11 have an 18 characters
+        // localpart.
         let raw_room_id = format!("!joinedchamber{i:05}:example.com");
 
         let room_id = if i % 20 == 19 {
-            // Make 1 in 20 rooms use a room v12 ID, which is a base64 hash similar to an
-            // event ID.
+            // Make 1 in 20 rooms use a room v12 ID, which is a base64 hash
+            // similar to an event ID.
             RoomId::new_v2(&base64_sha256_hash(raw_room_id.as_bytes())).unwrap()
         } else {
             OwnedRoomId::try_from(raw_room_id).unwrap()
@@ -39,12 +40,13 @@ pub fn restore_session(c: &mut Criterion) {
     }
 
     for i in 0..NUM_STRIPPED_JOINED_ROOMS {
-        // Synapse's room IDs for rooms v1 to v11 have an 18 characters localpart.
+        // Synapse's room IDs for rooms v1 to v11 have an 18 characters
+        // localpart.
         let raw_room_id = format!("!strippedlodge{i:05}:example.com");
 
         let room_id = if i % 20 == 19 {
-            // Make 1 in 20 rooms use a room v12 ID, which is a base64 hash similar to an
-            // event ID.
+            // Make 1 in 20 rooms use a room v12 ID, which is a base64 hash
+            // similar to an event ID.
             RoomId::new_v2(&base64_sha256_hash(raw_room_id.as_bytes())).unwrap()
         } else {
             OwnedRoomId::try_from(raw_room_id).unwrap()

--- a/bindings/matrix-sdk-crypto-ffi/build.rs
+++ b/bindings/matrix-sdk-crypto-ffi/build.rs
@@ -20,18 +20,19 @@ fn setup_x86_64_android_workaround() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
     if target_arch == "x86_64" && target_os == "android" {
-        // Configure rust to statically link against the `libclang_rt.builtins` supplied
-        // with clang.
+        // Configure rust to statically link against the `libclang_rt.builtins`
+        // supplied with clang.
 
-        // cargo-ndk sets CC_x86_64-linux-android to the path to `clang`, within the
-        // Android NDK.
+        // cargo-ndk sets CC_x86_64-linux-android to the path to `clang`, within
+        // the Android NDK.
         let clang_path = PathBuf::from(
             env::var("CC_x86_64-linux-android").expect("CC_x86_64-linux-android not set"),
         );
 
         // clang_path should now look something like
-        // `.../sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/linux-x86_64/bin/clang`.
-        // We strip `/bin/clang` from the end to get the toolchain path.
+        // `.../sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/linux-x86_64/bin/
+        // clang`. We strip `/bin/clang` from the end to get the
+        // toolchain path.
         let toolchain_path = clang_path
             .ancestors()
             .nth(2)
@@ -44,7 +45,8 @@ fn setup_x86_64_android_workaround() {
         println!("cargo:rustc-link-search={toolchain_path}/lib/clang/{clang_version}/lib/linux/");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
 
-        // Ensure we re-run this build script if the location of the toolchain changes.
+        // Ensure we re-run this build script if the location of the toolchain
+        // changes.
         println!("cargo:rerun-if-env-changed=CC_x86_64-linux-android");
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
@@ -58,7 +58,8 @@ pub struct DehydratedDevices {
 
 impl Drop for DehydratedDevices {
     fn drop(&mut self) {
-        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        // See the drop implementation for the `crate::OlmMachine` for an
+        // explanation.
         let _guard = self.runtime.enter();
         unsafe {
             ManuallyDrop::drop(&mut self.inner);
@@ -143,7 +144,8 @@ pub struct RehydratedDevice {
 
 impl Drop for RehydratedDevice {
     fn drop(&mut self) {
-        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        // See the drop implementation for the `crate::OlmMachine` for an
+        // explanation.
         let _guard = self.runtime.enter();
         unsafe {
             ManuallyDrop::drop(&mut self.inner);
@@ -173,7 +175,8 @@ pub struct DehydratedDevice {
 
 impl Drop for DehydratedDevice {
     fn drop(&mut self) {
-        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        // See the drop implementation for the `crate::OlmMachine` for an
+        // explanation.
         let _guard = self.runtime.enter();
         unsafe {
             ManuallyDrop::drop(&mut self.inner);

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -947,7 +947,8 @@ impl OlmMachine {
                 },
             },
             AlgorithmInfo::OlmV1Curve25519AesSha2 { .. } => {
-                // cannot happen because `decrypt_room_event` would have fail to decrypt olm for
+                // cannot happen because `decrypt_room_event` would have fail to
+                // decrypt olm for
                 // a room (EventError::UnsupportedAlgorithm)
                 panic!("Unsupported olm algorithm in room")
             }

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -260,9 +260,9 @@ impl Sas {
         listener: Box<dyn SasListener>,
     ) {
         while let Some(state) = stream.next().await {
-            // If we receive a done or a cancelled state we're at the end of our road, we
-            // break out of the loop to deallocate the stream and finish the
-            // task.
+            // If we receive a done or a cancelled state we're at the end of our
+            // road, we break out of the loop to deallocate the
+            // stream and finish the task.
             let should_break =
                 matches!(state, RustSasState::Done { .. } | RustSasState::Cancelled { .. });
 
@@ -442,9 +442,9 @@ impl QrCode {
         listener: Box<dyn QrCodeListener>,
     ) {
         while let Some(state) = stream.next().await {
-            // If we receive a done or a cancelled state we're at the end of our road, we
-            // break out of the loop to deallocate the stream and finish the
-            // task.
+            // If we receive a done or a cancelled state we're at the end of our
+            // road, we break out of the loop to deallocate the
+            // stream and finish the task.
             let should_break = matches!(
                 state,
                 QrVerificationState::Done { .. } | QrVerificationState::Cancelled { .. }
@@ -787,9 +787,9 @@ impl VerificationRequest {
         listener: Box<dyn VerificationRequestListener>,
     ) {
         while let Some(state) = stream.next().await {
-            // If we receive a done or a cancelled state we're at the end of our road, we
-            // break out of the loop to deallocate the stream and finish the
-            // task.
+            // If we receive a done or a cancelled state we're at the end of our
+            // road, we break out of the loop to deallocate the
+            // stream and finish the task.
             let should_break = matches!(
                 state,
                 RustVerificationRequestState::Done | RustVerificationRequestState::Cancelled { .. }

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -34,18 +34,19 @@ fn setup_x86_64_android_workaround() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
     if target_arch == "x86_64" && target_os == "android" {
-        // Configure rust to statically link against the `libclang_rt.builtins` supplied
-        // with clang.
+        // Configure rust to statically link against the `libclang_rt.builtins`
+        // supplied with clang.
 
-        // cargo-ndk sets CC_x86_64-linux-android to the path to `clang`, within the
-        // Android NDK.
+        // cargo-ndk sets CC_x86_64-linux-android to the path to `clang`, within
+        // the Android NDK.
         let clang_path = PathBuf::from(
             env::var("CC_x86_64-linux-android").expect("CC_x86_64-linux-android not set"),
         );
 
         // clang_path should now look something like
-        // `.../sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/linux-x86_64/bin/clang`.
-        // We strip `/bin/clang` from the end to get the toolchain path.
+        // `.../sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/linux-x86_64/bin/
+        // clang`. We strip `/bin/clang` from the end to get the
+        // toolchain path.
         let toolchain_path = clang_path
             .ancestors()
             .nth(2)
@@ -58,7 +59,8 @@ fn setup_x86_64_android_workaround() {
         println!("cargo:rustc-link-search={toolchain_path}/lib/clang/{clang_version}/lib/linux/");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
 
-        // Ensure we re-run this build script if the location of the toolchain changes.
+        // Ensure we re-run this build script if the location of the toolchain
+        // changes.
         println!("cargo:rerun-if-env-changed=CC_x86_64-linux-android");
     }
 }

--- a/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
+++ b/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
@@ -44,8 +44,8 @@ impl<T> ChunkIterator<T> {
             let chunk_size = cmp::min(items.len(), chunk_size.try_into().unwrap());
             // Split the items vector.
             let mut tail = items.split_off(chunk_size);
-            // `Vec::split_off` returns the tail, and `items` contains the head. Let's
-            // swap them.
+            // `Vec::split_off` returns the tail, and `items` contains the head.
+            // Let's swap them.
             mem::swap(&mut tail, &mut items);
             // Finally, let's rename `tail` to `head`.
             let head = tail;

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -890,8 +890,9 @@ impl Client {
         let mut subscriber = q.subscribe_errors();
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
-            // Respawn tasks for rooms that had unsent events. At this point we've just
-            // created the subscriber, so it'll be notified about errors.
+            // Respawn tasks for rooms that had unsent events. At this point
+            // we've just created the subscriber, so it'll be
+            // notified about errors.
             q.respawn_tasks_for_rooms_with_unsent_requests().await;
 
             loop {
@@ -959,7 +960,8 @@ impl Client {
     ) -> Arc<TaskHandle> {
         macro_rules! observe {
             ($t:ty, $cb: expr) => {{
-                // Using an Arc here is mandatory or else the subscriber will never trigger
+                // Using an Arc here is mandatory or else the subscriber will never
+                // trigger
                 let observer =
                     Arc::new(self.inner.observe_events::<RumaGlobalAccountDataEvent<$t>, ()>());
 
@@ -1030,7 +1032,8 @@ impl Client {
     ) -> Result<Arc<TaskHandle>, ClientError> {
         macro_rules! observe {
             ($t:ty, $cb: expr) => {{
-                // Using an Arc here is mandatory or else the subscriber will never trigger
+                // Using an Arc here is mandatory or else the subscriber will never
+                // trigger
                 let observer =
                     Arc::new(self.inner.observe_room_events::<RumaRoomAccountDataEvent<$t>, ()>(
                         &RoomId::parse(&room_id)?,
@@ -1311,8 +1314,9 @@ impl Client {
             });
         }
 
-        // UTDs detected before this duration may be reclassified as "late decryption"
-        // events (or discarded, if they get decrypted fast enough).
+        // UTDs detected before this duration may be reclassified as "late
+        // decryption" events (or discarded, if they get decrypted fast
+        // enough).
         const UTD_HOOK_GRACE_PERIOD: Duration = Duration::from_secs(60);
 
         let mut utd_hook_manager = UtdHookManager::new(
@@ -1389,8 +1393,8 @@ impl Client {
 
     /// Updates the user's avatar using the provided MXC url.
     pub async fn set_avatar_url(&self, url: String) -> Result<(), ClientError> {
-        // MxcUri can't just be instantiated, serde deserialization seems to be the only
-        // way
+        // MxcUri can't just be instantiated, serde deserialization seems to be
+        // the only way
         let mxc = serde_json::from_str::<OwnedMxcUri>(&url)?;
         // Validate the newly generated MxcUri
         mxc.validate().map_err(ClientError::from_err)?;
@@ -1697,7 +1701,8 @@ impl Client {
                     );
                 }
             } else {
-                // Room has no events; just clear any stale explicit unread flag.
+                // Room has no events; just clear any stale explicit unread
+                // flag.
                 if let Err(err) = sdk_room.set_unread_flag(false).await {
                     warn!(
                         "mark_all_rooms_as_read: failed to clear unread flag for {}: {err}",
@@ -1995,8 +2000,8 @@ impl Client {
             .collect::<Result<Vec<_>, _>>()
             .context("at least one `via` server name is invalid")?;
 
-        // The `into()` call below doesn't work if I do `(&room_id).into()`, so I let
-        // rustc win that one fight.
+        // The `into()` call below doesn't work if I do `(&room_id).into()`, so
+        // I let rustc win that one fight.
         let room_id: &RoomId = &room_id;
 
         let room_preview = self.inner.get_room_preview(room_id.into(), via_servers).await?;
@@ -2012,8 +2017,8 @@ impl Client {
         let room_alias =
             RoomAliasId::parse(&room_alias).context("room_alias is not a valid room alias")?;
 
-        // The `into()` call below doesn't work if I do `(&room_id).into()`, so I let
-        // rustc win that one fight.
+        // The `into()` call below doesn't work if I do `(&room_id).into()`, so
+        // I let rustc win that one fight.
         let room_alias: &RoomAliasId = &room_alias;
 
         let room_preview = self.inner.get_room_preview(room_alias.into(), Vec::new()).await?;
@@ -2121,14 +2126,16 @@ impl Client {
                 sync_service.inner.expire_sessions().await;
             }
 
-            // Disable the send queues, as they might read and write to the state store.
-            // Events being send might still be active, and cause errors if
-            // processing finishes, so this will only minimize damage. Since
-            // this method should only be called in exceptional cases, this has
-            // been deemed acceptable.
+            // Disable the send queues, as they might read and write to the
+            // state store. Events being send might still be active,
+            // and cause errors if processing finishes, so this will
+            // only minimize damage. Since this method should only
+            // be called in exceptional cases, this has been deemed
+            // acceptable.
             self.inner.send_queue().set_enabled(false).await;
 
-            // Clean up the media cache according to the current media retention policy.
+            // Clean up the media cache according to the current media retention
+            // policy.
             self.inner
                 .media_store()
                 .lock()
@@ -2139,9 +2146,9 @@ impl Client {
                 .map_err(Error::from)?;
 
             // Clear all the room chunks. It's important to *not* call
-            // `EventCacheStore::clear_all_events` here, because there might be live
-            // observers of the linked chunks, and that would cause some very bad state
-            // mismatch.
+            // `EventCacheStore::clear_all_events` here, because there might be
+            // live observers of the linked chunks, and that would
+            // cause some very bad state mismatch.
             self.inner.event_cache().clear_all_rooms().await?;
 
             // Delete the state store file, if it exists.
@@ -2149,11 +2156,13 @@ impl Client {
             if let Some(store_path) = &self.store_path {
                 debug!("Removing the state store: {}", store_path.display());
 
-                // The state store and the crypto store both live in the same store path, so we
-                // can't blindly delete the directory.
+                // The state store and the crypto store both live in the same
+                // store path, so we can't blindly delete the
+                // directory.
                 //
-                // Delete the state store SQLite file, as well as the write-ahead log (WAL) and
-                // shared-memory (SHM) files, if they exist.
+                // Delete the state store SQLite file, as well as the
+                // write-ahead log (WAL) and shared-memory (SHM)
+                // files, if they exist.
 
                 for file_name in [
                     PathBuf::from(STATE_STORE_DATABASE_NAME),
@@ -3689,7 +3698,8 @@ mod tests {
 
         let user_id = ruma::user_id!("@user:example.com");
 
-        // A display name with avatar/status/call explicitly set as `null` JSON values.
+        // A display name with avatar/status/call explicitly set as `null` JSON
+        // values.
         let mut profile = RumaUserProfile::new();
         profile
             .set(ProfileFieldName::DisplayName.as_str().to_owned(), serde_json::json!("Example"));

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -572,8 +572,9 @@ impl ClientBuilder {
         {
             let mut certificates = Vec::new();
             for certificate in builder.additional_root_certificates {
-                // We don't really know what type of certificate we may get here, so let's try
-                // first one type, then the other.
+                // We don't really know what type of certificate we may get
+                // here, so let's try first one type, then the
+                // other.
                 match Certificate::from_der(&certificate) {
                     Ok(cert) => {
                         certificates.push(cert);
@@ -672,8 +673,8 @@ impl ClientBuilder {
 
             use matrix_sdk_base::crypto::x509::X509SignatureSigningError;
 
-            // Wrap the provided RawX509Signer impl in a shim which converts the arguments
-            // and results.
+            // Wrap the provided RawX509Signer impl in a shim which converts the
+            // arguments and results.
             #[derive(Debug)]
             struct X509SignImpl(Arc<dyn RawX509Signer>);
 
@@ -708,8 +709,8 @@ impl ClientBuilder {
         if let Some(x509_verify) = builder.raw_x509_verifier {
             use matrix_sdk_base::crypto::x509::X509SignatureVerificationError;
 
-            // Wrap the provided RawX509Verifier impl in a shim which converts the
-            // arguments.
+            // Wrap the provided RawX509Verifier impl in a shim which converts
+            // the arguments.
             #[derive(Debug)]
             struct X509VerifyImpl(Arc<dyn RawX509Verifier>);
             impl matrix_sdk_base::crypto::x509::RawX509Verifier for X509VerifyImpl {

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -82,7 +82,8 @@ impl From<matrix_sdk::Error> for ClientError {
                     match &api_error.body {
                         ErrorBody::Standard(StandardErrorBody { kind, message, .. }) => {
                             let Ok(ffi_error_kind) = kind.clone().try_into() else {
-                                // We couldn't parse the API error, so we return a generic one
+                                // We couldn't parse the API error, so we return
+                                // a generic one
                                 // instead
                                 return (*http_error).into();
                             };
@@ -891,8 +892,8 @@ impl TryFrom<RumaApiErrorKind> for ErrorKind {
                 })
             }
             RumaApiErrorKind::_Custom(_) => {
-                // There is no way to map the extra values since they're private, so we omit
-                // them
+                // There is no way to map the extra values since they're
+                // private, so we omit them
                 Ok(ErrorKind::Custom { errcode: value.errcode().to_string() })
             }
             // In any other case, return it as the mapping not being yet implemented

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -512,8 +512,8 @@ impl NotificationSettings {
             return Ok(RoomNotificationSettings::new(mode.into(), false));
         }
 
-        // If the user has not defined a notification mode, return the default one for
-        // this room
+        // If the user has not defined a notification mode, return the default
+        // one for this room
         let mode = notification_settings
             .get_default_room_notification_mode(is_encrypted.into(), is_one_to_one.into())
             .await;

--- a/bindings/matrix-sdk-ffi/src/password_strength.rs
+++ b/bindings/matrix-sdk-ffi/src/password_strength.rs
@@ -428,8 +428,8 @@ mod tests {
         assert!(strong.feedback.is_none(), "expected no feedback for a strong password");
     }
 
-    // The same thresholds values passed into the constructor are retrievable via
-    // `thresholds()`
+    // The same thresholds values passed into the constructor are retrievable
+    // via `thresholds()`
     #[test]
     fn test_thresholds_roundtrip() {
         let thresholds =

--- a/bindings/matrix-sdk-ffi/src/platform/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/mod.rs
@@ -563,8 +563,9 @@ impl TracingConfiguration {
 
                     // Add a Sentry layer to the tracing subscriber.
                     //
-                    // Pass custom event and span filters, which will ignore anything, if the Sentry
-                    // support has been globally disabled, or if the statement doesn't include a
+                    // Pass custom event and span filters, which will ignore
+                    // anything, if the Sentry support has been
+                    // globally disabled, or if the statement doesn't include a
                     // `sentry` field set to `true`.
                     let sentry_layer = sentry_tracing::layer()
                         .event_filter({
@@ -631,10 +632,11 @@ impl TracingConfiguration {
 }
 
 fn build_tracing_filter(config: &TracingConfiguration) -> String {
-    // We are intentionally not setting a global log level because we don't want to
-    // risk third party crates logging sensitive information.
+    // We are intentionally not setting a global log level because we don't want
+    // to risk third party crates logging sensitive information.
     // As such we need to make sure that panics will be properly logged.
-    // On 2025-01-08, `log_panics` uses the `panic` target, at the error log level.
+    // On 2025-01-08, `log_panics` uses the `panic` target, at the error log
+    // level.
     let mut filters = vec!["panic=error".to_owned()];
 
     let global_level = config.log_level;
@@ -644,10 +646,12 @@ fn build_tracing_filter(config: &TracingConfiguration) -> String {
             // If the target is immutable, keep the log level.
             *default_level
         } else if config.trace_log_packs.iter().any(|pack| pack.targets().contains(target)) {
-            // If a log pack includes that target, set the associated log level to TRACE.
+            // If a log pack includes that target, set the associated log level
+            // to TRACE.
             LogLevel::Trace
         } else if *default_level > global_level {
-            // If the default level is more verbose than the global level, keep the default.
+            // If the default level is more verbose than the global level, keep
+            // the default.
             *default_level
         } else {
             // Otherwise, use the global level.
@@ -712,7 +716,8 @@ pub fn enable_sentry_logging(enabled: bool) {
             warn!("Sentry logging is not enabled");
         }
     } else {
-        // Can't use log statements here, since logging hasn't been enabled yet 🧠
+        // Can't use log statements here, since logging hasn't been enabled yet
+        // 🧠
         eprintln!("Logging hasn't been enabled yet");
     };
 }
@@ -771,7 +776,8 @@ fn setup_lightweight_tokio_runtime() {
         let num_available_cores =
             std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
 
-        // The number of worker threads will be either that or 4, whichever is smaller.
+        // The number of worker threads will be either that or 4, whichever is
+        // smaller.
         let num_worker_threads = num_available_cores.min(4);
 
         // Chosen by a fair dice roll.

--- a/bindings/matrix-sdk-ffi/src/platform/rolling_writer.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/rolling_writer.rs
@@ -579,8 +579,8 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let log_path = temp_dir.path();
 
-        // Manually create several log files with different timestamps (alphabetically
-        // sorted = oldest first) Total of 240 bytes
+        // Manually create several log files with different timestamps
+        // (alphabetically sorted = oldest first) Total of 240 bytes
         std::fs::write(log_path.join("total.2024-01-01-10-00.log"), "x".repeat(80)).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
         std::fs::write(log_path.join("total.2024-01-01-10-01.log"), "y".repeat(80)).unwrap();
@@ -673,7 +673,8 @@ mod tests {
 
     #[test]
     fn test_time_based_rotation_logic() {
-        // Test that the rotation logic correctly identifies when rotation is needed
+        // Test that the rotation logic correctly identifies when rotation is
+        // needed
         let temp_dir = tempdir().unwrap();
         let log_path = temp_dir.path();
 
@@ -735,8 +736,8 @@ mod tests {
         )
         .unwrap();
 
-        // The old file should still exist because we can't manipulate mtime easily
-        // But we verify that cleanup doesn't crash
+        // The old file should still exist because we can't manipulate mtime
+        // easily But we verify that cleanup doesn't crash
         writer.trim().unwrap();
 
         // Verify we can still write

--- a/bindings/matrix-sdk-ffi/src/platform/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/platform/tracing.rs
@@ -165,7 +165,8 @@ impl Span {
         let metadata = callsite.metadata();
 
         let span = if span_or_event_enabled(callsite) {
-            // This function is hidden from docs, but we have to use it (see above).
+            // This function is hidden from docs, but we have to use it (see
+            // above).
             let fields = metadata.fields();
 
             if let Some(parent_trace_id) = bridge_trace_id {

--- a/bindings/matrix-sdk-ffi/src/qr_code.rs
+++ b/bindings/matrix-sdk-ffi/src/qr_code.rs
@@ -81,8 +81,8 @@ impl LoginWithQrCodeHandler {
 
         let mut progress = login.subscribe_to_progress();
 
-        // We create this task, which will get cancelled once it's dropped, just in case
-        // the progress stream doesn't end.
+        // We create this task, which will get cancelled once it's dropped, just
+        // in case the progress stream doesn't end.
         let _progress_task = TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(state) = progress.next().await {
                 progress_listener.on_update(state.into());
@@ -125,8 +125,8 @@ impl LoginWithQrCodeHandler {
 
         let mut progress = login.subscribe_to_progress();
 
-        // We create this task, which will get cancelled once it's dropped, just in case
-        // the progress stream doesn't end.
+        // We create this task, which will get cancelled once it's dropped, just
+        // in case the progress stream doesn't end.
         let _progress_task = TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(state) = progress.next().await {
                 progress_listener.on_update(state.into());
@@ -181,8 +181,8 @@ impl GrantLoginWithQrCodeHandler {
 
         let mut progress = grant.subscribe_to_progress();
 
-        // We create this task, which will get cancelled once it's dropped, just in case
-        // the progress stream doesn't end.
+        // We create this task, which will get cancelled once it's dropped, just
+        // in case the progress stream doesn't end.
         let _progress_task = TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(state) = progress.next().await {
                 progress_listener.on_update(state.into());
@@ -219,8 +219,8 @@ impl GrantLoginWithQrCodeHandler {
 
         let mut progress = grant.subscribe_to_progress();
 
-        // We create this task, which will get cancelled once it's dropped, just in case
-        // the progress stream doesn't end.
+        // We create this task, which will get cancelled once it's dropped, just
+        // in case the progress stream doesn't end.
         let _progress_task = TaskHandle::new(get_runtime_handle().spawn(async move {
             while let Some(state) = progress.next().await {
                 progress_listener.on_update(state.into());

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -213,24 +213,26 @@ impl RoomList {
 
         // The following code deserves a bit of explanation.
         // `matrix_sdk_ui::room_list_service::RoomList::entries_with_dynamic_adapters`
-        // returns a `Stream` with a lifetime bounds to its `self` (`RoomList`). This is
-        // problematic here as this `Stream` is returned as part of
-        // `RoomListEntriesWithDynamicAdaptersResult` but it is not possible to store
-        // `RoomList` with it inside the `Future` that is run inside the `TaskHandle`
-        // that consumes this `Stream`. We have a lifetime issue: `RoomList` doesn't
+        // returns a `Stream` with a lifetime bounds to its `self` (`RoomList`).
+        // This is problematic here as this `Stream` is returned as part
+        // of `RoomListEntriesWithDynamicAdaptersResult` but it is not
+        // possible to store `RoomList` with it inside the `Future` that
+        // is run inside the `TaskHandle` that consumes this `Stream`.
+        // We have a lifetime issue: `RoomList` doesn't
         // live long enough!
         //
         // To solve this issue, the trick is to store the `RoomList` inside the
-        // `RoomListEntriesWithDynamicAdaptersResult`. Alright, but then we have another
-        // lifetime issue! `RoomList` cannot move inside this struct because it is
-        // borrowed by `entries_with_dynamic_adapters`. Indeed, the struct is built
+        // `RoomListEntriesWithDynamicAdaptersResult`. Alright, but then we have
+        // another lifetime issue! `RoomList` cannot move inside this
+        // struct because it is borrowed by
+        // `entries_with_dynamic_adapters`. Indeed, the struct is built
         // after the `Stream` is obtained.
         //
-        // To solve this issue, we need to build the struct field by field, starting
-        // with `this`, and use a reference to `this` to call
+        // To solve this issue, we need to build the struct field by field,
+        // starting with `this`, and use a reference to `this` to call
         // `entries_with_dynamic_adapters`. This is unsafe because a couple of
-        // invariants must hold, but all this is legal and correct if the invariants are
-        // properly fulfilled.
+        // invariants must hold, but all this is legal and correct if the
+        // invariants are properly fulfilled.
 
         // Create the struct result with uninitialized fields.
         let mut result = MaybeUninit::<RoomListEntriesWithDynamicAdaptersResult>::uninit();
@@ -238,7 +240,8 @@ impl RoomList {
 
         // Initialize the first field `this`.
         //
-        // SAFETY: `ptr` is correctly aligned, this is guaranteed by `MaybeUninit`.
+        // SAFETY: `ptr` is correctly aligned, this is guaranteed by
+        // `MaybeUninit`.
         unsafe {
             addr_of_mut!((*ptr).this).write(this);
         }
@@ -252,14 +255,15 @@ impl RoomList {
                 // SAFETY: `this` contains a non null value.
                 .unwrap();
 
-        // Now we can create `entries_stream` and `dynamic_entries_controller` by
-        // borrowing `this`, which is going to live long enough since it will live as
-        // long as `entries_stream` and `dynamic_entries_controller`.
+        // Now we can create `entries_stream` and `dynamic_entries_controller`
+        // by borrowing `this`, which is going to live long enough since
+        // it will live as long as `entries_stream` and
+        // `dynamic_entries_controller`.
         let (entries_stream, dynamic_entries_controller) =
             this.inner.entries_with_dynamic_adapters(page_size.try_into().unwrap());
 
-        // FFI dance to make those values consumable by foreign language, nothing fancy
-        // here, that's the real code for this method.
+        // FFI dance to make those values consumable by foreign language,
+        // nothing fancy here, that's the real code for this method.
         let dynamic_entries_controller =
             Arc::new(RoomListDynamicEntriesController::new(dynamic_entries_controller));
 
@@ -298,8 +302,8 @@ impl RoomList {
 
         // The result is complete, let's return it!
         //
-        // SAFETY: `result` is fully initialized, all its fields have received a valid
-        // value.
+        // SAFETY: `result` is fully initialized, all its fields have received a
+        // valid value.
         Arc::new(unsafe { result.assume_init() })
     }
 

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -257,9 +257,10 @@ impl SessionVerificationController {
                 return;
             }
         } else if !cross_signing_status.as_ref().is_some_and(|status| status.has_self_signing) {
-            // Signing one of our own devices needs the private self-signing key. Not
-            // having it is only fine while we are the session that is about to be
-            // verified. If we are already verified the flow could only fail, so
+            // Signing one of our own devices needs the private self-signing
+            // key. Not having it is only fine while we are the
+            // session that is about to be verified. If we are
+            // already verified the flow could only fail, so
             // don't surface the request at all.
             let we_are_verified = self
                 .encryption
@@ -421,8 +422,8 @@ impl SessionVerificationController {
                     break;
                 }
                 SasState::Cancelled(_cancel_info) => {
-                    // TODO: The cancel_info is usable, we should tell the user why we were
-                    // cancelled.
+                    // TODO: The cancel_info is usable, we should tell the user
+                    // why we were cancelled.
                     if let Some(current_delegate) = Self::current_delegate(&delegate) {
                         current_delegate.did_cancel()
                     }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -288,14 +288,15 @@ impl Timeline {
     pub async fn add_listener(&self, listener: Box<dyn TimelineListener>) -> Arc<TaskHandle> {
         let (timeline_items, timeline_stream) = self.inner.subscribe().await;
 
-        // It's important that the initial items are passed *before* we forward the
-        // stream updates, with a guaranteed ordering. Otherwise, it could
-        // be that the listener be called before the initial items have been
-        // handled by the caller. See #3535 for details.
+        // It's important that the initial items are passed *before* we forward
+        // the stream updates, with a guaranteed ordering. Otherwise, it
+        // could be that the listener be called before the initial items
+        // have been handled by the caller. See #3535 for details.
 
-        // Note we pass initial items as a reset update, as a way to give the callers a
-        // unified way to handle the initial batch of items as well as other
-        // batches, instead of having a separate callback for the initial items.
+        // Note we pass initial items as a reset update, as a way to give the
+        // callers a unified way to handle the initial batch of items as
+        // well as other batches, instead of having a separate callback
+        // for the initial items.
         listener.on_update(vec![TimelineDiff::new(VectorDiff::Reset { values: timeline_items })]);
 
         Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
@@ -330,9 +331,9 @@ impl Timeline {
 
         // Send the current state even if it hasn't changed right away.
         //
-        // Note: don't do it in the spawned function, so that the caller is immediately
-        // aware of the current state, and this doesn't depend on the async runtime
-        // having an available worker
+        // Note: don't do it in the spawned function, so that the caller is
+        // immediately aware of the current state, and this doesn't
+        // depend on the async runtime having an available worker
         listener.on_update(initial);
 
         Ok(Arc::new(TaskHandle::new(get_runtime_handle().spawn(async move {
@@ -580,8 +581,9 @@ impl Timeline {
             Ok(()) => Ok(()),
 
             Err(timeline::Error::EventNotInTimeline(_)) => {
-                // If we couldn't edit, assume it was an (remote) event that wasn't in the
-                // timeline, and try to edit it via the room itself.
+                // If we couldn't edit, assume it was an (remote) event that
+                // wasn't in the timeline, and try to edit it
+                // via the room itself.
                 let event_id = match event_or_transaction_id {
                     EventOrTransactionId::EventId { event_id } => EventId::parse(event_id)?,
                     EventOrTransactionId::TransactionId { .. } => {

--- a/bindings/matrix-sdk-ffi/src/utd.rs
+++ b/bindings/matrix-sdk-ffi/src/utd.rs
@@ -39,8 +39,8 @@ impl UnableToDecryptHook for UtdHook {
     fn on_utd(&self, info: SdkUnableToDecryptInfo) {
         const IGNORE_UTD_PERIOD: Duration = Duration::from_secs(4);
 
-        // UTDs that have been decrypted in the `IGNORE_UTD_PERIOD` are just ignored and
-        // not considered UTDs.
+        // UTDs that have been decrypted in the `IGNORE_UTD_PERIOD` are just
+        // ignored and not considered UTDs.
         if let Some(duration) = &info.time_to_decrypt
             && *duration < IGNORE_UTD_PERIOD
         {

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -515,15 +515,15 @@ mod tests {
 
         // We test two things:
 
-        // Converting the WidgetCapability (ffi struct) to Capabilities (rust sdk
-        // struct)
+        // Converting the WidgetCapability (ffi struct) to Capabilities (rust
+        // sdk struct)
         let cap = Into::<Capabilities>::into(widget_cap);
         // Converting Capabilities (rust sdk struct) to a json list.
         let cap_json_repr = serde_json::to_string(&cap).unwrap();
 
-        // Converting to a Vec<String> allows to check if the required elements exist
-        // without breaking the test each time the order of permissions might
-        // change.
+        // Converting to a Vec<String> allows to check if the required elements
+        // exist without breaking the test each time the order of
+        // permissions might change.
         let permission_array: Vec<String> = serde_json::from_str(&cap_json_repr).unwrap();
 
         let cap_assert = |capability: &str| {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -451,8 +451,8 @@ impl BaseClient {
         if room.state() != RoomState::Knocked {
             let store_guard = self.state_store.lock().lock().await;
 
-            // We are no longer joined to the room, so the invite acceptance details are no
-            // longer relevant.
+            // We are no longer joined to the room, so the invite acceptance
+            // details are no longer relevant.
             #[cfg(feature = "e2e-encryption")]
             if let Some(olm_machine) = self.olm_machine().await.as_ref() {
                 olm_machine.store().clear_room_pending_key_bundle(room_id).await?
@@ -520,23 +520,26 @@ impl BaseClient {
     ) -> Result<Room> {
         let room = self.state_store.get_or_create_room(room_id, RoomState::Joined);
 
-        // If the state isn't `RoomState::Joined` then this means that we knew about
-        // this room before. Let's modify the existing state now.
+        // If the state isn't `RoomState::Joined` then this means that we knew
+        // about this room before. Let's modify the existing state now.
         if room.state() != RoomState::Joined {
             let store_guard = self.state_store_lock().lock().await;
 
             #[cfg(feature = "e2e-encryption")]
             {
-                // If our previous state was an invite and we're now in the joined state, this
-                // means that the user has explicitly accepted an invite. Let's
-                // remember some details about the invite.
+                // If our previous state was an invite and we're now in the
+                // joined state, this means that the user has
+                // explicitly accepted an invite. Let's remember
+                // some details about the invite.
                 //
-                // This is somewhat of a workaround for our lack of cryptographic membership.
-                // Later on we will decide if historic room keys should be accepted
-                // based on this info. If a user has accepted an invite and we receive a room
-                // key bundle shortly after, we might accept it. If we don't do
-                // this, the homeserver could trick us into accepting any historic room key
-                // bundle.
+                // This is somewhat of a workaround for our lack of
+                // cryptographic membership. Later on we will
+                // decide if historic room keys should be accepted
+                // based on this info. If a user has accepted an invite and we
+                // receive a room key bundle shortly after, we
+                // might accept it. If we don't do
+                // this, the homeserver could trick us into accepting any
+                // historic room key bundle.
                 let previous_state = room.state();
                 if previous_state == RoomState::Invited
                     && let Some(inviter) = inviter
@@ -572,8 +575,8 @@ impl BaseClient {
         if room.state() != RoomState::Left {
             let store_guard = self.state_store.lock().lock().await;
 
-            // We are no longer joined to the room, so the invite acceptance details are no
-            // longer relevant.
+            // We are no longer joined to the room, so the invite acceptance
+            // details are no longer relevant.
             #[cfg(feature = "e2e-encryption")]
             if let Some(olm_machine) = self.olm_machine().await.as_ref() {
                 olm_machine.store().clear_room_pending_key_bundle(room_id).await?
@@ -822,8 +825,9 @@ impl BaseClient {
 
         let mut context = Context::default();
 
-        // Now that all the rooms information have been saved, update the display name
-        // of the updated rooms (which relies on information stored in the database).
+        // Now that all the rooms information have been saved, update the
+        // display name of the updated rooms (which relies on
+        // information stored in the database).
         processors::room::display_name::update_for_rooms(
             &mut context,
             &room_updates,
@@ -879,9 +883,10 @@ impl BaseClient {
     ) -> Result<()> {
         if request.membership.is_some() || request.not_membership.is_some() || request.at.is_some()
         {
-            // This function assumes all members are loaded at once to optimise how display
-            // name disambiguation works. Using it with partial member list results
-            // would produce incorrect disambiguated display name entries
+            // This function assumes all members are loaded at once to optimise
+            // how display name disambiguation works. Using it with
+            // partial member list results would produce incorrect
+            // disambiguated display name entries
             return Err(Error::InvalidReceiveMembersParameters);
         }
 
@@ -908,13 +913,14 @@ impl BaseClient {
                 }
             };
 
-            // TODO: All the actions in this loop used to be done only when the membership
-            // event was not in the store before. This was changed with the new room API,
-            // because e.g. leaving a room makes members events outdated and they need to be
-            // fetched by `members`. Therefore, they need to be overwritten here, even
-            // if they exist.
-            // However, this makes a new problem occur where setting the member events here
-            // potentially races with the sync.
+            // TODO: All the actions in this loop used to be done only when the
+            // membership event was not in the store before. This
+            // was changed with the new room API, because e.g.
+            // leaving a room makes members events outdated and they need to be
+            // fetched by `members`. Therefore, they need to be overwritten
+            // here, even if they exist.
+            // However, this makes a new problem occur where setting the member
+            // events here potentially races with the sync.
             // See <https://github.com/matrix-org/matrix-rust-sdk/issues/1205>.
 
             #[cfg(feature = "e2e-encryption")]
@@ -978,10 +984,12 @@ impl BaseClient {
 
         #[cfg(feature = "e2e-encryption")]
         if let Some(olm) = self.olm_machine().await.as_ref() {
-            // With the introduction of MSC4268, it is no longer sufficient to check for
-            // changes to session recipients when we send a message, since we may miss
-            // join/leave pairs in our view of the room state. Instead, we should rotate
-            // the room key whenever we fully reload the member list as a precaution.
+            // With the introduction of MSC4268, it is no longer sufficient to
+            // check for changes to session recipients when we send
+            // a message, since we may miss join/leave pairs in our
+            // view of the room state. Instead, we should rotate the
+            // room key whenever we fully reload the member list as a
+            // precaution.
             tracing::debug!("Rotating room key due to full member list reload");
             if let Err(e) = olm.discard_room_key(room_id).await {
                 tracing::warn!("Error discarding room key: {e:?}");
@@ -1313,12 +1321,14 @@ impl RequestedRequiredStates {
 
 impl From<&v5::Request> for RequestedRequiredStates {
     fn from(request: &v5::Request) -> Self {
-        // The following information is missing in the MSC4186 at the time of writing
-        // (2025-03-12) but: the `required_state`s from all lists and from all room
-        // subscriptions are combined by doing an union.
+        // The following information is missing in the MSC4186 at the time of
+        // writing (2025-03-12) but: the `required_state`s from all
+        // lists and from all room subscriptions are combined by doing
+        // an union.
         //
         // Thus, we can do the same here, put the union in `default` and keep
-        // `for_rooms` empty. The `Self::for_room` will automatically do the fallback.
+        // `for_rooms` empty. The `Self::for_room` will automatically do the
+        // fallback.
         let mut default = BTreeSet::new();
 
         for list in request.lists.values() {
@@ -1496,7 +1506,8 @@ mod tests {
         {
             let requested_required_states = RequestedRequiredStates::from(&request);
 
-            // Union of state events, all in `default`, still nothing in `for_rooms`.
+            // Union of state events, all in `default`, still nothing in
+            // `for_rooms`.
             assert_eq!(
                 requested_required_states.default,
                 &[
@@ -1524,7 +1535,8 @@ mod tests {
         {
             let requested_required_states = RequestedRequiredStates::from(&request);
 
-            // Union of state events, all in `default`, still nothing in `for_rooms`.
+            // Union of state events, all in `default`, still nothing in
+            // `for_rooms`.
             assert_eq!(
                 requested_required_states.default,
                 &[
@@ -1754,8 +1766,8 @@ mod tests {
             .build_sync_response();
         client.receive_sync_response(response).await.unwrap();
 
-        // When I process the result of a /members request that only contains an invited
-        // member,
+        // When I process the result of a /members request that only contains an
+        // invited member,
         let request = api::membership::get_member_events::v3::Request::new(room_id.to_owned());
 
         let raw_member_event = json!({
@@ -1812,7 +1824,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Preamble: let the SDK know about the room, and that the invited user left it.
+        // Preamble: let the SDK know about the room, and that the invited user
+        // left it.
         let f = EventFactory::new().sender(user_id);
         let mut sync_builder = SyncResponseBuilder::new();
         let response = sync_builder
@@ -2072,8 +2085,8 @@ mod tests {
             .build_sync_response();
         client.receive_sync_response(response).await.unwrap();
 
-        // Let us first check the initial state, we should have a room in the invite
-        // state.
+        // Let us first check the initial state, we should have a room in the
+        // invite state.
         let invited_room = client
             .get_room(known_room_id)
             .expect("The sync should have created a room in the invited state");
@@ -2097,8 +2110,8 @@ mod tests {
         );
         assert_eq!(details.inviter, user_id);
 
-        // If we didn't know about the room before the join, we assume that there wasn't
-        // an invite and we don't record the timestamp.
+        // If we didn't know about the room before the join, we assume that
+        // there wasn't an invite and we don't record the timestamp.
         assert!(client.get_room(unknown_room_id).is_none());
         let unknown_room = client
             .room_joined(unknown_room_id, Some(user_id.to_owned()))

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -196,8 +196,9 @@ impl DisplayName {
         let decancered = decancer::cure!(&replaced).ok().map(|cured| {
             let removed_left_to_right = LEFT_TO_RIGHT_REGEX.replace_all(cured.as_ref(), "");
             let replaced = I_REGEX.replace_all(&removed_left_to_right, "l");
-            // We re-run the dot replacement because decancer normalized a lot of weird
-            // characets into a `.`, it just doesn't do that for /u{1d16d}.
+            // We re-run the dot replacement because decancer normalized a lot
+            // of weird characets into a `.`, it just doesn't do
+            // that for /u{1d16d}.
             let replaced = DOT_REGEX.replace_all(&replaced, ":");
             let replaced = ZERO_REGEX.replace_all(&replaced, "o");
 
@@ -212,7 +213,8 @@ impl DisplayName {
     /// If the display name has cancer (i.e. fails normalisation or has a
     /// different normalised form) or looks like an MXID, then it's ambiguous.
     pub fn is_inherently_ambiguous(&self) -> bool {
-        // If we look like an MXID or have hidden characters then we're ambiguous.
+        // If we look like an MXID or have hidden characters then we're
+        // ambiguous.
         self.looks_like_an_mxid() || self.has_hidden_characters() || self.decancered.is_none()
     }
 
@@ -602,8 +604,9 @@ mod test {
 
     #[test]
     fn test_display_name_inherently_ambiguous() {
-        // These should not be inherently ambiguous, only if another similarly looking
-        // display name appears should they be considered to be ambiguous.
+        // These should not be inherently ambiguous, only if another similarly
+        // looking display name appears should they be considered to be
+        // ambiguous.
         assert_not_ambiguous!("Alice");
         assert_not_ambiguous!("Carol");
         assert_not_ambiguous!("Car0l");

--- a/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/integration_tests.rs
@@ -296,8 +296,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         {
             let first = chunks.next().unwrap();
-            // Note: we can't assert the previous/next chunks, as these fields and their
-            // getters are private.
+            // Note: we can't assert the previous/next chunks, as these fields
+            // and their getters are private.
             assert_eq!(first.identifier(), CId::new(0));
 
             assert_matches!(first.content(), ChunkContent::Items(events) => {
@@ -385,15 +385,16 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
     }
 
     async fn test_linked_chunk_allows_same_event_in_room_and_thread(&self) {
-        // This test verifies that the same event can appear in both a room's linked
-        // chunk and a thread's linked chunk. This is the real-world use case:
-        // a thread reply appears in both the main room timeline and the thread.
+        // This test verifies that the same event can appear in both a room's
+        // linked chunk and a thread's linked chunk. This is the
+        // real-world use case: a thread reply appears in both the main
+        // room timeline and the thread.
 
         let room_id = *DEFAULT_TEST_ROOM_ID;
         let thread_root = event_id!("$thread_root");
 
-        // Create an event that will be inserted into both the room and thread linked
-        // chunks.
+        // Create an event that will be inserted into both the room and thread
+        // linked chunks.
         let event_id = event_id!("$thread_reply");
         let event = make_test_event_with_event_id(room_id, "thread reply", Some(event_id));
 
@@ -422,7 +423,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .await
         .unwrap();
 
-        // Verify both entries exist by loading chunks from both linked chunk IDs.
+        // Verify both entries exist by loading chunks from both linked chunk
+        // IDs.
         let room_chunks = self.load_all_chunks(room_linked_chunk_id).await.unwrap();
         let thread_chunks = self.load_all_chunks(thread_linked_chunk_id).await.unwrap();
 
@@ -855,8 +857,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             assert!(previous_chunk.is_none());
         }
 
-        // One last check: a round of assert by using the forwards chunk iterator
-        // instead of the backwards chunk iterator.
+        // One last check: a round of assert by using the forwards chunk
+        // iterator instead of the backwards chunk iterator.
         {
             let mut chunks = linked_chunk.chunks();
 
@@ -990,7 +992,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         }
 
         let event_b = make_test_event_with_event_id(room_id, "b", Some(event_id!("$b")));
-        // Pushing an event to an occupied position should fail in every linked chunk.
+        // Pushing an event to an occupied position should fail in every linked
+        // chunk.
         for linked_chunk_id in linked_chunk_ids {
             self.handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -1011,8 +1014,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             });
         }
 
-        // Pushing an event to an unoccupied position should succeed in every linked
-        // chunk.
+        // Pushing an event to an unoccupied position should succeed in every
+        // linked chunk.
         for linked_chunk_id in linked_chunk_ids {
             self.handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -1037,8 +1040,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         // Create an updated version of event a
         let updated_event_a = make_test_event_with_event_id(room_id, "updated_a", Some(event_id_a));
 
-        // Pushing an updated event to a position occupied by the same event should
-        // fail in every linked chunk.
+        // Pushing an updated event to a position occupied by the same event
+        // should fail in every linked chunk.
         for linked_chunk_id in linked_chunk_ids {
             self.handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -1060,8 +1063,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             });
         }
 
-        // Pushing an updated event to a position occupied by a different event should
-        // fail in every linked chunk.
+        // Pushing an updated event to a position occupied by a different event
+        // should fail in every linked chunk.
         for linked_chunk_id in linked_chunk_ids {
             self.handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -1083,8 +1086,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             });
         }
 
-        // Pushing an updated event to an unoccupied position in a linked chunk should
-        // fail if the event already exists in the linked chunk.
+        // Pushing an updated event to an unoccupied position in a linked chunk
+        // should fail if the event already exists in the linked chunk.
         for linked_chunk_id in linked_chunk_ids {
             self.handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -1115,9 +1118,9 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .await
         .unwrap();
 
-        // Pushing an updated version of event a to an unoccupied position in the new
-        // linked chunk should succeed and also update the event content across all
-        // linked chunks in all rooms.
+        // Pushing an updated version of event a to an unoccupied position in
+        // the new linked chunk should succeed and also update the event
+        // content across all linked chunks in all rooms.
         self.handle_linked_chunk_updates(
             other_linked_chunk_id,
             vec![Update::PushItems {
@@ -1329,9 +1332,9 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let room_id = *DEFAULT_TEST_ROOM_ID;
         let linked_chunk_id = LinkedChunkId::Room(room_id);
 
-        // Same updates and checks as test_linked_chunk_push_items, but with extra
-        // `StartReattachItems` and `EndReattachItems` updates, which must have no
-        // effects.
+        // Same updates and checks as test_linked_chunk_push_items, but with
+        // extra `StartReattachItems` and `EndReattachItems` updates,
+        // which must have no effects.
         self.handle_linked_chunk_updates(
             linked_chunk_id,
             vec![
@@ -1568,8 +1571,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         for linked_chunk_id in linked_chunk_ids {
             let room_id = linked_chunk_id.room_id();
 
-            // Assume the thread has been “remembered” correctly (this is done in
-            // `ThreadEventCacheState::new`).
+            // Assume the thread has been “remembered” correctly (this is done
+            // in `ThreadEventCacheState::new`).
             if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
                 self.load_thread_info(room_id, thread_id).await.unwrap();
             }
@@ -1652,8 +1655,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         {
             let room_id = linked_chunk_id.room_id();
 
-            // Assume the thread has been “remembered” correctly (this is done in
-            // `ThreadEventCacheState::new`).
+            // Assume the thread has been “remembered” correctly (this is done
+            // in `ThreadEventCacheState::new`).
             if let LinkedChunkId::Thread(_, thread_id) = &linked_chunk_id {
                 self.load_thread_info(room_id, thread_id).await.unwrap();
             }
@@ -1769,8 +1772,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .await
         .unwrap();
 
-        // Add other events in another room, to ensure filtering take the `room_id` into
-        // account.
+        // Add other events in another room, to ensure filtering take the
+        // `room_id` into account.
         self.handle_linked_chunk_updates(
             another_linked_chunk_id,
             vec![
@@ -1869,7 +1872,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
 
         assert_eq!(event.event_id(), event_comte.event_id());
 
-        // Now let's try to find an event that exists, but not in the expected room.
+        // Now let's try to find an event that exists, but not in the expected
+        // room.
         assert!(
             self.find_event(room_id, event_gruyere.event_id().unwrap())
                 .await
@@ -1900,8 +1904,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let thread_event =
             make_test_event_with_event_id(room_id, "thread event", Some(thread_event_id));
 
-        // Create an event that will be inserted into both the room and thread linked
-        // chunks.
+        // Create an event that will be inserted into both the room and thread
+        // linked chunks.
         let room_and_thread_event_id = event_id!("$room_and_thread");
         let room_and_thread_event = make_test_event_with_event_id(
             room_id,
@@ -2034,8 +2038,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             .unwrap();
         assert!(relations.is_empty());
 
-        // But if an event exists in the linked chunk, we may have its position when
-        // it's found as a relationship.
+        // But if an event exists in the linked chunk, we may have its position
+        // when it's found as a relationship.
 
         // Add reaction_e1 to the room's linked chunk.
         self.handle_linked_chunk_updates(
@@ -2067,13 +2071,14 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let room_id = *DEFAULT_TEST_ROOM_ID;
         let thread_root = event_id!("$thread_root");
 
-        // Create an event that will inserted into both the room and thread linked
-        // chunks.
+        // Create an event that will inserted into both the room and thread
+        // linked chunks.
         let event_id = event_id!("$event");
         let event = make_test_event_with_event_id(room_id, "event", Some(event_id));
 
-        // Create an event that will only be inserted into the thread in order to help
-        // distinguish between the room and thread linked chunks.
+        // Create an event that will only be inserted into the thread in order
+        // to help distinguish between the room and thread linked
+        // chunks.
         let extra_thread_event_id = event_id!("$extra_thread_event");
         let extra_thread_event = make_test_event_with_event_id(
             room_id,
@@ -2099,8 +2104,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
             .event_id(thread_reaction_id)
             .into_event();
 
-        // Create a reaction that will be inserted into both the room and thread linked
-        // chunks.
+        // Create a reaction that will be inserted into both the room and thread
+        // linked chunks.
         let room_and_thread_reaction_id = event_id!("$room_and_thread_reaction");
         let room_and_thread_reaction = EventFactory::new()
             .room(room_id)
@@ -2299,8 +2304,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         assert_eq!(events.len(), 2);
         assert_expected_events!(events, [first_event, second_event]);
 
-        // Now let's find all the encrypted events which were encrypted using the first
-        // session ID.
+        // Now let's find all the encrypted events which were encrypted using
+        // the first session ID.
         let events = self
             .get_room_events(room_id, Some("m.room.encrypted"), Some("session_1"))
             .await
@@ -2318,15 +2323,15 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let room_event_id = event_id!("$room_event");
         let room_event = make_test_event_with_event_id(room_id, "room event", Some(room_event_id));
 
-        // Create an event that will only be inserted into the thread. This may not be a
-        // sensible operation in practice, as threads seem to always exist in a
-        // room, but let's test it anyway.
+        // Create an event that will only be inserted into the thread. This may
+        // not be a sensible operation in practice, as threads seem to
+        // always exist in a room, but let's test it anyway.
         let thread_event_id = event_id!("$thread_event");
         let thread_event =
             make_test_event_with_event_id(room_id, "thread event", Some(thread_event_id));
 
-        // Create an event that will be inserted into both the room and thread linked
-        // chunks.
+        // Create an event that will be inserted into both the room and thread
+        // linked chunks.
         let room_and_thread_event_id = event_id!("$room_and_thread");
         let room_and_thread_event = make_test_event_with_event_id(
             room_id,
@@ -2365,8 +2370,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .await
         .unwrap();
 
-        // Verify that all events can be retrieved and none are duplicated in the
-        // returned list.
+        // Verify that all events can be retrieved and none are duplicated in
+        // the returned list.
         let expected_event_ids =
             BTreeSet::from([room_event_id, thread_event_id, room_and_thread_event_id]);
         assert_matches!(self.get_room_events(room_id, None, None).await, Ok(events) => {
@@ -2425,8 +2430,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         let room_id = *DEFAULT_TEST_ROOM_ID;
         let thread_root = event_id!("$thread_root");
 
-        // Create an event that will be inserted into both the room and thread linked
-        // chunks.
+        // Create an event that will be inserted into both the room and thread
+        // linked chunks.
         let event_id = event_id!("$event");
         let event = make_test_event_with_event_id(room_id, "event", Some(event_id));
 
@@ -2455,8 +2460,8 @@ impl EventCacheStoreIntegrationTests for DynEventCacheStore {
         .await
         .unwrap();
 
-        // Save updated version of original event, which should replace the content of
-        // the existing event
+        // Save updated version of original event, which should replace the
+        // content of the existing event
         let updated_content = "updated content";
         let updated = make_test_event_with_event_id(room_id, updated_content, Some(event_id));
         self.save_event(room_id, updated).await.unwrap();

--- a/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/event_cache/store/memory_store.rs
@@ -282,8 +282,8 @@ impl EventCacheStore for MemoryStore {
             .collect();
 
         // Remove any duplicate events which may exist in both a room and thread
-        // linked chunk. Additionally, remove any position information from non-room
-        // linked chunks.
+        // linked chunk. Additionally, remove any position information from
+        // non-room linked chunks.
         let mut deduplicated = HashMap::new();
         for (linked_chunk_id, (event, position)) in related_events {
             let event_id = event

--- a/crates/matrix-sdk-base/src/media/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/media/store/integration_tests.rs
@@ -183,7 +183,8 @@ where
         let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_none());
 
-        // If there are both a cache size and a file size, the minimum value is used.
+        // If there are both a cache size and a file size, the minimum value is
+        // used.
         let policy = MediaRetentionPolicy::empty()
             .with_max_cache_size(Some(200))
             .with_max_file_size(Some(1000));
@@ -479,8 +480,8 @@ where
         let stored = self.get_media_content_inner(&request_small_5, time).await.unwrap();
         assert!(stored.is_some());
 
-        // Cleanup still removes the oldest content first, which is not the same as
-        // before.
+        // Cleanup still removes the oldest content first, which is not the same
+        // as before.
         time += Duration::from_secs(1);
         tracing::info!(?self, "before");
         self.clean_inner(policy, time).await.unwrap();
@@ -598,8 +599,8 @@ where
         let stored = self.get_media_content_inner(&request_5, time).await.unwrap();
         assert!(stored.is_some());
 
-        // We are now at UNIX_EPOCH + 10 seconds, the oldest content was accessed 5
-        // seconds ago.
+        // We are now at UNIX_EPOCH + 10 seconds, the oldest content was
+        // accessed 5 seconds ago.
         time += Duration::from_secs(1);
         assert_eq!(time, SystemTime::UNIX_EPOCH + Duration::from_secs(10));
 
@@ -622,12 +623,13 @@ where
         let stored = self.get_media_content_inner(&request_5, time).await.unwrap();
         assert!(stored.is_some());
 
-        // We are now at UNIX_EPOCH + 16 seconds, the oldest content was accessed 5
-        // seconds ago.
+        // We are now at UNIX_EPOCH + 16 seconds, the oldest content was
+        // accessed 5 seconds ago.
         time += Duration::from_secs(1);
         assert_eq!(time, SystemTime::UNIX_EPOCH + Duration::from_secs(16));
 
-        // Jump 26 seconds in the future, so the 2 first media contents are expired.
+        // Jump 26 seconds in the future, so the 2 first media contents are
+        // expired.
         time += Duration::from_secs(26);
 
         // Cleanup removes the two oldest media contents.
@@ -675,11 +677,13 @@ where
             format: MediaFormat::File,
         };
 
-        // A policy that will result in only one media content in the cache, which is
-        // the average or small content, depending on the last access time.
+        // A policy that will result in only one media content in the cache,
+        // which is the average or small content, depending on the last
+        // access time.
         let policy = MediaRetentionPolicy::empty().with_max_cache_size(Some(150));
 
-        // Try to add all the big content without ignoring the policy, it should fail.
+        // Try to add all the big content without ignoring the policy, it should
+        // fail.
         let mut time = SystemTime::UNIX_EPOCH;
         self.add_media_content_inner(
             &request_big,
@@ -694,7 +698,8 @@ where
         let stored = self.get_media_content_inner(&request_big, time).await.unwrap();
         assert!(stored.is_none());
 
-        // Try to add it again but ignore the policy this time, it should succeed.
+        // Try to add it again but ignore the policy this time, it should
+        // succeed.
         time += Duration::from_secs(1);
         self.add_media_content_inner(
             &request_big,
@@ -740,12 +745,14 @@ where
         let stored = self.get_media_content_inner(&request_avg, time).await.unwrap();
         assert!(stored.is_some());
 
-        // Ignore the average content for now so the max cache size is not reached.
+        // Ignore the average content for now so the max cache size is not
+        // reached.
         self.set_ignore_media_retention_policy_inner(&request_avg, IgnoreMediaRetentionPolicy::Yes)
             .await
             .unwrap();
 
-        // Because the big and average contents are ignored, cleanup has no effect.
+        // Because the big and average contents are ignored, cleanup has no
+        // effect.
         time += Duration::from_secs(1);
         self.clean_inner(policy, time).await.unwrap();
 
@@ -778,7 +785,8 @@ where
         assert!(stored.is_none());
 
         // Stop ignoring the average media. Since the cache size is bigger than
-        // the max, the content that was not the last accessed should be cleaned up.
+        // the max, the content that was not the last accessed should be cleaned
+        // up.
         self.set_ignore_media_retention_policy_inner(&request_avg, IgnoreMediaRetentionPolicy::No)
             .await
             .unwrap();

--- a/crates/matrix-sdk-base/src/media/store/media_service.rs
+++ b/crates/matrix-sdk-base/src/media/store/media_service.rs
@@ -572,8 +572,9 @@ mod tests {
             _policy: MediaRetentionPolicy,
             current_time: SystemTime,
         ) -> Result<(), Self::Error> {
-            // This is mostly a noop. We don't care about this test implementation, only
-            // whether this method was called with the right time.
+            // This is mostly a noop. We don't care about this test
+            // implementation, only whether this method was called
+            // with the right time.
             self.inner().cleanup_time = Some(current_time);
 
             Ok(())
@@ -667,7 +668,8 @@ mod tests {
         let media_content = store.inner().media_list[0].clone();
         assert!(media_content.ignore_policy);
 
-        // Try a cleanup. With the empty policy the store should not be accessed.
+        // Try a cleanup. With the empty policy the store should not be
+        // accessed.
         assert_eq!(store.last_media_cleanup_time_inner().await.unwrap(), None);
         store.reset_accessed();
 
@@ -715,8 +717,8 @@ mod tests {
 
         store.reset_accessed();
 
-        // Add small media, it should work because its size is lower than the max file
-        // size.
+        // Add small media, it should work because its size is lower than the
+        // max file size.
         service
             .add_media_content(
                 &store,
@@ -755,7 +757,8 @@ mod tests {
         service.inner.time_provider.set_now(now);
         store.reset_accessed();
 
-        // Add big media, it will not work because it is bigger than the max file size.
+        // Add big media, it will not work because it is bigger than the max
+        // file size.
         service
             .add_media_content(
                 &store,
@@ -880,8 +883,8 @@ mod tests {
 
         assert_eq!(store.last_media_cleanup_time_inner().await.unwrap(), Some(now));
 
-        // Try again one minute in the future, nothing is spawned because we need to
-        // wait for one hour.
+        // Try again one minute in the future, nothing is spawned because we
+        // need to wait for one hour.
         let now = now + Duration::from_secs(60);
         service.inner.time_provider.set_now(now);
         service.get_media_content(&store, &request_1).await.unwrap();

--- a/crates/matrix-sdk-base/src/media/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/media/store/memory_store.rs
@@ -77,7 +77,8 @@ const NUMBER_OF_MEDIAS: NonZeroUsize = NonZeroUsize::new(20).unwrap();
 
 impl Default for MemoryMediaStore {
     fn default() -> Self {
-        // Given that the store is empty, we won't need to clean it up right away.
+        // Given that the store is empty, we won't need to clean it up right
+        // away.
         let last_media_cleanup_time = SystemTime::now();
         let media_service = MediaService::new();
         media_service.restore(None, Some(last_media_cleanup_time));
@@ -181,7 +182,8 @@ impl MediaStore for MemoryMediaStore {
             .filter_map(|(position, media_content)| (media_content.uri == uri).then_some(position))
             .collect::<Vec<_>>();
 
-        // Iterate in reverse-order so that positions stay valid after first removals.
+        // Iterate in reverse-order so that positions stay valid after first
+        // removals.
         for position in positions.into_iter().rev() {
             inner.media.remove(position);
         }
@@ -303,8 +305,8 @@ impl MediaStoreInner for MemoryMediaStore {
         let mut inner = self.inner.write().unwrap();
         let expected_key = request.unique_key();
 
-        // First get the content out of the buffer, we are going to put it back at the
-        // end.
+        // First get the content out of the buffer, we are going to put it back
+        // at the end.
         let Some(index) = inner.media.iter().position(|media| media.key == expected_key) else {
             return Ok(None);
         };
@@ -351,10 +353,12 @@ impl MediaStoreInner for MemoryMediaStore {
             });
         }
 
-        // Finally, if the cache size is too big, remove old items until it fits.
+        // Finally, if the cache size is too big, remove old items until it
+        // fits.
         if let Some(max_cache_size) = policy.max_cache_size {
-            // Reverse the iterator because in case the cache size is overflowing, we want
-            // to count the number of old items to remove. Items are sorted by last access
+            // Reverse the iterator because in case the cache size is
+            // overflowing, we want to count the number of old items
+            // to remove. Items are sorted by last access
             // and old items are at the start.
             let (_, items_to_remove) = inner.media.iter().enumerate().rev().fold(
                 (0u64, Vec::with_capacity(NUMBER_OF_MEDIAS.into())),
@@ -368,16 +372,19 @@ impl MediaStoreInner for MemoryMediaStore {
                         // We have not reached the max cache size yet.
                         if let Some(sum) = cache_size.checked_add(content.data.len() as u64) {
                             cache_size = sum;
-                            // Start removing items if we have exceeded the max cache size.
+                            // Start removing items if we have exceeded the max
+                            // cache size.
                             cache_size > max_cache_size
                         } else {
-                            // The cache size is overflowing, remove the remaining items, since the
+                            // The cache size is overflowing, remove the
+                            // remaining items, since the
                             // max cache size cannot be bigger than
                             // usize::MAX.
                             true
                         }
                     } else {
-                        // We have reached the max cache size already, just remove it.
+                        // We have reached the max cache size already, just
+                        // remove it.
                         true
                     };
 
@@ -389,8 +396,8 @@ impl MediaStoreInner for MemoryMediaStore {
                 },
             );
 
-            // The indexes are already in reverse order so we can just iterate in that order
-            // to remove them starting by the end.
+            // The indexes are already in reverse order so we can just iterate
+            // in that order to remove them starting by the end.
             for index in items_to_remove {
                 inner.media.remove(index);
             }

--- a/crates/matrix-sdk-base/src/response_processors/changes.rs
+++ b/crates/matrix-sdk-base/src/response_processors/changes.rs
@@ -97,8 +97,9 @@ fn apply_changes(
                 let user_ids: Vec<String> =
                     event.content.ignored_users.keys().map(|id| id.to_string()).collect();
 
-                // Try to only trigger the observable if the ignored user list has changed,
-                // from the previous time we've seen it. If we couldn't load the previous event
+                // Try to only trigger the observable if the ignored user list
+                // has changed, from the previous time we've
+                // seen it. If we couldn't load the previous event
                 // for any reason, always trigger.
                 if let Some(prev_user_ids) =
                     previous_ignored_user_list.and_then(|raw| raw.deserialize().ok()).map(|event| {

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -112,10 +112,10 @@ async fn process(
 
         Output { processed_to_device_events: events }
     } else {
-        // If we have no `OlmMachine`, just return the clear events that were passed in.
-        // The encrypted ones are dropped as they are un-usable.
-        // This should not happen unless we forget to set things up by calling
-        // `Self::activate()`.
+        // If we have no `OlmMachine`, just return the clear events that were
+        // passed in. The encrypted ones are dropped as they are
+        // un-usable. This should not happen unless we forget to set
+        // things up by calling `Self::activate()`.
         Output {
             processed_to_device_events: encryption_sync_changes
                 .to_device_events

--- a/crates/matrix-sdk-base/src/response_processors/profiles.rs
+++ b/crates/matrix-sdk-base/src/response_processors/profiles.rs
@@ -32,9 +32,9 @@ pub fn upsert_or_delete(
     // Senders can fake the profile easily so we keep track of profiles that the
     // member set themselves to avoid having confusing profile changes when a
     // member gets kicked/banned.
-    // We don't want to update the profile if the member is leaving the room, as the
-    // server may return a dummy empty profile along the leave event. We want to
-    // keep the last known profile in that case.
+    // We don't want to update the profile if the member is leaving the room, as
+    // the server may return a dummy empty profile along the leave event. We
+    // want to keep the last known profile in that case.
     if event.state_key() == event.sender() && *event.membership() != MembershipState::Leave {
         context
             .state_changes
@@ -47,10 +47,11 @@ pub fn upsert_or_delete(
     if matches!(*event.membership(), MembershipState::Invite | MembershipState::Ban) {
         // Remove any profile previously stored for the invited/banned user.
         //
-        // A room member could have joined the room and left it later; in that case, the
-        // server may return a dummy, empty profile along the `leave` event. We
-        // don't want to reuse that empty profile when the member has been
-        // re-invited, so we remove it from the database.
+        // A room member could have joined the room and left it later; in that
+        // case, the server may return a dummy, empty profile along the
+        // `leave` event. We don't want to reuse that empty profile when
+        // the member has been re-invited, so we remove it from the
+        // database.
         context
             .state_changes
             .profiles_to_delete
@@ -59,8 +60,8 @@ pub fn upsert_or_delete(
             .push(event.state_key().clone());
 
         // Address the edge case of "in-flight" profiles. If an earlier event in
-        // this same sync batch inserted a profile (for example user joined then got
-        // banned by an admin of a room), we MUST NOT reinsert it.
+        // this same sync batch inserted a profile (for example user joined then
+        // got banned by an admin of a room), we MUST NOT reinsert it.
         if let Some(room_profiles) = context.state_changes.profiles.get_mut(room_id) {
             room_profiles.remove(event.state_key());
         }

--- a/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/display_name.rs
@@ -28,8 +28,8 @@ pub async fn update_for_rooms(
     let _timer = timer!(tracing::Level::TRACE, "display_name::update_for_rooms");
 
     for room in room_updates.iter_all_room_ids().filter_map(|room_id| state_store.room(room_id)) {
-        // Compute the display name. If it's different, let's register the `RoomInfo` in
-        // the `StateChanges`.
+        // Compute the display name. If it's different, let's register the
+        // `RoomInfo` in the `StateChanges`.
         if let Ok(UpdatedRoomDisplayName::New(_)) = room.compute_display_name().await {
             let room_id = room.room_id().to_owned();
 

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -177,8 +177,8 @@ pub async fn update_any_room(
     match (room_info.state(), maybe_room_update_kind) {
         (RoomState::Joined, None) => {
             // Ephemeral events are added separately, because we might not
-            // have a room subsection in the response, yet we may have receipts for
-            // that room.
+            // have a room subsection in the response, yet we may have receipts
+            // for that room.
             let ephemeral = Vec::new();
 
             Ok(Some((
@@ -241,8 +241,8 @@ fn membership(
     //
     // Let's find out.
     if let Some(state_events) = invite_state_events {
-        // We need to find the membership event since it could be for either an invited
-        // or knocked room.
+        // We need to find the membership event since it could be for either an
+        // invited or knocked room.
         let own_membership = state_events.iter_mut().find_map(|raw_event| {
             if raw_event.event_type == StateEventType::RoomMember
                 && raw_event.state_key == user_id.as_str()
@@ -292,16 +292,18 @@ fn membership(
         let room = store.get_or_create_room(room_id, RoomState::Joined);
         let mut room_info = room.clone_info();
 
-        // We default to considering this room joined if it's not an invite. If it's
-        // actually left (and we remembered to request membership events in our sync
-        // request), then we can find this out from the events in required_state by
+        // We default to considering this room joined if it's not an invite. If
+        // it's actually left (and we remembered to request membership
+        // events in our sync request), then we can find this out from
+        // the events in required_state by
         // calling handle_own_room_membership.
         room_info.mark_as_joined();
 
-        // We don't need to do this in a v2 sync, because the membership of a room can
-        // be figured out by whether the room is in the `join`, `leave` etc. property.
-        // In sliding sync we only have `invite_state`, `required_state` and `timeline`,
-        // so we must process `required_state` and `timeline` looking for relevant
+        // We don't need to do this in a v2 sync, because the membership of a
+        // room can be figured out by whether the room is in the `join`,
+        // `leave` etc. property. In sliding sync we only have
+        // `invite_state`, `required_state` and `timeline`, so we must
+        // process `required_state` and `timeline` looking for relevant
         // membership events.
         state_events::sync::own_membership_and_update_room_state(
             context,
@@ -335,8 +337,8 @@ fn properties(
         JsOption::Undefined => {}
     }
 
-    // Sliding sync doesn't have a room summary, nevertheless it contains the joined
-    // and invited member counts, in addition to the heroes.
+    // Sliding sync doesn't have a room summary, nevertheless it contains the
+    // joined and invited member counts, in addition to the heroes.
     if let Some(count) = room_response.joined_count {
         room_info.update_joined_member_count(count.into());
     }
@@ -370,8 +372,8 @@ fn properties(
             room_info.update_recency_stamp(recency_stamp);
 
             // If it's not a new room, let's emit a `RECENCY_STAMP` update.
-            // For a new room, the room will appear as new, so we don't care about this
-            // update.
+            // For a new room, the room will appear as new, so we don't care
+            // about this update.
             if !is_new_room {
                 context
                     .room_info_notable_updates

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -141,7 +141,8 @@ pub mod sync {
                         room_info.handle_state_event(&mut raw_event);
                     } else {
                         // Do not add the event to `room_info`.
-                        // Do not add the event to `context.state_changes.state`.
+                        // Do not add the event to
+                        // `context.state_changes.state`.
                         continue;
                     }
                 }
@@ -233,9 +234,9 @@ pub mod sync {
         state_events: &mut [RawStateEventWithKeys<AnySyncStateEvent>],
         room_info: &mut RoomInfo,
     ) {
-        // Start from the last event; the first membership event we see in that order is
-        // the last in the regular order, so that's the only one we need to
-        // consider.
+        // Start from the last event; the first membership event we see in that
+        // order is the last in the regular order, so that's the only
+        // one we need to consider.
         if let Some(member) = state_events.iter_mut().rev().find_map(|event| {
             // Find the event that updates the current user's membership.
             if event.event_type == StateEventType::RoomMember
@@ -365,9 +366,9 @@ pub mod stripped {
         user_id: &UserId,
         raw_state_events: &[RawStateEventWithKeys<AnyStrippedStateEvent>],
     ) {
-        // Start from the last event; the first membership event we see in that order is
-        // the last in the regular order, so that's the only one we need to
-        // consider.
+        // Start from the last event; the first membership event we see in that
+        // order is the last in the regular order, so that's the only
+        // one we need to consider.
         if raw_state_events.iter().rev().any(|raw_event| {
             // Find the event that updates the current user's membership.
             raw_event.event_type == StateEventType::RoomMember
@@ -416,9 +417,9 @@ pub fn validate_create_event_predecessor(
     };
 
     loop {
-        // We must check immediately if the `predecessor_room_id` is in `already_seen`
-        // in case of a room is created and marks itself as its predecessor in a single
-        // sync.
+        // We must check immediately if the `predecessor_room_id` is in
+        // `already_seen` in case of a room is created and marks itself
+        // as its predecessor in a single sync.
         if already_seen.contains(&predecessor_room_id) {
             // Ahhh, there is a loop with `m.room.create` events!
             // We remove the predecessor so that we don't process it later.
@@ -478,8 +479,9 @@ pub fn is_tombstone_event_valid(
     let mut successor_room_id = tombstone.replacement_room.clone();
 
     loop {
-        // We must check immediately if the `successor_room_id` is in `already_seen` in
-        // case of a room is created and tombstones itself in a single sync.
+        // We must check immediately if the `successor_room_id` is in
+        // `already_seen` in case of a room is created and tombstones
+        // itself in a single sync.
         if already_seen.contains(AsRef::<RoomId>::as_ref(&successor_room_id)) {
             // Ahhh, there is a loop with `m.room.tombstone` events!
             error!(?room_id, ?tombstone, "`m.room.tombstone` event is invalid, it creates a loop");
@@ -488,7 +490,8 @@ pub fn is_tombstone_event_valid(
 
         already_seen.insert(successor_room_id.clone());
 
-        // Where is the successor room? Check in `room_infos` and then in `state_store`.
+        // Where is the successor room? Check in `room_infos` and then in
+        // `state_store`.
         let Some(next_successor_room_id) = context
             .state_changes
             .room_infos
@@ -800,8 +803,8 @@ mod tests {
         let sender = user_id!("@mnt_io:matrix.org");
         let event_factory = EventFactory::new().sender(sender);
         let mut response_builder = SyncResponseBuilder::new();
-        // The room IDs are important because `SyncResponseBuilder` stores them in a
-        // `HashMap`, so they are going to be “shuffled”.
+        // The room IDs are important because `SyncResponseBuilder` stores them
+        // in a `HashMap`, so they are going to be “shuffled”.
         let room_id_0 = room_id!("!r1");
         let room_id_1 = room_id!("!r0");
         let room_id_2 = room_id!("!r2");
@@ -853,7 +856,8 @@ mod tests {
                 )
                 .build_sync_response();
 
-            // At this point, we can check that `response` contains misordered room updates.
+            // At this point, we can check that `response` contains misordered
+            // room updates.
             {
                 let mut rooms = response.rooms.join.keys();
 
@@ -1150,9 +1154,10 @@ mod tests {
 
         // Room 0, room 1 and room 2.
         //
-        // Doing that in one sync, it's the only way to create such loop (otherwise it
-        // implies overwriting the `m.room.create` event, or not setting it first, then
-        // setting it later… anyway, it works in one sync)
+        // Doing that in one sync, it's the only way to create such loop
+        // (otherwise it implies overwriting the `m.room.create` event,
+        // or not setting it first, then setting it later… anyway, it
+        // works in one sync)
         {
             let response = response_builder
                 .add_joined_room(
@@ -1205,8 +1210,8 @@ mod tests {
             // The sync doesn't fail but…
             assert!(client.receive_sync_response(response).await.is_ok());
 
-            // … the state event for room 2 -> room 0 has not been saved, but room 0 <- room
-            // 2 has been saved.
+            // … the state event for room 2 -> room 0 has not been saved, but
+            // room 0 <- room 2 has been saved.
             let room_0 = client.get_room(room_id_0).unwrap();
 
             assert_eq!(

--- a/crates/matrix-sdk-base/src/room/display_name.rs
+++ b/crates/matrix-sdk-base/src/room/display_name.rs
@@ -135,7 +135,8 @@ impl Room {
             DisplayNameOrSummary::DisplayName(display_name) => display_name,
         };
 
-        // Update the cached display name before we return the newly computed value.
+        // Update the cached display name before we return the newly computed
+        // value.
         let mut updated = false;
 
         self.info.update_if(|info| {
@@ -174,8 +175,8 @@ impl Room {
             .saturating_sub(num_service_members);
 
         let num_joined_invited = if self.state() == RoomState::Invited {
-            // when we were invited we don't have a proper summary, we have to do best
-            // guessing
+            // when we were invited we don't have a proper summary, we have to
+            // do best guessing
             heroes.len() as u64 + 1
         } else if summary_member_count == 0 {
             num_joined_invited_guess
@@ -217,17 +218,18 @@ impl Room {
         let own_user_id = self.own_user_id();
         let member_hints = self.get_member_hints().await?;
 
-        // If we have some service members in the heroes, that means that they are also
-        // part of the joined member counts. They shouldn't be so, otherwise
-        // we'll wrongly assume that there are more members in the room than
-        // they are for the "Bob and 2 others" case.
+        // If we have some service members in the heroes, that means that they
+        // are also part of the joined member counts. They shouldn't be
+        // so, otherwise we'll wrongly assume that there are more
+        // members in the room than they are for the "Bob and 2 others"
+        // case.
         let num_service_members = heroes
             .iter()
             .filter(|hero| member_hints.service_members.contains(&hero.user_id))
             .count() as u64;
 
-        // Construct a filter that is specific to this own user id, set of member hints,
-        // and accepts a `RoomHero` type.
+        // Construct a filter that is specific to this own user id, set of
+        // member hints, and accepts a `RoomHero` type.
         let heroes_filter = heroes_filter(own_user_id, &member_hints);
         let heroes_filter = |hero: &&RoomHero| heroes_filter(&hero.user_id);
 
@@ -251,8 +253,8 @@ impl Room {
 
         let num_joined_invited_guess = summary.joined_member_count + summary.invited_member_count;
 
-        // If the summary doesn't provide the number of joined/invited members, let's
-        // guess something.
+        // If the summary doesn't provide the number of joined/invited members,
+        // let's guess something.
         let num_joined_invited_guess = if num_joined_invited_guess == 0 {
             let guess = self
                 .store
@@ -262,7 +264,8 @@ impl Room {
 
             guess.saturating_sub(num_service_members)
         } else {
-            // Otherwise, accept the numbers provided by the summary as the guess.
+            // Otherwise, accept the numbers provided by the summary as the
+            // guess.
             num_joined_invited_guess
         };
 
@@ -277,33 +280,35 @@ impl Room {
     async fn compute_summary(&self) -> StoreResult<ComputedSummary> {
         let member_hints = self.get_member_hints().await?;
 
-        // Construct a filter that is specific to this own user id, set of member hints,
-        // and accepts a `RoomMember` type.
+        // Construct a filter that is specific to this own user id, set of
+        // member hints, and accepts a `RoomMember` type.
         let heroes_filter = heroes_filter(&self.own_user_id, &member_hints);
         let heroes_filter = |u: &RoomMember| heroes_filter(u.user_id());
 
         let mut members = self.members(RoomMemberships::JOIN | RoomMemberships::INVITE).await?;
 
-        // If we have some service members, they shouldn't count to the number of
-        // joined/invited members, otherwise we'll wrongly assume that there are more
-        // members in the room than they are for the "Bob and 2 others" case.
+        // If we have some service members, they shouldn't count to the number
+        // of joined/invited members, otherwise we'll wrongly assume
+        // that there are more members in the room than they are for the
+        // "Bob and 2 others" case.
         let num_service_members = members
             .iter()
             .filter(|member| member_hints.service_members.contains(member.user_id()))
             .count();
 
-        // We can make a good prediction of the total number of joined and invited
-        // members here. This might be incorrect if the database info is
-        // outdated.
+        // We can make a good prediction of the total number of joined and
+        // invited members here. This might be incorrect if the database
+        // info is outdated.
         //
-        // Note: Subtracting here is fine because `num_service_members` is a subset of
-        // `members.len()` due to the above filter operation.
+        // Note: Subtracting here is fine because `num_service_members` is a
+        // subset of `members.len()` due to the above filter operation.
         let num_joined_invited = members.len() - num_service_members;
 
         if num_joined_invited == 0
             || (num_joined_invited == 1 && members[0].user_id() == self.own_user_id)
         {
-            // No joined or invited members, heroes should be banned and left members.
+            // No joined or invited members, heroes should be banned and left
+            // members.
             members = self.members(RoomMemberships::LEAVE | RoomMemberships::BAN).await?;
         }
 
@@ -719,7 +724,8 @@ mod tests {
             RoomDisplayName::Aliased("test".to_owned())
         );
         room.info.update(|info| info.base_info.name = Some(make_name_event()));
-        // Display name wasn't cached when we asked for it above, and name overrides
+        // Display name wasn't cached when we asked for it above, and name
+        // overrides
         assert_eq!(
             room.compute_display_name().await.unwrap().into_inner(),
             RoomDisplayName::Named("Test Room".to_owned())
@@ -776,7 +782,8 @@ mod tests {
             RoomDisplayName::Aliased("test".to_owned())
         );
         room.info.update(|info| info.base_info.name = Some(make_name_event()));
-        // Display name wasn't cached when we asked for it above, and name overrides
+        // Display name wasn't cached when we asked for it above, and name
+        // overrides
         assert_eq!(
             room.compute_display_name().await.unwrap().into_inner(),
             RoomDisplayName::Named("Test Room".to_owned())
@@ -1037,8 +1044,8 @@ mod tests {
 
         let f = EventFactory::new().room(room_id!("!test:localhost"));
 
-        // Save members in two batches, so that there's no implied ordering in the
-        // store.
+        // Save members in two batches, so that there's no implied ordering in
+        // the store.
         {
             let members = changes
                 .state
@@ -1135,8 +1142,8 @@ mod tests {
 
         let mut changes = StateChanges::new("".to_owned());
 
-        // Save members in two batches, so that there's no implied ordering in the
-        // store.
+        // Save members in two batches, so that there's no implied ordering in
+        // the store.
         {
             let members = changes
                 .state

--- a/crates/matrix-sdk-base/src/room/knock.rs
+++ b/crates/matrix-sdk-base/src/room/knock.rs
@@ -42,8 +42,9 @@ impl Room {
             .await?;
         let mut event_to_user_ids = Vec::with_capacity(member_raw_events.len());
 
-        // Map the list of events ids to their user ids, if they are event ids for knock
-        // membership events. Log an error and continue otherwise.
+        // Map the list of events ids to their user ids, if they are event ids
+        // for knock membership events. Log an error and continue
+        // otherwise.
         for raw_event in member_raw_events {
             let event = raw_event.cast::<RoomMemberEventContent>().deserialize()?;
             match event {
@@ -93,13 +94,14 @@ impl Room {
         let mut ids_to_remove = Vec::new();
 
         for (event_id, user_id) in current_seen_events.iter() {
-            // Check the seen knock request ids against the current room member events for
-            // the room members associated to them
+            // Check the seen knock request ids against the current room member
+            // events for the room members associated to them
             let matching_member = member_events.iter().find(|event| event.user_id() == user_id);
 
             if let Some(member) = matching_member {
                 let member_event_id = member.event_id();
-                // If the member event is not a knock or it's different knock, it's outdated
+                // If the member event is not a knock or it's different knock,
+                // it's outdated
                 if *member.membership() != MembershipState::Knock
                     || member_event_id.is_some_and(|id| id != event_id)
                 {
@@ -138,7 +140,8 @@ impl Room {
         let mut guard = self.seen_knock_request_ids_map.write().await;
         // If there are no loaded request ids yet
         if guard.is_none() {
-            // Load the values from the store and update the shared observable contents
+            // Load the values from the store and update the shared observable
+            // contents
             let updated_seen_ids = self
                 .store
                 .get_kv_data(StateStoreDataKey::SeenKnockRequests(self.room_id()))

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -68,7 +68,8 @@ impl Room {
     /// Mark this Room as still missing member information.
     pub fn mark_members_missing(&self) {
         self.info.update_if(|info| {
-            // notify observable subscribers only if the previous value was false
+            // notify observable subscribers only if the previous value was
+            // false
             mem::replace(&mut info.members_synced, false)
         })
     }

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -508,7 +508,8 @@ impl Room {
             return Vec::new();
         }
 
-        // Return with empty profile fields when the user status feature is disabled.
+        // Return with empty profile fields when the user status feature is
+        // disabled.
         #[cfg(not(feature = "unstable-msc4426"))]
         {
             heroes.into_iter().map(RoomHeroWithProfile::from).collect()
@@ -885,7 +886,8 @@ mod tests {
         assert!(heroes[0].status.is_none());
         assert!(heroes[0].call.is_none());
 
-        // Store a global profile carrying an `m.status` and `m.call` for the hero.
+        // Store a global profile carrying an `m.status` and `m.call` for the
+        // hero.
         let mut call = CallProfileField::new();
         call.call_joined_ts = Some(SecondsSinceUnixEpoch(1_700_000_000u32.into()));
         let mut changes = StateChanges::default();

--- a/crates/matrix-sdk-base/src/room/room_info.rs
+++ b/crates/matrix-sdk-base/src/room/room_info.rs
@@ -126,8 +126,8 @@ impl Room {
 
         if reasons.is_empty() {
             // TODO: remove this block!
-            // Read `RoomInfoNotableUpdateReasons::NONE` to understand why it must be
-            // removed.
+            // Read `RoomInfoNotableUpdateReasons::NONE` to understand why it
+            // must be removed.
             reasons = RoomInfoNotableUpdateReasons::NONE;
         }
         let _ = self
@@ -253,9 +253,10 @@ impl BaseRoomInfo {
     ) -> bool {
         match (&raw_event.event_type, raw_event.state_key.as_str()) {
             (StateEventType::RoomEncryption, "") => {
-                // To avoid breaking encrypted rooms, we ignore `m.room.encryption` events that
-                // fail to deserialize or that are redacted (i.e. they don't contain the
-                // algorithm used for encryption).
+                // To avoid breaking encrypted rooms, we ignore
+                // `m.room.encryption` events that
+                // fail to deserialize or that are redacted (i.e. they don't
+                // contain the algorithm used for encryption).
                 if let Some(event) = raw_event.deserialize_as_minimal_event(|any_event| {
                     as_variant!(any_event, AnyPossiblyRedactedStateEventContent::RoomEncryption)
                 }) && event.content.algorithm.is_some()
@@ -273,7 +274,8 @@ impl BaseRoomInfo {
                     self.avatar = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.avatar.take().is_some()
                 }
             }
@@ -284,7 +286,8 @@ impl BaseRoomInfo {
                     self.name = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.name.take().is_some()
                 }
             }
@@ -318,7 +321,8 @@ impl BaseRoomInfo {
                     self.history_visibility = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.history_visibility.take().is_some()
                 }
             }
@@ -329,7 +333,8 @@ impl BaseRoomInfo {
                     self.retention = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.retention.take().is_some()
                 }
             }
@@ -340,7 +345,8 @@ impl BaseRoomInfo {
                     self.guest_access = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.guest_access.take().is_some()
                 }
             }
@@ -351,7 +357,8 @@ impl BaseRoomInfo {
                     self.member_hints = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.member_hints.take().is_some()
                 }
             }
@@ -371,12 +378,14 @@ impl BaseRoomInfo {
                         }
                         r => {
                             warn!(join_rule = ?r.as_str(), "Encountered a custom join rule, skipping");
-                            // Remove the previous content if the new content is unsupported.
+                            // Remove the previous content if the new content is
+                            // unsupported.
                             self.join_rules.take().is_some()
                         }
                     }
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.join_rules.take().is_some()
                 }
             }
@@ -387,7 +396,8 @@ impl BaseRoomInfo {
                     self.canonical_alias = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.canonical_alias.take().is_some()
                 }
             }
@@ -398,7 +408,8 @@ impl BaseRoomInfo {
                     self.topic = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.topic.take().is_some()
                 }
             }
@@ -409,7 +420,8 @@ impl BaseRoomInfo {
                     self.tombstone = Some(event);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.tombstone.take().is_some()
                 }
             }
@@ -461,13 +473,15 @@ impl BaseRoomInfo {
                         // Add the new event.
                         self.rtc_member_events.insert(call_member_key, event);
 
-                        // Remove all events that don't contain any memberships anymore.
+                        // Remove all events that don't contain any memberships
+                        // anymore.
                         self.rtc_member_events
                             .retain(|_, ev| !ev.content.active_memberships(None).is_empty());
 
                         true
                     } else {
-                        // Remove the previous content with the same state key if the new content is
+                        // Remove the previous content with the same state key
+                        // if the new content is
                         // unknown.
                         self.rtc_member_events.remove(&call_member_key).is_some()
                     }
@@ -482,7 +496,8 @@ impl BaseRoomInfo {
                     self.pinned_events = Some(event.content);
                     true
                 } else {
-                    // Remove the previous content if the new content is unknown.
+                    // Remove the previous content if the new content is
+                    // unknown.
                     self.pinned_events.take().is_some()
                 }
             }
@@ -830,9 +845,10 @@ impl RoomInfo {
             .iter()
             .any(|(state_event, _)| state_event == &StateEventType::RoomEncryption)
         {
-            // The `m.room.encryption` event was requested during the sync. Whether we have
-            // received a `m.room.encryption` event in return doesn't matter: we must mark
-            // the encryption state as synced; if the event is present, it means the room
+            // The `m.room.encryption` event was requested during the sync.
+            // Whether we have received a `m.room.encryption` event
+            // in return doesn't matter: we must mark the encryption
+            // state as synced; if the event is present, it means the room
             // _is_ encrypted, otherwise it means the room _is not_ encrypted.
 
             self.mark_encryption_state_synced();
@@ -868,10 +884,11 @@ impl RoomInfo {
 
         if raw_event.event_type == StateEventType::RoomEncryption && raw_event.state_key.is_empty()
         {
-            // The `m.room.encryption` event was or wasn't explicitly requested, we don't
-            // know here (see `Self::handle_encryption_state`) but we got one in
-            // return! In this case, we can deduce the room _is_ encrypted, but we cannot
-            // know if it _is not_ encrypted.
+            // The `m.room.encryption` event was or wasn't explicitly requested,
+            // we don't know here (see
+            // `Self::handle_encryption_state`) but we got one in
+            // return! In this case, we can deduce the room _is_ encrypted, but
+            // we cannot know if it _is not_ encrypted.
 
             self.mark_encryption_state_synced();
         }
@@ -1847,12 +1864,12 @@ mod tests {
     // schema
     //
     // In an ideal world, we must not change this test. Please see
-    // [`test_room_info_serialization`] if you want to test a “recent” `RoomInfo`
-    // deserialization.
+    // [`test_room_info_serialization`] if you want to test a “recent”
+    // `RoomInfo` deserialization.
     #[test]
     fn test_room_info_deserialization_without_optional_items() {
-        // The following JSON should never change if we want to be able to read in old
-        // cached state
+        // The following JSON should never change if we want to be able to read
+        // in old cached state
         let info_json = json!({
             "room_id": "!gda78o:server.tld",
             "room_state": "Invited",
@@ -2192,8 +2209,8 @@ mod tests {
             room.update_room_info(|info| (info, RoomInfoNotableUpdateReasons::NONE)).await
         });
 
-        // Ensure that the second task does not progress until the first task has
-        // completed and, therefore, releases the save lock
+        // Ensure that the second task does not progress until the first task
+        // has completed and, therefore, releases the save lock
         assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
             timeout(Duration::from_millis(100), save_task)
                 .await
@@ -2221,8 +2238,8 @@ mod tests {
             room.update_and_save_room_info(|info| (info, RoomInfoNotableUpdateReasons::NONE)).await
         });
 
-        // Ensure that the second task does not progress until the first task has
-        // completed and, therefore, releases the save lock
+        // Ensure that the second task does not progress until the first task
+        // has completed and, therefore, releases the save lock
         assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
             timeout(Duration::from_millis(100), save_task)
                 .await

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -109,8 +109,8 @@ impl BaseClient {
         );
 
         if rooms.is_empty() && extensions.is_empty() {
-            // we received a room reshuffling event only, there won't be anything for us to
-            // process. stop early
+            // we received a room reshuffling event only, there won't be
+            // anything for us to process. stop early
             return Ok(SyncResponse::default());
         }
 
@@ -186,9 +186,10 @@ impl BaseClient {
             }
         }
 
-        // Handle read receipts and typing notifications independently of the rooms:
-        // these both live in a different subsection of the server's response,
-        // so they may exist without any update for the associated room.
+        // Handle read receipts and typing notifications independently of the
+        // rooms: these both live in a different subsection of the
+        // server's response, so they may exist without any update for
+        // the associated room.
         processors::room::msc4186::extensions::dispatch_typing_ephemeral_events(
             &extensions.typing,
             &mut room_updates.joined,
@@ -206,7 +207,8 @@ impl BaseClient {
 
         context.state_changes.ambiguity_maps = ambiguity_cache.cache;
 
-        // Persist any global profile updates received through the profiles extension.
+        // Persist any global profile updates received through the profiles
+        // extension.
         context.state_changes.global_profiles = extensions.profiles.users.clone();
 
         // Save the changes and apply them.
@@ -219,8 +221,9 @@ impl BaseClient {
         )
         .await?;
 
-        // Profile-only updates don't modify any rooms, so nothing else broadcasts
-        // them. Surface the change so subscribers can react accordingly.
+        // Profile-only updates don't modify any rooms, so nothing else
+        // broadcasts them. Surface the change so subscribers can react
+        // accordingly.
         self.notify_global_profile_updates(
             extensions.profiles.users.keys().cloned().collect(),
             state_store_guard,
@@ -228,8 +231,9 @@ impl BaseClient {
 
         let mut context = processors::Context::default();
 
-        // Now that all the rooms information have been saved, update the display name
-        // of the updated rooms (which relies on information stored in the database).
+        // Now that all the rooms information have been saved, update the
+        // display name of the updated rooms (which relies on
+        // information stored in the database).
         processors::room::display_name::update_for_rooms(
             &mut context,
             &room_updates,
@@ -454,8 +458,8 @@ mod tests {
         let alice = user_id!("@alice:e.uk");
         let bob = user_id!("@bob:e.uk");
 
-        // Given a sliding sync response carrying the profiles extension (MSC4262)
-        // for two users, and no rooms.
+        // Given a sliding sync response carrying the profiles extension
+        // (MSC4262) for two users, and no rooms.
         let mut response = http::Response::new("0".to_owned());
         response.extensions.profiles.users.insert(
             alice.to_owned(),
@@ -539,7 +543,8 @@ mod tests {
         // Given a subscriber to global profile updates.
         let mut global_profile_updates = client.subscribe_to_global_profile_updates();
 
-        // When a sliding sync response carries the profiles extension for two users.
+        // When a sliding sync response carries the profiles extension for two
+        // users.
         let mut response = http::Response::new("0".to_owned());
         response.extensions.profiles.users.insert(
             alice.to_owned(),
@@ -593,8 +598,8 @@ mod tests {
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room (with identifiable data
-        // in joined_count)
+        // When I send sliding sync response containing a room (with
+        // identifiable data in joined_count)
         let mut room = http::response::Room::new();
         room.joined_count = Some(uint!(41));
         let response = response_with_room(room_id, room);
@@ -625,8 +630,8 @@ mod tests {
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room with a name set in the
-        // sliding sync response,
+        // When I send sliding sync response containing a room with a name set
+        // in the sliding sync response,
         let mut room = http::response::Room::new();
         room.name = Some("little room".to_owned());
         let response = response_with_room(room_id, room);
@@ -639,7 +644,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // No m.room.name event, no heroes, no members => considered an empty room!
+        // No m.room.name event, no heroes, no members => considered an empty
+        // room!
         let client_room = client.get_room(room_id).expect("No room found");
         assert!(client_room.name().is_none());
         assert_eq!(
@@ -661,8 +667,8 @@ mod tests {
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room with a name set in the
-        // sliding sync response, and a m.room.name event,
+        // When I send sliding sync response containing a room with a name set
+        // in the sliding sync response, and a m.room.name event,
         let mut room = http::response::Room::new();
 
         room.name = Some("little room".to_owned());
@@ -695,8 +701,8 @@ mod tests {
         let user_id = user_id!("@w:e.uk");
         let inviter = user_id!("@john:mastodon.org");
 
-        // When I send sliding sync response containing a room with a name set in the
-        // sliding sync response,
+        // When I send sliding sync response containing a room with a name set
+        // in the sliding sync response,
         let mut room = http::response::Room::new();
         set_room_invited(&mut room, inviter, user_id);
         room.name = Some("name from sliding sync response".to_owned());
@@ -734,8 +740,8 @@ mod tests {
         let user_id = user_id!("@w:e.uk");
         let inviter = user_id!("@john:mastodon.org");
 
-        // When I send sliding sync response containing a room with a name set in the
-        // sliding sync response, and a m.room.name event,
+        // When I send sliding sync response containing a room with a name set
+        // in the sliding sync response, and a m.room.name event,
         let mut room = http::response::Room::new();
 
         set_room_invited(&mut room, inviter, user_id);
@@ -769,8 +775,8 @@ mod tests {
         let room_id = room_id!("!r:e.uk");
         let user_id = client.session_meta().unwrap().user_id.to_owned();
 
-        // When the room is properly set as knocked with the current user id as state
-        // key,
+        // When the room is properly set as knocked with the current user id as
+        // state key,
         let mut room = http::response::Room::new();
         set_room_knocked(&mut room, &user_id);
 
@@ -811,8 +817,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // The room is invited since the membership event doesn't belong to the current
-        // user.
+        // The room is invited since the membership event doesn't belong to the
+        // current user.
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(client_room.state(), RoomState::Invited);
     }
@@ -993,7 +999,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // The room is NOT left because state events from `timeline` must be IGNORED!
+        // The room is NOT left because state events from `timeline` must be
+        // IGNORED!
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
     }
 
@@ -1072,9 +1079,9 @@ mod tests {
         // When B leaves
         update_room_membership(&client, room_id, user_b_id, MembershipState::Leave).await;
 
-        // Then B is still a direct target, and is in Leave state (B is a direct target
-        // because we want to return to our old DM in the UI even if the other
-        // user left, so we can reinvite them. See https://github.com/matrix-org/matrix-rust-sdk/issues/2017)
+        // Then B is still a direct target, and is in Leave state (B is a direct
+        // target because we want to return to our old DM in the UI even
+        // if the other user left, so we can reinvite them. See https://github.com/matrix-org/matrix-rust-sdk/issues/2017)
         assert!(
             direct_targets(&client, room_id).contains(<&DirectUserIdentifier>::from(user_b_id))
         );
@@ -1101,9 +1108,9 @@ mod tests {
         // When B declines the invitation (i.e. leaves)
         update_room_membership(&client, room_id, user_b_id, MembershipState::Leave).await;
 
-        // Then B is still a direct target, and is in Leave state (B is a direct target
-        // because we want to return to our old DM in the UI even if the other
-        // user left, so we can reinvite them. See https://github.com/matrix-org/matrix-rust-sdk/issues/2017)
+        // Then B is still a direct target, and is in Leave state (B is a direct
+        // target because we want to return to our old DM in the UI even
+        // if the other user left, so we can reinvite them. See https://github.com/matrix-org/matrix-rust-sdk/issues/2017)
         assert!(
             direct_targets(&client, room_id).contains(<&DirectUserIdentifier>::from(user_b_id))
         );
@@ -1248,7 +1255,8 @@ mod tests {
 
         // Avatar is unset.
 
-        // When I send sliding sync response containing an avatar set to `null` (!).
+        // When I send sliding sync response containing an avatar set to `null`
+        // (!).
         let room = {
             let mut room = http::response::Room::new();
             room.avatar = JsOption::Null;
@@ -1404,7 +1412,8 @@ mod tests {
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
-        // When I send sliding sync response containing an invited room with an avatar
+        // When I send sliding sync response containing an invited room with an
+        // avatar
         let mut room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
@@ -1434,7 +1443,8 @@ mod tests {
         let user_id = user_id!("@u:e.uk");
         let room_alias_id = room_alias_id!("#myroom:e.uk");
 
-        // When I send sliding sync response containing an invited room with an avatar
+        // When I send sliding sync response containing an invited room with an
+        // avatar
         let mut room = room_with_canonical_alias(room_alias_id, user_id);
         set_room_invited(&mut room, user_id, user_id);
         let response = response_with_room(room_id, room);
@@ -1460,8 +1470,8 @@ mod tests {
         let user_id = user_id!("@u:e.uk");
         let room_alias_id = room_alias_id!("#myroom:e.uk");
 
-        // When the sliding sync response contains an explicit room name as well as an
-        // alias
+        // When the sliding sync response contains an explicit room name as well
+        // as an alias
         let mut room = room_with_canonical_alias(room_alias_id, user_id);
         room.name = Some("This came from the server".to_owned());
         let response = response_with_room(room_id, room);
@@ -1474,7 +1484,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Then the room's name is NOT overridden by the server-computed display name.
+        // Then the room's name is NOT overridden by the server-computed display
+        // name.
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(
             client_room.compute_display_name().await.unwrap().into_inner().to_string(),
@@ -1550,8 +1561,8 @@ mod tests {
                 client
             };
 
-            // When the sliding sync response contains an explicit room name as well as an
-            // alias
+            // When the sliding sync response contains an explicit room name as
+            // well as an alias
             let room = room_with_name("Hello World", user_id);
             let response = response_with_room(room_id, room);
             client
@@ -1599,8 +1610,8 @@ mod tests {
         let gordon = owned_user_id!("@gordon:e.uk");
         let alice = owned_user_id!("@alice:e.uk");
 
-        // When I send sliding sync response containing a room (with identifiable data
-        // in `heroes`)
+        // When I send sliding sync response containing a room (with
+        // identifiable data in `heroes`)
         let mut room = http::response::Room::new();
         room.heroes = Some(vec![
             assign!(http::response::Hero::new(gordon), {
@@ -1672,7 +1683,8 @@ mod tests {
 
         assert_pending!(room_info_subscriber);
 
-        // When a subsequent sync carries only a profiles-extension update for Alice.
+        // When a subsequent sync carries only a profiles-extension update for
+        // Alice.
         let mut response = http::Response::new("1".to_owned());
         response.extensions.profiles.users.insert(
             alice.clone(),
@@ -1718,7 +1730,8 @@ mod tests {
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room with a recency stamp
+        // When I send sliding sync response containing a room with a recency
+        // stamp
         let room = assign!(http::response::Room::new(), {
             bump_stamp: Some(42u32.into()),
         });
@@ -1744,7 +1757,8 @@ mod tests {
         let room_id = room_id!("!r:e.uk");
 
         {
-            // When I send sliding sync response containing a room with a recency stamp
+            // When I send sliding sync response containing a room with a
+            // recency stamp
             let room = assign!(http::response::Room::new(), {
                 bump_stamp: Some(42u32.into()),
             });
@@ -1764,7 +1778,8 @@ mod tests {
         }
 
         {
-            // When I send sliding sync response containing a room with NO recency stamp
+            // When I send sliding sync response containing a room with NO
+            // recency stamp
             let room = assign!(http::response::Room::new(), {
                 bump_stamp: None,
             });
@@ -1784,8 +1799,8 @@ mod tests {
         }
 
         {
-            // When I send sliding sync response containing a room with a NEW recency
-            // timestamp
+            // When I send sliding sync response containing a room with a NEW
+            // recency timestamp
             let room = assign!(http::response::Room::new(), {
                 bump_stamp: Some(153u32.into()),
             });
@@ -1812,7 +1827,8 @@ mod tests {
         let mut room_info_notable_update_stream = client.room_info_notable_update_receiver();
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room with a recency stamp.
+        // When I send sliding sync response containing a room with a recency
+        // stamp.
         let room = assign!(http::response::Room::new(), {
             bump_stamp: Some(42u32.into()),
         });
@@ -1826,8 +1842,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Then a room info notable update is NOT received, because it's the first time
-        // the room is seen.
+        // Then a room info notable update is NOT received, because it's the
+        // first time the room is seen.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -1844,7 +1860,8 @@ mod tests {
         );
         assert!(room_info_notable_update_stream.is_empty());
 
-        // When I send sliding sync response containing a room with a recency stamp.
+        // When I send sliding sync response containing a room with a recency
+        // stamp.
         let room = assign!(http::response::Room::new(), {
             bump_stamp: Some(43u32.into()),
         });
@@ -1904,7 +1921,8 @@ mod tests {
             }
         );
 
-        // Send sliding sync response containing a membership event with 'join' value.
+        // Send sliding sync response containing a membership event with 'join'
+        // value.
         let room_id = room_id!("!r:e.uk");
         let events = vec![
             Raw::from_json_string(
@@ -1933,7 +1951,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Room was already joined, no `MEMBERSHIP` update should be triggered here
+        // Room was already joined, no `MEMBERSHIP` update should be triggered
+        // here
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -2000,7 +2019,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Other notable updates are received, but not the ones we are interested by.
+        // Other notable updates are received, but not the ones we are
+        // interested by.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -2017,8 +2037,8 @@ mod tests {
         );
         assert!(room_info_notable_update_stream.is_empty());
 
-        // When I receive a sliding sync response containing one update about an unread
-        // marker,
+        // When I receive a sliding sync response containing one update about an
+        // unread marker,
         let room_id = room_id!("!r:e.uk");
         let room_account_data_events = vec![
             Raw::from_json_string(
@@ -2126,7 +2146,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Other notable updates are received, but not the ones we are interested by.
+        // Other notable updates are received, but not the ones we are
+        // interested by.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -2249,7 +2270,8 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Other notable updates are received, but not the ones we are interested by.
+        // Other notable updates are received, but not the ones we are
+        // interested by.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -2308,7 +2330,8 @@ mod tests {
         );
         assert!(room_info_notable_update_stream.is_empty());
 
-        // When I receive a sliding sync response with a stable unread marker update,
+        // When I receive a sliding sync response with a stable unread marker
+        // update,
         let stable_room_account_data_events = vec![
             Raw::from_json_string(
                 json!({
@@ -2372,8 +2395,8 @@ mod tests {
         );
         assert!(room_info_notable_update_stream.is_empty());
 
-        // Finally, when I receive a sliding sync response with a stable unread marker
-        // update again,
+        // Finally, when I receive a sliding sync response with a stable unread
+        // marker update again,
         let stable_room_account_data_events = vec![
             Raw::from_json_string(
                 json!({
@@ -2538,8 +2561,8 @@ mod tests {
         let room_id_1 = room_id!("!r1");
         let room_id_2 = room_id!("!r2");
 
-        // A room is considered encrypted when it receives a `m.room.encryption` event,
-        // period.
+        // A room is considered encrypted when it receives a `m.room.encryption`
+        // event, period.
         //
         // A room is considered **not** encrypted when it receives no
         // `m.room.encryption` event but it was requested, period.
@@ -2548,8 +2571,8 @@ mod tests {
         //
         // - two of them receive a `m.room.encryption` event
         // - the last one does not receive a `m.room.encryption`.
-        // - the first one is configured with a `required_state` for this event, the
-        //   others have nothing.
+        // - the first one is configured with a `required_state` for this event,
+        //   the others have nothing.
         //
         // The trick is that, since sliding sync makes an union of all the
         // `required_state`s, then all rooms are technically requesting a
@@ -2572,9 +2595,10 @@ mod tests {
 
         let mut response = http::Response::new("0".to_owned());
 
-        // Create two rooms that are encrypted, i.e. they have a `m.room.encryption`
-        // state event in their `required_state`. Create a third room that is not
-        // encrypted, i.e. it doesn't have a `m.room.encryption` state event.
+        // Create two rooms that are encrypted, i.e. they have a
+        // `m.room.encryption` state event in their `required_state`.
+        // Create a third room that is not encrypted, i.e. it doesn't
+        // have a `m.room.encryption` state event.
         {
             let not_encrypted_room = http::response::Room::new();
             let mut encrypted_room = http::response::Room::new();
@@ -2617,8 +2641,8 @@ mod tests {
         let room_id_0 = room_id!("!r0");
         let room_id_1 = room_id!("!r1");
 
-        // A room is considered encrypted when it receives a `m.room.encryption` event,
-        // period.
+        // A room is considered encrypted when it receives a `m.room.encryption`
+        // event, period.
         //
         // A room is considered **not** encrypted when it receives no
         // `m.room.encryption` event but it was requested, period.
@@ -2652,14 +2676,14 @@ mod tests {
             .await
             .expect("Failed to process sync");
 
-        // Encrypted, because the presence of a `m.room.encryption` always mean the room
-        // is encrypted.
+        // Encrypted, because the presence of a `m.room.encryption` always mean
+        // the room is encrypted.
         assert_matches!(
             client.get_room(room_id_0).unwrap().encryption_state(),
             EncryptionState::Encrypted
         );
-        // Unknown, because the absence of `m.room.encryption` when not requested
-        // means we don't know what the state is.
+        // Unknown, because the absence of `m.room.encryption` when not
+        // requested means we don't know what the state is.
         assert_matches!(
             client.get_room(room_id_1).unwrap().encryption_state(),
             EncryptionState::Unknown
@@ -2815,8 +2839,8 @@ mod tests {
     }
 
     fn set_room_invited(room: &mut http::response::Room, inviter: &UserId, invitee: &UserId) {
-        // Sliding Sync shows an almost-empty event to indicate that we are invited to a
-        // room. Just the type is supplied.
+        // Sliding Sync shows an almost-empty event to indicate that we are
+        // invited to a room. Just the type is supplied.
 
         let evt = Raw::new(&json!({
             "type": "m.room.member",
@@ -2832,8 +2856,8 @@ mod tests {
 
         room.invite_state = Some(vec![evt]);
 
-        // We expect that there will also be an invite event in the required_state,
-        // assuming you've asked for this type of event.
+        // We expect that there will also be an invite event in the
+        // required_state, assuming you've asked for this type of event.
         room.required_state.push(make_state_event(
             inviter,
             invitee.as_str(),
@@ -2843,8 +2867,8 @@ mod tests {
     }
 
     fn set_room_knocked(room: &mut http::response::Room, knocker: &UserId) {
-        // Sliding Sync shows an almost-empty event to indicate that we are invited to a
-        // room. Just the type is supplied.
+        // Sliding Sync shows an almost-empty event to indicate that we are
+        // invited to a room. Just the type is supplied.
 
         let evt = Raw::new(&json!({
             "type": "m.room.member",

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -99,13 +99,14 @@ impl AmbiguityCache {
         room_id: &RoomId,
         member_event: &SyncRoomMemberEvent,
     ) -> Result<()> {
-        // Synapse seems to have a bug where it puts the same event into the state and
-        // the timeline sometimes.
+        // Synapse seems to have a bug where it puts the same event into the
+        // state and the timeline sometimes.
         //
-        // Since our state, e.g. the old display name, already ended up inside the state
-        // changes and we're pulling stuff out of the cache if it's there calculating
-        // this twice for the same event will result in an incorrect AmbiguityChange
-        // overwriting the correct one. In other words, this method is not idempotent so
+        // Since our state, e.g. the old display name, already ended up inside
+        // the state changes and we're pulling stuff out of the cache if
+        // it's there calculating this twice for the same event will
+        // result in an incorrect AmbiguityChange overwriting the
+        // correct one. In other words, this method is not idempotent so
         // we make it by ignoring duplicate events.
         if self.changes.get(room_id).is_some_and(|c| c.contains_key(member_event.event_id())) {
             return Ok(());
@@ -119,8 +120,8 @@ impl AmbiguityCache {
             _ => false,
         };
 
-        // If the user's display name didn't change, then there's nothing more to
-        // calculate here.
+        // If the user's display name didn't change, then there's nothing more
+        // to calculate here.
         if display_names_same {
             return Ok(());
         }
@@ -256,8 +257,8 @@ impl AmbiguityCache {
                 .and_then(|ev| ev.content.displayname.as_deref())
                 .unwrap_or_else(|| member_event.state_key().localpart());
 
-            // We don't allow other users to set the display name, so if we have a more
-            // trusted version of the display name use that.
+            // We don't allow other users to set the display name, so if we have
+            // a more trusted version of the display name use that.
             let new_display_name = if member_event.sender().as_str() == member_event.state_key() {
                 new
             } else if let Some(old) = old_display_name.as_deref() {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1517,8 +1517,9 @@ impl StateStoreIntegrationTests for DynStateStore {
             assert_ne!(pending[i].transaction_id, txn0);
         }
 
-        // Now add one event for two other rooms, remove one of the events, and then
-        // query all the rooms which have outstanding unsent events.
+        // Now add one event for two other rooms, remove one of the events, and
+        // then query all the rooms which have outstanding unsent
+        // events.
 
         // Add one event for room2.
         let room_id2 = room_id!("!test_send_queue_two:localhost");
@@ -1612,8 +1613,8 @@ impl StateStoreIntegrationTests for DynStateStore {
         )
         .await?;
 
-        // The requests should be ordered from higher priority to lower, and when equal,
-        // should use the insertion order instead.
+        // The requests should be ordered from higher priority to lower, and
+        // when equal, should use the insertion order instead.
         let pending = self.load_send_queue_requests(room_id).await?;
 
         assert_eq!(pending.len(), 3);
@@ -1726,8 +1727,8 @@ impl StateStoreIntegrationTests for DynStateStore {
         // It worked.
         assert!(self.load_dependent_queued_requests(room_id).await?.is_empty());
 
-        // Now, inserting a dependent event and removing the original send queue event
-        // will NOT remove the dependent event.
+        // Now, inserting a dependent event and removing the original send queue
+        // event will NOT remove the dependent event.
         let txn1 = TransactionId::new();
         let event1 =
             SerializableEventContent::new(&RoomMessageEventContent::text_plain("hey2").into())?;
@@ -1844,8 +1845,8 @@ impl StateStoreIntegrationTests for DynStateStore {
         {
             let mut all_rooms = self.get_room_infos(&RoomLoadSettings::All).await?;
 
-            // (We need to sort by `room_id` so that the test is stable across all
-            // `StateStore` implementations).
+            // (We need to sort by `room_id` so that the test is stable across
+            // all `StateStore` implementations).
             all_rooms.sort_by(|a, b| a.room_id.cmp(&b.room_id));
 
             assert_eq!(all_rooms.len(), 2);
@@ -1989,7 +1990,8 @@ impl StateStoreIntegrationTests for DynStateStore {
             event_id!("$t6"),
         ];
         // Helper for building the input for `upsert_thread_subscriptions()`,
-        // which is of the type: Vec<(&RoomId, &EventId, StoredThreadSubscription)>
+        // which is of the type: Vec<(&RoomId, &EventId,
+        // StoredThreadSubscription)>
         let build_subscription_updates = |subs: &[StoredThreadSubscription]| {
             threads
                 .iter()

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -479,7 +479,8 @@ impl StateStore for MemoryStore {
                             .or_default()
                             .insert(user_id.clone(), (event_id.clone(), receipt.clone()))
                         {
-                            // Remove the old receipt from the room event receipts
+                            // Remove the old receipt from the room event
+                            // receipts
                             if let Some(receipt_map) = inner.room_event_receipts.get_mut(room)
                                 && let Some(event_map) =
                                     receipt_map.get_mut(&(receipt_type.to_string(), thread.clone()))
@@ -897,7 +898,8 @@ impl StateStore for MemoryStore {
             // Find the event by id in its room queue, and remove it if present.
             if let Some(pos) = entry.iter().position(|item| item.transaction_id == transaction_id) {
                 entry.remove(pos);
-                // And if this was the last event before removal, remove the entire room entry.
+                // And if this was the last event before removal, remove the
+                // entire room entry.
                 if entry.is_empty() {
                     q.remove(room_id);
                 }
@@ -1090,7 +1092,8 @@ impl StateStore for MemoryStore {
         room_subs.remove(thread_id);
 
         if room_subs.is_empty() {
-            // If there are no more subscriptions for this room, remove the room entry.
+            // If there are no more subscriptions for this room, remove the room
+            // entry.
             inner.thread_subscriptions.remove(room);
         }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -204,9 +204,10 @@ impl BaseStateStore {
     pub fn new(inner: Arc<DynStateStore>) -> Self {
         // Create the channel to receive `RoomInfoNotableUpdate`.
         //
-        // Let's consider the channel will receive 5 updates for 100 rooms maximum. This
-        // is unrealistic in practise, as the sync mechanism is pretty unlikely to
-        // trigger such amount of updates, it's a safe value.
+        // Let's consider the channel will receive 5 updates for 100 rooms
+        // maximum. This is unrealistic in practise, as the sync
+        // mechanism is pretty unlikely to trigger such amount of
+        // updates, it's a safe value.
         //
         // Also, note that it must not be zero, because (i) it will panic,
         // (ii) a new user has no room, but can create rooms; remember that the
@@ -941,7 +942,8 @@ mod tests {
             assert_eq!(room_id, room_id_0);
         });
 
-        // The `RoomInfoNotableUpdate` is not derived. Every one has its own channel.
+        // The `RoomInfoNotableUpdate` is not derived. Every one has its own
+        // channel.
         assert!(
             store
                 .room_info_notable_update_sender

--- a/crates/matrix-sdk-base/src/store/observable_map.rs
+++ b/crates/matrix-sdk-base/src/store/observable_map.rs
@@ -139,8 +139,8 @@ where
     {
         let position = self.mapping.remove(key)?;
 
-        // Reindex every mapped entry that is after the position we're looking to
-        // remove.
+        // Reindex every mapped entry that is after the position we're looking
+        // to remove.
         for mapped_pos in self.mapping.values_mut().filter(|pos| **pos > position) {
             *mapped_pos = mapped_pos.saturating_sub(1);
         }

--- a/crates/matrix-sdk-base/src/store/send_queue.rs
+++ b/crates/matrix-sdk-base/src/store/send_queue.rs
@@ -513,8 +513,8 @@ impl DependentQueuedRequest {
             | DependentQueuedRequestKind::RedactEventWithReason { .. }
             | DependentQueuedRequestKind::ReactEvent { .. }
             | DependentQueuedRequestKind::UploadFileOrThumbnail { .. } => {
-                // These are all aggregated events, or non-visible items (file upload producing
-                // a new MXC ID).
+                // These are all aggregated events, or non-visible items (file
+                // upload producing a new MXC ID).
                 false
             }
             DependentQueuedRequestKind::FinishUpload { .. } => {
@@ -549,9 +549,10 @@ mod tests {
 
     #[test]
     fn test_deserialize_legacy_redact_event() {
-        // `RedactEvent` is a unit variant, and must stay one for as long as it exists:
-        // requests persisted before `RedactEventWithReason` are serialized as a plain
-        // string, and this is the only thing that still reads them.
+        // `RedactEvent` is a unit variant, and must stay one for as long as it
+        // exists: requests persisted before `RedactEventWithReason` are
+        // serialized as a plain string, and this is the only thing that
+        // still reads them.
         let deserialized: DependentQueuedRequestKind =
             serde_json::from_str("\"RedactEvent\"").unwrap();
         assert_matches!(deserialized, DependentQueuedRequestKind::RedactEvent);

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -2014,7 +2014,8 @@ pub trait StateStoreExt: StateStore {
             + RedactContent,
         C::Redacted: RedactedStateEventContent,
     {
-        // FIXME: Could be more efficient, if we had streaming store accessor functions
+        // FIXME: Could be more efficient, if we had streaming store accessor
+        // functions
         Ok(self
             .get_state_events(room_id, C::TYPE.into())
             .await?
@@ -2150,8 +2151,8 @@ impl SupportedVersionsResponse {
         let mut supported_versions =
             SupportedVersions::from_parts(&self.versions, &self.unstable_features);
 
-        // We need at least one supported version to be able to make requests, so we
-        // default to Matrix 1.0.
+        // We need at least one supported version to be able to make requests,
+        // so we default to Matrix 1.0.
         if supported_versions.versions.is_empty() {
             supported_versions.versions.insert(MatrixVersion::V1_0);
         }
@@ -2664,12 +2665,14 @@ mod tests {
                 }
             });
 
-            // Try to save changes to the state store while the lock is held by another task
+            // Try to save changes to the state store while the lock is held by
+            // another task
             let save_task =
                 spawn(async move { state_store.save_changes(&StateChanges::default()).await });
 
-            // Ensure that the second task does not progress until the first task has
-            // completed and therefore release the save lock
+            // Ensure that the second task does not progress until the first
+            // task has completed and therefore release the save
+            // lock
             assert_matches!(future::select(lock_task, save_task).await, Either::Left((_, save_task)) => {
                 timeout(Duration::from_millis(100), save_task)
                     .await
@@ -2693,13 +2696,14 @@ mod tests {
                 }
             });
 
-            // Try to remove room from the state store while the lock is held by another
-            // task
+            // Try to remove room from the state store while the lock is held by
+            // another task
             let remove_task =
                 spawn(async move { state_store.remove_room(room_id!("!room")).await });
 
-            // Ensure that the second task does not progress until the first task has
-            // completed and therefore release the save lock
+            // Ensure that the second task does not progress until the first
+            // task has completed and therefore release the save
+            // lock
             assert_matches!(future::select(lock_task, remove_task).await, Either::Left((_, remove_task)) => {
                 timeout(Duration::from_millis(100), remove_task)
                     .await

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -330,7 +330,8 @@ impl RawStateEventWithKeys<AnySyncStateEvent> {
             }
         };
 
-        // If the state key is missing, it is not a state event according to the spec.
+        // If the state key is missing, it is not a state event according to the
+        // spec.
         Some(Self {
             event_type,
             state_key: state_key?,

--- a/crates/matrix-sdk-common/src/cross_process_lock.rs
+++ b/crates/matrix-sdk-common/src/cross_process_lock.rs
@@ -148,8 +148,8 @@ pub struct CrossProcessLockGuard {
 
 impl CrossProcessLockGuard {
     fn new(inner: &Arc<CrossProcessLockInner>) -> Self {
-        // Downgrading the strong pointer to a weak pointer to represent a new lock
-        // holder.
+        // Downgrading the strong pointer to a weak pointer to represent a new
+        // lock holder.
         Self { inner: Arc::downgrade(inner) }
     }
 
@@ -175,9 +175,9 @@ impl CrossProcessLockGuard {
     /// this method is called. This allows recovering from a dirty state and
     /// marking that it has recovered.
     pub fn clear_dirty(&self) {
-        // If it's not possible to upgrade the weak pointer, it means the lock _and_ the
-        // `renew_task` have been dropped. Marking the lock as non-dirty makes no
-        // particular sense, so we do nothing.
+        // If it's not possible to upgrade the weak pointer, it means the lock
+        // _and_ the `renew_task` have been dropped. Marking the lock as
+        // non-dirty makes no particular sense, so we do nothing.
         if let Some(inner) = self.inner.upgrade() {
             inner.clear_dirty();
         }
@@ -385,16 +385,17 @@ where
         // function, to avoid multiple reentrant calls.
         let mut _attempt = self.locking_attempt.lock().await;
 
-        // If there is at least one other holder, it means the lock has already been
-        // acquired, and we can safely generate a new guard.
+        // If there is at least one other holder, it means the lock has already
+        // been acquired, and we can safely generate a new guard.
         if Self::count_holders(&self.inner) > 0 {
-            // Note: between the above “count” and the `CrossProcessLockGuard::new` below,
-            // another thread may decrement the number of holders. That's fine because that
+            // Note: between the above “count” and the
+            // `CrossProcessLockGuard::new` below, another thread
+            // may decrement the number of holders. That's fine because that
             // means the lock was taken by at least one thread, and after this
             // call it will be taken by at least one thread.
             //
-            // Because `locking_attempt` is acquired, the task cannot drop the lock while
-            // the “count” might change.
+            // Because `locking_attempt` is acquired, the task cannot drop the
+            // lock while the “count” might change.
             trace!("We already had the lock, incrementing holder count");
 
             return Ok(Ok(CrossProcessLockState::Clean(CrossProcessLockGuard::new(&self.inner))));
@@ -434,16 +435,17 @@ where
 
         trace!("Obtained the lock, spawning the lease extension task.");
 
-        // No lock was acquired before (either because it's the first time the lock is
-        // acquired, or because all previous guards have been dropped). We're going to
-        // spawn the task that will renew the lease.
+        // No lock was acquired before (either because it's the first time the
+        // lock is acquired, or because all previous guards have been
+        // dropped). We're going to spawn the task that will renew the
+        // lease.
 
         let mut renew_task = self.inner.renew_task.lock().await;
 
         // Cancel the previous task, if any. That's safe to do, because:
         // - either the task was done,
-        // - or it was still running, but taking a lock in the database has to be an
-        //   atomic operation running in a transaction.
+        // - or it was still running, but taking a lock in the database has to
+        //   be an atomic operation running in a transaction.
         drop(renew_task.take());
 
         // Restart a new one.
@@ -454,7 +456,8 @@ where
                 let locking_attempt = self.locking_attempt.clone();
                 let config = self.config.clone();
 
-                // By cloning `CrossProcessLockInner`, we ensure the task acts as a lock holder.
+                // By cloning `CrossProcessLockInner`, we ensure the task acts
+                // as a lock holder.
                 let inner = self.inner.clone();
 
                 async move {
@@ -464,11 +467,13 @@ where
 
                     loop {
                         {
-                            // First, check if there are still users of this lock.
+                            // First, check if there are still users of this
+                            // lock.
                             //
                             // This is not racy, because:
-                            // - the `locking_attempt` mutex makes sure we don't have unexpected
-                            //   interactions with the non-atomic sequence above in `try_lock_once`,
+                            // - the `locking_attempt` mutex makes sure we don't
+                            //   have unexpected interactions with the
+                            //   non-atomic sequence above in `try_lock_once`,
                             // - other holders will only decrease over time.
 
                             let _guard = locking_attempt.lock().await;
@@ -478,7 +483,8 @@ where
                                 trace!("exiting the lease extension loop");
 
                                 // Cancel the lease with another 0ms lease.
-                                // If we don't get the lock, that's (weird but) fine.
+                                // If we don't get the lock, that's (weird but)
+                                // fine.
                                 let fut = locker.try_lock(0, &lock_key, &holder_name);
                                 let _ = fut.await;
 
@@ -548,25 +554,26 @@ where
         // If there is no holder, this behaves as a no-op
         let max_backoff = max_backoff.unwrap_or(MAX_BACKOFF_MS);
 
-        // Note: reads/writes to the backoff are racy across threads in theory, but the
-        // lock in `try_lock_once` should sequentialize it all.
+        // Note: reads/writes to the backoff are racy across threads in theory,
+        // but the lock in `try_lock_once` should sequentialize it all.
 
         loop {
-            // If the cross-process lock config is not `MultiProcess`, this behaves as a
-            // no-op and we just return
+            // If the cross-process lock config is not `MultiProcess`, this
+            // behaves as a no-op and we just return
             let lock_result = self.try_lock_once().await?;
 
             if lock_result.is_ok() {
                 if matches!(self.config, CrossProcessLockConfig::MultiProcess { .. }) {
-                    // Reset backoff before returning, for the next attempt to lock.
+                    // Reset backoff before returning, for the next attempt to
+                    // lock.
                     *self.backoff.lock().await = WaitingTime::Some(INITIAL_BACKOFF_MS);
                 }
 
                 return Ok(lock_result);
             }
 
-            // Exponential backoff! Multiply by 2 the time we've waited before, cap it to
-            // max_backoff.
+            // Exponential backoff! Multiply by 2 the time we've waited before,
+            // cap it to max_backoff.
             let mut backoff = self.backoff.lock().await;
 
             let wait = match &mut *backoff {
@@ -832,7 +839,8 @@ mod tests {
 
         assert_eq!(CrossProcessLock::count_holders(&lock.inner), 0);
 
-        // Spin locking on the same lock always works, assuming no concurrent access.
+        // Spin locking on the same lock always works, assuming no concurrent
+        // access.
         let guard = lock.spin_lock(None).await?.expect("spin lock must be obtained successfully");
         assert_let!(CrossProcessLockState::Clean(guard) = guard);
         assert!(lock.is_dirty().not());
@@ -867,8 +875,8 @@ mod tests {
         // But then forgotten…
         drop(lock);
 
-        // Let's ensure the guard keeps acting as a lock holder even if the lock has
-        // dropped.
+        // Let's ensure the guard keeps acting as a lock holder even if the lock
+        // has dropped.
         assert_eq!(CrossProcessLockGuard::count_holders(&guard.inner), 1);
 
         // Okay, enough fun, time to drop it.
@@ -977,7 +985,8 @@ mod tests {
         assert!(lock1.is_dirty().not());
         assert!(lock2.is_dirty().not());
 
-        // Now if `lock1` tries to obtain the lock with a small timeout, it will fail.
+        // Now if `lock1` tries to obtain the lock with a small timeout, it will
+        // fail.
         assert_matches!(
             lock1.spin_lock(Some(200)).await,
             Ok(Err(CrossProcessLockUnobtained::TimedOut))
@@ -1021,8 +1030,8 @@ mod tests {
         }
 
         for _ in 0..3 {
-            // Obtain `lock1` once more. Now it's dirty because `lock2` has acquired the
-            // lock meanwhile.
+            // Obtain `lock1` once more. Now it's dirty because `lock2` has
+            // acquired the lock meanwhile.
             {
                 let guard =
                     lock1.try_lock_once().await?.expect("lock must be obtained successfully");
@@ -1033,8 +1042,8 @@ mod tests {
                 yield_now().await;
             }
 
-            // Obtain `lock1` once more! It still dirty because it has not been marked as
-            // non-dirty.
+            // Obtain `lock1` once more! It still dirty because it has not been
+            // marked as non-dirty.
             {
                 let guard =
                     lock1.try_lock_once().await?.expect("lock must be obtained successfully");

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -141,8 +141,8 @@ impl VerificationState {
             VerificationState::Verified => ShieldState::None,
             VerificationState::Unverified(level) => match level {
                 VerificationLevel::UnverifiedIdentity => {
-                    // If you didn't show interest in verifying that user we don't
-                    // nag you with an error message.
+                    // If you didn't show interest in verifying that user we
+                    // don't nag you with an error message.
                     ShieldState::None
                 }
                 VerificationLevel::VerificationViolation => {
@@ -154,7 +154,8 @@ impl VerificationState {
                     }
                 }
                 VerificationLevel::UnsignedDevice => {
-                    // This is a high warning. The sender hasn't verified his own device.
+                    // This is a high warning. The sender hasn't verified his
+                    // own device.
                     ShieldState::Red {
                         code: ShieldStateCode::UnsignedDevice,
                         message: UNSIGNED_DEVICE,
@@ -162,17 +163,20 @@ impl VerificationState {
                 }
                 VerificationLevel::None(link) => match link {
                     DeviceLinkProblem::MissingDevice => {
-                        // Have to warn as it could have been a temporary injected device.
-                        // Notice that the device might just not be known at this time, so callers
-                        // should retry when there is a device change for that user.
+                        // Have to warn as it could have been a temporary
+                        // injected device. Notice that
+                        // the device might just not be known at this time, so
+                        // callers should retry when
+                        // there is a device change for that user.
                         ShieldState::Red {
                             code: ShieldStateCode::UnknownDevice,
                             message: UNKNOWN_DEVICE,
                         }
                     }
                     DeviceLinkProblem::InsecureSource => {
-                        // In legacy mode, we tone down this warning as it is quite common and
-                        // mostly noise (due to legacy backup and lack of trusted forwards).
+                        // In legacy mode, we tone down this warning as it is
+                        // quite common and mostly noise
+                        // (due to legacy backup and lack of trusted forwards).
                         ShieldState::Grey {
                             code: ShieldStateCode::AuthenticityNotGuaranteed,
                             message: AUTHENTICITY_NOT_GUARANTEED,
@@ -368,8 +372,8 @@ impl<'de> Deserialize<'de> for EncryptionInfo {
     where
         D: serde::Deserializer<'de>,
     {
-        // Backwards compatibility: Capture session_id at root if exists. In legacy
-        // EncryptionInfo the session_id was not in AlgorithmInfo
+        // Backwards compatibility: Capture session_id at root if exists. In
+        // legacy EncryptionInfo the session_id was not in AlgorithmInfo
         #[derive(Deserialize)]
         struct Helper {
             pub sender: OwnedUserId,
@@ -706,7 +710,8 @@ impl TimelineEvent {
                 {
                     match unsigned_decryption_result {
                         UnsignedDecryptionResult::Decrypted(encryption_info) => {
-                            // The bundled event was encrypted, and we could decrypt it: pass that
+                            // The bundled event was encrypted, and we could
+                            // decrypt it: pass that
                             // information around.
                             return Some(Box::new(
                                 TimelineEvent::from_decrypted_with_max_timestamp(
@@ -728,7 +733,8 @@ impl TimelineEvent {
                         }
 
                         UnsignedDecryptionResult::UnableToDecrypt(utd_info) => {
-                            // The bundled event was a UTD; store that information.
+                            // The bundled event was a UTD; store that
+                            // information.
                             return Some(Box::new(TimelineEvent::from_utd_with_max_timestamp(
                                 latest_event.cast(),
                                 utd_info.clone(),
@@ -756,8 +762,9 @@ impl TimelineEvent {
             }
 
             Ok(Some(MessageLikeEventType::RoomEncrypted)) => {
-                // The bundled latest thread event is encrypted, but we didn't have any
-                // information about it in the unsigned map. Try to fetch the information from
+                // The bundled latest thread event is encrypted, but we didn't
+                // have any information about it in the unsigned
+                // map. Try to fetch the information from
                 // the content instead.
                 let session_id = if let Some(content) =
                     latest_event.get_field::<EncryptedEventScheme>("content").ok().flatten()
@@ -825,8 +832,9 @@ impl TimelineEvent {
             TimelineEventKind::Decrypted(decrypted) => decrypted.event = replacement,
             TimelineEventKind::UnableToDecrypt { event, .. }
             | TimelineEventKind::PlainText { event } => {
-                // It's safe to cast `AnyMessageLikeEvent` into `AnySyncMessageLikeEvent`,
-                // because the former contains a superset of the fields included in the latter.
+                // It's safe to cast `AnyMessageLikeEvent` into
+                // `AnySyncMessageLikeEvent`, because the former
+                // contains a superset of the fields included in the latter.
                 *event = replacement.cast();
             }
         }
@@ -1155,8 +1163,8 @@ where
 {
     // Start by deserializing as to an untyped JSON value.
     let v: serde_json::Value = Deserialize::deserialize(d)?;
-    // Backwards compatibility: `MissingMegolmSession` used to be stored without the
-    // withheld code.
+    // Backwards compatibility: `MissingMegolmSession` used to be stored without
+    // the withheld code.
     if v.as_str().is_some_and(|s| s == "MissingMegolmSession") {
         return Ok(UnableToDecryptReason::MissingMegolmSession { withheld_code: None });
     }
@@ -1221,8 +1229,9 @@ impl UnableToDecryptReason {
     /// Returns true if this UTD is due to a missing room key (and hence might
     /// resolve itself if we wait a bit.)
     pub fn is_missing_room_key(&self) -> bool {
-        // In case of MissingMegolmSession with a withheld code we return false here
-        // given that this API is used to decide if waiting a bit will help.
+        // In case of MissingMegolmSession with a withheld code we return false
+        // here given that this API is used to decide if waiting a bit
+        // will help.
         matches!(
             self,
             Self::MissingMegolmSession { withheld_code: None } | Self::UnknownMegolmMessageIndex
@@ -1344,10 +1353,11 @@ impl From<SyncTimelineEventDeserializationHelperV1> for TimelineEvent {
             thread_summary,
         } = value;
 
-        // If `timestamp` is `None`, it is very likely that the event was serialised
-        // before the addition of the `timestamp` field. We _could_ compute it here, but
-        // if the `timestamp` was malicious, it means we are going to _cap_ the
-        // `timestamp` to `now()` for every deserialisation. It is annoying because it
+        // If `timestamp` is `None`, it is very likely that the event was
+        // serialised before the addition of the `timestamp` field. We
+        // _could_ compute it here, but if the `timestamp` was
+        // malicious, it means we are going to _cap_ the `timestamp` to
+        // `now()` for every deserialisation. It is annoying because it
         // means the event is no longer deterministic, it's not constant.
         // We don't want that. Consequently, we keep `None` here, and we let
         // [`TimelineEvent::timestamp`] to handle that case for us.
@@ -1395,12 +1405,13 @@ impl From<SyncTimelineEventDeserializationHelperV0> for TimelineEvent {
             unsigned_encryption_info,
         } = value;
 
-        // We do not compute the `timestamp` value here because if the `timestamp` is
-        // malicious, it means we are going to _cap_ the `timestamp` to `now()` for
-        // every deserialisation. It is annoying because it means the event is no longer
-        // deterministic, it's not constant. We don't want that. Consequently, we keep
-        // `None` here, and we let [`TimelineEvent::timestamp`] to handle that case for
-        // us.
+        // We do not compute the `timestamp` value here because if the
+        // `timestamp` is malicious, it means we are going to _cap_ the
+        // `timestamp` to `now()` for every deserialisation. It is
+        // annoying because it means the event is no longer
+        // deterministic, it's not constant. We don't want that. Consequently,
+        // we keep `None` here, and we let [`TimelineEvent::timestamp`]
+        // to handle that case for us.
         let timestamp = None;
 
         let kind = match encryption_info {
@@ -1782,8 +1793,8 @@ mod tests {
         assert_eq!(event.timestamp(), Some(MilliSecondsSinceUnixEpoch(UInt::new_saturating(2189))));
         assert!(event.timestamp_raw().is_none());
 
-        // Test that the previous format, with an undecryptable unsigned event, can also
-        // be deserialized.
+        // Test that the previous format, with an undecryptable unsigned event,
+        // can also be deserialized.
         let serialized = json!({
             "event": {
                 "content": {"body": "secret", "msgtype": "m.text"},
@@ -1862,8 +1873,8 @@ mod tests {
 
         let raw = Raw::new(&event).unwrap().cast_unchecked();
 
-        // When creating a timeline event from a raw event, the thread summary is always
-        // extracted, if available.
+        // When creating a timeline event from a raw event, the thread summary
+        // is always extracted, if available.
         let timeline_event = TimelineEvent::from_plaintext(raw);
         assert_matches!(timeline_event.thread_summary, ThreadSummaryStatus::Some(ThreadSummary { num_replies, latest_reply }) => {
             assert_eq!(num_replies, 2);
@@ -1872,8 +1883,8 @@ mod tests {
 
         assert!(timeline_event.bundled_latest_thread_event.is_some());
 
-        // When deserializing an old serialized timeline event, the thread summary is
-        // also extracted, if it wasn't serialized.
+        // When deserializing an old serialized timeline event, the thread
+        // summary is also extracted, if it wasn't serialized.
         let serialized_timeline_item = json!({
             "kind": {
                 "PlainText": {
@@ -1886,8 +1897,9 @@ mod tests {
             serde_json::from_value(serialized_timeline_item).unwrap();
         assert_matches!(timeline_event.thread_summary, ThreadSummaryStatus::Unknown);
 
-        // The bundled latest thread event is not persisted, so it should be `None` when
-        // deserialized from a previously serialized `TimelineEvent`.
+        // The bundled latest thread event is not persisted, so it should be
+        // `None` when deserialized from a previously serialized
+        // `TimelineEvent`.
         assert!(timeline_event.bundled_latest_thread_event.is_none());
     }
 

--- a/crates/matrix-sdk-common/src/edit_validation.rs
+++ b/crates/matrix-sdk-common/src/edit_validation.rs
@@ -136,15 +136,15 @@ pub fn check_validity_of_replacement_events(
     // We don't check the room ID here since this event might have been received
     // over /sync, in this case the JSON likely won't contain the room ID field.
 
-    // The original event and replacement event must have the same sender (i.e. you
-    // cannot edit someone else’s messages).
+    // The original event and replacement event must have the same sender (i.e.
+    // you cannot edit someone else’s messages).
     if original_event.sender != replacement_event.sender {
         return Err(EditValidityError::InvalidSender);
     }
 
-    // This check isn't part of the list in the spec, but it makes sense to check if
-    // the replacement event is has the correct rel_type and if it's an edit for the
-    // original event.
+    // This check isn't part of the list in the spec, but it makes sense to
+    // check if the replacement event is has the correct rel_type and if
+    // it's an edit for the original event.
     if let Some(relates_to) = replacement_event.content.relates_to {
         if relates_to.rel_type != Some(REPLACEMENT_REL_TYPE)
             || relates_to.event_id != Some(original_event.event_id)
@@ -155,8 +155,8 @@ pub fn check_validity_of_replacement_events(
         return Err(EditValidityError::NotReplacement);
     }
 
-    // The replacement and original events must have the same type (i.e. you cannot
-    // change the original event’s type).
+    // The replacement and original events must have the same type (i.e. you
+    // cannot change the original event’s type).
     if original_event.event_type != replacement_event.event_type {
         return Err(EditValidityError::MismatchContentType {
             content_type: original_event.event_type.to_owned(),
@@ -164,15 +164,15 @@ pub fn check_validity_of_replacement_events(
         });
     }
 
-    // The replacement and original events must not have a state_key property (i.e.
-    // you cannot edit state events at all).
+    // The replacement and original events must not have a state_key property
+    // (i.e. you cannot edit state events at all).
     if original_event.state_key.is_some() || replacement_event.state_key.is_some() {
         return Err(EditValidityError::StateKeyPresent);
     }
 
-    // The original event must not, itself, have a rel_type of m.replace (i.e. you
-    // cannot edit an edit — though you can send multiple edits for a single
-    // original event).
+    // The original event must not, itself, have a rel_type of m.replace (i.e.
+    // you cannot edit an edit — though you can send multiple edits for a
+    // single original event).
     if let Some(relates_to) = original_event.content.relates_to
         && relates_to.rel_type == Some(REPLACEMENT_REL_TYPE)
     {

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -115,7 +115,8 @@ mod sys {
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             if self.abort_handle.is_aborted() {
-                // The future has been aborted. It is not possible to poll it again.
+                // The future has been aborted. It is not possible to poll it
+                // again.
                 Poll::Ready(Err(JoinError::Cancelled))
             } else if let Some(handle) = self.remote_handle.as_mut() {
                 Pin::new(handle).poll(cx).map(Ok)
@@ -136,8 +137,8 @@ mod sys {
         let future = Abortable::new(future, abort_registration);
 
         wasm_bindgen_futures::spawn_local(async {
-            // Poll the future, and ignore the result (either it's `Ok(())`, or it's
-            // `Err(Aborted)`).
+            // Poll the future, and ignore the result (either it's `Ok(())`, or
+            // it's `Err(Aborted)`).
             let _ = future.await;
         });
 

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -295,8 +295,8 @@ impl<'a> JsFieldVisitor<'a> {
     }
 
     fn pad_and_record(&mut self, name: &str, value: &dyn Debug) -> fmt::Result {
-        // If this is the first field since the message, make a new line. Otherwise,
-        // just print a space.
+        // If this is the first field since the message, make a new line.
+        // Otherwise, just print a space.
         if self.is_empty {
             self.is_empty = false;
             write!(self.writer, "\n    ")?;

--- a/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/as_vector.rs
@@ -214,20 +214,21 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
 
         // Flags specifying when updates are reattaching detached items.
         //
-        // TL;DR: This is an optimization to avoid that insertions in the middle of a
-        // chunk cause a large series of `VectorDiff::Remove` and
+        // TL;DR: This is an optimization to avoid that insertions in the middle
+        // of a chunk cause a large series of `VectorDiff::Remove` and
         // `VectorDiff::Insert` updates for the elements placed after the
         // inserted item.
         //
         // Why is it useful?
         //
-        // Imagine a `LinkedChunk::<3, char, ()>` containing `['a', 'b', 'c'] ['d']`. If
-        // one wants to insert [`w`, x`, 'y', 'z'] at position
-        // `Position(ChunkIdentifier(0), 1)`, i.e. at the position of `b`, here is what
-        // happens:
+        // Imagine a `LinkedChunk::<3, char, ()>` containing `['a', 'b', 'c']
+        // ['d']`. If one wants to insert [`w`, x`, 'y', 'z'] at
+        // position `Position(ChunkIdentifier(0), 1)`, i.e. at the
+        // position of `b`, here is what happens:
         //
-        // 1. `LinkedChunk` will split off `['a', 'b', 'c']` at index 1, the chunk
-        //    becomes `['a']` and `b` and `c` are _detached_, thus we have:
+        // 1. `LinkedChunk` will split off `['a', 'b', 'c']` at index 1, the
+        //    chunk becomes `['a']` and `b` and `c` are _detached_, thus we
+        //    have:
         //
         //     ['a'] ['d']
         //
@@ -239,8 +240,8 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
         //
         //     ['a', 'w', 'x'] ['y', 'z', 'b'] ['c'] ['d']
         //
-        // This detaching/reattaching approach makes it reliable and safe. Good. Now,
-        // what updates are we going to receive for each step?
+        // This detaching/reattaching approach makes it reliable and safe. Good.
+        // Now, what updates are we going to receive for each step?
         //
         // Step 1, detaching last items:
         //
@@ -291,11 +292,12 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
         // * `Update::DetachLastItems` must not emit `VectorDiff::Remove`,
         //
         // * `Update::PushItems` must not emit `VectorDiff::Insert`s or
-        //   `VectorDiff::Append`s if it happens after `StartReattachItems` and before
-        //   `EndReattachItems`. However, `Self::chunks` must always be updated.
+        //   `VectorDiff::Append`s if it happens after `StartReattachItems` and
+        //   before `EndReattachItems`. However, `Self::chunks` must always be
+        //   updated.
         //
-        // From the `VectorDiff` “point of view”, this optimisation aims at avoiding
-        // removing items to push them again later.
+        // From the `VectorDiff` “point of view”, this optimisation aims at
+        // avoiding removing items to push them again later.
         let mut reattaching = false;
         let mut detaching = false;
 
@@ -306,8 +308,10 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
                     match (previous, next) {
                         // New chunk at the end.
                         (Some(_previous), None) => {
-                            // No need to check `previous`. It's possible that the linked chunk is
-                            // lazily loaded, chunk by chunk. The `next` is always reliable, but the
+                            // No need to check `previous`. It's possible that
+                            // the linked chunk is
+                            // lazily loaded, chunk by chunk. The `next` is
+                            // always reliable, but the
                             // `previous` might not exist in-memory yet.
 
                             self.chunks.push_back((*new, 0));
@@ -336,8 +340,10 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
                                 // or `ObservableUpdates` contain a bug.
                                 .expect("Inserting new chunk: The chunk is not found");
 
-                            // No need to check `previous`. It's possible that the linked chunk is
-                            // lazily loaded, chunk by chunk. The `next` is always reliable, but the
+                            // No need to check `previous`. It's possible that
+                            // the linked chunk is
+                            // lazily loaded, chunk by chunk. The `next` is
+                            // always reliable, but the
                             // `previous` might not exist in-memory yet.
 
                             self.chunks.insert(next_chunk_index, (*new, 0));
@@ -367,7 +373,8 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
                         .remove(chunk_index)
                         .expect("Removing an index out of the bounds");
 
-                    // Removing at the same index because each `Remove` shifts items to the left.
+                    // Removing at the same index because each `Remove` shifts
+                    // items to the left.
                     acc.extend(repeat_n(VectorDiff::Remove { index: offset }, number_of_items));
                 }
 
@@ -386,7 +393,8 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
                         continue;
                     }
 
-                    // Optimisation: we can emit a `VectorDiff::Append` in this particular case.
+                    // Optimisation: we can emit a `VectorDiff::Append` in this
+                    // particular case.
                     if is_pushing_back && !detaching {
                         acc.extend([VectorDiff::Append { values: items.into() }]);
                     }
@@ -491,9 +499,11 @@ impl<Item, Acc: UpdatesAccumulator<Item>> UpdateToVectorDiff<Item, Acc> {
 
                 // Chunk has not been found.
                 ControlFlow::Continue(..) => {
-                    // SAFETY: Assuming `LinkedChunk` and `ObservableUpdates` are not buggy, and
-                    // assuming `Self::chunks` is correctly initialized, it is not possible to work
-                    // on a chunk that does not exist. If this predicate fails, it means
+                    // SAFETY: Assuming `LinkedChunk` and `ObservableUpdates`
+                    // are not buggy, and
+                    // assuming `Self::chunks` is correctly initialized, it is
+                    // not possible to work on a chunk that
+                    // does not exist. If this predicate fails, it means
                     // `LinkedChunk` or `ObservableUpdates` contain a bug.
                     panic!("The chunk is not found");
                 }
@@ -655,7 +665,8 @@ mod tests {
 
         // From an `ObservableVector` point of view, it would look like:
         //
-        // 0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16  17
+        // 0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15  16
+        // 17
         // +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
         // | m | a | w | x | y | z | b | c | d | i | j | k | l | e | f | g | h |
         // +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -807,8 +818,8 @@ mod tests {
             assert_eq!(diffs.len(), 1);
             assert_matches!(&diffs[0], VectorDiff::Clear);
 
-            // 0 chunk in the `UpdateToVectorDiff` mapper, because the new chunk is lazily
-            // created.
+            // 0 chunk in the `UpdateToVectorDiff` mapper, because the new chunk
+            // is lazily created.
             let chunks = &as_vector.mapper.chunks;
             assert!(chunks.is_empty());
         }
@@ -870,8 +881,8 @@ mod tests {
 
         assert!(as_vector.take().is_empty());
 
-        // It's important to cause a change that will create new chunks, like pushing
-        // enough items.
+        // It's important to cause a change that will create new chunks, like
+        // pushing enough items.
         linked_chunk.push_items_back(['e', 'f', 'g']);
         #[rustfmt::skip]
         assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d', 'e', 'f'] ['g']);

--- a/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/lazy_loader.rs
@@ -46,7 +46,8 @@ pub fn from_last_chunk<const CAP: usize, Item, Gap>(
 
     // Create the `LinkedChunk` from a single chunk.
     {
-        // Take the `previous` chunk and consider it becomes the `lazy_previous`.
+        // Take the `previous` chunk and consider it becomes the
+        // `lazy_previous`.
         let lazy_previous = chunk.previous.take();
 
         // Transform the `RawChunk` into a `Chunk`.
@@ -104,7 +105,8 @@ where
             return Err(LazyLoaderError::MissingNextChunk { id: new_first_chunk.identifier });
         };
 
-        // New chunk has a next chunk, and it is the first chunk of the `LinkedChunk`.
+        // New chunk has a next chunk, and it is the first chunk of the
+        // `LinkedChunk`.
         if next_chunk != expected_next_chunk {
             return Err(LazyLoaderError::CannotConnectTwoChunks {
                 new_chunk: new_first_chunk.identifier,
@@ -112,8 +114,8 @@ where
             });
         }
 
-        // Same check as before, but in reverse: the first chunk has a `lazy_previous`
-        // to the new first chunk.
+        // Same check as before, but in reverse: the first chunk has a
+        // `lazy_previous` to the new first chunk.
         if first_chunk.lazy_previous() != Some(new_first_chunk.identifier) {
             return Err(LazyLoaderError::CannotConnectTwoChunks {
                 new_chunk: first_chunk.identifier,
@@ -146,8 +148,8 @@ where
             first_chunk.lazy_previous = None;
             unsafe { new_first_chunk.as_mut() }.lazy_previous = lazy_previous;
 
-            // Link one way: `new_first_chunk` becomes the previous chunk of the first
-            // chunk.
+            // Link one way: `new_first_chunk` becomes the previous chunk of the
+            // first chunk.
             first_chunk.previous = Some(new_first_chunk);
         }
 
@@ -159,8 +161,8 @@ where
             // `new_first_chunk` becomes the new first chunk.
             *links.first_chunk_mut_ptr() = new_first_chunk;
 
-            // Link the other way: `old_first_chunk` becomes the next chunk of the first
-            // chunk.
+            // Link the other way: `old_first_chunk` becomes the next chunk of
+            // the first chunk.
             links.first_chunk_mut().next = Some(old_first_chunk);
 
             debug_assert!(
@@ -168,9 +170,10 @@ where
                 "The new first chunk is not supposed to have a previous chunk"
             );
 
-            // Update the last chunk. If it's `Some(_)`, no need to update the last chunk
-            // pointer. If it's `None`, it means we had only one chunk; now we have two, the
-            // last chunk is the `old_first_chunk`.
+            // Update the last chunk. If it's `Some(_)`, no need to update the
+            // last chunk pointer. If it's `None`, it means we had
+            // only one chunk; now we have two, the last chunk is
+            // the `old_first_chunk`.
             if links.last.is_none() {
                 links.last = Some(old_first_chunk);
             }
@@ -224,9 +227,10 @@ where
     Gap: Clone,
 {
     let Some(mut chunk) = chunk else {
-        // This is equivalent to clearing the linked chunk, and overriding the chunk ID
-        // generator afterwards. But, if there was no chunks in the DB, the generator
-        // should be reset too, so it's entirely equivalent to a clear.
+        // This is equivalent to clearing the linked chunk, and overriding the
+        // chunk ID generator afterwards. But, if there was no chunks in
+        // the DB, the generator should be reset too, so it's entirely
+        // equivalent to a clear.
         linked_chunk.clear();
         return Ok(());
     };
@@ -267,8 +271,8 @@ where
     unsafe { linked_chunk.links.replace_with(chunk_ptr) };
 
     if let Some(updates) = linked_chunk.updates.as_mut() {
-        // Clear the previous updates, as we're about to insert a clear they would be
-        // useless.
+        // Clear the previous updates, as we're about to insert a clear they
+        // would be useless.
         updates.clear_pending();
         updates.push(Update::Clear);
 
@@ -292,8 +296,8 @@ where
     }
 
     // Sort by `next` so that the search for the next chunk is faster (it should
-    // come first). The chunk with the biggest next chunk identifier comes first.
-    // Chunk with no next chunk comes last.
+    // come first). The chunk with the biggest next chunk identifier comes
+    // first. Chunk with no next chunk comes last.
     chunks.sort_by_key(|item| Reverse(item.next));
 
     let last_chunk = chunks
@@ -322,10 +326,10 @@ where
 
     let first_chunk = linked_chunk.links.first_chunk();
 
-    // It is expected that **all chunks** are passed to this function. If there was
-    // a previous chunk, `insert_new_first_chunk` has erased it and moved it to
-    // `lazy_previous`. Hence, let's check both (the former condition isn't
-    // necessary, but better be robust).
+    // It is expected that **all chunks** are passed to this function. If there
+    // was a previous chunk, `insert_new_first_chunk` has erased it and
+    // moved it to `lazy_previous`. Hence, let's check both (the former
+    // condition isn't necessary, but better be robust).
     if first_chunk.previous().is_some() || first_chunk.lazy_previous.is_some() {
         return Err(LazyLoaderError::ChunkIsNotFirst { id: first_chunk.identifier() });
     }
@@ -864,12 +868,12 @@ mod tests {
     fn test_from_all_chunks_success() {
         let cid0 = ChunkIdentifier::new(0);
         let cid1 = ChunkIdentifier::new(1);
-        // Note: cid2 is missing on purpose, to confirm that it's fine to have holes in
-        // the chunk id space.
+        // Note: cid2 is missing on purpose, to confirm that it's fine to have
+        // holes in the chunk id space.
         let cid3 = ChunkIdentifier::new(3);
 
-        // Check that we can successfully create a linked chunk, independently of the
-        // order in which chunks are added.
+        // Check that we can successfully create a linked chunk, independently
+        // of the order in which chunks are added.
         //
         // The final chunk will contain [cid0 <-> cid1 <-> cid3], in this order.
 
@@ -935,7 +939,8 @@ mod tests {
         // The linked chunk had 5 items.
         assert_eq!(lc.num_items(), 5);
 
-        // Now, if we add a new chunk, its identifier should be the previous one we used
+        // Now, if we add a new chunk, its identifier should be the previous one
+        // we used
         // + 1.
         lc.push_gap_back('h');
 
@@ -947,8 +952,8 @@ mod tests {
     fn test_from_all_chunks_chunk_too_large() {
         let cid0 = ChunkIdentifier::new(0);
 
-        // Adding a chunk with 4 items will fail, because the max capacity specified in
-        // the builder generics is 3.
+        // Adding a chunk with 4 items will fail, because the max capacity
+        // specified in the builder generics is 3.
         let res = from_all_chunks::<3, char, ()>(vec![RawChunk {
             previous: None,
             identifier: cid0,

--- a/crates/matrix-sdk-common/src/linked_chunk/mod.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/mod.rs
@@ -218,8 +218,8 @@ impl<const CAP: usize, Item, Gap> Ends<CAP, Item, Gap> {
 
     /// Lazily get an mutable pointer to the first chunk.
     fn first_chunk_mut_ptr(&mut self) -> &mut NonNull<Chunk<CAP, Item, Gap>> {
-        // `OnceLock::get_or_init_mut` is unstable. We can fake it by using a combo of
-        // `get_or_init` + `get_mut`.
+        // `OnceLock::get_or_init_mut` is unstable. We can fake it by using a
+        // combo of `get_or_init` + `get_mut`.
         let _ = self.first_chunk_ptr();
 
         self.first
@@ -233,23 +233,23 @@ impl<const CAP: usize, Item, Gap> Ends<CAP, Item, Gap> {
 
     /// Get the first chunk, as an immutable reference.
     fn first_chunk(&self) -> &Chunk<CAP, Item, Gap> {
-        // SAFETY: The pointer to the first chunk has been correctly initialised and is
-        // convertible to a reference.
+        // SAFETY: The pointer to the first chunk has been correctly initialised
+        // and is convertible to a reference.
         unsafe { self.first_chunk_ptr().as_ref() }
     }
 
     /// Get the first chunk, as a mutable reference.
     fn first_chunk_mut(&mut self) -> &mut Chunk<CAP, Item, Gap> {
-        // SAFETY: The pointer to the first chunk has been correctly initialised and is
-        // convertible to a mutable reference.
+        // SAFETY: The pointer to the first chunk has been correctly initialised
+        // and is convertible to a mutable reference.
         unsafe { self.first_chunk_mut_ptr().as_mut() }
     }
 
     /// Get the latest chunk, as an immutable reference.
     fn latest_chunk(&self) -> &Chunk<CAP, Item, Gap> {
         if let Some(last) = &self.last {
-            // SAFETY: The pointer to the last chunk has been correctly initialised and is
-            // convertible to a reference.
+            // SAFETY: The pointer to the last chunk has been correctly
+            // initialised and is convertible to a reference.
             unsafe { last.as_ref() }
         } else {
             self.first_chunk()
@@ -259,8 +259,9 @@ impl<const CAP: usize, Item, Gap> Ends<CAP, Item, Gap> {
     /// Get the latest chunk, as a mutable reference.
     fn latest_chunk_mut(&mut self) -> &mut Chunk<CAP, Item, Gap> {
         if let Some(last) = &mut self.last {
-            // SAFETY: The pointer to the last chunk has been correctly initialised and is
-            // convertible to a mutable reference.
+            // SAFETY: The pointer to the last chunk has been correctly
+            // initialised and is convertible to a mutable
+            // reference.
             unsafe { last.as_mut() }
         } else {
             self.first_chunk_mut()
@@ -296,8 +297,8 @@ impl<const CAP: usize, Item, Gap> Ends<CAP, Item, Gap> {
     /// Drop all the chunks, the first chunk will be created lazily with the
     /// identifier [`ChunkIdentifierGenerator::FIRST_IDENTIFIER`].
     fn clear(&mut self) {
-        // Loop over all chunks, from the last to the first chunk, and drop them.
-        // Take the latest chunk.
+        // Loop over all chunks, from the last to the first chunk, and drop
+        // them. Take the latest chunk.
         let mut current_chunk_ptr = self.last.or_else(|| self.first.get().copied());
 
         // As long as we have another chunk…
@@ -408,8 +409,8 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         // “Clear” `self.updates`.
         if let Some(updates) = self.updates.as_mut() {
-            // Clear the previous updates, as we're about to insert a clear they would be
-            // useless.
+            // Clear the previous updates, as we're about to insert a clear they
+            // would be useless.
             updates.clear_pending();
             updates.push(Update::Clear);
         }
@@ -437,12 +438,12 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         debug_assert!(last_chunk.is_last_chunk(), "`last_chunk` must be… the last chunk");
 
-        // We need to update `self.links.last` if and only if `last_chunk` _is not_ the
-        // first chunk, and _is_ the last chunk (ensured by the `debug_assert!`
-        // above).
+        // We need to update `self.links.last` if and only if `last_chunk` _is
+        // not_ the first chunk, and _is_ the last chunk (ensured by the
+        // `debug_assert!` above).
         if !last_chunk.is_first_chunk() {
-            // Maybe `last_chunk` is the same as the previous `self.links.last` chunk, but
-            // it's OK.
+            // Maybe `last_chunk` is the same as the previous `self.links.last`
+            // chunk, but it's OK.
             self.links.last = Some(last_chunk.as_ptr());
         }
     }
@@ -539,11 +540,11 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             }
         };
 
-        // We need to update `self.links.last` if and only if `chunk` _is not_ the first
-        // chunk, and _is_ the last chunk.
+        // We need to update `self.links.last` if and only if `chunk` _is not_
+        // the first chunk, and _is_ the last chunk.
         if !chunk.is_first_chunk() && chunk.is_last_chunk() {
-            // Maybe `chunk` is the same as the previous `self.links.last` chunk, but it's
-            // OK.
+            // Maybe `chunk` is the same as the previous `self.links.last`
+            // chunk, but it's OK.
             self.links.last = Some(chunk.as_ptr());
         }
 
@@ -594,8 +595,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
                 chunk_ptr = Some(chunk.as_ptr());
 
-                // We need to update `self.links.last` if and only if `chunk` _is_ the last
-                // chunk. The new last chunk is the chunk before `chunk`.
+                // We need to update `self.links.last` if and only if `chunk`
+                // _is_ the last chunk. The new last chunk is
+                // the chunk before `chunk`.
                 if chunk.is_last_chunk() {
                     self.links.last = chunk.previous;
                 }
@@ -609,8 +611,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
             // Re-box the chunk, and let Rust do its job.
             //
-            // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk` doesn't
-            // use it anymore, it's a leak. It is time to re-`Box` it and drop it.
+            // SAFETY: `chunk` is unlinked and not borrowed anymore.
+            // `LinkedChunk` doesn't use it anymore, it's a leak. It
+            // is time to re-`Box` it and drop it.
             let _chunk_boxed = unsafe { Box::from_raw(chunk_ptr.as_ptr()) };
         }
 
@@ -643,7 +646,8 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
                     return Err(Error::InvalidItemIndex { index: item_index });
                 }
 
-                // Avoid one spurious clone by notifying about the update *before* applying it.
+                // Avoid one spurious clone by notifying about the update
+                // *before* applying it.
                 if let Some(updates) = self.updates.as_mut() {
                     updates.push(Update::ReplaceItem {
                         at: Position(chunk_identifier, item_index),
@@ -681,8 +685,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             }
 
             ChunkContent::Items(current_items) => {
-                // If `item_index` is 0, we don't want to split the current items chunk to
-                // insert a new gap chunk, otherwise it would create an empty current items
+                // If `item_index` is 0, we don't want to split the current
+                // items chunk to insert a new gap chunk,
+                // otherwise it would create an empty current items
                 // chunk. Let's handle this case in particular.
                 if item_index == 0 {
                     let chunk_was_first = chunk.is_first_chunk();
@@ -698,12 +703,14 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
                     // `chunk` was the first: let's update `self.links.first`.
                     //
-                    // If `chunk` was not the first but was the last, there is nothing to do,
-                    // `self.links.last` is already up-to-date.
+                    // If `chunk` was not the first but was the last, there is
+                    // nothing to do, `self.links.last` is
+                    // already up-to-date.
                     if chunk_was_first {
                         *self.links.first_chunk_mut_ptr() = new_chunk_ptr;
 
-                        // `chunk` was the first __and__ the last: let's set `self.links.last`.
+                        // `chunk` was the first __and__ the last: let's set
+                        // `self.links.last`.
                         if chunk_was_last {
                             self.links.last = Some(chunk_ptr);
                         }
@@ -759,11 +766,11 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             }
         };
 
-        // We need to update `self.links.last` if and only if `chunk` _is not_ the first
-        // chunk, and _is_ the last chunk.
+        // We need to update `self.links.last` if and only if `chunk` _is not_
+        // the first chunk, and _is_ the last chunk.
         if !chunk.is_first_chunk() && chunk.is_last_chunk() {
-            // Maybe `chunk` is the same as the previous `self.links.last` chunk, but it's
-            // OK.
+            // Maybe `chunk` is the same as the previous `self.links.last`
+            // chunk, but it's OK.
             self.links.last = Some(chunk.as_ptr());
         }
 
@@ -818,8 +825,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
             self.links.last = previous_ptr;
         }
 
-        // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk` doesn't
-        // use it anymore, it's a leak. It is time to re-`Box` it and drop it.
+        // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk`
+        // doesn't use it anymore, it's a leak. It is time to re-`Box`
+        // it and drop it.
         let _chunk_boxed = unsafe { Box::from_raw(chunk_ptr.as_ptr()) };
 
         // Return the first position of the next chunk, if any.
@@ -890,8 +898,8 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
                 *self.links.first_chunk_mut_ptr() = new_chunk_ptr;
             }
 
-            // Update `self.links.last` if the gap (so the new) chunk was (is) the last
-            // chunk.
+            // Update `self.links.last` if the gap (so the new) chunk was (is)
+            // the last chunk.
             if let Some(last_chunk_ptr) = maybe_last_chunk_ptr {
                 self.links.last = Some(last_chunk_ptr);
             }
@@ -901,8 +909,9 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
 
         // Re-box the chunk, and let Rust do its job.
         //
-        // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk` doesn't
-        // use it anymore, it's a leak. It is time to re-`Box` it and drop it.
+        // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk`
+        // doesn't use it anymore, it's a leak. It is time to re-`Box`
+        // it and drop it.
         let _chunk_boxed = unsafe { Box::from_raw(chunk_ptr.as_ptr()) };
 
         Ok(
@@ -1130,7 +1139,8 @@ impl<const CAP: usize, Item, Gap> Drop for LinkedChunk<CAP, Item, Gap> {
         // Calling `Self::clear` would be an error as we don't want to emit an
         // `Update::Clear` when `self` is dropped. Instead, we only care about
         // freeing memory correctly. Rust can take care of everything except the
-        // pointers in `self.links`, hence the specific call to `self.links.clear()`.
+        // pointers in `self.links`, hence the specific call to
+        // `self.links.clear()`.
         self.links.clear();
     }
 }
@@ -1659,9 +1669,10 @@ impl<const CAPACITY: usize, Item, Gap> Chunk<CAPACITY, Item, Gap> {
     fn unlink(&mut self, updates: Option<&mut ObservableUpdates<Item, Gap>>) {
         let previous_ptr = self.previous;
         let next_ptr = self.next;
-        // If `self` is not the first, `lazy_previous` might be set on its previous
-        // chunk. Otherwise, if `lazy_previous` is set on `self`, it means it's the
-        // first chunk and it must be moved onto the next chunk.
+        // If `self` is not the first, `lazy_previous` might be set on its
+        // previous chunk. Otherwise, if `lazy_previous` is set on
+        // `self`, it means it's the first chunk and it must be moved
+        // onto the next chunk.
         let lazy_previous = self.lazy_previous.take();
 
         if let Some(previous) = self.previous_mut() {
@@ -2257,8 +2268,9 @@ mod tests {
         {
             let pos_e = linked_chunk.item_position(|item| *item == 'e').unwrap();
 
-            // Insert 4 elements, so that it overflows the chunk capacity. It's important to
-            // see whether chunks are correctly updated and linked.
+            // Insert 4 elements, so that it overflows the chunk capacity. It's
+            // important to see whether chunks are correctly updated
+            // and linked.
             linked_chunk.insert_items_at(pos_e, ['w', 'x', 'y', 'z'])?;
 
             assert_items_eq!(
@@ -2433,8 +2445,9 @@ mod tests {
         // Insert inside the last chunk.
         let pos_e = linked_chunk.item_position(|item| *item == 'e').unwrap();
 
-        // Insert 4 elements, so that it overflows the chunk capacity. It's important to
-        // see whether chunks are correctly updated and linked.
+        // Insert 4 elements, so that it overflows the chunk capacity. It's
+        // important to see whether chunks are correctly updated and
+        // linked.
         linked_chunk.insert_items_at(pos_e, ['w', 'x', 'y', 'z'])?;
 
         assert_items_eq!(
@@ -2684,8 +2697,8 @@ mod tests {
         // Ignore previous updates.
         let _ = linked_chunk.updates().unwrap().take();
 
-        // Remove the last item of the middle chunk, 3 times. The chunk is empty after
-        // that. The chunk is removed.
+        // Remove the last item of the middle chunk, 3 times. The chunk is empty
+        // after that. The chunk is removed.
         {
             let position_of_f = linked_chunk.item_position(|item| *item == 'f').unwrap();
             let removed_item = linked_chunk.remove_item_at(position_of_f)?;
@@ -2719,8 +2732,9 @@ mod tests {
             );
         }
 
-        // Remove the first item of the first chunk, 3 times. The chunk is empty after
-        // that. The chunk is NOT removed because it's the first chunk.
+        // Remove the first item of the first chunk, 3 times. The chunk is empty
+        // after that. The chunk is NOT removed because it's the first
+        // chunk.
         {
             let first_position = linked_chunk.item_position(|item| *item == 'a').unwrap();
             let removed_item = linked_chunk.remove_item_at(first_position)?;
@@ -2751,8 +2765,8 @@ mod tests {
             );
         }
 
-        // Remove the first item of the middle chunk, 3 times. The chunk is empty after
-        // that. The chunk is removed.
+        // Remove the first item of the middle chunk, 3 times. The chunk is
+        // empty after that. The chunk is removed.
         {
             let first_position = linked_chunk.item_position(|item| *item == 'g').unwrap();
             let removed_item = linked_chunk.remove_item_at(first_position)?;
@@ -2784,8 +2798,8 @@ mod tests {
             );
         }
 
-        // Remove the last item of the last chunk, twice. The chunk is empty after that.
-        // The chunk is removed.
+        // Remove the last item of the last chunk, twice. The chunk is empty
+        // after that. The chunk is removed.
         {
             let position_of_k = linked_chunk.item_position(|item| *item == 'k').unwrap();
             let removed_item = linked_chunk.remove_item_at(position_of_k)?;
@@ -2812,7 +2826,8 @@ mod tests {
             );
         }
 
-        // Add a couple more items, delete one, add a gap, and delete more items.
+        // Add a couple more items, delete one, add a gap, and delete more
+        // items.
         {
             linked_chunk.push_items_back(['a', 'b', 'c', 'd']);
 
@@ -2826,7 +2841,8 @@ mod tests {
                 Err(Error::InvalidItemIndex { index: 3 })
             );
 
-            // Delete at an out-of-bound position (way after `c`), that is invalid.
+            // Delete at an out-of-bound position (way after `c`), that is
+            // invalid.
             assert_matches!(
                 linked_chunk.remove_item_at(Position(ChunkIdentifier(0), 42)),
                 Err(Error::InvalidItemIndex { index: 42 })
@@ -2932,14 +2948,15 @@ mod tests {
             );
         }
 
-        // Insert at the beginning of a chunk. The targeted chunk is the first chunk.
-        // `Ends::first` and `Ends::last` may be updated differently.
+        // Insert at the beginning of a chunk. The targeted chunk is the first
+        // chunk. `Ends::first` and `Ends::last` may be updated
+        // differently.
         {
             let position_of_a = linked_chunk.item_position(|item| *item == 'a').unwrap();
             linked_chunk.insert_gap_at((), position_of_a)?;
 
-            // A new empty chunk is NOT created, i.e. `['a']` is not split into `[]` +
-            // `['a']` because it's a waste of space.
+            // A new empty chunk is NOT created, i.e. `['a']` is not split into
+            // `[]` + `['a']` because it's a waste of space.
             assert_items_eq!(linked_chunk, [-] ['a'] [-] ['b', 'c'] ['d', 'e', 'f']);
             assert_eq!(
                 linked_chunk.updates().unwrap().take(),
@@ -2952,8 +2969,9 @@ mod tests {
             );
         }
 
-        // Insert at the beginning of a chunk. The targeted chunk is not the first
-        // chunk. `Ends::first` and `Ends::last` may be updated differently.
+        // Insert at the beginning of a chunk. The targeted chunk is not the
+        // first chunk. `Ends::first` and `Ends::last` may be updated
+        // differently.
         {
             let position_of_d = linked_chunk.item_position(|item| *item == 'd').unwrap();
             linked_chunk.insert_gap_at((), position_of_d)?;
@@ -3027,8 +3045,9 @@ mod tests {
 
         // Insert in an existing gap.
         {
-            // It is impossible to get the item position inside a gap. It's only possible if
-            // the item position is crafted by hand or is outdated.
+            // It is impossible to get the item position inside a gap. It's only
+            // possible if the item position is crafted by hand or
+            // is outdated.
             let position_of_a_gap = Position(ChunkIdentifier(2), 0);
             assert_matches!(
                 linked_chunk.insert_gap_at((), position_of_a_gap),
@@ -3364,8 +3383,8 @@ mod tests {
         assert!(chunks.next().is_none());
     }
 
-    // Test `LinkedChunk::clear`. This test creates a `LinkedChunk` with `new` to
-    // avoid creating too much confusion with `Update`s. The next test
+    // Test `LinkedChunk::clear`. This test creates a `LinkedChunk` with `new`
+    // to avoid creating too much confusion with `Update`s. The next test
     // `test_clear_emit_an_update_clear` uses `new_with_update_history` and only
     // test `Update::Clear`.
     #[test]
@@ -3397,8 +3416,8 @@ mod tests {
 
         assert_eq!(Arc::strong_count(&item), 1);
         assert_eq!(Arc::strong_count(&gap), 1);
-        // One chunk because the first chunk is created lazily, which happens when
-        // iterating over the chunks.
+        // One chunk because the first chunk is created lazily, which happens
+        // when iterating over the chunks.
         assert_eq!(linked_chunk.chunks().filter(|chunk| chunk.is_items()).count(), 1);
         assert_eq!(linked_chunk.chunks().filter(|chunk| chunk.is_gap()).count(), 0);
         assert_eq!(linked_chunk.num_items(), 0);
@@ -3453,8 +3472,8 @@ mod tests {
         // When clearing an already clear linked chunk…
         linked_chunk.clear();
 
-        // … we see only `Clear` without `NewItemsChunk`, i.e. the first chunk is NOT
-        // created lazily!
+        // … we see only `Clear` without `NewItemsChunk`, i.e. the first chunk
+        // is NOT created lazily!
         assert_eq!(linked_chunk.updates().unwrap().take(), &[Clear]);
     }
 
@@ -3513,8 +3532,8 @@ mod tests {
             marker: PhantomData,
         };
 
-        // Insert items in the first loaded chunk (chunk 1), with an overflow to a new
-        // chunk.
+        // Insert items in the first loaded chunk (chunk 1), with an overflow to
+        // a new chunk.
         {
             linked_chunk.push_items_back(['a', 'b', 'c', 'd']);
 
@@ -3577,7 +3596,8 @@ mod tests {
                 assert!(chunks.next().is_none());
             }
 
-            // In the updates, we observe that the new gap **has** a previous chunk!
+            // In the updates, we observe that the new gap **has** a previous
+            // chunk!
             assert_eq!(
                 linked_chunk.updates().unwrap().take(),
                 &[NewGapChunk {
@@ -3683,7 +3703,8 @@ mod tests {
                 assert!(chunks.next().is_none());
             }
 
-            // In the updates, we observe that the new gap **has** a previous chunk!
+            // In the updates, we observe that the new gap **has** a previous
+            // chunk!
             assert_eq!(
                 linked_chunk.updates().unwrap().take(),
                 &[NewGapChunk {

--- a/crates/matrix-sdk-common/src/linked_chunk/order_tracker.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/order_tracker.rs
@@ -136,8 +136,8 @@ where
     /// Will return `None` if the position doesn't match a known chunk in the
     /// linked chunk, or if the chunk is a gap.
     pub fn ordering(&self, event_pos: Position) -> Option<usize> {
-        // Check the precondition: there must not be any pending updates for this
-        // reader.
+        // Check the precondition: there must not be any pending updates for
+        // this reader.
         debug_assert!(self.updates.read().unwrap().is_reader_up_to_date(self.token));
 
         // Find the chunk that contained the event.
@@ -149,12 +149,12 @@ where
                     // The event is out of bounds for this chunk, return None.
                     return None;
                 }
-                // The final ordering is the number of items before the event, plus its own
-                // index within the chunk.
+                // The final ordering is the number of items before the event,
+                // plus its own index within the chunk.
                 return Some(ordering + offset_within_chunk);
             }
-            // This is not the target chunk yet, so add the size of the current chunk to the
-            // number of seen items, and continue.
+            // This is not the target chunk yet, so add the size of the current
+            // chunk to the number of seen items, and continue.
             ordering += *chunk_length;
         }
 
@@ -276,9 +276,9 @@ mod tests {
 
     #[async_test]
     async fn test_lazy_loading() {
-        // Assume that all the chunks haven't been loaded yet, so we have a few of them
-        // in some memory, and some of them are still in an hypothetical
-        // database.
+        // Assume that all the chunks haven't been loaded yet, so we have a few
+        // of them in some memory, and some of them are still in an
+        // hypothetical database.
         let db_metadata = vec![
             // Hypothetical non-empty items chunk with items 'a', 'b', 'c'.
             ChunkMetadata {
@@ -325,8 +325,8 @@ mod tests {
 
         let tracker = linked_chunk.order_tracker(Some(db_metadata)).unwrap();
 
-        // At first, even if the main linked chunk is empty, the order tracker can
-        // compute the position for unloaded items.
+        // At first, even if the main linked chunk is empty, the order tracker
+        // can compute the position for unloaded items.
 
         // Order of 'a':
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(0), 0)), Some(0));
@@ -347,7 +347,8 @@ mod tests {
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(2), 1)), Some(4));
         // Order of 'f':
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(2), 2)), Some(5));
-        // No subsequent entry in the same chunk, it's been split when inserting g.
+        // No subsequent entry in the same chunk, it's been split when inserting
+        // g.
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(2), 3)), None);
 
         // Order of 'g':
@@ -358,9 +359,9 @@ mod tests {
 
     #[async_test]
     async fn test_lazy_updates() {
-        // Assume that all the chunks haven't been loaded yet, so we have a few of them
-        // in some memory, and some of them are still in an hypothetical
-        // database.
+        // Assume that all the chunks haven't been loaded yet, so we have a few
+        // of them in some memory, and some of them are still in an
+        // hypothetical database.
         let db_metadata = vec![
             // Hypothetical non-empty items chunk with items 'a', 'b'.
             ChunkMetadata {
@@ -511,9 +512,9 @@ mod tests {
 
     #[async_test]
     async fn test_out_of_band_updates() {
-        // Assume that all the chunks haven't been loaded yet, so we have a few of them
-        // in some memory, and some of them are still in an hypothetical
-        // database.
+        // Assume that all the chunks haven't been loaded yet, so we have a few
+        // of them in some memory, and some of them are still in an
+        // hypothetical database.
         let db_metadata = vec![
             // Hypothetical non-empty items chunk with items 'a', 'b'.
             ChunkMetadata {
@@ -555,15 +556,16 @@ mod tests {
         // Order of 'e':
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(2), 1)), Some(3));
 
-        // It's possible to apply updates out of band, i.e. without affecting the
-        // observed linked chunk. This can be useful when an update only applies
-        // to a database, but not to the in-memory linked chunk.
+        // It's possible to apply updates out of band, i.e. without affecting
+        // the observed linked chunk. This can be useful when an update
+        // only applies to a database, but not to the in-memory linked
+        // chunk.
         tracker.map_updates(&[Update::RemoveChunk(ChunkIdentifier::new(0))]);
 
         // 'b' doesn't exist anymore, so its ordering is now undefined.
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(0), 1)), None);
-        // 'e' has been shifted back by 2 places, aka the number of items in the first
-        // chunk.
+        // 'e' has been shifted back by 2 places, aka the number of items in the
+        // first chunk.
         assert_eq!(tracker.ordering(Position::new(ChunkIdentifier::new(2), 1)), Some(1));
     }
 }

--- a/crates/matrix-sdk-common/src/linked_chunk/relational.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/relational.rs
@@ -220,21 +220,24 @@ where
                         let linked_chunk_items =
                             self.items.entry(linked_chunk_id.to_owned()).or_default();
 
-                        // Ensure item does not already exist in another position
-                        // in this linked chunk.
+                        // Ensure item does not already exist in another
+                        // position in this linked
+                        // chunk.
                         //
-                        // Note that we do not check `items_chunks`, going through each
-                        // `ItemRow` is very slow. So, it is imperative that `items` is
-                        // kept in sync with `items_chunks` in order for the check below
-                        // to be sufficient.
+                        // Note that we do not check `items_chunks`, going
+                        // through each `ItemRow` is
+                        // very slow. So, it is imperative that `items` is
+                        // kept in sync with `items_chunks` in order for the
+                        // check below to be sufficient.
                         if let Some((_, position)) = linked_chunk_items.get(&item_id)
                             && position.is_some()
                         {
                             return Err(RelationalLinkedChunkError::ItemAlreadyInLinkedChunk);
                         }
 
-                        // Ensure position is not occupied by another item. If position
-                        // is already occupied, return an error.
+                        // Ensure position is not occupied by another item. If
+                        // position is already occupied,
+                        // return an error.
                         if self.items_positions.insert((linked_chunk_id.to_owned(), at)).not() {
                             return Err(RelationalLinkedChunkError::PositionAlreadyOccupied);
                         }
@@ -246,7 +249,8 @@ where
                             item: Either::Item(item_id),
                         });
 
-                        // Ensure item is updated if it exists anywhere else in the store
+                        // Ensure item is updated if it exists anywhere else in
+                        // the store
                         for items in &mut self.items.values_mut() {
                             items.entry(item.id()).and_modify(|e| e.0 = item.clone());
                         }
@@ -272,7 +276,8 @@ where
                         .insert(item_id.clone(), (item.clone(), Some(at)));
                     existing.item = Either::Item(item_id.clone());
 
-                    // Ensure item is updated if it exists anywhere else in the store
+                    // Ensure item is updated if it exists anywhere else in the
+                    // store
                     for items in &mut self.items.values_mut() {
                         items.entry(item_id.clone()).and_modify(|e| e.0 = item.clone());
                     }
@@ -307,7 +312,8 @@ where
                             entry_to_remove = Some(nth);
                         }
 
-                        // Update all items that come _after_ `at` to shift their index.
+                        // Update all items that come _after_ `at` to shift
+                        // their index.
                         if position.chunk_identifier() == at.chunk_identifier()
                             && position.index() > at.index()
                         {
@@ -588,7 +594,8 @@ where
         &self,
         linked_chunk_id: LinkedChunkId<'_>,
     ) -> Result<(Option<RawChunk<Item, Gap>>, ChunkIdentifierGenerator), String> {
-        // Find the latest chunk identifier to generate a `ChunkIdentifierGenerator`.
+        // Find the latest chunk identifier to generate a
+        // `ChunkIdentifierGenerator`.
         let chunk_identifier_generator = match self
             .chunks
             .iter()
@@ -651,7 +658,8 @@ where
         linked_chunk_id: LinkedChunkId<'_>,
         before_chunk_identifier: ChunkIdentifier,
     ) -> Result<Option<RawChunk<Item, Gap>>, String> {
-        // Find the chunk before the chunk identified by `before_chunk_identifier`.
+        // Find the chunk before the chunk identified by
+        // `before_chunk_identifier`.
         let Some(chunk_row) = self.chunks.iter().find(|chunk_row| {
             chunk_row.linked_chunk_id == linked_chunk_id
                 && chunk_row.next_chunk == Some(before_chunk_identifier)
@@ -813,8 +821,9 @@ where
     Ok(match first_item.item {
         // This is a chunk of kind `Items`.
         Either::Item(_) => {
-            // Count all the items. We add an additional filter that will exclude gaps, in
-            // case the chunk is malformed, but we should not have to, in theory.
+            // Count all the items. We add an additional filter that will
+            // exclude gaps, in case the chunk is malformed, but we
+            // should not have to, in theory.
 
             let mut num_items = 0;
             for item in items {

--- a/crates/matrix-sdk-common/src/linked_chunk/updates.rs
+++ b/crates/matrix-sdk-common/src/linked_chunk/updates.rs
@@ -193,8 +193,8 @@ impl<Item, Gap> ObservableUpdates<Item, Gap> {
     pub(super) fn new_reader_token(&mut self) -> ReaderToken {
         let mut inner = self.inner.write().unwrap();
 
-        // Add 1 before reading the `last_token`, in this particular order, because the
-        // 0 token is reserved by `MAIN_READER_TOKEN`.
+        // Add 1 before reading the `last_token`, in this particular order,
+        // because the 0 token is reserved by `MAIN_READER_TOKEN`.
         inner.last_token += 1;
         let last_token = inner.last_token;
 
@@ -362,7 +362,8 @@ impl<Item, Gap> UpdatesInner<Item, Gap> {
         if min_index > 0 {
             let _ = self.updates.drain(0..min_index);
 
-            // Let's shift the indices to the left by `min_index` to preserve them.
+            // Let's shift the indices to the left by `min_index` to preserve
+            // them.
             for index in self.last_index_per_reader.values_mut() {
                 *index -= min_index;
             }
@@ -400,7 +401,8 @@ where
 
     fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let Some(updates) = self.updates.upgrade() else {
-            // The `ObservableUpdates` has been dropped. It's time to close this stream.
+            // The `ObservableUpdates` has been dropped. It's time to close this
+            // stream.
             return Poll::Ready(None);
         };
 
@@ -424,14 +426,15 @@ where
 impl<Item, Gap> Drop for UpdatesSubscriber<Item, Gap> {
     fn drop(&mut self) {
         // Remove `Self::token` from `UpdatesInner::last_index_per_reader`.
-        // This is important so that the garbage collector can do its jobs correctly
-        // without a dead dangling reader token.
+        // This is important so that the garbage collector can do its jobs
+        // correctly without a dead dangling reader token.
         if let Some(updates) = self.updates.upgrade() {
             let mut updates = updates.write().unwrap();
 
             // Remove the reader token from `UpdatesInner`.
-            // It's safe to ignore the result of `remove` here: `None` means the token was
-            // already removed (note: it should be unreachable).
+            // It's safe to ignore the result of `remove` here: `None` means the
+            // token was already removed (note: it should be
+            // unreachable).
             let _ = updates.last_index_per_reader.remove(&self.token);
         }
     }
@@ -499,8 +502,8 @@ mod tests {
         linked_chunk.push_items_back(['b']);
         linked_chunk.push_items_back(['c']);
 
-        // Scenario 1: “main” takes the new updates, “other” doesn't take the new
-        // updates.
+        // Scenario 1: “main” takes the new updates, “other” doesn't take the
+        // new updates.
         //
         // 0   1   2   3
         // +---+---+---+
@@ -530,8 +533,9 @@ mod tests {
                 let inner = updates.inner.read().unwrap();
 
                 // Inspect number of updates in memory.
-                // It must be the same number as before as the garbage collector weren't not
-                // able to remove any unused updates.
+                // It must be the same number as before as the garbage collector
+                // weren't not able to remove any unused
+                // updates.
                 assert_eq!(inner.len(), 3);
 
                 // Inspect the indices.
@@ -575,8 +579,9 @@ mod tests {
                 let inner = updates.inner.read().unwrap();
 
                 // Inspect number of updates in memory.
-                // It must be the same number as before as the garbage collector will be able to
-                // remove unused updates but at the next call…
+                // It must be the same number as before as the garbage collector
+                // will be able to remove unused updates but at
+                // the next call…
                 assert_eq!(inner.len(), 6);
 
                 // Inspect the indices.
@@ -658,7 +663,8 @@ mod tests {
                 let inner = updates.inner.read().unwrap();
 
                 // Inspect number of updates in memory.
-                // The garbage collector had a chance to collect the first 3 updates.
+                // The garbage collector had a chance to collect the first 3
+                // updates.
                 assert_eq!(inner.len(), 3);
 
                 // Inspect the indices.
@@ -752,8 +758,8 @@ mod tests {
         // The waker must have been called only once for the two updates.
         assert_eq!(*counter_waker.number_of_wakeup.lock().unwrap(), 2);
 
-        // We can consume the updates without the stream, but the stream continues to
-        // know it has updates.
+        // We can consume the updates without the stream, but the stream
+        // continues to know it has updates.
         assert_eq!(
             linked_chunk.updates().unwrap().take(),
             &[
@@ -822,7 +828,8 @@ mod tests {
             assert_eq!(*counter_waker1.number_of_wakeup.lock().unwrap(), 1);
             assert_eq!(*counter_waker2.number_of_wakeup.lock().unwrap(), 1);
 
-            // There is an update! Right after that, the streams are pending again.
+            // There is an update! Right after that, the streams are pending
+            // again.
             assert_matches!(
                 updates_subscriber1.as_mut().poll_next(&mut context1),
                 Poll::Ready(Some(items)) => {
@@ -854,12 +861,14 @@ mod tests {
             linked_chunk.push_items_back(['b']);
             linked_chunk.push_items_back(['c']);
 
-            // A waker is consumed when called. The first call to `push_items_back` will
-            // call and consume the wakers. The second call to `push_items_back` will do
-            // nothing as the wakers have been consumed. New wakers will be registered on
-            // polling.
+            // A waker is consumed when called. The first call to
+            // `push_items_back` will call and consume the wakers.
+            // The second call to `push_items_back` will do
+            // nothing as the wakers have been consumed. New wakers will be
+            // registered on polling.
             //
-            // So, the waker must have been called only once for the two updates.
+            // So, the waker must have been called only once for the two
+            // updates.
             assert_eq!(*counter_waker1.number_of_wakeup.lock().unwrap(), 2);
             assert_eq!(*counter_waker2.number_of_wakeup.lock().unwrap(), 2);
 
@@ -878,21 +887,23 @@ mod tests {
             );
             assert_matches!(updates_subscriber1.as_mut().poll_next(&mut context1), Poll::Pending);
 
-            // For the sake of this test, we also need to advance the main reader token.
+            // For the sake of this test, we also need to advance the main
+            // reader token.
             let _ = linked_chunk.updates().unwrap().take();
             let _ = linked_chunk.updates().unwrap().take();
 
-            // If we inspect the garbage collector state, `a`, `b` and `c` should still be
-            // present because not all of them have been consumed by `updates_subscriber2`
-            // yet.
+            // If we inspect the garbage collector state, `a`, `b` and `c`
+            // should still be present because not all of them have
+            // been consumed by `updates_subscriber2` yet.
             {
                 let updates = linked_chunk.updates().unwrap();
 
                 let inner = updates.inner.read().unwrap();
 
                 // Inspect number of updates in memory.
-                // We get 2 because the garbage collector runs before data are taken, not after:
-                // `updates_subscriber2` has read `a` only, so `b` and `c` remain.
+                // We get 2 because the garbage collector runs before data are
+                // taken, not after: `updates_subscriber2` has
+                // read `a` only, so `b` and `c` remain.
                 assert_eq!(inner.len(), 2);
 
                 // Inspect the indices.
@@ -902,12 +913,12 @@ mod tests {
                 assert_eq!(indices.get(&updates_subscriber2.token), Some(&0));
             }
 
-            // Poll `updates_subscriber1` again: there is no new update so it must be
-            // pending.
+            // Poll `updates_subscriber1` again: there is no new update so it
+            // must be pending.
             assert_matches!(updates_subscriber1.as_mut().poll_next(&mut context1), Poll::Pending);
 
-            // The state of the garbage collector is unchanged: `a`, `b` and `c` are still
-            // in memory.
+            // The state of the garbage collector is unchanged: `a`, `b` and `c`
+            // are still in memory.
             {
                 let updates = linked_chunk.updates().unwrap();
 
@@ -927,10 +938,10 @@ mod tests {
             // Drop `updates_subscriber2`!
         };
 
-        // `updates_subscriber2` has been dropped. Poll `updates_subscriber1` again:
-        // still no new update, but it will run the garbage collector again, and this
-        // time `updates_subscriber2` is not “retaining” `b` and `c`. The garbage
-        // collector must be empty.
+        // `updates_subscriber2` has been dropped. Poll `updates_subscriber1`
+        // again: still no new update, but it will run the garbage
+        // collector again, and this time `updates_subscriber2` is not
+        // “retaining” `b` and `c`. The garbage collector must be empty.
         assert_matches!(updates_subscriber1.as_mut().poll_next(&mut context1), Poll::Pending);
 
         // Inspect the garbage collector.

--- a/crates/matrix-sdk-common/src/serde_helpers.rs
+++ b/crates/matrix-sdk-common/src/serde_helpers.rs
@@ -127,9 +127,10 @@ pub fn extract_bundled_thread_summary(
 ) -> (ThreadSummaryStatus, Option<Raw<AnySyncMessageLikeEvent>>) {
     match event.get_field::<Unsigned>("unsigned") {
         Ok(Some(Unsigned { relations: Some(Relations { thread: Some(bundled_thread) }) })) => {
-            // Take the count from the bundled thread summary, if available. If it can't be
-            // converted to a `u32`, we use `u32::MAX` as a fallback, as this is unlikely
-            // to happen to have that many events in real-world threads.
+            // Take the count from the bundled thread summary, if available. If
+            // it can't be converted to a `u32`, we use `u32::MAX`
+            // as a fallback, as this is unlikely to happen to have
+            // that many events in real-world threads.
             let count = bundled_thread.count.try_into().unwrap_or(u32::MAX);
 
             let latest_reply =
@@ -202,10 +203,11 @@ mod tests {
 
     #[test]
     fn test_extract_thread_root() {
-        // No event factory in this crate :( There would be a dependency cycle with the
-        // `matrix-sdk-test` crate if we tried to use it here.
+        // No event factory in this crate :( There would be a dependency cycle
+        // with the `matrix-sdk-test` crate if we tried to use it here.
 
-        // We can extract the thread root from a regular message that contains one.
+        // We can extract the thread root from a regular message that contains
+        // one.
         let thread_root = event_id!("$thread_root_event_id:example.com");
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
@@ -228,8 +230,8 @@ mod tests {
         let observed_relation = extract_relation(&event).unwrap();
         assert_eq!(observed_relation, (RelationType::Thread, thread_root.to_owned()));
 
-        // If the event doesn't have a content for some reason (redacted), it returns
-        // None.
+        // If the event doesn't have a content for some reason (redacted), it
+        // returns None.
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
             "type": "m.room.message",
@@ -243,7 +245,8 @@ mod tests {
         assert_matches!(observed_thread_root, None);
         assert_matches!(extract_relation(&event), None);
 
-        // If the event has a content but with no `m.relates_to` field, it returns None.
+        // If the event has a content but with no `m.relates_to` field, it
+        // returns None.
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
             "type": "m.room.message",
@@ -260,7 +263,8 @@ mod tests {
         assert_matches!(observed_thread_root, None);
         assert_matches!(extract_relation(&event), None);
 
-        // If the event has a relation, but it's not a thread reply, it returns None.
+        // If the event has a relation, but it's not a thread reply, it returns
+        // None.
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
             "type": "m.room.message",
@@ -323,7 +327,8 @@ mod tests {
             (ThreadSummaryStatus::Some(ThreadSummary { .. }), Some(..))
         );
 
-        // When there's a bundled thread summary, we can assert it with certainty.
+        // When there's a bundled thread summary, we can assert it with
+        // certainty.
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
             "type": "m.room.message",
@@ -335,7 +340,8 @@ mod tests {
 
         assert_matches!(extract_bundled_thread_summary(&event), (ThreadSummaryStatus::None, None));
 
-        // When there's a bundled replace, we can assert there's no thread summary.
+        // When there's a bundled replace, we can assert there's no thread
+        // summary.
         let event = Raw::new(&json!({
             "event_id": "$eid:example.com",
             "type": "m.room.message",

--- a/crates/matrix-sdk-common/src/task_monitor.rs
+++ b/crates/matrix-sdk-common/src/task_monitor.rs
@@ -315,8 +315,8 @@ impl TaskMonitor {
             let failure_reason = match result {
                 Ok(()) => {
                     if runs_forever {
-                        // The background forever task ended, this is considered an early
-                        // termination.
+                        // The background forever task ended, this is considered
+                        // an early termination.
                         BackgroundTaskFailureReason::EarlyTermination
                     } else {
                         // The task ended successfully, no failure to report.
@@ -469,10 +469,10 @@ impl BackgroundTaskHandle {
     /// The task will be stopped and will NOT be reported as a failure
     /// (this is considered intentional termination).
     pub fn abort(&self) {
-        // Note: ordering matters here, we set the flag before aborting otherwise
-        // there's a possible race condition where the abort() is observed
-        // before the flag is set, and the task monitor would consider this an
-        // unexpected termination.
+        // Note: ordering matters here, we set the flag before aborting
+        // otherwise there's a possible race condition where the abort()
+        // is observed before the flag is set, and the task monitor
+        // would consider this an unexpected termination.
         self.intentionally_aborted.store(true, Ordering::Release);
         self.abort_handle.abort();
     }

--- a/crates/matrix-sdk-common/src/ttl.rs
+++ b/crates/matrix-sdk-common/src/ttl.rs
@@ -74,8 +74,8 @@ impl<T> TtlValue<T> {
 
     /// Mark this value has expired.
     pub fn expire(&mut self) {
-        // We assume that the system time is always correct and we are far from the UNIX
-        // epoch so a timestamp of 0 should always be expired.
+        // We assume that the system time is always correct and we are far from
+        // the UNIX epoch so a timestamp of 0 should always be expired.
         self.last_fetch_ts = Some(0.0)
     }
 

--- a/crates/matrix-sdk-contentscanner/src/lib.rs
+++ b/crates/matrix-sdk-contentscanner/src/lib.rs
@@ -227,8 +227,9 @@ impl MediaFetcher for ContentScannerMediaFetcher {
                         let mut reader =
                             AttachmentDecryptor::new(&mut cursor, file.as_ref().clone().into())?;
 
-                        // Encrypted size should be the same as the decrypted size,
-                        // rounded up to a cipher block.
+                        // Encrypted size should be the same as the decrypted
+                        // size, rounded up to a cipher
+                        // block.
                         let mut decrypted = Vec::with_capacity(content_len);
 
                         reader.read_to_end(&mut decrypted)?;
@@ -597,7 +598,8 @@ mod tests {
         // The encrypted media content to return
         let encrypted: Vec<u8> = vec![0xEA, 0x10, 0x2D, 0x01, 0x53, 0xB7, 0x87, 0xF0, 0x75, 0xED];
 
-        // Set up the mock server as the content scanner one, with the expected endpoint
+        // Set up the mock server as the content scanner one, with the expected
+        // endpoint
         Mock::given(method("POST"))
             .and(path("/_matrix/media_proxy/unstable/download_encrypted"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(encrypted.clone()))
@@ -625,8 +627,8 @@ mod tests {
             format: MediaFormat::File,
         };
 
-        // If there was a decryption error, we'd be able to check the decryption took
-        // place
+        // If there was a decryption error, we'd be able to check the decryption
+        // took place
         let result = client
             .media()
             .get_media_content(&request, false)

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -107,8 +107,9 @@ impl MegolmV1BackupKey {
     ) -> Result<KeyBackupData, vodozemac::pk_encryption::Error> {
         let pk = PkEncryption::from_key(self.inner.key);
 
-        // The forwarding chains don't mean much, we only care whether we received the
-        // session directly from the creator of the session or not.
+        // The forwarding chains don't mean much, we only care whether we
+        // received the session directly from the creator of the session
+        // or not.
         let forwarded_count = (session.has_been_imported() as u8).into();
         let first_message_index = session.first_known_index().into();
 

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -225,7 +225,8 @@ impl BackupMachine {
         if let Some(user_signatures) = signatures.get(&self.store.static_account().user_id) {
             for device_key_id in user_signatures.keys() {
                 if device_key_id.algorithm() == DeviceKeyAlgorithm::Ed25519 {
-                    // No need to check our own device here, we're doing that using
+                    // No need to check our own device here, we're doing that
+                    // using
                     // the check_own_device_signature().
                     if device_key_id.key_name() == self.store.static_account().device_id {
                         continue;
@@ -622,10 +623,10 @@ impl BackupMachine {
             }
         }
 
-        // FIXME: This method is a bit flawed: we have no real idea which backup version
-        //   these keys came from. For example, we might have reset the backup
-        //   since the keys were downloaded. For now, let's assume they came from
-        //   the "current" backup version.
+        // FIXME: This method is a bit flawed: we have no real idea which backup
+        // version   these keys came from. For example, we might have
+        // reset the backup   since the keys were downloaded. For now,
+        // let's assume they came from   the "current" backup version.
         let backup_version = self.backup_version().await;
 
         self.store
@@ -840,7 +841,8 @@ mod tests {
         let machine = OlmMachine::new(alice_id(), alice_device_id()).await;
         let backup_machine = machine.backup_machine();
 
-        // We set up a backup key, so that we can test `backup_machine.backup()` later.
+        // We set up a backup key, so that we can test `backup_machine.backup()`
+        // later.
         let decryption_key = BackupDecryptionKey::new();
         let backup_key = decryption_key.megolm_v1_public_key();
         backup_key.set_version("1".to_owned());
@@ -865,8 +867,8 @@ mod tests {
             .await
             .expect("We should be able to import a room key");
 
-        // Now check that the session was correctly imported, and that it is marked as
-        // backed up
+        // Now check that the session was correctly imported, and that it is
+        // marked as backed up
         let session = machine.store().get_inbound_group_session(room_id, session_id).await.unwrap();
         assert_let!(Some(session) = session);
         assert!(
@@ -918,8 +920,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Create the machine using `with_store` and without a call to enable_backup_v1,
-        // like regenerate_olm would do
+        // Create the machine using `with_store` and without a call to
+        // enable_backup_v1, like regenerate_olm would do
         let alice = OlmMachineBuilder::new(alice_id(), alice_device_id())
             .with_crypto_store(store)
             .build()

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -291,8 +291,9 @@ impl RehydratedDevice {
             unused_fallback_keys: None,
         };
 
-        // Let us first give the events to the rehydrated device, this will decrypt any
-        // encrypted to-device events and fetch out the room keys.
+        // Let us first give the events to the rehydrated device, this will
+        // decrypt any encrypted to-device events and fetch out the room
+        // keys.
         let mut rehydrated_transaction = self.rehydrated.store().transaction().await;
 
         let (_, changes) = self
@@ -449,8 +450,8 @@ mod tests {
         olm_machine
     }
 
-    // Insert some device keys into a [`OlmMachine`] making the [`Device`] available
-    // to the [`OlmMachine`].
+    // Insert some device keys into a [`OlmMachine`] making the [`Device`]
+    // available to the [`OlmMachine`].
     async fn receive_device_keys(
         olm_machine: &OlmMachine,
         user_id: &UserId,
@@ -552,7 +553,8 @@ mod tests {
         // Send a room key to the dehydrated device.
         let (event, group_session) = send_room_key(&alice, room_id, user_id()).await;
 
-        // Let's now create a new `OlmMachine` which doesn't know about the room key.
+        // Let's now create a new `OlmMachine` which doesn't know about the room
+        // key.
         let bob = get_olm_machine().await;
 
         let room_key = bob
@@ -579,7 +581,8 @@ mod tests {
         let decryption_settings =
             DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
 
-        // Push the to-device event containing the room key into the rehydrated device.
+        // Push the to-device event containing the room key into the rehydrated
+        // device.
         let ret = rehydrated
             .receive_events(vec![event], &decryption_settings)
             .await
@@ -587,8 +590,8 @@ mod tests {
 
         assert_eq!(ret.len(), 1, "The rehydrated device should have imported a room key");
 
-        // The `OlmMachine` now does know about the room key since the rehydrated device
-        // shared it with us.
+        // The `OlmMachine` now does know about the room key since the
+        // rehydrated device shared it with us.
         let room_key = bob
             .store()
             .get_inbound_group_session(room_id, group_session.session_id())
@@ -667,7 +670,8 @@ mod tests {
         // Send a room key to the dehydrated device.
         let (event, group_session) = send_room_key(&alice, room_id, user_id()).await;
 
-        // Let's now create a new `OlmMachine` which doesn't know about the room key.
+        // Let's now create a new `OlmMachine` which doesn't know about the room
+        // key.
         let bob = get_olm_machine().await;
 
         let room_key = bob
@@ -694,7 +698,8 @@ mod tests {
         let decryption_settings =
             DecryptionSettings { sender_device_trust_requirement: TrustRequirement::Untrusted };
 
-        // Push the to-device event containing the room key into the rehydrated device.
+        // Push the to-device event containing the room key into the rehydrated
+        // device.
         let ret = rehydrated
             .receive_events(vec![event], &decryption_settings)
             .await
@@ -702,8 +707,8 @@ mod tests {
 
         assert_eq!(ret.len(), 1, "The rehydrated device should have imported a room key");
 
-        // The `OlmMachine` now does know about the room key since the rehydrated device
-        // shared it with us.
+        // The `OlmMachine` now does know about the room key since the
+        // rehydrated device shared it with us.
         let room_key = bob
             .store()
             .get_inbound_group_session(room_id, group_session.session_id())

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -763,8 +763,8 @@ impl GossipMachine {
             .await
             .filter(|outgoing_session| outgoing_session.session_id() == session.session_id());
 
-        // If this is our own, verified device, we share the entire session from the
-        // earliest known index.
+        // If this is our own, verified device, we share the entire session from
+        // the earliest known index.
         if device.user_id() == self.user_id() && device.is_verified() {
             Ok(None)
         // Otherwise, if the records show we previously shared with this device,
@@ -800,15 +800,16 @@ impl GossipMachine {
         if self.inner.room_key_requests_enabled.load(Ordering::SeqCst) {
             let request = self.inner.store.get_secret_request_by_info(key_info).await?;
 
-            // Don't send out duplicate requests, users can re-request them if they
-            // think a second request might succeed.
+            // Don't send out duplicate requests, users can re-request them if
+            // they think a second request might succeed.
             if request.is_none() {
                 let devices = self.inner.store.get_user_devices(self.user_id()).await?;
 
                 // Devices will only respond to key requests if the devices are
-                // verified, if the device isn't verified by us it's unlikely that
-                // we're verified by them either. Don't request keys if there isn't
-                // at least one verified device.
+                // verified, if the device isn't verified by us it's unlikely
+                // that we're verified by them either. Don't
+                // request keys if there isn't at least one
+                // verified device.
                 Ok(devices.is_any_verified())
             } else {
                 Ok(false)
@@ -1009,12 +1010,13 @@ impl GossipMachine {
                 }
             }
         } else {
-            // We would need to fire out a request to figure out if this backup decryption
-            // key is the one that is used for the current backup and if the
-            // backup is trusted.
+            // We would need to fire out a request to figure out if this backup
+            // decryption key is the one that is used for the
+            // current backup and if the backup is trusted.
             //
-            // So we put the secret into our inbox. Later users can inspect the contents of
-            // the inbox and decide if they want to activate the backup.
+            // So we put the secret into our inbox. Later users can inspect the
+            // contents of the inbox and decide if they want to
+            // activate the backup.
             info!("Received a backup decryption key, storing it into the secret inbox.");
             changes.secrets.push(secret.into());
         }
@@ -1322,8 +1324,8 @@ mod tests {
         user_id: &UserId,
         device_id: &DeviceId,
     ) -> CryptoStoreWrapper {
-        // Properly create the store by first saving the own device and then the account
-        // data.
+        // Properly create the store by first saving the own device and then the
+        // account data.
         let account = Account::with_device_id(user_id, device_id);
         let device = DeviceData::from_account(&account);
         device.set_trust_state(LocalTrust::Verified);
@@ -1791,8 +1793,8 @@ mod tests {
             Err(KeyForwardDecision::MissingOutboundSession)
         );
 
-        // Finally, let's ensure we don't share the session with a device that rotated
-        // its curve25519 key.
+        // Finally, let's ensure we don't share the session with a device that
+        // rotated its curve25519 key.
         let bob_device = DeviceData::from_account(&bob_account());
         machine.inner.store.save_device_data(&[bob_device]).await.unwrap();
 
@@ -1803,8 +1805,9 @@ mod tests {
             Err(KeyForwardDecision::ChangedSenderKey)
         );
 
-        // Now let's encrypt some messages in another session to increment the message
-        // index and then share it with our own untrusted device.
+        // Now let's encrypt some messages in another session to increment the
+        // message index and then share it with our own untrusted
+        // device.
         own_device.set_trust_state(LocalTrust::Unset);
 
         for _ in 1..=3 {
@@ -1820,9 +1823,9 @@ mod tests {
 
         machine.inner.outbound_group_sessions.insert(other_outbound.clone());
 
-        // Since our device is untrusted, we should share the session starting only from
-        // the current index (at which the message was marked as shared). This
-        // should be 3 since we encrypted 3 messages.
+        // Since our device is untrusted, we should share the session starting
+        // only from the current index (at which the message was marked
+        // as shared). This should be 3 since we encrypted 3 messages.
         assert_matches!(machine.should_share_key(&own_device, &other_inbound).await, Ok(Some(3)));
 
         own_device.set_trust_state(LocalTrust::Verified);
@@ -2155,7 +2158,8 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // We need a trusted device, otherwise we won't serve nor accept secrets.
+        // We need a trusted device, otherwise we won't serve nor accept
+        // secrets.
         bob_device.set_trust_state(LocalTrust::Verified);
         alice_device.set_trust_state(LocalTrust::Verified);
         alice_machine.store().save_device_data(&[bob_device.inner]).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -189,59 +189,69 @@ impl Device {
         session: &InboundGroupSession,
     ) -> Result<bool, MismatchedIdentityKeysError> {
         if session.has_been_imported() {
-            // An imported room key means that we did not receive the room key as a
-            // `m.room_key` event when the room key was initially exchanged.
+            // An imported room key means that we did not receive the room key
+            // as a `m.room_key` event when the room key was
+            // initially exchanged.
             //
             // This could mean a couple of things:
             //      1. We received the room key as a `m.forwarded_room_key`.
             //      2. We imported the room key through a file export.
             //      3. We imported the room key through a backup.
             //
-            // To be certain that a `Device` is the owner of a room key we need to have a
-            // proof that the `Curve25519` key of this `Device` was used to
-            // initially exchange the room key. This proof is provided by the Olm decryption
+            // To be certain that a `Device` is the owner of a room key we need
+            // to have a proof that the `Curve25519` key of this
+            // `Device` was used to initially exchange the room key.
+            // This proof is provided by the Olm decryption
             // step, see below for further clarification.
             //
-            // Each of the above room key methods that receive room keys do not contain this
-            // proof and we received only a claim that the room key is tied to a
-            // `Curve25519` key.
+            // Each of the above room key methods that receive room keys do not
+            // contain this proof and we received only a claim that
+            // the room key is tied to a `Curve25519` key.
             //
-            // Since there's no way to verify that the claim is true, we say that we don't
-            // know that the room key belongs to this device.
+            // Since there's no way to verify that the claim is true, we say
+            // that we don't know that the room key belongs to this
+            // device.
             Ok(false)
         } else if let Some(key) =
             session.signing_keys().get(&DeviceKeyAlgorithm::Ed25519).and_then(|k| k.ed25519())
         {
-            // Room keys are received as an `m.room.encrypted` to-device message using the
-            // `m.olm` algorithm. Upon decryption of the `m.room.encrypted` to-device
-            // message, the decrypted content will contain also an `Ed25519` public key[1].
+            // Room keys are received as an `m.room.encrypted` to-device message
+            // using the `m.olm` algorithm. Upon decryption of the
+            // `m.room.encrypted` to-device message, the decrypted
+            // content will contain also an `Ed25519` public key[1].
             //
-            // The inclusion of this key means that the `Curve25519` key of the `Device` and
-            // Olm `Session`, established using the DH authentication of the
-            // double ratchet, "binds" the `Ed25519` key of the `Device`. In other words, it
-            // prevents an attack in which Mallory publishes Bob's public `Curve25519` key
-            // as her own, and subsequently forwards an Olm message she received from Bob to
-            // Alice, claiming that she, Mallory, originated the Olm message (leading Alice
-            // to believe that Mallory also sent the messages in the subsequent Megolm
-            // session).
+            // The inclusion of this key means that the `Curve25519` key of the
+            // `Device` and Olm `Session`, established using the DH
+            // authentication of the double ratchet, "binds" the
+            // `Ed25519` key of the `Device`. In other words, it
+            // prevents an attack in which Mallory publishes Bob's public
+            // `Curve25519` key as her own, and subsequently
+            // forwards an Olm message she received from Bob to
+            // Alice, claiming that she, Mallory, originated the Olm message
+            // (leading Alice to believe that Mallory also sent the
+            // messages in the subsequent Megolm session).
             //
             // On the other hand, the `Ed25519` key binds the `Curve25519` key
             // using a signature which is uploaded to the server as
             // `device_keys` and downloaded by us using a `/keys/query` request.
             //
             // A `Device` is considered to be the owner of a room key iff:
-            //     1. The `Curve25519` key that was used to establish the Olm `Session` that
-            //        was used to decrypt the to-device message is binding the `Ed25519` key
-            //        of this `Device` via the content of the to-device message, and:
-            //     2. The `Ed25519` key of this device has signed a `device_keys` object
-            //        that contains the `Curve25519` key from step 1.
+            //     1. The `Curve25519` key that was used to establish the Olm
+            //        `Session` that was used to decrypt the to-device message
+            //        is binding the `Ed25519` key of this `Device` via the
+            //        content of the to-device message, and:
+            //     2. The `Ed25519` key of this device has signed a
+            //        `device_keys` object that contains the `Curve25519` key
+            //        from step 1.
             //
-            // We don't need to check the signature of the `Device` here, since we don't
-            // accept a `Device` unless it has a valid `Ed25519` signature.
+            // We don't need to check the signature of the `Device` here, since
+            // we don't accept a `Device` unless it has a valid
+            // `Ed25519` signature.
             //
-            // We do check that the `Curve25519` that was used to decrypt the event carrying
-            // the `m.room_key` and the `Ed25519` key that was part of the
-            // decrypted content matches the keys found in this `Device`.
+            // We do check that the `Curve25519` that was used to decrypt the
+            // event carrying the `m.room_key` and the `Ed25519` key
+            // that was part of the decrypted content matches the
+            // keys found in this `Device`.
             //
             // ```text
             //                                              ┌───────────────────────┐
@@ -1149,7 +1159,8 @@ pub(crate) mod tests {
         assert!(device.update_device(&device_keys).unwrap());
         assert_eq!(&display_name, device.display_name().as_ref().unwrap());
 
-        // A second call to `update_device` with the same data should return `false`.
+        // A second call to `update_device` with the same data should return
+        // `false`.
         assert!(!device.update_device(&device_keys).unwrap());
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -185,9 +185,9 @@ impl IdentityManager {
             "Handling a `/keys/query` response"
         );
 
-        // Parse the strings into server names and filter out our own server. We should
-        // never get failures from our own server but let's remove it as a
-        // precaution anyways.
+        // Parse the strings into server names and filter out our own server. We
+        // should never get failures from our own server but let's
+        // remove it as a precaution anyways.
         let failed_servers = response
             .failures
             .keys()
@@ -214,22 +214,25 @@ impl IdentityManager {
 
         self.store.save_changes(changes).await?;
 
-        // Update the sender data on any existing inbound group sessions based on the
-        // changes in this response.
+        // Update the sender data on any existing inbound group sessions based
+        // on the changes in this response.
         //
-        // `update_sender_data_from_device_changes` relies on being able to look up the
-        // user identities from the store, so this has to happen *after* the
-        // changes from `handle_cross_signing_keys` are saved.
+        // `update_sender_data_from_device_changes` relies on being able to look
+        // up the user identities from the store, so this has to happen
+        // *after* the changes from `handle_cross_signing_keys` are
+        // saved.
         //
-        // Note: it might be possible for this to race against session creation. If a
-        // new session is received at the same time as a `/keys/query` response is being
-        // processed, it could be saved without up-to-date sender data, but it might be
+        // Note: it might be possible for this to race against session creation.
+        // If a new session is received at the same time as a
+        // `/keys/query` response is being processed, it could be saved
+        // without up-to-date sender data, but it might be
         // saved too late for it to be picked up by
-        // `update_sender_data_from_device_changes`. However, this should be rare,
-        // since, in general, /sync responses which might create a new session
-        // are not processed at the same time as /keys/query responses (assuming
-        // that the application does not call `OlmMachine::receive_sync_changes`
-        // at the same time as `OlmMachine::mark_request_as_sent`).
+        // `update_sender_data_from_device_changes`. However, this should be
+        // rare, since, in general, /sync responses which might create a
+        // new session are not processed at the same time as /keys/query
+        // responses (assuming that the application does not call
+        // `OlmMachine::receive_sync_changes` at the same time as
+        // `OlmMachine::mark_request_as_sent`).
         self.update_sender_data_from_device_changes(&devices).await?;
 
         // if this request is one of those we expected to be in flight, pass the
@@ -485,7 +488,8 @@ impl IdentityManager {
             }
             #[cfg(feature = "experimental-x509-identity-verification")]
             {
-                // Check if we need to re-sign our identity with the X.509 signer.
+                // Check if we need to re-sign our identity with the X.509
+                // signer.
                 *self.x509_signature_upload_request.lock().await =
                     identity.refresh_x509_signature(&self.store).await.unwrap_or(None).into();
             }
@@ -603,7 +607,8 @@ impl IdentityManager {
             *changed_private_identity = self.check_private_identity(&identity).await;
             Ok(identity.into())
         } else {
-            // First time seen, create the identity. The current MSK will be pinned.
+            // First time seen, create the identity. The current MSK will be
+            // pinned.
             let identity = OtherUserIdentityData::new(master_key, self_signing)?;
             let is_verified = maybe_verified_own_identity
                 .is_some_and(|own_user_identity| own_user_identity.is_identity_signed(&identity));
@@ -803,8 +808,9 @@ impl IdentityManager {
         let mut changes = IdentityChanges::default();
         let mut changed_identity = None;
 
-        // We want to check if the updated/new other identities are trusted by us or
-        // not. This is based on the current verified state of the own identity.
+        // We want to check if the updated/new other identities are trusted by
+        // us or not. This is based on the current verified state of the
+        // own identity.
         let maybe_own_verified_identity = self
             .store
             .get_identity(self.user_id())
@@ -813,8 +819,9 @@ impl IdentityManager {
             .filter(|own| own.is_verified());
 
         for (user_id, master_key) in &response.master_keys {
-            // Get the master and self-signing key for each identity; those are required for
-            // every user identity type. If we don't have those we skip over.
+            // Get the master and self-signing key for each identity; those are
+            // required for every user identity type. If we don't
+            // have those we skip over.
             let Some((master_key, self_signing)) =
                 Self::get_minimal_set_of_keys(master_key.cast_ref(), response)
             else {
@@ -857,14 +864,16 @@ impl IdentityManager {
         &self,
         users: impl IntoIterator<Item = &'a UserId>,
     ) -> (OwnedTransactionId, KeysQueryRequest) {
-        // Since this is an "out-of-band" request, we just make up a transaction ID and
-        // do not store the details in `self.keys_query_request_details`.
+        // Since this is an "out-of-band" request, we just make up a transaction
+        // ID and do not store the details in
+        // `self.keys_query_request_details`.
         //
-        // `receive_keys_query_response` will process the response as normal, except
-        // that it will not mark the users as "up-to-date".
+        // `receive_keys_query_response` will process the response as normal,
+        // except that it will not mark the users as "up-to-date".
 
-        // We assume that there aren't too many users here; if we find a usecase that
-        // requires lots of users to be up-to-date we may need to rethink this.
+        // We assume that there aren't too many users here; if we find a usecase
+        // that requires lots of users to be up-to-date we may need to
+        // rethink this.
         (TransactionId::new(), KeysQueryRequest::new(users.into_iter().map(|u| u.to_owned())))
     }
 
@@ -925,9 +934,9 @@ impl IdentityManager {
         // Forget about any previous key queries in flight.
         *self.keys_query_request_details.lock().await = None;
 
-        // We always want to track our own user, but in case we aren't in an encrypted
-        // room yet, we won't be tracking ourselves yet. This ensures we are always
-        // tracking ourselves.
+        // We always want to track our own user, but in case we aren't in an
+        // encrypted room yet, we won't be tracking ourselves yet. This
+        // ensures we are always tracking ourselves.
         //
         // The check for emptiness is done first for performance.
         let (users, sequence_number) = {
@@ -947,15 +956,17 @@ impl IdentityManager {
         if users.is_empty() {
             Ok(BTreeMap::new())
         } else {
-            // Let's remove users that are part of the `FailuresCache`. The cache, which is
-            // a TTL cache, remembers users for which a previous `/key/query` request has
-            // failed. We don't retry a `/keys/query` for such users for a
+            // Let's remove users that are part of the `FailuresCache`. The
+            // cache, which is a TTL cache, remembers users for
+            // which a previous `/key/query` request has failed. We
+            // don't retry a `/keys/query` for such users for a
             // certain amount of time.
             let users = users.into_iter().filter(|u| !self.failures.contains(u.server_name()));
 
-            // We don't want to create a single `/keys/query` request with an infinite
-            // amount of users. Some servers will likely bail out after a
-            // certain amount of users and the responses will be large. In the
+            // We don't want to create a single `/keys/query` request with an
+            // infinite amount of users. Some servers will likely
+            // bail out after a certain amount of users and the
+            // responses will be large. In the
             // case of a transmission error, we'll have to retransmit the large
             // response.
             //
@@ -974,8 +985,8 @@ impl IdentityManager {
                 .collect();
 
             // Collect the request IDs, these will be used later in the
-            // `receive_keys_query_response()` method to figure out if the user can be
-            // marked as up-to-date/non-dirty.
+            // `receive_keys_query_response()` method to figure out if the user
+            // can be marked as up-to-date/non-dirty.
             let request_ids = requests.keys().cloned().collect();
             let request_details = KeysQueryRequestDetails { sequence_number, request_ids };
 
@@ -1033,36 +1044,41 @@ impl IdentityManager {
 
             // Now, look for users who have no devices at all.
             //
-            // If a user has no devices at all, that implies we have never (successfully)
-            // done a `/keys/query` for them; we wait for one to complete if it is
-            // in flight. (Of course, the user might genuinely have no devices, but
-            // that's fine, it just means we redundantly grab the cache guard and
-            // check the pending-query flag.)
+            // If a user has no devices at all, that implies we have never
+            // (successfully) done a `/keys/query` for them; we wait
+            // for one to complete if it is in flight. (Of course,
+            // the user might genuinely have no devices, but
+            // that's fine, it just means we redundantly grab the cache guard
+            // and check the pending-query flag.)
             if !devices.is_empty() {
                 // This user has at least one known device.
                 //
-                // The device list may also be outdated in this case; but in this
-                // situation, we are racing between sending a message and retrieving their
-                // device list. That's an inherently racy situation and there is no real
-                // benefit to waiting for the `/keys/query` request to complete. So we don't
-                // bother.
+                // The device list may also be outdated in this case; but in
+                // this situation, we are racing between sending
+                // a message and retrieving their device list.
+                // That's an inherently racy situation and there is no real
+                // benefit to waiting for the `/keys/query` request to complete.
+                // So we don't bother.
                 //
                 // We just add their devices to the result and carry on.
                 devices_by_user.insert(user_id.to_owned(), devices);
                 continue;
             }
 
-            // *However*, if the user's server is currently subject to a backoff due to
-            // previous failures, then `users_for_key_query` won't attempt to query
-            // for the user's devices, so there's no point waiting.
+            // *However*, if the user's server is currently subject to a backoff
+            // due to previous failures, then `users_for_key_query`
+            // won't attempt to query for the user's devices, so
+            // there's no point waiting.
             //
             // XXX: this is racy. It's possible that:
-            //  * `failures` included the user's server when `users_for_key_query` was
-            //    called, so the user was not returned in the `KeyQueryRequest`, and:
+            //  * `failures` included the user's server when
+            //    `users_for_key_query` was called, so the user was not returned
+            //    in the `KeyQueryRequest`, and:
             //  * The backoff has now expired.
             //
-            // In that case, we'll end up waiting for the *next* `users_for_key_query` call,
-            // which might not be for 30 seconds or so. (And by then, it might be `failed`
+            // In that case, we'll end up waiting for the *next*
+            // `users_for_key_query` call, which might not be for 30
+            // seconds or so. (And by then, it might be `failed`
             // again.)
             if self.failures.contains(user_id.server_name()) {
                 users_with_no_devices_on_failed_servers.push(user_id);
@@ -1080,12 +1096,13 @@ impl IdentityManager {
         }
 
         if !users_with_no_devices_on_unfailed_servers.is_empty() {
-            // For each user with no devices, fire off a task to wait for a `/keys/query`
-            // result if one is pending.
+            // For each user with no devices, fire off a task to wait for a
+            // `/keys/query` result if one is pending.
             //
-            // We don't actually update the `devices_by_user` map here since that could
-            // require concurrent access to it. Instead each task returns a
-            // `(OwnedUserId, HashMap)` pair (or rather, an `Option` of one) so that we can
+            // We don't actually update the `devices_by_user` map here since
+            // that could require concurrent access to it. Instead
+            // each task returns a `(OwnedUserId, HashMap)` pair (or
+            // rather, an `Option` of one) so that we can
             // add the results to the map.
             let results = join_all(
                 users_with_no_devices_on_unfailed_servers
@@ -1147,26 +1164,28 @@ impl IdentityManager {
         device_changes: &DeviceChanges,
     ) -> Result<(), CryptoStoreError> {
         for device in device_changes.new.iter().chain(device_changes.changed.iter()) {
-            // 1. Look for InboundGroupSessions from the device whose sender_data is
-            //    UnknownDevice. For such sessions, we now have the device, and can update
-            //    the sender_data accordingly.
+            // 1. Look for InboundGroupSessions from the device whose
+            //    sender_data is UnknownDevice. For such sessions, we now have
+            //    the device, and can update the sender_data accordingly.
             //
-            // In theory, we only need to do this for new devices. In practice, I'm a bit
-            // worried about races leading us to getting stuck in the
-            // UnknownDevice state, so we'll paper over that by doing this check
-            // on device updates too.
+            // In theory, we only need to do this for new devices. In practice,
+            // I'm a bit worried about races leading us to getting
+            // stuck in the UnknownDevice state, so we'll paper over
+            // that by doing this check on device updates too.
             self.update_sender_data_for_sessions_for_device(device, SenderDataType::UnknownDevice)
                 .await?;
 
             // 2. If, and only if, the device is now correctly cross-signed (ie,
-            //    device.is_cross_signed_by_owner() is true, and we have the master
-            //    cross-signing key for the owner), look for InboundGroupSessions from the
-            //    device whose sender_data is DeviceInfo. We can also update the sender_data
-            //    for these sessions.
+            //    device.is_cross_signed_by_owner() is true, and we have the
+            //    master cross-signing key for the owner), look for
+            //    InboundGroupSessions from the device whose sender_data is
+            //    DeviceInfo. We can also update the sender_data for these
+            //    sessions.
             //
-            // In theory, we can skip a couple of steps of the SenderDataFinder algorithm,
-            // because we're doing the cross-signing check here. In practice,
-            // it's *way* easier just to use the same logic.
+            // In theory, we can skip a couple of steps of the SenderDataFinder
+            // algorithm, because we're doing the cross-signing
+            // check here. In practice, it's *way* easier just to
+            // use the same logic.
             let device_owner_identity = self.store.get_user_identity(device.user_id()).await?;
             if device_owner_identity.is_some_and(|id| device.is_cross_signed_by_owner(&id)) {
                 self.update_sender_data_for_sessions_for_device(device, SenderDataType::DeviceInfo)
@@ -1414,9 +1433,9 @@ pub(crate) mod testing {
         ruma_response_from_json(data)
     }
 
-    // An updated version of `other_key_query` featuring an additional signature on
-    // the master key *Note*: The added signature is actually not valid, but a
-    // valid signature  is not required for our test.
+    // An updated version of `other_key_query` featuring an additional signature
+    // on the master key *Note*: The added signature is actually not valid,
+    // but a valid signature  is not required for our test.
     pub fn other_key_query_cross_signed() -> KeyQueryResponse {
         let data = json!({
             "device_keys": {
@@ -1932,7 +1951,8 @@ pub(crate) mod tests {
                 .any(|(_, r)| r.device_keys.contains_key(alice))
         );
 
-        // clearing the failure flag should make the user reappear in the query list.
+        // clearing the failure flag should make the user reappear in the query
+        // list.
         manager.failures.remove([alice.server_name().to_owned()].iter());
         assert!(
             manager
@@ -2075,8 +2095,9 @@ pub(crate) mod tests {
         let (new_request_id, _) =
             manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
 
-        // A second `/keys/query` response with the same result shouldn't fire a change
-        // notification: the identity and device should be unchanged.
+        // A second `/keys/query` response with the same result shouldn't fire a
+        // change notification: the identity and device should be
+        // unchanged.
         manager
             .as_ref()
             .unwrap()
@@ -2086,7 +2107,8 @@ pub(crate) mod tests {
 
         assert_pending!(stream);
 
-        // dropping the manager (and hence dropping the store) should close the stream
+        // dropping the manager (and hence dropping the store) should close the
+        // stream
         manager.take();
         assert_closed!(stream);
     }
@@ -2291,8 +2313,8 @@ pub(crate) mod tests {
         assert!(!other_identity.has_pin_violation());
     }
 
-    // Set up a machine do initial own key query and import cross-signing secret to
-    // make the current session verified.
+    // Set up a machine do initial own key query and import cross-signing secret
+    // to make the current session verified.
     async fn common_verified_identity_changes_machine_setup() -> OlmMachine {
         use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
@@ -2338,8 +2360,8 @@ pub(crate) mod tests {
         assert!(bob_identity.is_verified());
 
         // ######
-        // Second test: Assert that the local latch stays on if the identity is rotated
-        // ######
+        // Second test: Assert that the local latch stays on if the identity is
+        // rotated ######
         let keys_query = DataSet::bob_keys_query_response_rotated();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
@@ -2388,8 +2410,8 @@ pub(crate) mod tests {
         // The verified latch is off
         assert!(!carol_identity.was_previously_verified());
 
-        // Carol is verified, likely from another session. Ensure the latch is updated
-        // when the key query response is processed
+        // Carol is verified, likely from another session. Ensure the latch is
+        // updated when the key query response is processed
         let keys_query = DataSet::carol_keys_query_response_signed();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
@@ -2453,17 +2475,20 @@ pub(crate) mod tests {
             machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap().own().unwrap();
 
         let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
-        // Bob is verified by our identity but our own identity is not yet trusted
+        // Bob is verified by our identity but our own identity is not yet
+        // trusted
         assert!(!bob_identity.was_previously_verified());
         assert!(own_identity.is_identity_signed(&bob_identity.other().unwrap()));
 
         let carol_identity =
             machine.get_identity(DataSet::carol_id(), None).await.unwrap().unwrap();
-        // Carol is verified by our identity but our own identity is not yet trusted
+        // Carol is verified by our identity but our own identity is not yet
+        // trusted
         assert!(!carol_identity.was_previously_verified());
         assert!(own_identity.is_identity_signed(&carol_identity.other().unwrap()));
 
-        // Marking our own identity as trusted should update the existing identities
+        // Marking our own identity as trusted should update the existing
+        // identities
         let _ = own_identity.verify().await;
 
         let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
@@ -2491,7 +2516,8 @@ pub(crate) mod tests {
 
         let bob_identity =
             machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
-        // Carol is verified by our identity but our own identity is not yet trusted
+        // Carol is verified by our identity but our own identity is not yet
+        // trusted
         assert!(own_identity.is_identity_signed(&bob_identity));
         assert!(!bob_identity.was_previously_verified());
 
@@ -2502,11 +2528,13 @@ pub(crate) mod tests {
             .unwrap()
             .other()
             .unwrap();
-        // Carol is verified by our identity but our own identity is not yet trusted
+        // Carol is verified by our identity but our own identity is not yet
+        // trusted
         assert!(own_identity.is_identity_signed(&carol_identity));
         assert!(!carol_identity.was_previously_verified());
 
-        // Marking our own identity as trusted should update the existing identities
+        // Marking our own identity as trusted should update the existing
+        // identities
         machine
             .import_cross_signing_keys(CrossSigningKeyExport {
                 master_key: DataSet::MASTER_KEY_PRIVATE_EXPORT.to_owned().into(),
@@ -2548,7 +2576,8 @@ pub(crate) mod tests {
         async fn test_adds_device_info_to_existing_sessions() {
             let manager = manager_test_helper(user_id(), device_id()).await;
 
-            // Given that we have lots of sessions in the store, from each of two devices
+            // Given that we have lots of sessions in the store, from each of
+            // two devices
             let account1 = Account::new(user_id());
             let account2 = Account::new(other_user_id());
 
@@ -2733,8 +2762,8 @@ pub(crate) mod tests {
         .await;
         assert!(manager_old.get_x509_signature_upload_request().await.is_none());
 
-        // If we have an identity manager with the same signer, then it won't try
-        // to re-sign the master key.
+        // If we have an identity manager with the same signer, then it won't
+        // try to re-sign the master key.
         let manager_current = manager_with_private_identity_and_x509(
             identity.clone(),
             account.deep_clone(),

--- a/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
+++ b/crates/matrix-sdk-crypto/src/identities/room_identity_state.rs
@@ -136,15 +136,16 @@ impl<R: RoomIdentityProvider> RoomIdentityState<R> {
         &mut self,
         sync_room_member_event: Box<SyncRoomMemberEvent>,
     ) -> Vec<IdentityStatusChange> {
-        // Ignore redacted events - memberships should come through as new events, not
-        // redactions.
+        // Ignore redacted events - memberships should come through as new
+        // events, not redactions.
         if let SyncStateEvent::Original(event) = sync_room_member_event.deref() {
             let user_id = &event.state_key;
             // Ignore non-existent users, and changes to our own identity
             if let Some(user_identity @ UserIdentity::Other(_)) =
                 self.room.user_identity(user_id).await
             {
-                // Don't notify on membership changes of verified or pinned identities
+                // Don't notify on membership changes of verified or pinned
+                // identities
                 if matches!(
                     self.room.state_of(&user_identity),
                     IdentityState::Verified | IdentityState::Pinned
@@ -154,15 +155,16 @@ impl<R: RoomIdentityProvider> RoomIdentityState<R> {
 
                 match event.content.membership {
                     MembershipState::Join | MembershipState::Invite => {
-                        // They are joining the room - check whether we need to display a
-                        // warning to the user
+                        // They are joining the room - check whether we need to
+                        // display a warning to the user
                         if let Some(update) = self.update_user_state(user_id, &user_identity) {
                             return vec![update];
                         }
                     }
                     MembershipState::Leave | MembershipState::Ban => {
-                        // They are leaving the room - treat that as if they are becoming
-                        // Pinned, which means the UI will remove any banner it was displaying
+                        // They are leaving the room - treat that as if they are
+                        // becoming Pinned, which means
+                        // the UI will remove any banner it was displaying
                         // for them.
 
                         if let Some(update) =
@@ -442,7 +444,8 @@ mod tests {
         let mut room = FakeRoom::new();
         let mut state = RoomIdentityState::new(room.clone()).await;
 
-        // When a new unpinned user identity appears but they are not in the room
+        // When a new unpinned user identity appears but they are not in the
+        // room
         let updates =
             identity_change(&mut room, user_id, IdentityState::PinViolation, true, false).await;
         let update = state.process_change(updates).await;

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -89,8 +89,8 @@ impl UserIdentity {
                 Self::Own(OwnUserIdentity { inner: i, verification_machine, store })
             }
             UserIdentityData::Other(i) => {
-                // X509Verifier holds an Arc so cloning it gives us a reference to the single
-                // underlying RustRawX509Verifier
+                // X509Verifier holds an Arc so cloning it gives us a reference
+                // to the single underlying RustRawX509Verifier
                 #[cfg(feature = "experimental-x509-identity-verification")]
                 let x509_verifier = store.x509_verifier().cloned();
 
@@ -524,7 +524,8 @@ impl OtherUserIdentity {
     ///   [`OtherUserIdentity::withdraw_verification`].
     pub fn has_verification_violation(&self) -> bool {
         if !self.inner.was_previously_verified() {
-            // If that identity has never been verified it cannot be in violation.
+            // If that identity has never been verified it cannot be in
+            // violation.
             return false;
         }
 
@@ -906,8 +907,8 @@ impl OtherUserIdentityData {
     /// reported to the user. In order to remove this notice users have to
     /// verify again or to withdraw the verification requirement.
     pub fn withdraw_verification(&self) {
-        // We also pin when we withdraw, since withdrawing implicitly acknowledges
-        // the identity change
+        // We also pin when we withdraw, since withdrawing implicitly
+        // acknowledges the identity change
         self.pin();
         self.previously_verified.store(false, Ordering::SeqCst)
     }
@@ -949,10 +950,10 @@ impl OtherUserIdentityData {
     ) -> Result<bool, SignatureError> {
         master_key.verify_subkey(&self_signing_key)?;
 
-        // We update the identity with the new master and self signing key, but we keep
-        // the previous pinned master key.
-        // This identity will have a pin violation until the new master key is pinned
-        // (see `has_pin_violation()`).
+        // We update the identity with the new master and self signing key, but
+        // we keep the previous pinned master key.
+        // This identity will have a pin violation until the new master key is
+        // pinned (see `has_pin_violation()`).
         let pinned_master_key = self.pinned_master_key.read().clone();
 
         // Check if the new master_key is signed by our own **verified**
@@ -1506,8 +1507,8 @@ pub(crate) mod testing {
             .expect("There should be a user signing key")
             .0;
 
-        // Add the signature from the SignatureUploadRequest to their master key, under
-        // our user ID
+        // Add the signature from the SignatureUploadRequest to their master
+        // key, under our user ID
         their_msk.signatures.add_signature(
             my_user_id.to_owned(),
             my_user_signing_key_id.to_owned(),
@@ -1816,8 +1817,8 @@ pub(crate) mod tests {
         let usage = user_signing_key_json.get_mut("usage").unwrap();
         *usage = json!([]);
 
-        // It should now be impossible to deserialize the keys into their corresponding
-        // high-level cross-signing key structs.
+        // It should now be impossible to deserialize the keys into their
+        // corresponding high-level cross-signing key structs.
         assert_matches!(serde_json::from_value::<MasterPubkey>(master_key_json.clone()), Err(_));
         assert_matches!(
             serde_json::from_value::<SelfSigningPubkey>(self_signing_key_json.clone()),
@@ -2069,15 +2070,15 @@ pub(crate) mod tests {
         let own_keys = DataSet::own_keys_query_response_2();
         machine.mark_request_as_sent(&TransactionId::new(), &own_keys).await.unwrap();
 
-        // That should give an identity that is no longer verified, with a verification
-        // violation.
+        // That should give an identity that is no longer verified, with a
+        // verification violation.
         let own_identity = machine.get_identity(DataSet::own_id(), None).await.unwrap().unwrap();
         assert!(!own_identity.is_verified());
         assert!(own_identity.was_previously_verified());
         assert!(own_identity.has_verification_violation());
 
-        // Now check that we can withdraw verification for our own identity, and that it
-        // becomes valid again.
+        // Now check that we can withdraw verification for our own identity, and
+        // that it becomes valid again.
         own_identity.withdraw_verification().await.unwrap();
 
         assert!(!own_identity.is_verified());
@@ -2216,8 +2217,8 @@ pub(crate) mod tests {
         let user_id = user_id!("@own_user:localhost");
         let account = Account::with_device_id(user_id, device_id!("DEV123"));
 
-        // We create three signers with different validity periods: an "old" signer, a
-        // "current" signer, and a "new" signer
+        // We create three signers with different validity periods: an "old"
+        // signer, a "current" signer, and a "new" signer
         let (x509_signer_old, x509_signer_current, x509_signer_new) =
             crate::x509::tests::signers_with_different_validity();
 

--- a/crates/matrix-sdk-crypto/src/machine/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/mod.rs
@@ -458,9 +458,10 @@ impl OlmMachine {
 
                 let device = DeviceData::from_account(&account);
 
-                // We just created this device from our own Olm `Account`. Since we are the
-                // owners of the private keys of this device we can safely mark
-                // the device as verified.
+                // We just created this device from our own Olm `Account`. Since
+                // we are the owners of the private keys of this
+                // device we can safely mark the device as
+                // verified.
                 device.set_trust_state(LocalTrust::Verified);
 
                 let changes = Changes {
@@ -519,8 +520,8 @@ impl OlmMachine {
             x509_signer,
         );
 
-        // FIXME: We might want in the future a more generic high-level data migration
-        // mechanism (at the store wrapper layer).
+        // FIXME: We might want in the future a more generic high-level data
+        // migration mechanism (at the store wrapper layer).
         Self::migration_post_verified_latch_support(&store, &identity_manager).await?;
 
         Ok(Self::new_helper(
@@ -535,9 +536,9 @@ impl OlmMachine {
 
     // The sdk now support verified identity change detection.
     // This introduces a new local flag (`verified_latch` on
-    // `OtherUserIdentityData`). In order to ensure that this flag is up-to-date and
-    // for the sake of simplicity we force a re-download of tracked users by marking
-    // them as dirty.
+    // `OtherUserIdentityData`). In order to ensure that this flag is up-to-date
+    // and for the sake of simplicity we force a re-download of tracked
+    // users by marking them as dirty.
     //
     // pub(crate) visibility for testing.
     pub(crate) async fn migration_post_verified_latch_support(
@@ -844,9 +845,9 @@ impl OlmMachine {
             (upload_signing_keys_req, upload_signatures_req)
         };
 
-        // If there are any *device* keys to upload (i.e. the account isn't shared),
-        // upload them before we upload the signatures, since the signatures may
-        // reference keys to be uploaded.
+        // If there are any *device* keys to upload (i.e. the account isn't
+        // shared), upload them before we upload the signatures, since
+        // the signatures may reference keys to be uploaded.
         let upload_keys_req =
             self.upload_device_keys().await?.map(|(_, request)| OutgoingRequest::from(request));
 
@@ -961,10 +962,11 @@ impl OlmMachine {
         // This will mark the device as verified if the user identity (i.e., the
         // cross-signing keys) is also marked as verified.
         //
-        // This approach eliminates the need to upload signatures in a separate request,
-        // ensuring that other users/devices will never encounter this device
-        // without a signature from their user identity. Consequently, they will
-        // never see the device as unverified.
+        // This approach eliminates the need to upload signatures in a separate
+        // request, ensuring that other users/devices will never
+        // encounter this device without a signature from their user
+        // identity. Consequently, they will never see the device as
+        // unverified.
         if let Some(device_keys) = &mut device_keys {
             let private_identity = self.store().private_identity();
             let guard = private_identity.lock().await;
@@ -1027,7 +1029,8 @@ impl OlmMachine {
         // Return early if the sending device is a dehydrated device
         self.check_to_device_event_is_not_from_dehydrated_device(&decrypted, &event.sender).await?;
 
-        // Device is not dehydrated: handle it as normal e.g. create a Megolm session
+        // Device is not dehydrated: handle it as normal e.g. create a Megolm
+        // session
         self.handle_decrypted_to_device_event(transaction.cache(), &mut decrypted, changes).await?;
 
         Ok(decrypted)
@@ -1105,9 +1108,10 @@ impl OlmMachine {
             return Ok(());
         };
 
-        // NOTE: We already checked that `sender_device_keys` matches the actual sender
-        // of the message when we decrypted the message, which included doing
-        // `DeviceData::try_from` on it, so it can't fail.
+        // NOTE: We already checked that `sender_device_keys` matches the actual
+        // sender of the message when we decrypted the message, which
+        // included doing `DeviceData::try_from` on it, so it can't
+        // fail.
 
         let sender_device_data =
             DeviceData::try_from(sender_device_keys).expect("failed to verify sender device keys");
@@ -1816,8 +1820,9 @@ impl OlmMachine {
     ) -> OlmResult<bool> {
         // Does the to-device message include device info?
         if let Some(device_keys) = decrypted.result.event.sender_device_keys() {
-            // There is no need to check whether the device keys are signed correctly - any
-            // to-device message that claims to be from a dehydrated device is weird, so we
+            // There is no need to check whether the device keys are signed
+            // correctly - any to-device message that claims to be
+            // from a dehydrated device is weird, so we
             // will drop it.
 
             // Does the included device info say the device is dehydrated?
@@ -1924,8 +1929,8 @@ impl OlmMachine {
             .preprocess_sync_changes(&mut store_transaction, sync_changes, decryption_settings)
             .await?;
 
-        // Technically save_changes also does the same work, so if it's slow we could
-        // refactor this to do it only once.
+        // Technically save_changes also does the same work, so if it's slow we
+        // could refactor this to do it only once.
         let room_key_updates: Vec<_> =
             changes.inbound_group_sessions.iter().map(RoomKeyInfo::from).collect();
 
@@ -1969,8 +1974,8 @@ impl OlmMachine {
             // Just use PlainText for that.
             .map(|e| ProcessedToDeviceEvent::PlainText(e.clone()))
             .collect();
-        // The account is automatically saved by the store transaction created by the
-        // caller.
+        // The account is automatically saved by the store transaction created
+        // by the caller.
         let mut changes = Default::default();
 
         if let Err(e) = self
@@ -2055,14 +2060,15 @@ impl OlmMachine {
     ) -> MegolmResult<(VerificationState, Option<OwnedDeviceId>)> {
         let sender_data = self.get_or_update_sender_data(session, sender).await?;
 
-        // If the user ID in the sender data doesn't match that in the event envelope,
-        // this event is not from who it appears to be from.
+        // If the user ID in the sender data doesn't match that in the event
+        // envelope, this event is not from who it appears to be from.
         //
-        // If `sender_data.user_id()` returns `None`, that means we don't have any
-        // information about the owner of the session (i.e. we have
+        // If `sender_data.user_id()` returns `None`, that means we don't have
+        // any information about the owner of the session (i.e. we have
         // `SenderData::UnknownDevice`); in that case we fall through to the
-        // logic in `sender_data_to_verification_state` which will pick an appropriate
-        // `DeviceLinkProblem` for `VerificationLevel::None`.
+        // logic in `sender_data_to_verification_state` which will pick an
+        // appropriate `DeviceLinkProblem` for
+        // `VerificationLevel::None`.
         let (verification_state, device_id) = match sender_data.user_id() {
             Some(i) if i != sender => {
                 (VerificationState::Unverified(VerificationLevel::MismatchedSender), None)
@@ -2096,22 +2102,26 @@ impl OlmMachine {
         sender: &UserId,
     ) -> MegolmResult<SenderData> {
         let sender_data = if session.sender_data.should_recalculate() {
-            // The session is not sure of the sender yet. Try to find a matching device
-            // belonging to the claimed sender of the recently-received event.
+            // The session is not sure of the sender yet. Try to find a matching
+            // device belonging to the claimed sender of the
+            // recently-received event.
             //
-            // It's worth noting that this could in theory result in unintuitive changes,
-            // like a session which initially appears to belong to Alice turning into a
-            // session which belongs to Bob [1]. This could mean that a session initially
-            // successfully decrypts events from Alice, but then stops decrypting those same
-            // events once we get an update.
+            // It's worth noting that this could in theory result in unintuitive
+            // changes, like a session which initially appears to
+            // belong to Alice turning into a session which belongs
+            // to Bob [1]. This could mean that a session initially
+            // successfully decrypts events from Alice, but then stops
+            // decrypting those same events once we get an update.
             //
-            // That's ok though: if we get good evidence that the session belongs to Bob,
-            // it's correct to update the session even if we previously had weak
-            // evidence it belonged to Alice.
+            // That's ok though: if we get good evidence that the session
+            // belongs to Bob, it's correct to update the session
+            // even if we previously had weak evidence it belonged
+            // to Alice.
             //
-            // [1] For example: maybe Alice and Bob both publish devices with the *same*
-            // keys (presumably because they are colluding). Initially we think
-            // the session belongs to Alice, but then we do a device lookup for
+            // [1] For example: maybe Alice and Bob both publish devices with
+            // the *same* keys (presumably because they are
+            // colluding). Initially we think the session belongs to
+            // Alice, but then we do a device lookup for
             // Bob, we find a matching device with a cross-signature, so prefer
             // that.
             let calculated_sender_data = SenderDataFinder::find_using_curve_key(
@@ -2233,9 +2243,11 @@ impl OlmMachine {
             sender: sender.to_owned(),
             sender_device: device_id,
             forwarder: session.forwarder_data.as_ref().and_then(|data| {
-                // Per the comment on `KnownSenderData::device_id`, we should never encounter a
-                // `None` value here, but must still deal with an `Optional` for backwards
-                // compatibility. The approach below allows us to avoid unwrapping.
+                // Per the comment on `KnownSenderData::device_id`, we should
+                // never encounter a `None` value here, but must
+                // still deal with an `Optional` for backwards
+                // compatibility. The approach below allows us to avoid
+                // unwrapping.
                 data.device_id().map(|device_id| ForwarderInfo {
                     device_id: device_id.to_owned(),
                     user_id: data.user_id().to_owned(),
@@ -2267,8 +2279,9 @@ impl OlmMachine {
         // This function is only ever called by decrypt_room_event, so
         // room_id, sender, algorithm and session_id are recorded already
         //
-        // While we already record the sender key in some cases from the event, the
-        // sender key in the event is deprecated, so let's record it now.
+        // While we already record the sender key in some cases from the event,
+        // the sender key in the event is deprecated, so let's record it
+        // now.
         Span::current().record("sender_key", debug(session.sender_key()));
 
         let result = session.decrypt(event).await;
@@ -2294,7 +2307,8 @@ impl OlmMachine {
                         .map(|e| e.content.withheld_code());
 
                     if withheld_code.is_some() {
-                        // Partially withheld, report with a withheld code if we have one.
+                        // Partially withheld, report with a withheld code if we
+                        // have one.
                         MegolmError::MissingRoomKey(withheld_code)
                     } else {
                         error
@@ -2322,8 +2336,8 @@ impl OlmMachine {
             ?trust_requirement, "check_sender_trust_requirement",
         );
 
-        // VerificationState::Verified is acceptable for all TrustRequirement levels, so
-        // let's get that out of the way
+        // VerificationState::Verified is acceptable for all TrustRequirement
+        // levels, so let's get that out of the way
         let verification_level = match &encryption_info.verification_state {
             VerificationState::Verified => return Ok(()),
             VerificationState::Unverified(verification_level) => verification_level,
@@ -2333,7 +2347,8 @@ impl OlmMachine {
             TrustRequirement::Untrusted => true,
 
             TrustRequirement::CrossSignedOrLegacy => {
-                // `VerificationLevel::UnsignedDevice` and `VerificationLevel::None` correspond
+                // `VerificationLevel::UnsignedDevice` and
+                // `VerificationLevel::None` correspond
                 // to `SenderData::DeviceInfo` and `SenderData::UnknownDevice`
                 // respectively, and those cases may be acceptable if the reason
                 // for the lack of data is that the sessions were established
@@ -2346,12 +2361,12 @@ impl OlmMachine {
 
                 // In the CrossSignedOrLegacy case the following rules apply:
                 //
-                // 1. Identities we have not yet verified can be decrypted regardless of the
-                //    legacy state of the session.
-                // 2. Devices that aren't signed by the owning identity of the device can only
-                //    be decrypted if it's a legacy session.
-                // 3. If we have no information about the device, we should only decrypt if it's
-                //    a legacy session.
+                // 1. Identities we have not yet verified can be decrypted
+                //    regardless of the legacy state of the session.
+                // 2. Devices that aren't signed by the owning identity of the
+                //    device can only be decrypted if it's a legacy session.
+                // 3. If we have no information about the device, we should only
+                //    decrypt if it's a legacy session.
                 // 4. Anything else, should throw an error.
                 match (verification_level, legacy_session) {
                     // Case 1
@@ -2575,7 +2590,8 @@ impl OlmMachine {
             .deserialize_as_unchecked()
             .map_err(|_| MegolmError::StateKeyVerificationFailed)?;
 
-        // Ensure we have a state key on the outer event iff there is one in the inner.
+        // Ensure we have a state key on the outer event iff there is one in the
+        // inner.
         let (raw_state_key, inner_state_key) = match (&original.state_key, &inner_state_key) {
             (Some(raw_state_key), Some(inner_state_key)) => (raw_state_key, inner_state_key),
             (None, None) => return Ok(()),
@@ -2679,9 +2695,11 @@ impl OlmMachine {
                     Some(UnsignedDecryptionResult::Decrypted(decrypted_event.encryption_info))
                 }
                 Err(err) => {
-                    // For now, we throw away crypto store errors and just treat the unsigned event
-                    // as unencrypted. Crypto store errors represent problems with the application
-                    // rather than normal UTD errors, so they should probably be propagated
+                    // For now, we throw away crypto store errors and just treat
+                    // the unsigned event as unencrypted.
+                    // Crypto store errors represent problems with the
+                    // application rather than normal UTD
+                    // errors, so they should probably be propagated
                     // rather than swallowed.
                     let utd_info = megolm_error_to_utd_info(&raw_event, err).ok()?;
                     Some(UnsignedDecryptionResult::UnableToDecrypt(utd_info))
@@ -2712,13 +2730,14 @@ impl OlmMachine {
                 (&c.session_id, c.ciphertext.message_index())
             }
             RoomEventEncryptionScheme::Unknown(_) => {
-                // We don't support this encryption algorithm, so clearly don't have its key.
+                // We don't support this encryption algorithm, so clearly don't
+                // have its key.
                 return Ok(false);
             }
         };
 
-        // Check that we have the session in the store, and that its first known index
-        // predates the index of our message.
+        // Check that we have the session in the store, and that its first known
+        // index predates the index of our message.
         Ok(self
             .store()
             .get_inbound_group_session(room_id, session_id)
@@ -3033,8 +3052,8 @@ impl OlmMachine {
         &self,
         generation: &Mutex<Option<u64>>,
     ) -> StoreResult<()> {
-        // Avoid reentrant initialization by taking the lock for the entire's function
-        // scope.
+        // Avoid reentrant initialization by taking the lock for the entire's
+        // function scope.
         let mut gen_guard = generation.lock().await;
 
         let prev_generation =
@@ -3042,8 +3061,9 @@ impl OlmMachine {
 
         let generation = match prev_generation {
             Some(val) => {
-                // There was a value in the store. We need to signal that we're a different
-                // process, so we don't just reuse the value but increment it.
+                // There was a value in the store. We need to signal that we're
+                // a different process, so we don't just reuse
+                // the value but increment it.
                 u64::from_le_bytes(val.try_into().map_err(|_| {
                     CryptoStoreError::InvalidLockGeneration("invalid format".to_owned())
                 })?)
@@ -3095,9 +3115,10 @@ impl OlmMachine {
         let mut gen_guard = generation.lock().await;
 
         // The database value must be there:
-        // - either we could initialize beforehand, thus write into the database,
-        // - or we couldn't, and then another process was holding onto the database's
-        //   lock, thus
+        // - either we could initialize beforehand, thus write into the
+        //   database,
+        // - or we couldn't, and then another process was holding onto the
+        //   database's lock, thus
         // has written a generation counter in there.
         let actual_gen = self
             .inner
@@ -3122,8 +3143,9 @@ impl OlmMachine {
                 actual_gen.max(*expected_gen).wrapping_add(1)
             }
             None => {
-                // Some other process hold onto the lock when initializing, so we must reload.
-                // Increment database value, and store it everywhere.
+                // Some other process hold onto the lock when initializing, so
+                // we must reload. Increment database value, and
+                // store it everywhere.
                 actual_gen.wrapping_add(1)
             }
         };
@@ -3179,24 +3201,26 @@ impl OlmMachine {
     ) -> Result<(), SetRoomSettingsError> {
         let store = &self.inner.store;
 
-        // We want to make sure that we do not race against a second concurrent call to
-        // `set_room_settings`. By way of an easy way to do so, we start a
-        // StoreTransaction. There's no need to commit() it: we're just using it as a
-        // lock guard.
+        // We want to make sure that we do not race against a second concurrent
+        // call to `set_room_settings`. By way of an easy way to do so,
+        // we start a StoreTransaction. There's no need to commit() it:
+        // we're just using it as a lock guard.
         let _store_transaction = store.transaction().await;
 
         let old_settings = store.get_room_settings(room_id).await?;
 
-        // We want to make sure that the change to the room settings does not represent
-        // a downgrade in security. The [E2EE implementation guide] recommends:
+        // We want to make sure that the change to the room settings does not
+        // represent a downgrade in security. The [E2EE implementation
+        // guide] recommends:
         //
-        //  > This flag should **not** be cleared if a later `m.room.encryption` event
+        //  > This flag should **not** be cleared if a later `m.room.encryption`
+        //  > event
         //  > changes the configuration.
         //
-        // (However, it doesn't really address how to handle changes to the rotation
-        // parameters, etc.) For now at least, we are very conservative here:
-        // any new settings are rejected if they differ from the existing settings.
-        // merit improvement (cf https://github.com/element-hq/element-meta/issues/69).
+        // (However, it doesn't really address how to handle changes to the
+        // rotation parameters, etc.) For now at least, we are very
+        // conservative here: any new settings are rejected if they
+        // differ from the existing settings. merit improvement (cf https://github.com/element-hq/element-meta/issues/69).
         //
         // [E2EE implementation guide]: https://matrix.org/docs/matrix-concepts/end-to-end-encryption/#handling-an-m-room-encryption-state-event
         if let Some(old_settings) = old_settings {

--- a/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/decryption_verification_state.rs
@@ -361,8 +361,8 @@ async fn test_verification_states_spoofed_sender(
         VerificationState::Unverified(VerificationLevel::UnverifiedIdentity)
     );
 
-    // Alice now sends a second message to Bob, using the same room key, but the HS
-    // admin rewrites the 'sender' to Charlie.
+    // Alice now sends a second message to Bob, using the same room key, but the
+    // HS admin rewrites the 'sender' to Charlie.
     let result = alice
         .encrypt_room_event(
             room_id,

--- a/crates/matrix-sdk-crypto/src/machine/tests/interactive_verification.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/interactive_verification.rs
@@ -154,8 +154,8 @@ async fn test_interactive_verification_started_from_request() {
     let event = request_to_event(bob.user_id(), &start_request_from_bob);
     alice.handle_verification_event(&event).await;
 
-    // Since Alice's user id is lexicographically smaller than Bob's, Alice does not
-    // do anything with the request, however.
+    // Since Alice's user id is lexicographically smaller than Bob's, Alice does
+    // not do anything with the request, however.
     assert!(alice.user_id() < bob.user_id());
 
     // ----------------------------------------------------------------------------

--- a/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/megolm_sender_data.rs
@@ -55,8 +55,9 @@ async fn test_receive_megolm_session_from_unknown_device() {
     let (alice, bob) = get_machine_pair().await;
     let mut bob_room_keys_received_stream = Box::pin(bob.store().room_keys_received_stream());
 
-    // `get_machine_pair_with_setup_sessions_test_helper` tells Bob about Alice's
-    // device keys, so to run this test, we need to make him forget them.
+    // `get_machine_pair_with_setup_sessions_test_helper` tells Bob about
+    // Alice's device keys, so to run this test, we need to make him forget
+    // them.
     forget_devices_for_user(&bob, alice.user_id()).await;
 
     // When Alice starts a megolm session and shares the key with Bob, *without*
@@ -238,12 +239,13 @@ async fn test_update_unknown_device_senderdata_on_keys_query() {
     let (alice, bob) = get_machine_pair().await;
     let mut bob_room_keys_received_stream = Box::pin(bob.store().room_keys_received_stream());
 
-    // `get_machine_pair_with_setup_sessions_test_helper` tells Bob about Alice's
-    // device keys, so to run this test, we need to make him forget them.
+    // `get_machine_pair_with_setup_sessions_test_helper` tells Bob about
+    // Alice's device keys, so to run this test, we need to make him forget
+    // them.
     forget_devices_for_user(&bob, alice.user_id()).await;
 
-    // Alice starts a megolm session and shares the key with Bob, *without* sending
-    // the sender data.
+    // Alice starts a megolm session and shares the key with Bob, *without*
+    // sending the sender data.
     let room_id = room_id!("!test:example.org");
     let event = create_and_share_session_with_custom_sender_data(&alice, &bob, room_id, None).await;
 
@@ -274,8 +276,8 @@ async fn test_update_unknown_device_senderdata_on_keys_query() {
     .await
     .unwrap();
 
-    // Then Bob should have received an update about the session, and it should now
-    // be `SenderData::DeviceInfo`
+    // Then Bob should have received an update about the session, and it should
+    // now be `SenderData::DeviceInfo`
     let room_key_info = get_room_key_received_update(&mut bob_room_keys_received_stream);
     let session = get_inbound_group_session_or_panic(&bob, &room_key_info).await;
 
@@ -321,14 +323,14 @@ async fn test_update_device_info_senderdata_on_keys_query() {
     // Double-check that it is, in fact, an unverified device session.
     assert_matches!(session.sender_data, SenderData::DeviceInfo { .. });
 
-    // When Bob receives a /keys/query response for Alice that includes a verifiable
-    // signature for her device
+    // When Bob receives a /keys/query response for Alice that includes a
+    // verifiable signature for her device
     let bootstrap_requests = alice.bootstrap_cross_signing(false).await.unwrap();
     let kq_response = bootstrap_requests_to_keys_query_response(bootstrap_requests);
     bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
 
-    // Then Bob should have received an update about the session, and it should now
-    // be `SenderData::SenderUnverified`
+    // Then Bob should have received an update about the session, and it should
+    // now be `SenderData::SenderUnverified`
     let room_key_info = get_room_key_received_update(&mut bob_room_keys_received_stream);
     let session = get_inbound_group_session_or_panic(&bob, &room_key_info).await;
 
@@ -381,8 +383,8 @@ async fn create_and_share_session_with_custom_sender_data(
         .await
         .unwrap();
 
-    // In future, we might want to save the session to the store, to better match
-    // the behaviour of the real implementation. See
+    // In future, we might want to save the session to the store, to better
+    // match the behaviour of the real implementation. See
     // `GroupSessionManager::share_room_key` for inspiration on how to do that.
 
     let olm_sessions = alice

--- a/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/mod.rs
@@ -483,8 +483,8 @@ async fn steal_account_private_key(machine: &OlmMachine) -> Box<Ed25519SecretKey
         signing_key: SecretKeysHack,
     }
 
-    // Serialize the underlying AccountPickle which contains the account's private
-    // key
+    // Serialize the underlying AccountPickle which contains the account's
+    // private key
     let account_pickle =
         machine.inner.store.transaction().await.account().await.unwrap().pickle().pickle;
 
@@ -624,13 +624,14 @@ async fn test_to_device_messages_from_dehydrated_devices_are_ignored() {
     let (alice, bob) = create_dehydrated_machine_and_pair().await;
 
     // When we send a to-device message from alice to bob
-    // (Note: we send a room_key message, but it could be any to-device message.)
+    // (Note: we send a room_key message, but it could be any to-device
+    // message.)
     let room_id = room_id!("!test:example.org");
     let (decrypted, room_key_updates) =
         send_room_key_to_device(&alice, &bob, room_id).await.unwrap();
 
-    // Then the to-device message was discarded, because it was from a dehydrated
-    // device
+    // Then the to-device message was discarded, because it was from a
+    // dehydrated device
     assert!(decrypted.is_empty());
 
     // And the room key was not imported as a session
@@ -686,9 +687,9 @@ async fn send_room_key_to_device(
 /// session for messages from alice to bob, and ensure bob knows alice's device
 /// is dehydrated.
 async fn create_dehydrated_machine_and_pair() -> (OlmMachine, OlmMachine) {
-    // Create a store holding info about an account that is linked to a dehydrated
-    // device. This should never happen in real life, so we have to poke the
-    // info into the store directly.
+    // Create a store holding info about an account that is linked to a
+    // dehydrated device. This should never happen in real life, so we have
+    // to poke the info into the store directly.
     let alice_store = MemoryStore::new();
     let alice_dehydrated_account = Account::new_dehydrated(alice_id());
     let mut alice_static_account = alice_dehydrated_account.static_data().clone();
@@ -742,8 +743,8 @@ async fn test_request_missing_secrets() {
 
     assert_eq!(outgoing_to_device.len(), 4);
 
-    // The second time, as there are already in-flight requests, it should have no
-    // effect.
+    // The second time, as there are already in-flight requests, it should have
+    // no effect.
     let should_query_secrets_now = alice.query_missing_secrets_from_other_sessions().await.unwrap();
     assert!(!should_query_secrets_now);
 }
@@ -772,8 +773,8 @@ async fn test_request_missing_secrets_cross_signed() {
         .collect_vec();
     assert_eq!(outgoing_to_device.len(), 1);
 
-    // The second time, as there are already in-flight requests, it should have no
-    // effect.
+    // The second time, as there are already in-flight requests, it should have
+    // no effect.
     let should_query_secrets_now = alice.query_missing_secrets_from_other_sessions().await.unwrap();
     assert!(!should_query_secrets_now);
 }
@@ -1193,7 +1194,8 @@ async fn test_withheld_unverified() {
     .await
     .unwrap();
 
-    // We should receive a notification on the room_keys_withheld_received_stream
+    // We should receive a notification on the
+    // room_keys_withheld_received_stream
     let withheld_received = room_keys_withheld_received_stream
         .next()
         .now_or_never()
@@ -1707,18 +1709,18 @@ async fn test_importing_private_cross_signing_keys_verifies_the_public_identity(
 
 #[async_test]
 async fn test_wait_on_key_query_doesnt_block_store() {
-    // Waiting for a key query shouldn't delay other write attempts to the store.
-    // This test will end immediately if it works, and times out after a few seconds
-    // if it failed.
+    // Waiting for a key query shouldn't delay other write attempts to the
+    // store. This test will end immediately if it works, and times out
+    // after a few seconds if it failed.
 
     let machine = OlmMachine::new(bob_id(), bob_device_id()).await;
 
-    // Mark Alice as a tracked user, so it gets into the groups of users for which
-    // we need to query keys.
+    // Mark Alice as a tracked user, so it gets into the groups of users for
+    // which we need to query keys.
     machine.update_tracked_users([alice_id()]).await.unwrap();
 
-    // Start a background task that will wait for the key query to finish silently
-    // in the background.
+    // Start a background task that will wait for the key query to finish
+    // silently in the background.
     let machine_cloned = machine.clone();
     let wait = spawn(async move {
         let machine = machine_cloned;
@@ -1783,8 +1785,8 @@ async fn test_fix_incorrect_usage_of_backup_key_causing_decryption_errors() {
 
     let backed_up_room_key: BackedUpRoomKey = serde_json::from_value(data).unwrap();
 
-    // Create the machine using `with_store` and without a call to enable_backup_v1,
-    // like regenerate_olm would do
+    // Create the machine using `with_store` and without a call to
+    // enable_backup_v1, like regenerate_olm would do
     let alice = OlmMachineBuilder::new(user_id(), alice_device_id())
         .with_crypto_store(store)
         .build()

--- a/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/olm_encryption.rs
@@ -109,9 +109,10 @@ async fn test_getting_most_recent_session() {
 
     let mut changes = Changes::default();
 
-    // Since the sessions are created quickly in succession and our timestamps have
-    // a resolution in seconds, it's very likely that we're going to end up
-    // with the same timestamps, so we manually masage them to be 10s apart.
+    // Since the sessions are created quickly in succession and our timestamps
+    // have a resolution in seconds, it's very likely that we're going to
+    // end up with the same timestamps, so we manually masage them to be 10s
+    // apart.
     let session_id = {
         let sessions = alice_machine
             .store()
@@ -126,8 +127,9 @@ async fn test_getting_most_recent_session() {
 
         let mut session_id = None;
 
-        // Iterate through the sessions skipping the first and last element so we know
-        // that the correct session isn't the first nor the last one.
+        // Iterate through the sessions skipping the first and last element so
+        // we know that the correct session isn't the first nor the last
+        // one.
         let (_, sessions_slice) = sessions.as_mut_slice().split_last_mut().unwrap();
 
         for session in sessions_slice.iter_mut().skip(1) {
@@ -160,8 +162,8 @@ async fn test_get_most_recent_session_of_device_with_no_curve_key() {
     let bob_device_id = device_id!("BOB_DEVICE");
 
     let bob_device_data = {
-        // Create a device with no Curve25519 key. It has to have an Ed25519 key, and be
-        // signed, for us to accept it
+        // Create a device with no Curve25519 key. It has to have an Ed25519
+        // key, and be signed, for us to accept it
         let bob_signing_key = Ed25519SecretKey::new();
 
         // Generate the unsigned structure
@@ -190,8 +192,8 @@ async fn test_get_most_recent_session_of_device_with_no_curve_key() {
 
     alice_machine.store().save_device_data(&[bob_device_data]).await.unwrap();
 
-    // Now, fetch the device from the store, and the most recent session should be
-    // None.
+    // Now, fetch the device from the store, and the most recent session should
+    // be None.
     let device = alice_machine.get_device(bob_user_id, bob_device_id, None).await.unwrap().unwrap();
     let newest_session = device.get_most_recent_session().await.unwrap();
     assert!(newest_session.is_none());

--- a/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
+++ b/crates/matrix-sdk-crypto/src/machine/tests/send_encrypted_to_device.rs
@@ -684,8 +684,8 @@ async fn create_and_share_session_without_sender_data(
         .await
         .unwrap();
 
-    // In future, we might want to save the session to the store, to better match
-    // the behaviour of the real implementation. See
+    // In future, we might want to save the session to the store, to better
+    // match the behaviour of the real implementation. See
     // `GroupSessionManager::share_room_key` for inspiration on how to do that.
 
     let bob_device = alice

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -423,17 +423,17 @@ impl Account {
     ) -> Self {
         let identity_keys = account.identity_keys();
 
-        // Let's generate some initial one-time keys while we're here. Since we know
-        // that this is a completely new [`Account`] we're certain that the
-        // server does not yet have any one-time keys of ours.
+        // Let's generate some initial one-time keys while we're here. Since we
+        // know that this is a completely new [`Account`] we're certain
+        // that the server does not yet have any one-time keys of ours.
         //
         // This ensures we upload one-time keys along with our device keys right
         // away, rather than waiting for the key counts to be echoed back to us
         // from the server.
         //
-        // It would be nice to do this for the fallback key as well but we can't assume
-        // that the server supports fallback keys. Maybe one of these days we
-        // will be able to do so.
+        // It would be nice to do this for the fallback key as well but we can't
+        // assume that the server supports fallback keys. Maybe one of
+        // these days we will be able to do so.
         account.generate_one_time_keys(account.max_number_of_one_time_keys());
 
         Self {
@@ -578,9 +578,10 @@ impl Account {
             self.generate_one_time_keys_if_needed();
         }
 
-        // If the server supports fallback keys or if it did so in the past, shown by
-        // the existence of a fallback creation timestamp, generate a new one if
-        // we don't have one, or if the current fallback key expired.
+        // If the server supports fallback keys or if it did so in the past,
+        // shown by the existence of a fallback creation timestamp,
+        // generate a new one if we don't have one, or if the current
+        // fallback key expired.
         if unused_fallback_keys.is_some() || self.fallback_creation_timestamp.is_some() {
             self.generate_fallback_key_if_needed();
         }
@@ -654,28 +655,32 @@ impl Account {
         const FALLBACK_KEY_MAX_AGE: Duration = Duration::from_secs(3600 * 24 * 7);
 
         if let Some(time) = self.fallback_creation_timestamp {
-            // `to_system_time()` returns `None` if the the UNIX_EPOCH + `time` doesn't fit
-            // into a i64. This will likely never happen, but let's rotate the
-            // key in case the values are messed up for some other reason.
+            // `to_system_time()` returns `None` if the the UNIX_EPOCH + `time`
+            // doesn't fit into a i64. This will likely never
+            // happen, but let's rotate the key in case the values
+            // are messed up for some other reason.
             let Some(system_time) = time.to_system_time() else {
                 return true;
             };
 
-            // `elapsed()` errors if the `system_time` is in the future, this should mean
-            // that our clock has changed to the past, let's rotate just in case
-            // and then we'll get to a normal time.
+            // `elapsed()` errors if the `system_time` is in the future, this
+            // should mean that our clock has changed to the past,
+            // let's rotate just in case and then we'll get to a
+            // normal time.
             let Ok(elapsed) = system_time.elapsed() else {
                 return true;
             };
 
-            // Alright, our times are normal and we know how much time elapsed since the
-            // last time we created/rotated a fallback key.
+            // Alright, our times are normal and we know how much time elapsed
+            // since the last time we created/rotated a fallback
+            // key.
             //
             // If the key is older than a week, then we rotate it.
             elapsed > FALLBACK_KEY_MAX_AGE
         } else {
-            // We never created a fallback key, or we're migrating to the time-based
-            // fallback key rotation, so let's generate a new fallback key.
+            // We never created a fallback key, or we're migrating to the
+            // time-based fallback key rotation, so let's generate a
+            // new fallback key.
             true
         }
     }
@@ -1309,8 +1314,8 @@ impl Account {
         self.mark_as_shared();
 
         debug!("Marking one-time keys as published");
-        // First mark the current keys as published, as updating the key counts might
-        // generate some new keys if we're still below the limit.
+        // First mark the current keys as published, as updating the key counts
+        // might generate some new keys if we're still below the limit.
         self.mark_keys_as_published();
         self.update_key_counts(&response.one_time_key_counts, None, false);
 
@@ -1332,8 +1337,8 @@ impl Account {
                 let mut errors_by_olm_session = Vec::new();
 
                 if let Some(sessions) = existing_sessions {
-                    // Try to decrypt the message using each Session we share with the
-                    // given curve25519 sender key.
+                    // Try to decrypt the message using each Session we share
+                    // with the given curve25519 sender key.
                     for session in sessions.lock().await.iter_mut() {
                         match session.decrypt(message).await {
                             Ok(p) => {
@@ -1342,9 +1347,11 @@ impl Account {
                             }
 
                             Err(e) => {
-                                // An error here is completely normal, after all we don't know
+                                // An error here is completely normal, after all
+                                // we don't know
                                 // which session was used to encrypt a message.
-                                // We keep hold of the error, so that if *all* sessions fail to
+                                // We keep hold of the error, so that if *all*
+                                // sessions fail to
                                 // decrypt, we can log something useful.
                                 errors_by_olm_session.push((session.session_id().to_owned(), e));
                             }
@@ -1373,18 +1380,22 @@ impl Account {
                             return Ok((SessionType::Existing(session.clone()), p));
                         }
 
-                        // The message was intended for this session, but we weren't able to
-                        // decrypt it.
+                        // The message was intended for this session, but we
+                        // weren't able to decrypt it.
                         //
-                        // There's no point trying any other sessions, nor should we try to
-                        // create a new one since we have already previously created a `Session`
-                        // with the same keys.
+                        // There's no point trying any other sessions, nor
+                        // should we try to create a new
+                        // one since we have already previously created a
+                        // `Session` with the same keys.
                         //
-                        // (Attempts to create a new session would likely fail anyway since the
-                        // corresponding one-time key would've been already used up in the
-                        // previous session creation operation. The one exception where this
-                        // would not be so is if the fallback key was used for creating the
-                        // session in lieu of an OTK.)
+                        // (Attempts to create a new session would likely fail
+                        // anyway since the
+                        // corresponding one-time key would've been already used
+                        // up in the previous session
+                        // creation operation. The one exception where this
+                        // would not be so is if the fallback key was used for
+                        // creating the session in lieu
+                        // of an OTK.)
 
                         warn!(
                             session_id = session.session_id(),
@@ -1410,9 +1421,10 @@ impl Account {
                         }
                     };
 
-                // We need to add the new session to the session cache, otherwise
-                // we might try to create the same session again.
-                // TODO: separate the session cache from the storage so we only add
+                // We need to add the new session to the session cache,
+                // otherwise we might try to create the same
+                // session again. TODO: separate the session
+                // cache from the storage so we only add
                 // it to the cache but don't store it.
                 let mut changes =
                     Changes { sessions: vec![result.session.clone()], ..Default::default() };
@@ -1466,9 +1478,10 @@ impl Account {
         {
             Ok(result) => Ok((session, result)),
             Err(e) => {
-                // We might have created a new session but decryption might still
-                // have failed, store it for the error case here, this is fine
-                // since we don't expect this to happen often or at all.
+                // We might have created a new session but decryption might
+                // still have failed, store it for the error
+                // case here, this is fine since we don't expect
+                // this to happen often or at all.
                 match session {
                     SessionType::New(s) | SessionType::Existing(s) => {
                         store.save_sessions(&[s]).await?;
@@ -1574,9 +1587,9 @@ impl Account {
         event: &AnyDecryptedOlmEvent,
     ) -> OlmResult<Option<Device>> {
         // If the event contained sender_device_keys, check them now.
-        // WARN: If you move or modify this check, ensure that the code below is still
-        // valid. The processing of the historic room key bundle depends on this being
-        // here.
+        // WARN: If you move or modify this check, ensure that the code below is
+        // still valid. The processing of the historic room key bundle
+        // depends on this being here.
         let sender_device_keys = Self::check_sender_device_keys(event, sender_key)?;
         if let AnyDecryptedOlmEvent::RoomKey(_) = event {
             // If this event is an `m.room_key` event, defer the check for
@@ -1586,18 +1599,18 @@ impl Account {
             return Ok(None);
         }
 
-        // MSC4268 requires room key bundle events to have a `sender_device_keys` field.
-        // Enforce that now.
+        // MSC4268 requires room key bundle events to have a
+        // `sender_device_keys` field. Enforce that now.
         if let AnyDecryptedOlmEvent::RoomKeyBundle(_) = event {
             sender_device_keys.ok_or(EventError::MissingSigningKey).inspect_err(|_| {
                 warn!("The room key bundle was missing the sender device keys in the event")
             })?;
         }
 
-        // For event types other than `m.room_key`, we need to look up the device in the
-        // database irrespective of whether the `sender_device_keys` field is
-        // present in the event, because it may have been marked as "locally
-        // trusted" in the database.
+        // For event types other than `m.room_key`, we need to look up the
+        // device in the database irrespective of whether the
+        // `sender_device_keys` field is present in the event, because
+        // it may have been marked as "locally trusted" in the database.
         let store_device = store.get_device_from_curve_key(event.sender(), sender_key).await?;
 
         match (store_device, sender_device_keys) {
@@ -1616,8 +1629,9 @@ impl Account {
             }
 
             (None, Some(sender_device_keys)) => {
-                // We have already validated the signature on `sender_device_keys`, so this
-                // try_into cannot fail.
+                // We have already validated the signature on
+                // `sender_device_keys`, so this try_into cannot
+                // fail.
                 let sender_device_data = sender_device_keys.try_into().expect("Conversion of DeviceKeys to DeviceData failed despite the signature already having been checked");
                 Ok(Some(store.wrap_device_data(sender_device_data).await?))
             }
@@ -1649,13 +1663,14 @@ impl Account {
         // to-device events with unverified senders from being allowed
         // through here, but there are some exceptions:
         //
-        // * m.room_key - we hold on to these until later, so if the sender becomes
-        //   verified later we can still use the key.
+        // * m.room_key - we hold on to these until later, so if the sender
+        //   becomes verified later we can still use the key.
         //
         // * m.room_key_request, m.room_key.withheld, m.key.verification.*,
-        //   m.secret.request - these are allowed as plaintext events, so we also allow
-        //   them encrypted from insecure devices. Note: the list of allowed types here
-        //   should match with what is allowed in handle_to_device_event.
+        //   m.secret.request - these are allowed as plaintext events, so we
+        //   also allow them encrypted from insecure devices. Note: the list of
+        //   allowed types here should match with what is allowed in
+        //   handle_to_device_event.
         match event_type {
             "m.room_key"
             | "m.room_key.withheld"
@@ -1669,13 +1684,14 @@ impl Account {
             | "m.key.verification.accept"
             | "m.key.verification.cancel"
             | "m.key.verification.request" => {
-                // This is one of the exception types - we allow it even if the sender device is
-                // not verified.
+                // This is one of the exception types - we allow it even if the
+                // sender device is not verified.
                 true
             }
             _ => {
-                // This is not an exception type - check for "exclude insecure devices" mode,
-                // and whether the sender is verified.
+                // This is not an exception type - check for "exclude insecure
+                // devices" mode, and whether the sender is
+                // verified.
                 satisfies_sender_trust_requirement(
                     &result.encryption_info,
                     &decryption_settings.sender_device_trust_requirement,
@@ -1699,7 +1715,8 @@ impl Account {
             .as_ref()
             .map(|device| {
                 if device.is_verified() {
-                    // The device is locally verified or signed by a verified user
+                    // The device is locally verified or signed by a verified
+                    // user
                     VerificationState::Verified
                 } else if device.is_cross_signed_by_owner() {
                     // The device is not verified, but it is signed by its owner
@@ -1806,8 +1823,8 @@ impl Account {
             OlmError::EventError(EventError::InvalidSenderDeviceKeys)
         })?;
 
-        // Check that the Ed25519 key in the sender_device_keys matches the `ed25519`
-        // key in the `keys` field in the event.
+        // Check that the Ed25519 key in the sender_device_keys matches the
+        // `ed25519` key in the `keys` field in the event.
         if sender_device_keys.ed25519_key() != Some(event.keys().ed25519) {
             warn!(
                 "Received a to-device message with sender_device_keys with incorrect \
@@ -1818,8 +1835,8 @@ impl Account {
             return Err(OlmError::EventError(EventError::InvalidSenderDeviceKeys));
         }
 
-        // Check that the Curve25519 key in the sender_device_keys matches the key that
-        // was used for the Olm session.
+        // Check that the Curve25519 key in the sender_device_keys matches the
+        // key that was used for the Olm session.
         if sender_device_keys.curve25519_key() != Some(sender_key) {
             warn!(
                 "Received a to-device message with sender_device_keys with incorrect \
@@ -1838,7 +1855,8 @@ impl Account {
     /// that we don't want the inner state to be shared.
     #[doc(hidden)]
     pub fn deep_clone(&self) -> Self {
-        // `vodozemac::Account` isn't really cloneable, but... Don't tell anyone.
+        // `vodozemac::Account` isn't really cloneable, but... Don't tell
+        // anyone.
         Self::from_pickle(self.pickle()).unwrap()
     }
 }
@@ -2048,8 +2066,8 @@ mod tests {
         );
         account.mark_keys_as_published();
 
-        // There's no unused fallback key on the server, but our initial fallback key
-        // did not yet expire.
+        // There's no unused fallback key on the server, but our initial
+        // fallback key did not yet expire.
         let unused_fallback_keys = &[];
         account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()), false);
         let (_, _, fallback_keys) = account.keys_for_upload();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/forwarder_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/forwarder_data.rs
@@ -44,9 +44,9 @@ impl TryFrom<&SenderData> for ForwarderData {
     type Error = ();
 
     fn try_from(value: &SenderData) -> Result<Self, Self::Error> {
-        // The sender's device must be either `SenderData::SenderUnverified` (i.e.,
-        // TOFU-trusted) or `SenderData::SenderVerified` (i.e., fully verified
-        // via user verification and cross-signing).
+        // The sender's device must be either `SenderData::SenderUnverified`
+        // (i.e., TOFU-trusted) or `SenderData::SenderVerified` (i.e.,
+        // fully verified via user verification and cross-signing).
         match value {
             SenderData::SenderUnverified(known_sender_data) => {
                 Ok(Self::SenderUnverified(known_sender_data.clone()))
@@ -107,8 +107,8 @@ mod tests {
     }
 
     // A previous version of this implementation used [`SenderData`] instead of
-    // [`ForwarderData`]. To ensure we can still treat existing serialised data as
-    // `ForwarderData`, we check we can deserialise the old variants.
+    // [`ForwarderData`]. To ensure we can still treat existing serialised data
+    // as `ForwarderData`, we check we can deserialise the old variants.
     #[test]
     fn test_deserialize_old_format() {
         let master_key = Ed25519PublicKey::from_slice(&[1u8; 32]).unwrap();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -565,8 +565,9 @@ impl InboundGroupSession {
     /// depending on whether this session's first known index is equal to,
     /// lower than, or higher than, that of `other`.
     pub async fn compare_ratchet(&self, other: &InboundGroupSession) -> SessionOrdering {
-        // If this is the same object the ordering is the same, we can't compare because
-        // we would deadlock while trying to acquire the same lock twice.
+        // If this is the same object the ordering is the same, we can't compare
+        // because we would deadlock while trying to acquire the same
+        // lock twice.
         if Arc::ptr_eq(&self.inner, &other.inner) {
             SessionOrdering::Equal
         } else if self.sender_key() != other.sender_key()
@@ -971,7 +972,8 @@ mod tests {
 
     #[async_test]
     async fn test_can_deserialise_pickled_session_without_sender_data() {
-        // Given the raw JSON for a picked inbound group session without any sender_data
+        // Given the raw JSON for a picked inbound group session without any
+        // sender_data
         let pickle = r#"
         {
             "pickle": {
@@ -1017,8 +1019,8 @@ mod tests {
         // Then it was parsed correctly
         assert_eq!(unpickled.session_id(), "XbmrPa1kMwmdtNYng1B2gsfoo8UtF+NklzsTZiaVKyY");
 
-        // And we populated the InboundGroupSession's sender_data with a default value,
-        // with legacy_session set to true.
+        // And we populated the InboundGroupSession's sender_data with a default
+        // value, with legacy_session set to true.
         assert_let!(
             SenderData::UnknownDevice { legacy_session, owner_check_failed } =
                 unpickled.sender_data
@@ -1052,7 +1054,8 @@ mod tests {
 
         // Then it looks as we expect
 
-        // (Break out this list of numbers as otherwise it bothers the json macro below)
+        // (Break out this list of numbers as otherwise it bothers the json
+        // macro below)
         let expected_inner = vec![
             193, 203, 223, 152, 33, 132, 200, 168, 24, 197, 79, 174, 231, 202, 45, 245, 128, 131,
             178, 165, 148, 37, 241, 214, 178, 218, 25, 33, 68, 48, 153, 104, 122, 6, 249, 198, 97,
@@ -1097,7 +1100,8 @@ mod tests {
 
     #[async_test]
     async fn test_can_deserialise_pickled_session_with_sender_data() {
-        // Given the raw JSON for a picked inbound group session (including sender_data)
+        // Given the raw JSON for a picked inbound group session (including
+        // sender_data)
         let pickle = r#"
         {
             "pickle": {
@@ -1148,8 +1152,8 @@ mod tests {
         // Then it was parsed correctly
         assert_eq!(unpickled.session_id(), "XbmrPa1kMwmdtNYng1B2gsfoo8UtF+NklzsTZiaVKyY");
 
-        // And we populated the InboundGroupSession's sender_data with the provided
-        // values
+        // And we populated the InboundGroupSession's sender_data with the
+        // provided values
         assert_let!(
             SenderData::UnknownDevice { legacy_session, owner_check_failed } =
                 unpickled.sender_data

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -211,12 +211,14 @@ impl TryFrom<ExportedRoomKey> for ForwardedRoomKeyContent {
     fn try_from(room_key: ExportedRoomKey) -> Result<ForwardedRoomKeyContent, Self::Error> {
         match room_key.algorithm {
             EventEncryptionAlgorithm::MegolmV1AesSha2 => {
-                // The forwarded room key content only supports a single claimed sender
-                // key and it requires it to be a Ed25519 key. This here will be lossy
-                // conversion since we're dropping all other key types.
+                // The forwarded room key content only supports a single claimed
+                // sender key and it requires it to be a Ed25519
+                // key. This here will be lossy conversion since
+                // we're dropping all other key types.
                 //
-                // This was fixed by the megolm v2 content. Hopefully we'll deprecate megolm v1
-                // before we have multiple signing keys.
+                // This was fixed by the megolm v2 content. Hopefully we'll
+                // deprecate megolm v1 before we have multiple
+                // signing keys.
                 if let Some(SigningKey::Ed25519(claimed_ed25519_key)) =
                     room_key.sender_claimed_keys.get(&DeviceKeyAlgorithm::Ed25519)
                 {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -1087,8 +1087,8 @@ mod tests {
             let now = SecondsSinceUnixEpoch::now();
             session.creation_time = SecondsSinceUnixEpoch(now.get() - uint!(1800));
 
-            // Then the session is expired: the feature flag has prevented us enforcing a
-            // minimum
+            // Then the session is expired: the feature flag has prevented us
+            // enforcing a minimum
             assert!(session.expired());
         }
 
@@ -1103,8 +1103,8 @@ mod tests {
 
             // When we send no messages
 
-            // Then the session is not expired: we are protected against this nonsensical
-            // setup
+            // Then the session is not expired: we are protected against this
+            // nonsensical setup
             assert!(!session.expired());
         }
 
@@ -1126,8 +1126,8 @@ mod tests {
                 )
                 .await;
 
-            // Then the session is expired: we treated rotation_period_msgs=0 as if it were
-            // =1
+            // Then the session is expired: we treated rotation_period_msgs=0 as
+            // if it were =1
             assert!(session.expired());
 
             Ok(())
@@ -1152,8 +1152,8 @@ mod tests {
             // When we have sent >= 10K messages
             session.message_count.store(10_000, Ordering::SeqCst);
 
-            // Then it is considered expired: we enforce a maximum of 10K messages before
-            // rotation.
+            // Then it is considered expired: we enforce a maximum of 10K
+            // messages before rotation.
             assert!(session.expired());
         }
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -269,7 +269,8 @@ impl SenderData {
 
         match (device_owner, master_key) {
             (Some(device_owner), Some(master_key)) => {
-                // We have user_id and master_key for the user sending the to-device message.
+                // We have user_id and master_key for the user sending the
+                // to-device message.
                 let master_key = Box::new(master_key);
                 let known_sender_data = KnownSenderData { user_id, device_id, master_key };
                 if sender_device.is_cross_signing_trusted() {
@@ -282,8 +283,9 @@ impl SenderData {
             }
 
             (_, _) => {
-                // Surprisingly, there was no key in the MasterPubkey. We did not expect this:
-                // treat it as if the device was not signed by this master key.
+                // Surprisingly, there was no key in the MasterPubkey. We did
+                // not expect this: treat it as if the device
+                // was not signed by this master key.
                 //
                 error!("MasterPubkey for user {user_id} does not contain any keys!");
                 Self::device_info(sender_device.as_device_keys().clone())
@@ -496,8 +498,9 @@ mod tests {
 
     #[test]
     fn deserializing_unknown_device_with_extra_retry_info_ignores_it() {
-        // Previously, SenderData contained `retry_details` but it is no longer needed -
-        // just check that we are able to deserialize even if it is present.
+        // Previously, SenderData contained `retry_details` but it is no longer
+        // needed - just check that we are able to deserialize even if
+        // it is present.
         let json = r#"
             {
                 "UnknownDevice":{
@@ -720,11 +723,13 @@ mod tests {
 
     #[test]
     fn test_sender_known_data_migration_with_efficient_bytes_array() {
-        // This is an serialized PickledInboundGroupSession as rmp_serde will generate.
+        // This is an serialized PickledInboundGroupSession as rmp_serde will
+        // generate.
         //
-        // This export usse a more efficient serialization format for bytes. This was
-        // exported when the `KnownSenderData` master_key was serialized as an byte
-        // array instead of a base64 encoded string.
+        // This export usse a more efficient serialization format for bytes.
+        // This was exported when the `KnownSenderData` master_key was
+        // serialized as an byte array instead of a base64 encoded
+        // string.
         const SERIALIZED_B64: &str = "\
             iaZwaWNrbGWEr2luaXRpYWxfcmF0Y2hldIKlaW5uZXLcAIABYMzfSnBRzMlPKF1uKjYbzLtkzNJ4RcylzN0HzP\
             9DzON1Tm05zO7M2MzFQsy9Acz9zPnMqDvM4syQzNrMzxF5KzbM4sy9zPUbBWfM7m4/zJzM18zDzMESKgfMkE7M\

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data_finder.rs
@@ -169,14 +169,16 @@ impl<'a> SenderDataFinder<'a> {
         sender_curve_key: Curve25519PublicKey,
         room_key_event: &'a DecryptedRoomKeyEvent,
     ) -> Result<SenderData, SessionDeviceKeysCheckError> {
-        // Does the to-device message contain the device_keys property from MSC4147?
+        // Does the to-device message contain the device_keys property from
+        // MSC4147?
         if let Some(sender_device_keys) = &room_key_event.sender_device_keys {
             // Yes: use the device keys to continue.
 
-            // Validate the signature of the DeviceKeys supplied. (We've actually already
-            // done this when decrypting the event, but doing it again here is
-            // relatively harmless and is the easiest way of getting hold of a
-            // DeviceData so that we can follow the rest of this logic).
+            // Validate the signature of the DeviceKeys supplied. (We've
+            // actually already done this when decrypting the event,
+            // but doing it again here is relatively harmless and is
+            // the easiest way of getting hold of a DeviceData so
+            // that we can follow the rest of this logic).
             let sender_device_data = DeviceData::try_from(sender_device_keys)?;
             Ok(self.have_device_data(sender_device_data).await?)
         } else {
@@ -191,8 +193,8 @@ impl<'a> SenderDataFinder<'a> {
         sender_curve_key: Curve25519PublicKey,
         sender_user_id: &UserId,
     ) -> Result<SenderData, SessionDeviceCheckError> {
-        // Does the locally-cached (in the store) devices list contain a device with the
-        // curve key of the sender of the to-device message?
+        // Does the locally-cached (in the store) devices list contain a device
+        // with the curve key of the sender of the to-device message?
         if let Some(sender_device) =
             self.store.get_device_from_curve_key(sender_user_id, sender_curve_key).await?
         {
@@ -201,8 +203,8 @@ impl<'a> SenderDataFinder<'a> {
         } else {
             // Step C (we don't know the sending device)
             //
-            // We have no device data for this session so we can't continue in the "fast
-            // lane" (blocking sync).
+            // We have no device data for this session so we can't continue in
+            // the "fast lane" (blocking sync).
             let sender_data = SenderData::UnknownDevice {
                 // This is not a legacy session since we did attempt to look
                 // up its sender data at the time of reception.
@@ -233,8 +235,8 @@ impl<'a> SenderDataFinder<'a> {
             // Give up: something is wrong with the session.
             Ok(SenderData::UnknownDevice { legacy_session: false, owner_check_failed: true })
         } else {
-            // Steps F, G, and H: we have a device, which may or may not be signed by the
-            // sender.
+            // Steps F, G, and H: we have a device, which may or may not be
+            // signed by the sender.
             Ok(SenderData::from_device(&sender_device))
         }
     }
@@ -365,8 +367,8 @@ mod tests {
 
     #[async_test]
     async fn test_providing_no_device_data_returns_sender_data_with_no_device_info() {
-        // Given that the device is not in the store and the initial event has no device
-        // info
+        // Given that the device is not in the store and the initial event has
+        // no device info
         let setup = TestSetup::new(TestOptions::new()).await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
@@ -405,8 +407,8 @@ mod tests {
 
     #[async_test]
     async fn test_picks_up_device_info_from_the_store_if_missing_from_the_todevice_event() {
-        // Given that the device keys are not in the event but the device is in the
-        // store
+        // Given that the device keys are not in the event but the device is in
+        // the store
         let setup =
             TestSetup::new(TestOptions::new().store_contains_device().device_is_signed()).await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
@@ -436,8 +438,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Then we store the device info even though it is useless, in case we want to
-        // check it matches up later.
+        // Then we store the device info even though it is useless, in case we
+        // want to check it matches up later.
         assert_let!(SenderData::DeviceInfo { device_keys, legacy_session } = sender_data);
         assert_eq!(&device_keys, setup.sender_device.as_device_keys());
         assert!(!legacy_session);
@@ -531,7 +533,8 @@ mod tests {
 
     #[async_test]
     async fn test_adds_sender_data_for_other_verified_device_and_user_using_device_from_event() {
-        // Given the device keys are in the event, and someone else sent the event
+        // Given the device keys are in the event, and someone else sent the
+        // event
         let setup = TestSetup::new(
             TestOptions::new()
                 .store_contains_sender_identity()
@@ -627,7 +630,8 @@ mod tests {
 
     #[async_test]
     async fn test_notes_master_key_is_verified_for_own_identity() {
-        // Given we can find the device, and we sent the event, and we are verified
+        // Given we can find the device, and we sent the event, and we are
+        // verified
         let setup = TestSetup::new(
             TestOptions::new()
                 .store_contains_device()
@@ -695,7 +699,8 @@ mod tests {
                 .await;
         let finder = SenderDataFinder::new(&setup.store, &setup.session);
 
-        // When we supply the device keys directly while asking for the sender data
+        // When we supply the device keys directly while asking for the sender
+        // data
         let sender_data = finder.have_device_data(setup.sender_device.inner.clone()).await.unwrap();
 
         // Then it is found using the device we supplied

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -159,15 +159,17 @@ impl Session {
         }
 
         impl EventType for Content<'_> {
-            // This is a bit of a hack: usually we just define the `EVENT_TYPE` and use the
-            // default implementation of `event_type()`. We can't do this here
-            // because the event type isn't static.
+            // This is a bit of a hack: usually we just define the `EVENT_TYPE`
+            // and use the default implementation of `event_type()`.
+            // We can't do this here because the event type isn't
+            // static.
             //
-            // We have to provide `EVENT_TYPE` to conform to the `EventType` trait, but
-            // don't actually use it, so we just leave it empty.
+            // We have to provide `EVENT_TYPE` to conform to the `EventType`
+            // trait, but don't actually use it, so we just leave it
+            // empty.
             //
-            // This works because the serialization uses `event_type()` and this type is
-            // contained to this function.
+            // This works because the serialization uses `event_type()` and this
+            // type is contained to this function.
             const EVENT_TYPE: &'static str = "";
 
             fn event_type(&self) -> &str {
@@ -405,7 +407,8 @@ mod tests {
             panic!("Wrong Olm message type");
         };
 
-        // Then Bob should be able to create a session from the message and decrypt it.
+        // Then Bob should be able to create a session from the message and
+        // decrypt it.
         let bob_session_result = bob
             .create_inbound_session(
                 alice_device.curve25519_key().unwrap(),
@@ -414,8 +417,8 @@ mod tests {
             )
             .unwrap();
 
-        // Also ensure that the encrypted payload has the device keys under the stable
-        // prefix
+        // Also ensure that the encrypted payload has the device keys under the
+        // stable prefix
         let plaintext: Value = serde_json::from_str(&bob_session_result.plaintext).unwrap();
         assert_eq!(plaintext["sender_device_keys"]["user_id"].as_str(), Some("@alice:localhost"));
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -577,16 +577,18 @@ impl PrivateCrossSigningIdentity {
 
         // This is duplicated with
         // `matrix_sdk_crypto::identities::user::OwnUserIdentity::verify`,
-        // but there's no good way to prevent this (at least not one we can see).
+        // but there's no good way to prevent this (at least not one we can
+        // see).
         let cross_signing_key: &mut CrossSigningKey = &mut *master.public_key_mut().as_mut();
 
         account.sign_cross_signing_key(cross_signing_key)?;
 
         #[cfg(feature = "experimental-x509-identity-verification")]
         if let Some(x509_signer) = x509_signer {
-            // X.509 signing can and will fail - the user may enter the wrong PIN, the
-            // hardware key could vanish mid-sign, etc. We should not, however, let this
-            // prevent us from setting up normal cross-signing, so we log and disregard
+            // X.509 signing can and will fail - the user may enter the wrong
+            // PIN, the hardware key could vanish mid-sign, etc. We
+            // should not, however, let this prevent us from setting
+            // up normal cross-signing, so we log and disregard
             // any errors.
             x509_signer
                 .sign_cross_signing_key(&account.user_id, cross_signing_key)

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -275,13 +275,14 @@ impl SecretStorageKey {
                 let mut iv_array = [0u8; 16];
                 iv_array.copy_from_slice(iv);
 
-                // I'm not particularly convinced that this couldn't have been done simpler.
-                // Why do we need to reproduce the ciphertext?
-                // Couldn't we just generate the MAC tag
-                // using the `ZERO_MESSAGE`?
+                // I'm not particularly convinced that this couldn't have been
+                // done simpler. Why do we need to reproduce the
+                // ciphertext? Couldn't we just generate the MAC
+                // tag using the `ZERO_MESSAGE`?
                 //
-                // If someone is reading this and is designing a new secret encryption
-                // algorithm, please consider the above suggestion.
+                // If someone is reading this and is designing a new secret
+                // encryption algorithm, please consider the
+                // above suggestion.
                 let key = AesHmacSha2Key::from_secret_storage_key(&self.secret_key, "");
                 let ciphertext = key.apply_keystream(Self::ZERO_MESSAGE.to_vec(), &iv_array);
                 let expected_mac = HmacSha256Mac::from_slice(mac.as_bytes())
@@ -420,7 +421,8 @@ impl SecretStorageKey {
     // method.
     fn parse_base58_key(value: &str) -> Result<Box<[u8; 32]>, DecodeError> {
         // The spec tells us to remove any whitespace:
-        // > When decoding a raw key, the process should be reversed, with the exception
+        // > When decoding a raw key, the process should be reversed, with the
+        // > exception
         // > that whitespace is insignificant in the user’s input.
         //
         // Spec link: https://spec.matrix.org/unstable/client-server-api/#key-representation
@@ -486,19 +488,20 @@ impl SecretStorageKey {
         bytes[0..2].copy_from_slice(Self::PREFIX.as_slice());
         bytes[2..34].copy_from_slice(self.secret_key.as_slice());
 
-        // All the bytes in the string above, including the two header bytes, are XORed
-        // together to form a parity byte. This parity byte is appended to the byte
-        // string.
+        // All the bytes in the string above, including the two header bytes,
+        // are XORed together to form a parity byte. This parity byte is
+        // appended to the byte string.
         bytes[34] = Self::parity_byte(self.secret_key.as_slice());
 
-        // The byte string is encoded using Base58, using the same mapping as is used
-        // for Bitcoin addresses.
+        // The byte string is encoded using Base58, using the same mapping as is
+        // used for Bitcoin addresses.
         let base_58 =
             bs58::encode(bytes.as_slice()).with_alphabet(bs58::Alphabet::BITCOIN).into_string();
 
         bytes.zeroize();
 
-        // The string is formatted into groups of four characters separated by spaces.
+        // The string is formatted into groups of four characters separated by
+        // spaces.
         base_58
             .chars()
             .collect::<Vec<char>>()

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -434,9 +434,9 @@ impl GroupSessionManager {
                 .create_outbound_group_session(room_id, encryption_settings, SenderData::unknown())
                 .await?;
 
-            // Use our own device info to populate the SenderData that validates the
-            // InboundGroupSession that we create as a pair to the OutboundGroupSession we
-            // are sending out.
+            // Use our own device info to populate the SenderData that validates
+            // the InboundGroupSession that we create as a pair to
+            // the OutboundGroupSession we are sending out.
             let own_sender_data = if let Some(device) = own_device {
                 SenderDataFinder::find_using_device_data(
                     &self.store,
@@ -532,23 +532,24 @@ impl GroupSessionManager {
         device: &DeviceData,
         code: &WithheldCode,
     ) -> bool {
-        // The `m.no_olm` withheld code is special because it is supposed to be sent
-        // only once for a given device. The `Device` remembers the flag if we
-        // already sent a `m.no_olm` to this particular device so let's check
-        // that first.
+        // The `m.no_olm` withheld code is special because it is supposed to be
+        // sent only once for a given device. The `Device` remembers the
+        // flag if we already sent a `m.no_olm` to this particular
+        // device so let's check that first.
         //
-        // Keep in mind that any outbound group session might want to send this code to
-        // the device. So we need to check if any of our outbound group sessions
-        // is attempting to send the code to the device.
+        // Keep in mind that any outbound group session might want to send this
+        // code to the device. So we need to check if any of our
+        // outbound group sessions is attempting to send the code to the
+        // device.
         //
         // This still has a slight race where some other thread might remove the
         // outbound group session while a third is marking the device as having
         // received the code.
         //
-        // Since nothing terrible happens if we do end up sending the withheld code
-        // twice, and removing the race requires us to lock the store because the
-        // `OutboundGroupSession` and the `Device` both interact with the flag we'll
-        // leave it be.
+        // Since nothing terrible happens if we do end up sending the withheld
+        // code twice, and removing the race requires us to lock the
+        // store because the `OutboundGroupSession` and the `Device`
+        // both interact with the flag we'll leave it be.
         if code == &WithheldCode::NoOlm {
             device.was_withheld_code_sent() || self.sessions.has_session_withheld_to(device, code)
         } else {
@@ -561,14 +562,15 @@ impl GroupSessionManager {
         group_session: &OutboundGroupSession,
         withheld_devices: Vec<(DeviceData, WithheldCode)>,
     ) -> OlmResult<()> {
-        // Convert a withheld code for the group session into a to-device event content.
+        // Convert a withheld code for the group session into a to-device event
+        // content.
         let to_content = |code| {
             let content = group_session.withheld_code(code);
             Raw::new(&content).expect("We can always serialize a withheld content info").cast()
         };
 
-        // Helper to convert a chunk of device and withheld code pairs into a to-device
-        // request and it's accompanying share info.
+        // Helper to convert a chunk of device and withheld code pairs into a
+        // to-device request and it's accompanying share info.
         let chunk_to_request = |chunk| {
             let mut messages = BTreeMap::new();
             let mut share_infos = BTreeMap::new();
@@ -706,9 +708,9 @@ impl GroupSessionManager {
         // Having an inbound group session here means that we created a new
         // group session pair, which we then need to store.
         if let Some(mut inbound) = inbound {
-            // Use our own device info to populate the SenderData that validates the
-            // InboundGroupSession that we create as a pair to the OutboundGroupSession we
-            // are sending out.
+            // Use our own device info to populate the SenderData that validates
+            // the InboundGroupSession that we create as a pair to
+            // the OutboundGroupSession we are sending out.
             let own_sender_data = if let Some(device) = &device {
                 SenderDataFinder::find_using_device_data(
                     &self.store,
@@ -764,10 +766,11 @@ impl GroupSessionManager {
             })
             .collect();
 
-        // The `encrypt_for_devices()` method adds the to-device requests that will send
-        // out the room key to the `OutboundGroupSession`. It doesn't do that
-        // for the m.room_key_withheld events since we might have more of those
-        // coming from the `collect_session_recipients()` method. Instead they get
+        // The `encrypt_for_devices()` method adds the to-device requests that
+        // will send out the room key to the `OutboundGroupSession`. It
+        // doesn't do that for the m.room_key_withheld events since we
+        // might have more of those coming from the
+        // `collect_session_recipients()` method. Instead they get
         // returned by the method.
         let unable_to_encrypt_devices =
             self.encrypt_for_devices(devices, &outbound, &mut changes).await?;
@@ -775,8 +778,8 @@ impl GroupSessionManager {
         // Merge the withheld recipients.
         withheld_devices.extend(unable_to_encrypt_devices);
 
-        // Now handle and add the withheld recipients to the resulting requests to the
-        // `OutboundGroupSession`.
+        // Now handle and add the withheld recipients to the resulting requests
+        // to the `OutboundGroupSession`.
         self.handle_withheld_devices(&outbound, withheld_devices)?;
 
         // The to-device requests get added to the outbound group session, this
@@ -1328,8 +1331,8 @@ mod tests {
         let withheld_count: usize = count_withheld_from(&requests, WithheldCode::NoOlm);
         assert_eq!(withheld_count, 2);
 
-        // Re-sharing same session while request has not been sent should not produces
-        // withheld
+        // Re-sharing same session while request has not been sent should not
+        // produces withheld
         let new_requests = machine
             .share_room_key(first_room_id, users, EncryptionSettings::default())
             .await
@@ -1343,8 +1346,8 @@ mod tests {
             machine.mark_request_as_sent(&request.txn_id, &response).await.unwrap();
         }
 
-        // The fact that an olm was sent should be remembered even if sharing another
-        // session in an other room.
+        // The fact that an olm was sent should be remembered even if sharing
+        // another session in an other room.
         let second_room_id = room_id!("!other:localhost");
         let users = keys_claim.one_time_keys.keys().map(Deref::deref);
         let requests = machine
@@ -1576,7 +1579,8 @@ mod tests {
             .map(|r| r.message_count())
             .sum();
 
-        // withhelds are sent in clear so all device should be counted (even if no OTK)
+        // withhelds are sent in clear so all device should be counted (even if
+        // no OTK)
         assert_eq!(event_count, 149);
 
         // One should be blacklisted
@@ -1625,8 +1629,8 @@ mod tests {
         assert_eq!(withheld_count, 1);
         assert_eq!(requests.len(), 1);
 
-        // On the second room key share attempt we're not sending another `m.no_olm`
-        // code since the first one is taking care of this.
+        // On the second room key share attempt we're not sending another
+        // `m.no_olm` code since the first one is taking care of this.
         let second_requests =
             machine.share_room_key(second_room, users.into_iter(), settings).await.unwrap();
 
@@ -1640,8 +1644,8 @@ mod tests {
 
         let device = machine.get_device(bob_id, "BOBDEVICE".into(), None).await.unwrap().unwrap();
 
-        // The device should be marked as having the `m.no_olm` code received only after
-        // the request has been marked as sent.
+        // The device should be marked as having the `m.no_olm` code received
+        // only after the request has been marked as sent.
         assert!(!device.was_withheld_code_sent());
 
         for request in requests {
@@ -1684,7 +1688,8 @@ mod tests {
         let alice_device = DeviceData::new(alice_device_keys, LocalTrust::Unset);
 
         {
-            // Bob creates an Olm session with Alice and encrypts a message to her
+            // Bob creates an Olm session with Alice and encrypts a message to
+            // her
             let (alice_otk_id, alice_otk) = alice_otks.next().unwrap();
             let mut session = bob_account
                 .create_outbound_session(

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/share_strategy.rs
@@ -200,8 +200,8 @@ pub(crate) async fn collect_session_recipients(
     // 3. The history visibility changed.
     // 4. The encryption algorithm changed.
     //
-    // `result.should_rotate` is true if the first or second in that list is true;
-    // we now need to check for the other two.
+    // `result.should_rotate` is true if the first or second in that list is
+    // true; we now need to check for the other two.
     let device_removed = result.should_rotate;
 
     let visibility_changed = outbound.settings().history_visibility != settings.history_visibility;
@@ -240,8 +240,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
     let mut result = CollectRecipientsResult::default();
     let mut verified_users_with_new_identities: Vec<OwnedUserId> = Default::default();
 
-    // If we have an outbound session, check if a user is missing from the set of
-    // users that should get the session but is in the set of users that
+    // If we have an outbound session, check if a user is missing from the set
+    // of users that should get the session but is in the set of users that
     // received the session.
     if let Some(outbound) = outbound {
         let view = outbound.sharing_view();
@@ -322,8 +322,8 @@ pub(crate) async fn collect_recipients_for_share_strategy(
             }
 
             // If `error_on_verified_user_problem` is set, then
-            // `unsigned_devices_of_verified_users` may be populated. If so, we need to bail
-            // out with an error.
+            // `unsigned_devices_of_verified_users` may be populated. If so, we
+            // need to bail out with an error.
             if !unsigned_devices_of_verified_users.is_empty() {
                 return Err(OlmError::SessionRecipientCollectionError(
                     SessionRecipientCollectionError::VerifiedUserHasUnsignedDevice(
@@ -470,9 +470,10 @@ fn is_session_overshared_for_user(
     let newly_deleted_or_blacklisted: BTreeSet<&DeviceId> = view
         .iter_shares(Some(user_id), None)
         .filter_map(|(_user_id, device_id, info)| {
-            // If a devices who we've shared the session with before is not in the
-            // list of devices that should receive the session, we need to rotate.
-            // We also collect all of those device IDs to log them out.
+            // If a devices who we've shared the session with before is not in
+            // the list of devices that should receive the session,
+            // we need to rotate. We also collect all of those
+            // device IDs to log them out.
             if matches!(info, ShareInfo::Shared(_)) && !recipient_device_ids.contains(device_id) {
                 Some(device_id)
             } else {
@@ -911,8 +912,8 @@ fn split_devices_for_user_for_error_on_verified_user_problem_strategy(
 ) -> ErrorOnVerifiedUserProblemResult {
     let mut recipient_devices = RecipientDevicesForUser::default();
 
-    // We construct unsigned_devices_of_verified_users lazily, because chances are
-    // we won't need it.
+    // We construct unsigned_devices_of_verified_users lazily, because chances
+    // are we won't need it.
     let mut unsigned_devices_of_verified_users: Option<Vec<OwnedDeviceId>> = None;
 
     for d in user_devices.into_values() {
@@ -975,8 +976,8 @@ fn handle_device_for_user_for_error_on_verified_user_problem_strategy(
         ErrorOnVerifiedUserProblemDeviceDecision::UnsignedOfVerified
     } else if device.is_dehydrated()
         && device_owner_identity.is_none_or(|owner_id| {
-            // Dehydrated devices must be signed by their owners, whether or not that
-            // owner is verified
+            // Dehydrated devices must be signed by their owners, whether or not
+            // that owner is verified
             !device.is_cross_signed_by_owner(owner_id)
         })
     {
@@ -992,8 +993,8 @@ fn split_devices_for_user_for_identity_based_strategy(
 ) -> RecipientDevicesForUser {
     match device_owner_identity {
         None => {
-            // withheld all the users devices, we need to have an identity for this
-            // distribution mode
+            // withheld all the users devices, we need to have an identity for
+            // this distribution mode
             RecipientDevicesForUser {
                 allowed_devices: Vec::default(),
                 denied_devices_with_code: user_devices
@@ -1451,8 +1452,8 @@ mod tests {
         assert!(dave_devices_shared.unwrap().is_empty());
         assert!(good_devices_shared.unwrap().is_empty());
 
-        // dan is verified by me and has one of his devices self signed, so should get
-        // the key
+        // dan is verified by me and has one of his devices self signed, so
+        // should get the key
         let dan_devices_shared =
             share_result.devices.get(KeyDistributionTestData::dan_id()).unwrap();
 
@@ -1758,7 +1759,8 @@ mod tests {
         let encryption_settings = error_on_verification_problem_encryption_settings();
         let group_session = create_test_outbound_group_session(&machine, &encryption_settings);
 
-        // We should be able to share a key, and it should include the unsigned device.
+        // We should be able to share a key, and it should include the unsigned
+        // device.
         let share_result = collect_session_recipients(
             machine.store(),
             iter::once(DataSet::bob_id()),
@@ -1830,7 +1832,8 @@ mod tests {
         let encryption_settings = error_on_verification_problem_encryption_settings();
         let group_session = create_test_outbound_group_session(&machine, &encryption_settings);
 
-        // We should be able to share a key, and it should exclude the unsigned device.
+        // We should be able to share a key, and it should exclude the unsigned
+        // device.
         let share_result = collect_session_recipients(
             machine.store(),
             iter::once(DataSet::bob_id()),
@@ -2012,8 +2015,8 @@ mod tests {
         let bob_keys = DataSet::bob_keys_query_response_rotated();
         machine.mark_request_as_sent(&TransactionId::new(), &bob_keys).await.unwrap();
 
-        // Double-check the state of Bob: he should be unverified, and should have an
-        // unsigned device.
+        // Double-check the state of Bob: he should be unverified, and should
+        // have an unsigned device.
         let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
         assert!(!bob_identity.other().unwrap().is_verified());
 
@@ -2088,8 +2091,8 @@ mod tests {
         let keys_query = DataSet::bob_keys_query_response_signed();
         machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
-        // Double-check the state of Bob: his identity should be signed but unverified,
-        // and he should have an unsigned device.
+        // Double-check the state of Bob: his identity should be signed but
+        // unverified, and he should have an unsigned device.
         let bob_identity =
             machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap().other().unwrap();
         assert!(
@@ -2160,8 +2163,8 @@ mod tests {
     async fn test_verified_user_changed_identity() {
         use test_json::keys_query_sets::VerificationViolationTestData as DataSet;
 
-        // We start with Bob, who is verified and has one unsigned device. We have also
-        // verified our own identity.
+        // We start with Bob, who is verified and has one unsigned device. We
+        // have also verified our own identity.
         let machine = unsigned_of_verified_setup().await;
 
         // Bob then rotates his identity
@@ -2446,8 +2449,8 @@ mod tests {
         ) {
             let machine = test_machine().await;
 
-            // Bob is a user with cross-signing, who has a single (verified) dehydrated
-            // device.
+            // Bob is a user with cross-signing, who has a single (verified)
+            // dehydrated device.
             let bob_user_id = user_id!("@bob:localhost");
             let bob_dehydrated_device_id = device_id!("DEHYDRATED_DEVICE");
             let keys_query = key_query_response_template_with_cross_signing(bob_user_id)
@@ -2502,8 +2505,8 @@ mod tests {
         ) {
             let machine = test_machine().await;
 
-            // Bob is a user with cross-signing, who has a single (unverified) dehydrated
-            // device.
+            // Bob is a user with cross-signing, who has a single (unverified)
+            // dehydrated device.
             let bob_user_id = user_id!("@bob:localhost");
             let bob_dehydrated_device_id = device_id!("DEHYDRATED_DEVICE");
             let keys_query = key_query_response_template_with_cross_signing(bob_user_id)
@@ -2524,8 +2527,8 @@ mod tests {
             )
             .await;
 
-            // ... it shouldn't be shared with anyone, and there should be a withheld
-            // message for the dehydrated device.
+            // ... it shouldn't be shared with anyone, and there should be a
+            // withheld message for the dehydrated device.
             assert_withheld_to(recips, bob_user_id, bob_dehydrated_device_id);
         }
 
@@ -2571,8 +2574,8 @@ mod tests {
                 key_query_response_template_with_cross_signing(bob_user_id).build_response();
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
-            // He then changes identity, and adds a dehydrated device (signed with his new
-            // identity)
+            // He then changes identity, and adds a dehydrated device (signed
+            // with his new identity)
             let bob_dehydrated_device_id = device_id!("DEHYDRATED_DEVICE");
             let keys_query = key_query_response_template_with_changed_cross_signing(bob_user_id)
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
@@ -2626,8 +2629,8 @@ mod tests {
             )
             .await;
 
-            // ... it shouldn't be shared with anyone, and there should be a withheld
-            // message for the dehydrated device.
+            // ... it shouldn't be shared with anyone, and there should be a
+            // withheld message for the dehydrated device.
             assert_withheld_to(recips, bob_user_id, bob_dehydrated_device_id);
         }
 
@@ -2675,8 +2678,8 @@ mod tests {
             )
             .await;
 
-            // The key share should fail with an error indicating that recipients
-            // were previously verified.
+            // The key share should fail with an error indicating that
+            // recipients were previously verified.
             assert_matches::assert_matches!(
                 share_result,
                 Err(crate::OlmError::SessionRecipientCollectionError(
@@ -2703,8 +2706,8 @@ mod tests {
                 .build_response();
             machine.mark_request_as_sent(&TransactionId::new(), &keys_query).await.unwrap();
 
-            // He then changes identity, and adds a dehydrated device (signed with his new
-            // identity)
+            // He then changes identity, and adds a dehydrated device (signed
+            // with his new identity)
             let keys_query = key_query_response_template_with_changed_cross_signing(bob_user_id)
                 .with_dehydrated_device(bob_dehydrated_device_id, true)
                 .build_response();
@@ -3338,8 +3341,8 @@ mod tests {
         let bob_keys = DataSet::bob_keys_query_response_signed();
         machine.mark_request_as_sent(&TransactionId::new(), &bob_keys).await.unwrap();
 
-        // Double-check the state of Bob: he should be verified, and should have one
-        // signed and one unsigned device.
+        // Double-check the state of Bob: he should be verified, and should have
+        // one signed and one unsigned device.
         let bob_identity = machine.get_identity(DataSet::bob_id(), None).await.unwrap().unwrap();
         assert!(bob_identity.other().unwrap().is_verified());
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -277,7 +277,8 @@ impl SessionManager {
         }
 
         if tracing::level_enabled!(tracing::Level::DEBUG) {
-            // Reformat the map to skip the encryption algorithm, which isn't very useful.
+            // Reformat the map to skip the encryption algorithm, which isn't
+            // very useful.
             let missing_session_devices_by_user = missing_session_devices_by_user
                 .iter()
                 .map(|(user_id, devices)| (user_id, devices.keys().collect::<BTreeSet<_>>()))
@@ -307,8 +308,8 @@ impl SessionManager {
             ))
         };
 
-        // stash the details of the request so that we can refer to it when handling the
-        // response
+        // stash the details of the request so that we can refer to it when
+        // handling the response
         *(self.current_key_claim_request.write()) = result.clone();
         Ok(result)
     }
@@ -348,8 +349,8 @@ impl SessionManager {
             let expected_request_id = guard.as_ref().map(|e| e.0.as_ref());
 
             if Some(request_id) == expected_request_id {
-                // We have a confirmed match. Clear the expectation, but hang onto the details
-                // of the request.
+                // We have a confirmed match. Clear the expectation, but hang
+                // onto the details of the request.
                 guard.take().map(|(_, request)| request)
             } else {
                 warn!(
@@ -361,8 +362,9 @@ impl SessionManager {
             }
         };
 
-        // If we were able to pair this response with a request, look for devices that
-        // were present in the request but did not elicit a successful response.
+        // If we were able to pair this response with a request, look for
+        // devices that were present in the request but did not elicit a
+        // successful response.
         if let Some(request) = request {
             let devices_in_response: BTreeSet<_> = one_time_keys
                 .iter()
@@ -388,8 +390,9 @@ impl SessionManager {
             let missing_devices: BTreeSet<_> = devices_in_request
                 .difference(&devices_in_response)
                 .filter(|(user_id, _)| {
-                    // Skip over users whose homeservers were in the "failed servers" list: we don't
-                    // want to mark individual devices as broken *as well as* the server.
+                    // Skip over users whose homeservers were in the "failed
+                    // servers" list: we don't want to mark
+                    // individual devices as broken *as well as* the server.
                     !failed_servers.contains(user_id.server_name())
                 })
                 .collect();
@@ -430,7 +433,8 @@ impl SessionManager {
         request_id: &TransactionId,
         response: &KeysClaimResponse,
     ) -> OlmResult<()> {
-        // Collect the (user_id, device_id, device_key_id) triple for logging reasons.
+        // Collect the (user_id, device_id, device_key_id) triple for logging
+        // reasons.
         let one_time_keys: BTreeMap<_, BTreeMap<_, BTreeSet<_>>> = response
             .one_time_keys
             .iter()
@@ -458,8 +462,8 @@ impl SessionManager {
             .collect();
         let successful_servers = response.one_time_keys.keys().map(|u| u.server_name());
 
-        // Add the user/device pairs that don't have any one-time keys to the failures
-        // cache.
+        // Add the user/device pairs that don't have any one-time keys to the
+        // failures cache.
         self.handle_otk_exhaustion_failure(request_id, &failed_servers, &one_time_keys);
         // Add the failed servers to the failures cache.
         self.failures.extend(failed_servers);
@@ -721,8 +725,8 @@ mod tests {
     async fn test_session_creation_waits_for_keys_query() {
         let (manager, identity_manager) = session_manager_test_helper().await;
 
-        // start a `/keys/query` request. At this point, we are only interested in our
-        // own devices.
+        // start a `/keys/query` request. At this point, we are only interested
+        // in our own devices.
         let (key_query_txn_id, key_query_request) =
             identity_manager.users_for_key_query().await.unwrap().pop_first().unwrap();
         info!("Initial key query: {:?}", key_query_request);
@@ -742,8 +746,8 @@ mod tests {
                 .unwrap();
         }
 
-        // ... and start off an attempt to get the missing sessions. This should block
-        // for now.
+        // ... and start off an attempt to get the missing sessions. This should
+        // block for now.
         let missing_sessions_task = {
             let manager = manager.clone();
             let bob_user_id = bob.user_id().to_owned();
@@ -805,8 +809,8 @@ mod tests {
         );
         identity_manager.receive_keys_query_response(&key_query_txn_id, &response).await.unwrap();
 
-        // Now, an attempt to get the missing sessions should now *not* block. We use a
-        // timeout so that we can detect the call blocking.
+        // Now, an attempt to get the missing sessions should now *not* block.
+        // We use a timeout so that we can detect the call blocking.
         let result = tokio::time::timeout(
             Duration::from_millis(10),
             manager.get_missing_sessions(iter::once(other_user_id.as_ref())),
@@ -975,14 +979,14 @@ mod tests {
         let (manager, _identity_manager) = session_manager_test_helper().await;
         manager.store.save_device_data(&[alice_device]).await.unwrap();
 
-        // Since we don't have a session with Alice yet, the machine will try to claim
-        // some keys for alice.
+        // Since we don't have a session with Alice yet, the machine will try to
+        // claim some keys for alice.
         let (txn_id, users_for_key_claim) =
             manager.get_missing_sessions(iter::once(alice)).await.unwrap().unwrap();
         assert!(users_for_key_claim.one_time_keys.contains_key(alice));
 
-        // We receive a response with an invalid one-time key, this will mark Alice as
-        // timed out.
+        // We receive a response with an invalid one-time key, this will mark
+        // Alice as timed out.
         manager.receive_keys_claim_response(&txn_id, &response).await.unwrap();
         // Since alice is timed out, we won't claim keys for her.
         assert!(manager.get_missing_sessions(iter::once(alice)).await.unwrap().is_none());
@@ -997,7 +1001,8 @@ mod tests {
             .or_insert_with(BTreeMap::new)
             .insert(alice_account.device_id().to_owned(), one_time);
 
-        // Now we expire Alice's timeout, and receive a valid one-time key for her.
+        // Now we expire Alice's timeout, and receive a valid one-time key for
+        // her.
         manager
             .failed_devices
             .write()

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -242,13 +242,14 @@ impl UsersForKeyQuery {
     ) -> bool {
         let last_invalidation = self.user_map.get(user).copied();
 
-        // If there were any jobs waiting for this key query to complete, we can flag
-        // them as completed and remove them from our list. We also clear out any tasks
-        // that have been cancelled.
+        // If there were any jobs waiting for this key query to complete, we can
+        // flag them as completed and remove them from our list. We also
+        // clear out any tasks that have been cancelled.
         self.tasks_awaiting_key_query.retain(|waiter| {
             let Some(waiter) = waiter.upgrade() else {
-                // the TaskAwaitingKeyQuery has been dropped, so it probably timed out and the
-                // caller went away. We can remove it from our list whether or not it's for this
+                // the TaskAwaitingKeyQuery has been dropped, so it probably
+                // timed out and the caller went away. We can
+                // remove it from our list whether or not it's for this
                 // user.
                 trace!("removing expired waiting task");
 

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -63,8 +63,8 @@ impl CryptoStoreWrapper {
         let room_keys_received_sender = broadcast::Sender::new(10);
         let room_keys_withheld_received_sender = broadcast::Sender::new(10);
         let secrets_broadcaster = broadcast::Sender::new(10);
-        // The identities broadcaster is responsible for user identities as well as
-        // devices, that's why we increase the capacity here.
+        // The identities broadcaster is responsible for user identities as well
+        // as devices, that's why we increase the capacity here.
         let identities_broadcaster = broadcast::Sender::new(20);
         let historic_room_key_bundles_broadcaster = broadcast::Sender::new(10);
 
@@ -105,9 +105,9 @@ impl CryptoStoreWrapper {
             })
             .collect();
 
-        // If our own identity verified status changes we need to do some checks on
-        // other identities. So remember the verification status before
-        // processing the changes
+        // If our own identity verified status changes we need to do some checks
+        // on other identities. So remember the verification status
+        // before processing the changes
         let own_identity_was_verified_before_change = self
             .store
             .get_user_identity(self.user_id.as_ref())
@@ -178,26 +178,29 @@ impl CryptoStoreWrapper {
         }
 
         if !devices.is_empty() || !identities.is_empty() {
-            // Mapping the devices and user identities from the read-only variant to one's
-            // that contain side-effects requires our own identity. This is
-            // guaranteed to be up-to-date since we just persisted it.
+            // Mapping the devices and user identities from the read-only
+            // variant to one's that contain side-effects requires
+            // our own identity. This is guaranteed to be up-to-date
+            // since we just persisted it.
             let maybe_own_identity =
                 self.store.get_user_identity(&self.user_id).await?.and_then(|i| i.into_own());
 
-            // If our identity was not verified before the change and is now, that means
-            // this could impact the verification chain of other known
-            // identities.
+            // If our identity was not verified before the change and is now,
+            // that means this could impact the verification chain
+            // of other known identities.
             if let Some(own_identity_after) = maybe_own_identity.as_ref() {
-                // Only do this if our identity is passing from not verified to verified,
-                // the previously_verified can only change in that case.
+                // Only do this if our identity is passing from not verified to
+                // verified, the previously_verified can only
+                // change in that case.
                 let own_identity_is_verified = own_identity_after.is_verified();
 
                 if !own_identity_was_verified_before_change && own_identity_is_verified {
                     debug!(
                         "Own identity is now verified, check all known identities for verification status changes"
                     );
-                    // We need to review all the other identities to see if they are verified now
-                    // and mark them as such
+                    // We need to review all the other identities to see if they
+                    // are verified now and mark them as
+                    // such
                     self.check_all_identities_and_update_was_previously_verified_flag_if_needed(
                         own_identity_after,
                     )

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -387,7 +387,8 @@ impl CryptoStore for MemoryStore {
             let room_id = session.room_id();
             let session_id = session.session_id();
 
-            // Sanity-check that the data in the sessions corresponds to backed_up_version
+            // Sanity-check that the data in the sessions corresponds to
+            // backed_up_version
             let backed_up = session.backed_up();
             if backed_up != backed_up_to_version.is_some() {
                 warn!(
@@ -507,9 +508,9 @@ impl CryptoStore for MemoryStore {
                 .filter(|(_, o)| o.as_ref().is_some_and(|o| o.as_str() == backup_version))
                 .count()
         } else {
-            // We asked about a nonexistent backup version - this doesn't make much sense,
-            // but we can easily answer that nothing is backed up in this
-            // nonexistent backup.
+            // We asked about a nonexistent backup version - this doesn't make
+            // much sense, but we can easily answer that nothing is
+            // backed up in this nonexistent backup.
             0
         };
 
@@ -543,8 +544,8 @@ impl CryptoStore for MemoryStore {
         after_session_id: Option<String>,
         limit: usize,
     ) -> Result<Vec<InboundGroupSession>> {
-        // First, find all InboundGroupSessions, filtering for those that match the
-        // device and sender_data type.
+        // First, find all InboundGroupSessions, filtering for those that match
+        // the device and sender_data type.
         let mut sessions: Vec<_> = self
             .get_inbound_group_sessions()
             .await?
@@ -563,7 +564,8 @@ impl CryptoStore for MemoryStore {
             match after_session_id {
                 None => 0,
                 Some(id) => {
-                    // We're looking for the first session with a session ID strictly after `id`; if
+                    // We're looking for the first session with a session ID
+                    // strictly after `id`; if
                     // there are none, the end of the array.
                     sessions
                         .iter()
@@ -573,7 +575,8 @@ impl CryptoStore for MemoryStore {
             }
         };
 
-        // Return up to `limit` items from the array, starting from `start_index`
+        // Return up to `limit` items from the array, starting from
+        // `start_index`
         Ok(sessions.drain(start_index..).take(limit).collect())
     }
 
@@ -593,7 +596,8 @@ impl CryptoStore for MemoryStore {
                     // This session is already backed up in the required backup
                     None
                 } else {
-                    // It's not backed up, or it's backed up in a different backup
+                    // It's not backed up, or it's backed up in a different
+                    // backup
                     Some(session)
                 }
             })
@@ -633,11 +637,11 @@ impl CryptoStore for MemoryStore {
     }
 
     async fn reset_backup_state(&self) -> Result<()> {
-        // Nothing to do here, because we remember which backup versions we backed up to
-        // in `mark_inbound_group_sessions_as_backed_up`, so we don't need to
-        // reset anything here because the required version is passed in to
-        // `inbound_group_sessions_for_backup`, and we can compare against the
-        // version we stored.
+        // Nothing to do here, because we remember which backup versions we
+        // backed up to in `mark_inbound_group_sessions_as_backed_up`,
+        // so we don't need to reset anything here because the required
+        // version is passed in to `inbound_group_sessions_for_backup`,
+        // and we can compare against the version we stored.
 
         Ok(())
     }
@@ -969,8 +973,8 @@ mod tests {
 
     #[async_test]
     async fn test_backing_up_to_an_old_backup_version_can_increase_backed_up_to() {
-        // Given we have backed up some sessions to 2 backup versions, an older and a
-        // newer
+        // Given we have backed up some sessions to 2 backup versions, an older
+        // and a newer
         let room_id = room_id!("!test:localhost");
         let (store, sessions) = store_with_sessions(4, room_id).await;
         mark_backed_up(&store, room_id, "older_bkp", &sessions[..2]).await;
@@ -1051,7 +1055,8 @@ mod tests {
 
     #[async_test]
     async fn test_sessions_backed_up_to_a_later_version_are_eligible_for_backup() {
-        // Given there are 4 sessions, some backed up to three different versions
+        // Given there are 4 sessions, some backed up to three different
+        // versions
         let room_id = room_id!("!test:localhost");
         let (store, sessions) = store_with_sessions(4, room_id).await;
         mark_backed_up(&store, room_id, "bkp0", &sessions[..1]).await;
@@ -1247,7 +1252,8 @@ mod tests {
         // When we count keys for bkp2
         let key_counts = store.inbound_group_session_counts(Some("bkp2")).await.unwrap();
 
-        // Then the backed_up count reflects how many were backed up in bkp2 only
+        // Then the backed_up count reflects how many were backed up in bkp2
+        // only
         assert_eq!(key_counts.backed_up, 1);
     }
 
@@ -1381,10 +1387,10 @@ mod integration_tests {
         _passphrase: Option<&str>,
         clear_data: bool,
     ) -> PersistentMemoryStore {
-        // Holds on to one [PersistentMemoryStore] per test, so even if the test drops
-        // the store, we keep its data alive. This simulates the behaviour of
-        // the other stores, which keep their data in a real DB, allowing us to
-        // test MemoryStore using the same code.
+        // Holds on to one [PersistentMemoryStore] per test, so even if the test
+        // drops the store, we keep its data alive. This simulates the
+        // behaviour of the other stores, which keep their data in a
+        // real DB, allowing us to test MemoryStore using the same code.
         static STORES: OnceLock<Mutex<HashMap<String, PersistentMemoryStore>>> = OnceLock::new();
         let stores = STORES.get_or_init(|| Mutex::new(HashMap::new()));
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -165,9 +165,10 @@ impl KeyQueryManager {
         drop(loaded);
         let mut loaded = cache.loaded_tracked_users.write().await;
 
-        // Check again if the users have been loaded, in case another call to this
-        // method loaded the tracked users between the time we tried to
-        // acquire the lock and the time we actually acquired the lock.
+        // Check again if the users have been loaded, in case another call to
+        // this method loaded the tracked users between the time we
+        // tried to acquire the lock and the time we actually acquired
+        // the lock.
         if *loaded {
             return Ok(());
         }
@@ -205,8 +206,9 @@ impl KeyQueryManager {
         user: &UserId,
     ) -> Result<UserKeyQueryResult> {
         {
-            // Drop the cache early, so we don't keep it while waiting (since writing the
-            // results requires to write in the cache, thus take another lock).
+            // Drop the cache early, so we don't keep it while waiting (since
+            // writing the results requires to write in the cache,
+            // thus take another lock).
             self.ensure_sync_tracked_users(&cache).await?;
             drop(cache);
         }
@@ -713,8 +715,9 @@ impl Store {
 
         let result = match (index_comparison, trust_level_comparison) {
             (SessionOrdering::Unconnected, _) => {
-                // If this happens, it means that we have two sessions purporting to have the
-                // same session id, but where the ratchets do not match up.
+                // If this happens, it means that we have two sessions
+                // purporting to have the same session id, but
+                // where the ratchets do not match up.
                 // In other words, someone is playing silly buggers.
                 warn!(
                     "Received a group session with an ratchet that does not connect to the one in the store, discarding"
@@ -725,7 +728,8 @@ impl Store {
             (SessionOrdering::Better, std::cmp::Ordering::Greater)
             | (SessionOrdering::Better, std::cmp::Ordering::Equal)
             | (SessionOrdering::Equal, std::cmp::Ordering::Greater) => {
-                // The new session is unambiguously better than what we have in the store.
+                // The new session is unambiguously better than what we have in
+                // the store.
                 info!(
                     ?index_comparison,
                     ?trust_level_comparison,
@@ -737,7 +741,8 @@ impl Store {
             (SessionOrdering::Worse, std::cmp::Ordering::Less)
             | (SessionOrdering::Worse, std::cmp::Ordering::Equal)
             | (SessionOrdering::Equal, std::cmp::Ordering::Less) => {
-                // The new session is unambiguously worse than the one we have in the store.
+                // The new session is unambiguously worse than the one we have
+                // in the store.
                 warn!(
                     ?index_comparison,
                     ?trust_level_comparison,
@@ -1688,7 +1693,8 @@ impl Store {
         &self,
         predicate: impl FnMut(&InboundGroupSession) -> bool,
     ) -> Result<impl Stream<Item = ExportedRoomKey>> {
-        // TODO: if/when there is a get_inbound_group_sessions_stream, use that here.
+        // TODO: if/when there is a get_inbound_group_sessions_stream, use that
+        // here.
         let sessions = self.get_inbound_group_sessions().await?;
         Ok(futures_util::stream::iter(sessions.into_iter().filter(predicate))
             .then(|session| async move { session.export().await }))
@@ -1720,8 +1726,9 @@ impl Store {
             }
         }
 
-        // If we received a key bundle ourselves, in which one or more sessions was
-        // marked as "history not shared", pass that on to the new user.
+        // If we received a key bundle ourselves, in which one or more sessions
+        // was marked as "history not shared", pass that on to the new
+        // user.
         let withhelds = self.get_withheld_sessions_by_room_id(room_id).await?;
         for withheld in withhelds {
             if withheld.content.withheld_code() == WithheldCode::HistoryNotShared {
@@ -1763,9 +1770,9 @@ impl Store {
 
         tracing::Span::current().record("sender_data", tracing::field::debug(&sender_data));
 
-        // The sender's device must be either `SenderData::SenderUnverified` (i.e.,
-        // TOFU-trusted) or `SenderData::SenderVerified` (i.e., fully verified
-        // via user verification and cross-signing).
+        // The sender's device must be either `SenderData::SenderUnverified`
+        // (i.e., TOFU-trusted) or `SenderData::SenderVerified` (i.e.,
+        // fully verified via user verification and cross-signing).
         let Ok(forwarder_data) = (&sender_data).try_into() else {
             warn!(
                 "Not accepting a historic room key bundle due to insufficient trust in the sender"
@@ -1820,8 +1827,8 @@ impl Store {
 
             // Case 3: A bundle containing useful room keys.
             (_, false) => {
-                // We have at least some good keys, if we also have some bad ones let's
-                // mention that here.
+                // We have at least some good keys, if we also have some bad
+                // ones let's mention that here.
                 if !bad.is_empty() {
                     warn!(
                         bad_key_count = bad.len(),
@@ -2004,7 +2011,8 @@ mod tests {
         let megolm_signing_key = Ed25519Keypair::new();
         let inbound = make_inbound_group_session(&alice_account, &megolm_signing_key, room_id);
 
-        // Bob already knows about the session, at index 5, with the device keys.
+        // Bob already knows about the session, at index 5, with the device
+        // keys.
         let mut inbound_at_index_5 =
             InboundGroupSession::from_export(&inbound.export_at_index(5).await).unwrap();
         inbound_at_index_5.sender_data = inbound.sender_data.clone();
@@ -2025,7 +2033,8 @@ mod tests {
         copy.sender_data = inbound.sender_data.clone();
         assert_eq!(bob.store().merge_received_group_session(copy).await.unwrap(), None);
 
-        // But when we receive a better copy of the session, we should get it back
+        // But when we receive a better copy of the session, we should get it
+        // back
         let mut better =
             InboundGroupSession::from_export(&inbound.export_at_index(0).await).unwrap();
         better.sender_data = inbound.sender_data.clone();
@@ -2109,9 +2118,9 @@ mod tests {
     /// Make a Megolm [`SessionKey`] using the given Ed25519 key as a signing
     /// key/session ID.
     fn make_session_key(signing_key: &Ed25519Keypair) -> SessionKey {
-        // `SessionKey::new` is not public, so the easiest way to construct a Megolm
-        // session using a known Ed25519 key is to build a byte array in the export
-        // format.
+        // `SessionKey::new` is not public, so the easiest way to construct a
+        // Megolm session using a known Ed25519 key is to build a byte
+        // array in the export format.
 
         let mut session_key_bytes = vec![0u8; 229];
         // 0: version
@@ -2291,8 +2300,8 @@ mod tests {
 
     #[async_test]
     async fn test_build_room_key_bundle() {
-        // Given: Alice has sent a number of room keys to Bob, including some in the
-        // wrong room, and some that are not marked as shared...
+        // Given: Alice has sent a number of room keys to Bob, including some in
+        // the wrong room, and some that are not marked as shared...
         let alice = OlmMachine::new(user_id!("@a:s.co"), device_id!("ALICE")).await;
         let bob = OlmMachine::new(user_id!("@b:s.co"), device_id!("BOB")).await;
 
@@ -2344,7 +2353,8 @@ mod tests {
         // We sort the sessions in the bundle, so that the snapshot is stable.
         bundle.room_keys.sort_by_key(|session| session.session_id.clone());
 
-        // We substitute the algorithm, since this changes based on feature flags.
+        // We substitute the algorithm, since this changes based on feature
+        // flags.
         let algorithm = if cfg!(feature = "experimental-algorithms") {
             "m.megolm.v2.aes-sha2"
         } else {

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/mod.rs
@@ -144,8 +144,8 @@ mod tests {
             };
         }
 
-        // The last argument is deliberately some usage which is *not* correct for the
-        // type.
+        // The last argument is deliberately some usage which is *not* correct
+        // for the type.
         test_partial_eq!(MasterPubkey, master_key, master_keys, KeyUsage::SelfSigning);
         test_partial_eq!(SelfSigningPubkey, self_signing_key, self_signing_keys, KeyUsage::Master);
         test_partial_eq!(UserSigningPubkey, user_signing_key, user_signing_keys, KeyUsage::Master);

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -645,8 +645,8 @@ mod tests {
     fn sender_device_keys_are_deserialized_unstable() {
         let (sender_device_keys_json, sender_device_keys) = sender_device_keys();
 
-        // Given JSON for a room key event with sender_device_keys using the unstable
-        // prefix
+        // Given JSON for a room key event with sender_device_keys using the
+        // unstable prefix
         let mut event_json = room_key_event();
         event_json
             .as_object_mut()

--- a/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/utd_cause.rs
@@ -171,7 +171,8 @@ impl UtdCause {
                 if let Ok(timeline_event) = raw_event.deserialize()
                     && timeline_event.origin_server_ts() < crypto_context_info.device_creation_ts
                 {
-                    // This event was sent before this device existed, so it is "historical"
+                    // This event was sent before this device existed, so it is
+                    // "historical"
                     return UtdCause::determine_historical(crypto_context_info);
                 }
 
@@ -222,12 +223,12 @@ impl UtdCause {
         } else if backup_failing && unverified {
             UtdCause::HistoricalMessageAndDeviceIsUnverified
         } else {
-            // We didn't get the key from key storage backup, but we think we should have,
-            // because either:
+            // We didn't get the key from key storage backup, but we think we
+            // should have, because either:
             //
             // * backup is working (so why didn't we get it?), or
-            // * backup is not working for an unknown reason (because the device is
-            //   verified, and that is the only reason we check).
+            // * backup is not working for an unknown reason (because the device
+            //   is verified, and that is the only reason we check).
             //
             // In either case, we shrug and give an `Unknown` cause.
             UtdCause::Unknown
@@ -252,7 +253,8 @@ mod tests {
 
     #[test]
     fn test_if_there_is_no_membership_info_we_guess_unknown() {
-        // If our JSON contains no membership info, then we guess the UTD is unknown.
+        // If our JSON contains no membership info, then we guess the UTD is
+        // unknown.
         assert_eq!(
             UtdCause::determine(&raw_event(json!({})), device_old(), &missing_megolm_session()),
             UtdCause::Unknown
@@ -261,8 +263,8 @@ mod tests {
 
     #[test]
     fn test_if_membership_info_cant_be_parsed_we_guess_unknown() {
-        // If our JSON contains a membership property but not the JSON we expected, then
-        // we guess the UTD is unknown.
+        // If our JSON contains a membership property but not the JSON we
+        // expected, then we guess the UTD is unknown.
         assert_eq!(
             UtdCause::determine(
                 &raw_event(json!({ "unsigned": { "membership": 3 } })),
@@ -275,8 +277,8 @@ mod tests {
 
     #[test]
     fn test_if_membership_is_invite_we_guess_unknown() {
-        // If membership=invite then we expected to be sent the keys so the cause of the
-        // UTD is unknown.
+        // If membership=invite then we expected to be sent the keys so the
+        // cause of the UTD is unknown.
         assert_eq!(
             UtdCause::determine(
                 &raw_event(json!({ "unsigned": { "membership": "invite" } }),),
@@ -289,8 +291,8 @@ mod tests {
 
     #[test]
     fn test_if_membership_is_join_we_guess_unknown() {
-        // If membership=join then we expected to be sent the keys so the cause of the
-        // UTD is unknown.
+        // If membership=join then we expected to be sent the keys so the cause
+        // of the UTD is unknown.
         assert_eq!(
             UtdCause::determine(
                 &raw_event(json!({ "unsigned": { "membership": "join" } })),
@@ -303,8 +305,8 @@ mod tests {
 
     #[test]
     fn test_if_membership_is_leave_we_guess_membership() {
-        // If membership=leave then we have an explanation for why we can't decrypt,
-        // until we have MSC3061.
+        // If membership=leave then we have an explanation for why we can't
+        // decrypt, until we have MSC3061.
         assert_eq!(
             UtdCause::determine(
                 &raw_event(json!({ "unsigned": { "membership": "leave" } })),
@@ -317,8 +319,8 @@ mod tests {
 
     #[test]
     fn test_if_membership_is_leave_and_session_not_shared_we_guess_membership() {
-        // Even under MSC4268 (history sharing), the session may have been withheld. We
-        // use the same UTD cause.
+        // Even under MSC4268 (history sharing), the session may have been
+        // withheld. We use the same UTD cause.
         assert_eq!(
             UtdCause::determine(
                 &raw_event(json!({ "unsigned": { "membership": "leave" } })),
@@ -413,8 +415,8 @@ mod tests {
         // There is no key storage backup on the server.
         context.backup_exists_on_server = false;
 
-        // So this UTD is expected, and the solution (for future messages!) is to turn
-        // on key storage backups.
+        // So this UTD is expected, and the solution (for future messages!) is
+        // to turn on key storage backups.
         assert_eq!(
             UtdCause::determine(&utd_event(), context, &info),
             UtdCause::HistoricalMessageAndBackupIsDisabled
@@ -439,8 +441,9 @@ mod tests {
         // There is no key storage backup on the server.
         context.backup_exists_on_server = false;
 
-        // So this could be expected historical like the previous test, but because the
-        // encrypted event is malformed, that takes precedence, and it's unexpected.
+        // So this could be expected historical like the previous test, but
+        // because the encrypted event is malformed, that takes
+        // precedence, and it's unexpected.
         assert_eq!(UtdCause::determine(&utd_event(), context, &info), UtdCause::Unknown);
 
         // Same for decryption failures
@@ -494,8 +497,8 @@ mod tests {
         // The key storage backup is working.
         context.is_backup_configured = true;
 
-        // So this UTD is unexpected since we should be able to fetch the key from
-        // storage.
+        // So this UTD is unexpected since we should be able to fetch the key
+        // from storage.
         assert_eq!(UtdCause::determine(&utd_event(), context, &info), UtdCause::Unknown);
 
         // Same for unknown megolm message index
@@ -521,12 +524,13 @@ mod tests {
         // Our device is verified.
         context.this_device_is_verified = true;
 
-        // So this UTD is unexpected since we can't explain why our backup is not
-        // working.
+        // So this UTD is unexpected since we can't explain why our backup is
+        // not working.
         //
-        // TODO: it might be nice to tell the user that our backup is not working!
-        // Currently we don't distinguish between Unknown cases, since we want
-        // to make sure they are all reported as unexpected UTDs.
+        // TODO: it might be nice to tell the user that our backup is not
+        // working! Currently we don't distinguish between Unknown
+        // cases, since we want to make sure they are all reported as
+        // unexpected UTDs.
         assert_eq!(UtdCause::determine(&utd_event(), context, &info), UtdCause::Unknown);
 
         // Same for unknown megolm message index

--- a/crates/matrix-sdk-crypto/src/types/qr_login/msc_4108.rs
+++ b/crates/matrix-sdk-crypto/src/types/qr_login/msc_4108.rs
@@ -117,17 +117,17 @@ impl QrCodeData {
         // 2. One byte version, only 0x02 is supported.
         // 3. One byte intent, either 0x03 or 0x04.
         // 4. 32 bytes for the ephemeral Curve25519 key.
-        // 5. Two bytes for the length of the rendezvous URL, a u16 in big-endian
-        //    encoding.
+        // 5. Two bytes for the length of the rendezvous URL, a u16 in
+        //    big-endian encoding.
         // 6. The UTF-8 encoded string containing the rendezvous URL.
-        // 7. If the intent from point 3. is 0x04, then two bytes for the length of the
-        //    homeserver URL, a u16 in big-endian encoding.
+        // 7. If the intent from point 3. is 0x04, then two bytes for the length
+        //    of the homeserver URL, a u16 in big-endian encoding.
         // 8. If the intent from point 3. is 0x04, then the UTF-8 encoded string
         //    containing the homeserver URL.
         let mut reader = Cursor::new(bytes);
 
-        // 1. Let's get the prefix first and double check if this QR code is intended
-        //    for the QR code login mechanism.
+        // 1. Let's get the prefix first and double check if this QR code is
+        //    intended for the QR code login mechanism.
         let mut prefix = [0u8; PREFIX.len()];
         reader.read_exact(&mut prefix)?;
 
@@ -141,8 +141,8 @@ impl QrCodeData {
         // 2. Next up is the version, we continue only if the version matches.
         let version = reader.read_u8()?;
         if version == VERSION {
-            // 3. The intent is the next one to parse, we return an error immediately the
-            //    intent isn't 0x03 or 0x04.
+            // 3. The intent is the next one to parse, we return an error
+            //    immediately the intent isn't 0x03 or 0x04.
             let intent = QrCodeIntent::try_from(reader.read_u8()?)?;
 
             // 4. Let's get the public key and convert it to our strongly typed
@@ -161,8 +161,8 @@ impl QrCodeData {
             let intent_data = match intent {
                 QrCodeIntent::Login => Msc4108IntentData::Login,
                 QrCodeIntent::Reciprocate => {
-                    // 7. If the intent is 0x04, we attempt to read the two bytes for the length of
-                    //    the homeserver URL.
+                    // 7. If the intent is 0x04, we attempt to read the two
+                    //    bytes for the length of the homeserver URL.
                     let server_name_len = reader.read_u16::<BigEndian>()?;
 
                     // 8. We read and parse the homeserver URL.
@@ -232,8 +232,8 @@ pub(super) mod test {
         0x64, 0x39, 0x38, 0x33, 0x30, 0x36, 0x36, 0x38,
     ];
 
-    // Test vector for the QR code data, copied from the MSC, with the intent set to
-    // reciprocate.
+    // Test vector for the QR code data, copied from the MSC, with the intent
+    // set to reciprocate.
     const QR_CODE_DATA_RECIPROCATE: &[u8] = &[
         0x4D, 0x41, 0x54, 0x52, 0x49, 0x58, 0x02, 0x04, 0xd8, 0x86, 0x68, 0x6a, 0xb2, 0x19, 0x7b,
         0x78, 0x0e, 0x30, 0x0a, 0x9d, 0x4a, 0x21, 0x47, 0x48, 0x07, 0x00, 0xd7, 0x92, 0x9f, 0x39,

--- a/crates/matrix-sdk-crypto/src/types/qr_login/msc_4388.rs
+++ b/crates/matrix-sdk-crypto/src/types/qr_login/msc_4388.rs
@@ -97,13 +97,13 @@ impl QrCodeData {
         // 5. Two bytes for the length of the rendezvous ID, a u16 in big-endian
         //    encoding.
         // 6. The UTF-8 encoded string containing the rendezvous ID.
-        // 7. Two bytes for the length of the server base URL, a u16 in big-endian
-        //    encoding.
+        // 7. Two bytes for the length of the server base URL, a u16 in
+        //    big-endian encoding.
         // 8. The UTF-8 encoded string containing the server base URL.
         let mut reader = Cursor::new(bytes);
 
-        // 1. Let's get the prefix first and double check if this QR code is intended
-        //    for the QR code login mechanism.
+        // 1. Let's get the prefix first and double check if this QR code is
+        //    intended for the QR code login mechanism.
         let mut prefix = [0u8; PREFIX.len()];
         reader.read_exact(&mut prefix)?;
 
@@ -118,8 +118,8 @@ impl QrCodeData {
         let qr_type = reader.read_u8()?;
 
         if qr_type == TYPE {
-            // 3. The intent is the next one to parse, we return an error immediately if the
-            //    intent isn't 0x00 or 0x01.
+            // 3. The intent is the next one to parse, we return an error
+            //    immediately if the intent isn't 0x00 or 0x01.
             let intent = QrCodeIntent::try_from(reader.read_u8()?)?;
 
             // 4. Let's get the public key and convert it to our strongly typed
@@ -199,8 +199,8 @@ mod test {
         0x2E, 0x6F, 0x72, 0x67,
     ];
 
-    // Test vector for the QR code data, copied from the MSC, with the intent set to
-    // login
+    // Test vector for the QR code data, copied from the MSC, with the intent
+    // set to login
     const QR_CODE_DATA_LOGIN: &[u8] = &[
         0x49, 0x4F, 0x5F, 0x45, 0x4C, 0x45, 0x4D, 0x45, 0x4E, 0x54, 0x5F, 0x4D, 0x53, 0x43, 0x34,
         0x33, 0x38, 0x38, 0x03, 0x00, 0xd8, 0x86, 0x68, 0x6a, 0xb2, 0x19, 0x7b, 0x78, 0x0e, 0x30,

--- a/crates/matrix-sdk-crypto/src/types/signatures/x509_signature.rs
+++ b/crates/matrix-sdk-crypto/src/types/signatures/x509_signature.rs
@@ -51,8 +51,9 @@ impl X509Signature {
     /// Encode an X509 signature into the string format that is used to
     /// represent it in a Matrix `signatures` object.
     pub fn to_cms_pem(&self) -> String {
-        // Given that we've either constructed this object ourselves, or successfully
-        // parsed it from PEM, I don't think it's possible for encoding to fail.
+        // Given that we've either constructed this object ourselves, or
+        // successfully parsed it from PEM, I don't think it's possible
+        // for encoding to fail.
         self.0.to_pem(der::pem::LineEnding::LF).expect("Failed to encode an X.509 signature")
     }
 }

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -44,9 +44,9 @@ const ISO8601_WITH_MILLIS: iso8601::EncodedConfig = iso8601::Config::DEFAULT
 pub fn timestamp_to_iso8601(ts: MilliSecondsSinceUnixEpoch) -> Option<String> {
     let nanos_since_epoch = i128::from(ts.get()) * 1_000_000;
 
-    // OffsetDateTime has a max year of 9999, whereas MilliSecondsSinceUnixEpoch has
-    // a max year of 285427, so `from_unix_timestamp_nanos` can overflow for very
-    // large timestamps. (The Y10K problem!)
+    // OffsetDateTime has a max year of 9999, whereas MilliSecondsSinceUnixEpoch
+    // has a max year of 285427, so `from_unix_timestamp_nanos` can overflow
+    // for very large timestamps. (The Y10K problem!)
     let dt = OffsetDateTime::from_unix_timestamp_nanos(nanos_since_epoch).ok()?;
 
     // SAFETY: `format` can fail if:

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -208,8 +208,8 @@ impl VerificationMachine {
     fn is_timestamp_valid(timestamp: MilliSecondsSinceUnixEpoch) -> bool {
         // The event should be ignored if the event is older than 10 minutes
         let old_timestamp_threshold: UInt = uint!(600);
-        // The event should be ignored if the event is 5 minutes or more into the
-        // future.
+        // The event should be ignored if the event is 5 minutes or more into
+        // the future.
         let timestamp_threshold: UInt = uint!(300);
 
         let timestamp = timestamp.as_secs();

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -91,20 +91,22 @@ pub fn format_emojis(emojis: [Emoji; 7]) -> String {
 
     let center_emoji = |emoji: &str| -> String {
         const EMOJI_WIDTH: usize = 2;
-        // These are emojis that need VARIATION-SELECTOR-16 (U+FE0F) so that they are
-        // rendered with coloured glyphs. For these, we need to add an extra
-        // space after them so that they are rendered properly in terminals.
+        // These are emojis that need VARIATION-SELECTOR-16 (U+FE0F) so that
+        // they are rendered with coloured glyphs. For these, we need to
+        // add an extra space after them so that they are rendered
+        // properly in terminals.
         const VARIATION_SELECTOR_EMOJIS: [&str; 7] = ["☁️", "❤️", "☂️", "✏️", "✂️", "☎️", "✈️"];
 
-        // Hack to make terminals behave properly when one of the above is printed.
+        // Hack to make terminals behave properly when one of the above is
+        // printed.
         let emoji = if VARIATION_SELECTOR_EMOJIS.contains(&emoji) {
             format!("{emoji} ")
         } else {
             emoji.to_owned()
         };
 
-        // This is a trick to account for the fact that emojis are wider than other
-        // monospace characters.
+        // This is a trick to account for the fact that emojis are wider than
+        // other monospace characters.
         let placeholder = ".".repeat(EMOJI_WIDTH);
 
         format!("{placeholder:^12}").replace(&placeholder, &emoji)
@@ -650,9 +652,11 @@ impl IdentitiesBeingVerified {
 
                     (Some(identity), should_request_secrets)
                 } else {
-                    // Note, this is normal. For example, if we're an existing device in a device
-                    // verification, we don't need to verify our identity: instead the verification
-                    // process should verify the new device.
+                    // Note, this is normal. For example, if we're an existing
+                    // device in a device verification, we
+                    // don't need to verify our identity: instead the
+                    // verification process should verify
+                    // the new device.
                     debug!(
                         user_id = ?self.other_user_id(),
                         "The interactive verification process didn't verify \
@@ -718,9 +722,10 @@ impl IdentitiesBeingVerified {
 
             Ok(Some(device))
         } else {
-            // Note, this is normal. For example, if we're a new device in a QR code device
-            // verification, we'll verify the master key but not (directly) the
-            // remote device. Likewise, in a QR code identity verification, we'll verify the
+            // Note, this is normal. For example, if we're a new device in a QR
+            // code device verification, we'll verify the master key
+            // but not (directly) the remote device. Likewise, in a
+            // QR code identity verification, we'll verify the
             // master key of the remote user but not (directly) their device.
             debug!(
                 user_id = ?device.user_id(),

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -449,9 +449,9 @@ impl VerificationRequest {
             _ => return Ok(None),
         };
 
-        // We may have previously started our own QR verification (e.g. two devices
-        // displaying QR code at the same time), so we need to replace it with the newly
-        // scanned code.
+        // We may have previously started our own QR verification (e.g. two
+        // devices displaying QR code at the same time), so we need to
+        // replace it with the newly scanned code.
         if self
             .verification_cache
             .get_qr(qr_verification.other_user_id(), qr_verification.flow_id().as_str())
@@ -742,12 +742,14 @@ impl VerificationRequest {
                 Ok(())
             }
             InnerRequest::Transitioned(s) => {
-                // This is the same as the `Ready` state. We need to support this in the case
-                // someone tries QR code verification and notices that they can't scan the QR
+                // This is the same as the `Ready` state. We need to support
+                // this in the case someone tries QR code
+                // verification and notices that they can't scan the QR
                 // code for one reason or the other, in that case they are able
                 // to transition into the emoji based SAS verification.
                 //
-                // In this case we're going to from one `Transitioned` state into another.
+                // In this case we're going to from one `Transitioned` state
+                // into another.
                 let s = s.clone();
 
                 if let Some(new_state) = s
@@ -808,8 +810,9 @@ impl VerificationRequest {
         content: OutgoingContent,
         other_device_id: DeviceIdOrAllDevices,
     ) -> Option<(Sas, OutgoingVerificationRequest)> {
-        // We may have previously started QR verification and generated a QR code. If we
-        // now switch to SAS flow, the previous verification has to be replaced
+        // We may have previously started QR verification and generated a QR
+        // code. If we now switch to SAS flow, the previous verification
+        // has to be replaced
         cfg_if::cfg_if! {
             if #[cfg(feature = "qrcode")] {
                 if self.verification_cache.get_qr(sas.other_user_id(), sas.flow_id().as_str()).is_some() {
@@ -1378,9 +1381,12 @@ async fn receive_start<T: Clone>(
                         .get(sender, request_state.flow_id.as_str());
                     match old_verification {
                         Some(Verification::SasV1(_old)) => {
-                            // If there is already a SAS verification, i.e. we already started one
-                            // before the other side tried to do the same; ignore it if we did and
-                            // we're the lexicographically smaller user ID (or device ID if equal).
+                            // If there is already a SAS verification, i.e. we
+                            // already started one
+                            // before the other side tried to do the same;
+                            // ignore it if we did and
+                            // we're the lexicographically smaller user ID (or
+                            // device ID if equal).
                             use std::cmp::Ordering;
                             if !matches!(
                                 (
@@ -1403,17 +1409,23 @@ async fn receive_start<T: Clone>(
                         }
                         #[cfg(feature = "qrcode")]
                         Some(Verification::QrV1(old)) => {
-                            // If there is already a QR verification, our ability to transition to
-                            // SAS depends on how far we got through the QR flow.
+                            // If there is already a QR verification, our
+                            // ability to transition to
+                            // SAS depends on how far we got through the QR
+                            // flow.
                             if let QrVerificationState::Started = old.state() {
-                                // it is legit to transition from QR display to SAS
+                                // it is legit to transition from QR display to
+                                // SAS
                                 info!("Transitioned from QR display to SAS");
                                 request_state.verification_cache.replace_sas(new.to_owned());
                                 Ok(Some(state.to_transitioned(request_state, new.into())))
                             } else {
-                                // otherwise, we've either scanned their QR code, or they have
-                                // scanned ours -- i.e., an `m.key.verification.start` with method
-                                // `m.reciprocate.v1` has already been sent/received and, per the
+                                // otherwise, we've either scanned their QR
+                                // code, or they have
+                                // scanned ours -- i.e., an
+                                // `m.key.verification.start` with method
+                                // `m.reciprocate.v1` has already been
+                                // sent/received and, per the
                                 // spec, it is too late to switch to SAS.
                                 warn!(qr_state = ?old.state(), "Invalid transition from QR to SAS");
                                 request_state.verification_cache.insert_sas(new.to_owned());
@@ -1707,8 +1719,8 @@ mod tests {
 
     #[async_test]
     async fn test_request_refusal_to_device() {
-        // test what happens when we cancel() a request that we have just received over
-        // to-device messages.
+        // test what happens when we cancel() a request that we have just
+        // received over to-device messages.
         let (_alice, alice_store, bob, bob_store) = setup_stores().await;
         let bob_device = DeviceData::from_account(&bob);
 
@@ -1880,7 +1892,8 @@ mod tests {
             Some(vec![VerificationMethod::QrCodeScanV1, VerificationMethod::QrCodeShowV1]),
         );
 
-        // Each side can start its own QR verification flow by generating QR code
+        // Each side can start its own QR verification flow by generating QR
+        // code
         let alice_verification = alice_request.generate_qr_code().await.unwrap();
         let bob_verification = bob_request.generate_qr_code().await.unwrap();
 
@@ -1919,8 +1932,8 @@ mod tests {
 
         assert_eq!(bob_device_data, other_device_data);
 
-        // Finally we assert that the verification has been reciprocated rather than
-        // cancelled due to a duplicate verification flow
+        // Finally we assert that the verification has been reciprocated rather
+        // than cancelled due to a duplicate verification flow
         assert!(!alice_verification.is_cancelled());
         assert!(alice_verification.reciprocated());
     }
@@ -1943,7 +1956,8 @@ mod tests {
             Some(all_methods()),
         );
 
-        // Each side can start its own QR verification flow by generating QR code
+        // Each side can start its own QR verification flow by generating QR
+        // code
         let alice_verification = alice_request.generate_qr_code().await.unwrap();
         let bob_verification = bob_request.generate_qr_code().await.unwrap();
 
@@ -1959,8 +1973,8 @@ mod tests {
         assert!(alice_verification.is_some());
         assert!(bob_verification.is_some());
 
-        // Alice can now start SAS verification flow instead of QR without cancelling
-        // the request
+        // Alice can now start SAS verification flow instead of QR without
+        // cancelling the request
         let (sas, request) = alice_request.start_sas().await.unwrap().unwrap();
         assert_let!(
             VerificationRequestState::Transitioned {

--- a/crates/matrix-sdk-crypto/src/x509/mod.rs
+++ b/crates/matrix-sdk-crypto/src/x509/mod.rs
@@ -250,9 +250,10 @@ pub(crate) mod tests {
 
         use sha2::{Digest, Sha256};
 
-        // The actual bytes in the SKI don't actually matter that much (and the RFC just
-        // makes a couple of suggestions): they just need to be a reasonably
-        // unique way of referring to the certificate with the right public key.
+        // The actual bytes in the SKI don't actually matter that much (and the
+        // RFC just makes a couple of suggestions): they just need to be
+        // a reasonably unique way of referring to the certificate with
+        // the right public key.
         let spki = signing_key.subject_public_key_info();
         let spki_hash = Sha256::digest(&spki);
         let ski_bytes = &spki_hash.as_slice()[0..20];

--- a/crates/matrix-sdk-crypto/src/x509/raw_x509_signature.rs
+++ b/crates/matrix-sdk-crypto/src/x509/raw_x509_signature.rs
@@ -75,7 +75,8 @@ impl RawX509Signature {
             [first, .., last] => (first, last),
         };
 
-        // The subject key identifier of the cert for the key that we signed with.
+        // The subject key identifier of the cert for the key that we signed
+        // with.
         let leaf_ski = first_cert
             .tbs_certificate
             .get::<SubjectKeyIdentifier>()
@@ -83,8 +84,8 @@ impl RawX509Signature {
             .ok_or(IntoX509SignatureError::LeafCertificateMissingSubjectKeyIdentifier)?
             .1;
 
-        // The authority key identifier of the highest cert in the chain, which should
-        // be the subject key identifier of the CA.
+        // The authority key identifier of the highest cert in the chain, which
+        // should be the subject key identifier of the CA.
         let authority_key_identifier = last_cert
             .tbs_certificate
             .get::<AuthorityKeyIdentifier>()
@@ -157,8 +158,8 @@ impl RawX509Signature {
                 .expect("Unable to encode SignedData as DER"),
         });
 
-        // Construct a device ID from the authority key identifier to guarantee a unique
-        // ID per CA.
+        // Construct a device ID from the authority key identifier to guarantee
+        // a unique ID per CA.
         let device_id = OwnedDeviceId::from(base64_encode(authority_key_identifier_bytes));
 
         Ok((device_id, signature))
@@ -173,9 +174,9 @@ trait IntoSetOfVec<T: der::DerOrd> {
 
 impl<T: der::DerOrd> IntoSetOfVec<T> for Vec<T> {
     fn into_set_of_vec(self) -> SetOfVec<T> {
-        // Building a SetOfVec has to calculate the lengths of each of the entries,
-        // which is theoretically fallible if the lengths cannot be represented as a
-        // `usize`.
+        // Building a SetOfVec has to calculate the lengths of each of the
+        // entries, which is theoretically fallible if the lengths
+        // cannot be represented as a `usize`.
         //
         // In practice, I can't see why it would fail.
         self.try_into().expect("Unable to construct SetOfVec")
@@ -423,20 +424,23 @@ impl X509SignatureScheme {
     pub fn get_signature_algorithm(&self) -> AlgorithmIdentifierOwned {
         match self {
             X509SignatureScheme::RsaPssSha512 => {
-                // The format of the AlgorithmIdentifier for RSA-PSS is defined by
-                // [RFC 4055 §3.1]( https://www.rfc-editor.org/info/rfc4055/#section-3.1) and
+                // The format of the AlgorithmIdentifier for RSA-PSS is defined
+                // by [RFC 4055 §3.1]( https://www.rfc-editor.org/info/rfc4055/#section-3.1) and
                 // [RFC 8017 §A.2.3](https://www.rfc-editor.org/info/rfc8017#appendix-A.2.3).
                 //
-                // If you are interested in the details of all the parameters, then
-                // https://crypto.stackexchange.com/a/58708 is a decent primer. Happily,
-                // there are established conventions followed by any sane implementation
-                // of RSA-PSS, and the RustCrypto folks have done most of the legwork
-                // for us in `pkcs1::RsaPssParams`.
+                // If you are interested in the details of all the parameters,
+                // then https://crypto.stackexchange.com/a/58708 is a decent primer. Happily,
+                // there are established conventions followed by any sane
+                // implementation of RSA-PSS, and the RustCrypto
+                // folks have done most of the legwork for us in
+                // `pkcs1::RsaPssParams`.
                 //
-                // Normal behaviour is to use the digest length as the length of the salt
-                // (as recommended by RFC 4055) - 64 bytes in the case of SHA-512.
+                // Normal behaviour is to use the digest length as the length of
+                // the salt (as recommended by RFC 4055) - 64
+                // bytes in the case of SHA-512.
                 //
-                // This code is inlined from `rsa::pss::get_default_pss_signature_algo_id`,
+                // This code is inlined from
+                // `rsa::pss::get_default_pss_signature_algo_id`,
                 // to avoid bringing in the entire `rsa` crate just for this.
                 AlgorithmIdentifierOwned {
                     oid: const_oid::db::rfc5912::ID_RSASSA_PSS,
@@ -502,8 +506,8 @@ mod test {
         assert_eq!(roundtripped.to_cms_pem(), SIG);
 
         // The SKI of the CA cert is
-        // D8:5E:91:9A:17:F0:C3:5B:13:DB:75:42:7D:21:37:9A:DF:3E:96:11, which when
-        // base64-encoded is...
+        // D8:5E:91:9A:17:F0:C3:5B:13:DB:75:42:7D:21:37:9A:DF:3E:96:11, which
+        // when base64-encoded is...
         assert_eq!(authority_key_identifier, "2F6Rmhfww1sT23VCfSE3mt8+lhE");
     }
 }

--- a/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_signer.rs
@@ -98,7 +98,8 @@ impl X509Signer {
         // them have a strictly earlier expiry, so we return `true`.
         for sig in this_user_sigs.values() {
             if let Ok(Signature::X509(sig)) = sig {
-                // We get the earliest expiry date from all the certificates in the signature.
+                // We get the earliest expiry date from all the certificates in
+                // the signature.
                 let data: cms::signed_data::SignedData =
                     match sig.get_signature().content.decode_as() {
                         Ok(res) => res,
@@ -235,8 +236,8 @@ mod tests {
         cert_params.use_authority_key_identifier_extension = true;
         cert_params.custom_extensions.push(subject_key_identifier_extension(&signing_key));
 
-        // We create three signers with different validity dates: an "old" signer, a
-        // "current" signer, and a "new" signer.
+        // We create three signers with different validity dates: an "old"
+        // signer, a "current" signer, and a "new" signer.
         let (x509_signer_old, x509_signer_current, x509_signer_new) =
             crate::x509::tests::signers_with_different_validity();
 

--- a/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
+++ b/crates/matrix-sdk-crypto/src/x509/x509_verify.rs
@@ -73,8 +73,8 @@ impl X509Verifier {
         };
 
         for sig in this_user_sigs.values().flatten() {
-            // `this_user_sigs` can and will contain non-X.509 signatures, which we should
-            // ignore.
+            // `this_user_sigs` can and will contain non-X.509 signatures, which
+            // we should ignore.
             if let Signature::X509(sig) = sig
                 && self
                     .verify_x509_signature(user_id, &msg, sig)
@@ -106,8 +106,8 @@ impl X509Verifier {
         let res: RawX509SignatureAndFirstCertificate =
             sig.try_into().map_err(X509SignatureVerificationError::RawSignatureParseError)?;
 
-        // Before we pass over to the X.509 certificate verifier, check that the leaf
-        // certificate is valid for the given user_id.
+        // Before we pass over to the X.509 certificate verifier, check that the
+        // leaf certificate is valid for the given user_id.
         if !cert_contains_user_id_or_equivalent_email(user_id, &res.leaf_cert) {
             tracing::warn!(?user_id, "Verifying certificate user ID or email failed");
             return Err(X509SignatureVerificationError::BadUserIdOrEmail);
@@ -169,15 +169,16 @@ pub trait RawX509Verifier: Debug + Send + Sync {
 }
 
 fn map_user_id_to_email(user_id: &UserId) -> String {
-    // TODO RAV: this is not a reliable way to map from user_ids to email addresses.
+    // TODO RAV: this is not a reliable way to map from user_ids to email
+    // addresses.
     format!("{}@{}", user_id.localpart(), user_id.server_name())
 }
 
 /// Search this certificate's Subject Alternative Name for a URI that matches
 /// the format of a Matrix URI that contains a valid Matrix user ID.
 fn get_user_id_from_certificate(certificate: &Certificate) -> Option<OwnedUserId> {
-    // If we have no SAN or SAN is not understood here, we definitely can't find a
-    // user ID.
+    // If we have no SAN or SAN is not understood here, we definitely can't find
+    // a user ID.
     let Ok(Some((_, san))) = certificate.tbs_certificate.get::<SubjectAltName>() else {
         return None;
     };
@@ -337,7 +338,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_can_verify_cert_containing_email_in_dn() {
-        // Given a cert containing the email address in the Subject Distinguished Name
+        // Given a cert containing the email address in the Subject
+        // Distinguished Name
         let (cert, signing_key) =
             cert_and_key_with_email_in_subject_distinguished_name("alice@localhost");
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
@@ -129,8 +129,8 @@ pub async fn open_and_upgrade_db(
 
     let old_version = db_version(name).await?;
 
-    // If the database version is too new, bail out. We assume that schema updates
-    // all the way up to `MAX_SUPPORTED_SCHEMA_VERSION` will be
+    // If the database version is too new, bail out. We assume that schema
+    // updates all the way up to `MAX_SUPPORTED_SCHEMA_VERSION` will be
     // backwards-compatible.
     if old_version > MAX_SUPPORTED_SCHEMA_VERSION {
         return Err(IndexeddbCryptoStoreError::SchemaTooNewError {
@@ -220,9 +220,10 @@ pub async fn open_and_upgrade_db(
     // If you add more migrations here, you'll need to update
     // `tests::EXPECTED_SCHEMA_VERSION`.
 
-    // NOTE: IF YOU MAKE A BREAKING CHANGE TO THE SCHEMA, BUMP THE SCHEMA VERSION TO
-    // SOMETHING HIGHER THAN `MAX_SUPPORTED_SCHEMA_VERSION`! (And then bump
-    // `MAX_SUPPORTED_SCHEMA_VERSION` itself to the next multiple of 10).
+    // NOTE: IF YOU MAKE A BREAKING CHANGE TO THE SCHEMA, BUMP THE SCHEMA
+    // VERSION TO SOMETHING HIGHER THAN `MAX_SUPPORTED_SCHEMA_VERSION`! (And
+    // then bump `MAX_SUPPORTED_SCHEMA_VERSION` itself to the next multiple
+    // of 10).
 
     // Open and return the DB (we know it's at the latest version)
     Ok(Database::open(name).await?)
@@ -256,8 +257,8 @@ where
     let db = Database::open(name)
         .with_version(version)
         .with_on_upgrade_needed(move |evt, tx| {
-            // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
-            // works with an unsigned integer.
+            // Even if the web-sys bindings expose the version as a f64, the
+            // IndexedDB API works with an unsigned integer.
             // See <https://github.com/rustwasm/wasm-bindgen/issues/1149>
             let old_version = evt.old_version() as u32;
 
@@ -329,8 +330,8 @@ mod tests {
     async fn test_count_lots_of_sessions_v8() {
         let cipher = Arc::new(StoreCipher::new().unwrap());
         let serializer = SafeEncodeSerializer::new(Some(cipher.clone()));
-        // Session keys are slow to create, so make one upfront and use it for every
-        // session
+        // Session keys are slow to create, so make one upfront and use it for
+        // every session
         let session_key = create_session_key();
 
         // Create lots of InboundGroupSessionIndexedDbObject2 objects
@@ -374,8 +375,8 @@ mod tests {
     async fn test_count_lots_of_sessions_v10() {
         let serializer = SafeEncodeSerializer::new(Some(Arc::new(StoreCipher::new().unwrap())));
 
-        // Session keys are slow to create, so make one upfront and use it for every
-        // session
+        // Session keys are slow to create, so make one upfront and use it for
+        // every session
         let session_key = create_session_key();
 
         // Create lots of InboundGroupSessionIndexedDbObject objects
@@ -601,7 +602,8 @@ mod tests {
         let store =
             IndexeddbCryptoStore::open_with_store_cipher(&db_prefix, store_cipher).await.unwrap();
 
-        // Then I can find the sessions using their keys and their info is correct
+        // Then I can find the sessions using their keys and their info is
+        // correct
         let fetched_backed_up_session = store
             .get_inbound_group_session(room_id, backed_up_session.session_id())
             .await
@@ -623,8 +625,8 @@ mod tests {
         // For v10: they have the backed_up_to property and it is indexed
         assert_matches_v10_schema(&db_name, &store, &fetched_backed_up_session).await;
 
-        // For v12: they have the session_id, sender_key and sender_data_type properties
-        // and they are indexed
+        // For v12: they have the session_id, sender_key and sender_data_type
+        // properties and they are indexed
         assert_matches_v12_schema(&db_name, &store, &fetched_backed_up_session).await;
     }
 
@@ -747,8 +749,8 @@ mod tests {
         session_entries: &[&InboundGroupSession],
     ) {
         // Schema V7 migrated the inbound group sessions to a new format.
-        // To test, first create a database and populate it with the *old* style of
-        // entry.
+        // To test, first create a database and populate it with the *old* style
+        // of entry.
         let db = create_v5_db(&db_name).await.unwrap();
 
         let serializer = SafeEncodeSerializer::new(store_cipher.clone());
@@ -766,15 +768,15 @@ mod tests {
                 serializer.encode_key(old_keys::INBOUND_GROUP_SESSIONS_V1, (room_id, session_id));
             let pickle = session.pickle().await;
 
-            // Serialize the session with the old style of serialization, since that's what
-            // we used at the time.
+            // Serialize the session with the old style of serialization, since
+            // that's what we used at the time.
             let serialized_session = serialize_value_as_legacy(&store_cipher, &pickle);
             sessions.put(&serialized_session).with_key(key).build().unwrap();
         }
         txn.commit().await.unwrap();
 
-        // now close our DB, reopen it properly, and check that we can still read our
-        // data.
+        // now close our DB, reopen it properly, and check that we can still
+        // read our data.
         db.close();
     }
 
@@ -1068,8 +1070,8 @@ mod tests {
         // Open, and close, the store at the regular version.
         IndexeddbCryptoStore::open_with_store_cipher(&db_prefix, None).await.unwrap();
 
-        // Now upgrade to the given version, keeping a record of the previous version so
-        // that we can double-check it.
+        // Now upgrade to the given version, keeping a record of the previous
+        // version so that we can double-check it.
         let old_version: Rc<Cell<Option<u32>>> = Rc::new(Cell::new(None));
         let old_version2 = old_version.clone();
 
@@ -1102,7 +1104,8 @@ mod tests {
         value: &T,
     ) -> JsValue {
         if let Some(cipher) = &store_cipher {
-            // Old-style serialization/encryption. First JSON-serialize into a byte array...
+            // Old-style serialization/encryption. First JSON-serialize into a
+            // byte array...
             let data = serde_json::to_vec(&value).unwrap();
             // ... then encrypt...
             let encrypted = cipher.encrypt_value_data(data).unwrap();

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
@@ -30,10 +30,11 @@ use crate::crypto_store::{
 pub(crate) async fn schema_add(name: &str) -> Result<(), OpenDbError> {
     do_schema_upgrade(name, 5, |tx, old_version| {
         let db = tx.db();
-        // An old_version of 1 could either mean actually the first version of the
-        // schema, or a completely empty schema that has been created with a
-        // call to `Database::open` with no explicit "version". So, to determine
-        // if we need to create the V1 stores, we actually check if the schema is empty.
+        // An old_version of 1 could either mean actually the first version of
+        // the schema, or a completely empty schema that has been
+        // created with a call to `Database::open` with no explicit
+        // "version". So, to determine if we need to create the V1
+        // stores, we actually check if the schema is empty.
         if db.object_store_names().next().is_none() {
             schema_add_v1(db)?;
         }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10_to_v11.rs
@@ -44,9 +44,9 @@ pub(crate) async fn data_migrate(
         return Ok(());
     };
 
-    // backup_key_v1 was only ever serialized with the legacy format. Also, it's a
-    // string, so if we use `deserialize_value` on it, it will be incorrectly
-    // handled as a new-format object.
+    // backup_key_v1 was only ever serialized with the legacy format. Also, it's
+    // a string, so if we use `deserialize_value` on it, it will be
+    // incorrectly handled as a new-format object.
     let bv: String = serializer.deserialize_legacy_value(bv)?;
 
     // Re-serialize as new format, then store in the new field.
@@ -59,7 +59,7 @@ pub(crate) async fn data_migrate(
 
 /// Perform the schema upgrade v10 to v11, just bumping the schema version.
 pub(crate) async fn schema_bump(name: &str) -> crate::crypto_store::Result<(), OpenDbError> {
-    // Just bump the version number to 11 to demonstrate that we have run the data
-    // changes from data_migrate.
+    // Just bump the version number to 11 to demonstrate that we have run the
+    // data changes from data_migrate.
     do_schema_upgrade(name, 11, |_, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v14.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v13_to_v14.rs
@@ -42,7 +42,7 @@ pub(crate) async fn data_migrate(name: &str, _: &SafeEncodeSerializer) -> Result
 /// Perform the schema upgrade v13 to v14, just bumping the schema version since
 /// the schema didn't actually change.
 pub(crate) async fn schema_bump(name: &str) -> Result<(), OpenDbError> {
-    // Just bump the version number to 14 to demonstrate that we have run the data
-    // changes from data_migrate.
+    // Just bump the version number to 14 to demonstrate that we have run the
+    // data changes from data_migrate.
     do_schema_upgrade(name, 14, |_, _| Ok(())).await
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
@@ -56,7 +56,8 @@ pub(crate) async fn schema_add(name: &str) -> Result<(), OpenDbError> {
 pub(crate) async fn data_migrate(name: &str, serializer: &SafeEncodeSerializer) -> Result<()> {
     let db = MigrationDb::new(name, 7).await?;
 
-    // The new store has been made for inbound group sessions; time to populate it.
+    // The new store has been made for inbound group sessions; time to populate
+    // it.
     let txn = db
         .transaction([old_keys::INBOUND_GROUP_SESSIONS_V1, old_keys::INBOUND_GROUP_SESSIONS_V2])
         .with_mode(TransactionMode::Readwrite)

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -83,7 +83,8 @@ pub(crate) async fn data_migrate(name: &str, serializer: &SafeEncodeSerializer) 
             );
 
             if new_key != old_key {
-                // We have found an entry that is stored under the incorrect old key
+                // We have found an entry that is stored under the incorrect old
+                // key
 
                 // Delete the old entry under the wrong key
                 cursor.delete()?;
@@ -91,10 +92,11 @@ pub(crate) async fn data_migrate(name: &str, serializer: &SafeEncodeSerializer) 
                 // Check for an existing entry with the new key
                 let new_value = store.get::<JsValue, _, _>(&new_key).await?;
 
-                // If we found an existing entry, it is more up-to-date, so we don't need to do
-                // anything more.
+                // If we found an existing entry, it is more up-to-date, so we
+                // don't need to do anything more.
 
-                // If we didn't find an existing entry, we must create one with the correct key
+                // If we didn't find an existing entry, we must create one with
+                // the correct key
                 if new_value.is_none() {
                     store
                         .add(&serde_wasm_bindgen::to_value(&idb_object)?)
@@ -120,8 +122,8 @@ pub(crate) async fn data_migrate(name: &str, serializer: &SafeEncodeSerializer) 
 /// Perform the schema upgrade v7 to v8, Just bumping the schema version.
 pub(crate) async fn schema_bump(name: &str) -> Result<(), OpenDbError> {
     do_schema_upgrade(name, 8, |_, _| {
-        // Just bump the version number to 8 to demonstrate that we have run the data
-        // changes from prepare_data_for_v8.
+        // Just bump the version number to 8 to demonstrate that we have run the
+        // data changes from prepare_data_for_v8.
         Ok(())
     })
     .await

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -47,8 +47,8 @@ pub(crate) async fn schema_add(name: &str) -> Result<(), OpenDbError> {
         )?;
 
         // See https://github.com/element-hq/element-web/issues/26892#issuecomment-1906336076
-        // for the plan concerning this property and index. At time of writing, it is
-        // unused, and needs_backup is still used.
+        // for the plan concerning this property and index. At time of writing,
+        // it is unused, and needs_backup is still used.
         add_nonunique_index(
             &object_store,
             keys::INBOUND_GROUP_SESSIONS_BACKED_UP_TO_INDEX,

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -450,8 +450,9 @@ impl IndexeddbCryptoStore {
     /// * `key` - Key with which to encrypt the key which is used to encrypt the
     ///   store. Must be the same each time the store is opened.
     pub async fn open_with_key(prefix: &str, key: &[u8; 32]) -> Result<Self> {
-        // The application might also use the provided key for something else, so to
-        // avoid key reuse, we pass the provided key through an HKDF
+        // The application might also use the provided key for something else,
+        // so to avoid key reuse, we pass the provided key through an
+        // HKDF
         let mut chacha_key = zeroize::Zeroizing::new([0u8; 32]);
         const HKDF_INFO: &[u8] = b"CRYPTOSTORE_CIPHER";
         let hkdf = Hkdf::<Sha256>::new(None, key);
@@ -525,9 +526,10 @@ impl IndexeddbCryptoStore {
         let session = InboundGroupSession::from_pickle(pickled_session)
             .map_err(|e| IndexeddbCryptoStoreError::CryptoStoreError(e.into()))?;
 
-        // Although a "backed up" flag is stored inside `idb_object.pickled_session`, it
-        // is not maintained when backups are reset. Overwrite the flag with the
-        // needs_backup value from the IDB object.
+        // Although a "backed up" flag is stored inside
+        // `idb_object.pickled_session`, it is not maintained when
+        // backups are reset. Overwrite the flag with the needs_backup
+        // value from the IDB object.
         if idb_object.needs_backup {
             session.reset_backup_state();
         } else {
@@ -744,8 +746,9 @@ impl IndexeddbCryptoStore {
 
             for secret in &changes.secrets {
                 use std::ops::Deref;
-                // The (hashed) secret value is included in the key to allow us to receive
-                // multiple secrets of the same name (indexeddb store entries must have a unique
+                // The (hashed) secret value is included in the key to allow us
+                // to receive multiple secrets of the same name
+                // (indexeddb store entries must have a unique
                 // key), and allow the client to determine which one is the
                 // current secret.
                 let key = self.serializer.encode_key(
@@ -1869,16 +1872,18 @@ async fn import_store_cipher_with_key(
     let cipher = match StoreCipher::import_with_key(chacha_key, serialised_cipher) {
         Ok(cipher) => cipher,
         Err(matrix_sdk_store_encryption::Error::KdfMismatch) => {
-            // Old versions of the matrix-js-sdk used to base64-encode their encryption
-            // key, and pass it into [`IndexeddbCryptoStore::open_with_passphrase`]. For
-            // backwards compatibility, we fall back to that if we discover we have a cipher
-            // encrypted with a KDF when we expected it to be encrypted directly with a key.
+            // Old versions of the matrix-js-sdk used to base64-encode their
+            // encryption key, and pass it into
+            // [`IndexeddbCryptoStore::open_with_passphrase`]. For
+            // backwards compatibility, we fall back to that if we discover we
+            // have a cipher encrypted with a KDF when we expected
+            // it to be encrypted directly with a key.
             let cipher = StoreCipher::import(&base64_encode(original_key), serialised_cipher)
                 .map_err(|_| CryptoStoreError::UnpicklingError)?;
 
-            // Loading the cipher with the passphrase was successful. Let's update the
-            // stored version of the cipher so that it is encrypted with a key,
-            // to save doing this again.
+            // Loading the cipher with the passphrase was successful. Let's
+            // update the stored version of the cipher so that it is
+            // encrypted with a key, to save doing this again.
             debug!(
                 "IndexedDbCryptoStore: Migrating passphrase-encrypted store cipher to key-encryption"
             );
@@ -1906,7 +1911,8 @@ where
     let mut result = Vec::new();
     let mut batch_n = 0;
 
-    // The empty string is before all keys in Indexed DB - first batch starts there.
+    // The empty string is before all keys in Indexed DB - first batch starts
+    // there.
     let mut latest_key: JsValue = "".into();
 
     loop {
@@ -1916,9 +1922,9 @@ where
         // would like to use `get_all_with_key_and_limit` if it ever exists
         // but for now we use a cursor and manually limit batch size.
 
-        // Get hold of a cursor for this batch. (This should not panic in expect()
-        // because we always use "", or the result of cursor.key(), both of
-        // which are valid keys.)
+        // Get hold of a cursor for this batch. (This should not panic in
+        // expect() because we always use "", or the result of
+        // cursor.key(), both of which are valid keys.)
         let after_latest_key = KeyRange::LowerBound(&latest_key, true);
         let cursor = object_store.open_cursor().with_query(&after_latest_key).await?;
 
@@ -2337,7 +2343,8 @@ mod encrypted_tests {
             .await
             .expect("Can't save account");
 
-        // Now reopen the store, passing the key directly rather than as a b64 string.
+        // Now reopen the store, passing the key directly rather than as a b64
+        // string.
         let store = IndexeddbCryptoStore::open_with_key(&store_name, &passdata)
             .await
             .expect("Can't create a key-protected store");

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/integration_tests.rs
@@ -30,9 +30,9 @@ pub async fn test_linked_chunk_update_is_a_transaction(store: IndexeddbEventCach
     ];
     store.handle_linked_chunk_updates(linked_chunk_id, updates).await.unwrap_err();
 
-    // If the updates have been handled transactionally, then no new chunks should
-    // have been added; failure of the second update leads to the first one being
-    // rolled back.
+    // If the updates have been handled transactionally, then no new chunks
+    // should have been added; failure of the second update leads to the
+    // first one being rolled back.
     let chunks = store.load_all_chunks(linked_chunk_id).await.unwrap();
     assert!(chunks.is_empty());
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -283,8 +283,8 @@ mod v3 {
     /// Remove events object store
     pub fn remove_events_object_store(transaction: &Transaction<'_>) -> Result<(), Error> {
         let object_store = transaction.object_store(keys::EVENTS)?;
-        // It is faster to clear all events first, then delete the object store rather
-        // than immediately deleting.
+        // It is faster to clear all events first, then delete the object store
+        // rather than immediately deleting.
         //
         // For details, see https://www.artificialworlds.net/blog/2024/02/02/deleting-an-indexed-db-store-can-be-incredibly-slow-on-firefox/
         object_store.clear()?;

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/mod.rs
@@ -360,19 +360,22 @@ impl EventCacheStore for IndexeddbEventCacheStore {
         // have a next chunk.
         match transaction.get_chunk_by_next_chunk_id(linked_chunk_id, None).await {
             Err(TransactionError::ItemIsNotUnique) => {
-                // If there are multiple chunks that do not have a next chunk, that
-                // means we have more than one last chunk, which means that we have
-                // more than one list in the room.
+                // If there are multiple chunks that do not have a next chunk,
+                // that means we have more than one last chunk,
+                // which means that we have more than one list
+                // in the room.
                 Err(IndexeddbEventCacheStoreError::ChunksContainDisjointLists)
             }
             Err(e) => {
-                // There was some error querying IndexedDB, but it is not necessarily
-                // a violation of our data constraints.
+                // There was some error querying IndexedDB, but it is not
+                // necessarily a violation of our data
+                // constraints.
                 Err(e.into())
             }
             Ok(None) => {
-                // If there is no chunk without a next chunk, that means every chunk
-                // points to another chunk, which means that we have a cycle in our list.
+                // If there is no chunk without a next chunk, that means every
+                // chunk points to another chunk, which means
+                // that we have a cycle in our list.
                 Err(IndexeddbEventCacheStoreError::ChunksContainCycle)
             }
             Ok(Some(last_chunk)) => {
@@ -495,7 +498,8 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                     for linked_chunk_id in
                         [LinkedChunkId::Room(room_id), LinkedChunkId::PinnedEvents(room_id)]
                     {
-                        // Remove all the items, gaps and events about the current `LinkedChunkId`.
+                        // Remove all the items, gaps and events about the
+                        // current `LinkedChunkId`.
                         transaction.delete_chunks_by_linked_chunk_id(linked_chunk_id).await?;
                         transaction.delete_gaps_by_linked_chunk_id(linked_chunk_id).await?;
                         transaction.delete_events_by_linked_chunk_id(linked_chunk_id).await?;
@@ -507,7 +511,8 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                     for thread in transaction.get_threads_by_room_id(room_id).await? {
                         let linked_chunk_id = thread.linked_chunk();
 
-                        // Remove all the items, gaps and events about the current `LinkedChunkId`.
+                        // Remove all the items, gaps and events about the
+                        // current `LinkedChunkId`.
                         transaction.delete_chunks_by_linked_chunk_id(linked_chunk_id).await?;
                         transaction.delete_gaps_by_linked_chunk_id(linked_chunk_id).await?;
                         transaction.delete_events_by_linked_chunk_id(linked_chunk_id).await?;
@@ -584,12 +589,14 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                         };
                         match event.linked_chunk_id() {
                             LinkedChunkId::Room(_) => {
-                                // Prioritize events that come from a room linked chunk
+                                // Prioritize events that come from a room
+                                // linked chunk
                                 related_events.insert(event_id.to_owned(), event);
                             }
                             _ => {
-                                // Remove position information from events that come
-                                // from any other type of linked chunk
+                                // Remove position information from events that
+                                // come from any
+                                // other type of linked chunk
                                 related_events
                                     .entry(event_id.to_owned())
                                     .or_insert_with(|| event.into_out_of_band_event());
@@ -605,7 +612,8 @@ impl EventCacheStore for IndexeddbEventCacheStore {
                     };
                     match event.linked_chunk_id() {
                         LinkedChunkId::Room(_) => {
-                            // Prioritize events that come from a room linked chunk
+                            // Prioritize events that come from a room linked
+                            // chunk
                             related_events.insert(event_id.to_owned(), event);
                         }
                         _ => {
@@ -637,8 +645,8 @@ impl EventCacheStore for IndexeddbEventCacheStore {
     ) -> Result<Vec<Event>, IndexeddbEventCacheStoreError> {
         let _timer = timer!("method");
 
-        // TODO: Make this more efficient so we don't load all events and filter them
-        // here. We should instead only load the relevant events.
+        // TODO: Make this more efficient so we don't load all events and filter
+        // them here. We should instead only load the relevant events.
 
         let transaction = self.transaction(&[keys::EVENTS], IdbTransactionMode::Readonly)?;
         transaction

--- a/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/media_store/mod.rs
@@ -182,7 +182,8 @@ impl MediaStore for IndexeddbMediaStore {
         let transaction =
             self.transaction(&[MediaMetadata::OBJECT_STORE], TransactionMode::Readwrite)?;
         if let Some(mut metadata) = transaction.get_media_metadata_by_id(from).await? {
-            // delete before adding, in case `from` and `to` generate the same key
+            // delete before adding, in case `from` and `to` generate the same
+            // key
             transaction.delete_media_metadata_by_id(from).await?;
             metadata.request_parameters = to.clone();
             transaction.add_media_metadata(&metadata).await?;

--- a/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
+++ b/crates/matrix-sdk-indexeddb/src/serializer/safe_encode/types.rs
@@ -230,37 +230,42 @@ impl SafeEncodeSerializer {
         // `MaybeEncrypted`. However, `serialize_value` previously used a
         // different format, so we need to handle that in case we have old data.
         //
-        // If we can convert the JsValue into a `MaybeEncrypted`, then it's probably one
-        // of those.
+        // If we can convert the JsValue into a `MaybeEncrypted`, then it's
+        // probably one of those.
         //
-        // - `MaybeEncrypted::Encrypted` becomes a JS object with properties {`version`,
-        //   `nonce`, `ciphertext`}.
+        // - `MaybeEncrypted::Encrypted` becomes a JS object with properties
+        //   {`version`, `nonce`, `ciphertext`}.
         //
-        // - `MaybeEncrypted::Unencrypted` becomes a JS string containing base64 text.
+        // - `MaybeEncrypted::Unencrypted` becomes a JS string containing base64
+        //   text.
         //
         // Otherwise, it probably uses our old serialization format:
         //
-        // - Encrypted values were: serialized to an array of JSON bytes; encrypted to
-        //   an array of u8 bytes; stored in a Rust object; serialized (again) into an
-        //   array of JSON bytes. Net result is a JS array.
+        // - Encrypted values were: serialized to an array of JSON bytes;
+        //   encrypted to an array of u8 bytes; stored in a Rust object;
+        //   serialized (again) into an array of JSON bytes. Net result is a JS
+        //   array.
         //
-        // - Unencrypted values were serialized to JSON, then deserialized into a
-        //   javascript object/string/array/bool.
+        // - Unencrypted values were serialized to JSON, then deserialized into
+        //   a javascript object/string/array/bool.
         //
         // Note that there are several potential ambiguities here:
         //
         // - A JS string could either be a legacy unencrypted value, or a
-        //   `MaybeEncrypted::Unencrypted`. However, the only thing that actually got
-        //   stored as a string under the legacy system was `backup_key_v1`, and that is
-        //   special-cased not to use this path — so if we can convert it into a
-        //   `MaybeEncrypted::Unencrypted`, then we assume it is one.
+        //   `MaybeEncrypted::Unencrypted`. However, the only thing that
+        //   actually got stored as a string under the legacy system was
+        //   `backup_key_v1`, and that is special-cased not to use this path —
+        //   so if we can convert it into a `MaybeEncrypted::Unencrypted`, then
+        //   we assume it is one.
         //
-        // - A JS array could be either a legacy encrypted value or a legacy unencrypted
-        //   value. We can tell the difference by whether we have a `cipher`.
+        // - A JS array could be either a legacy encrypted value or a legacy
+        //   unencrypted value. We can tell the difference by whether we have a
+        //   `cipher`.
         //
         // - A JS object could be either a legacy unencrypted value or a
-        //   `MaybeEncrypted::Encrypted`. We assume that no legacy JS objects have the
-        //   properties to be successfully decoded into a `MaybeEncrypted::Encrypted`.
+        //   `MaybeEncrypted::Encrypted`. We assume that no legacy JS objects
+        //   have the properties to be successfully decoded into a
+        //   `MaybeEncrypted::Encrypted`.
 
         // First check if it looks like a `MaybeEncrypted`, of either type.
         if let Ok(maybe_encrypted) = serde_wasm_bindgen::from_value(value.clone()) {
@@ -290,25 +295,27 @@ impl SafeEncodeSerializer {
 
                 // Looks like legacy encrypted format.
                 //
-                // `value` is a JS-side array containing the byte values. Turn it into a
-                // rust-side Vec<u8>, then decrypt.
+                // `value` is a JS-side array containing the byte values. Turn
+                // it into a rust-side Vec<u8>, then decrypt.
                 let value: Vec<u8> = serde_wasm_bindgen::from_value(value)?;
                 Ok(cipher.decrypt_value(&value).map_err(CryptoStoreError::backend)?)
             }
 
             None => {
-                // Legacy unencrypted format could be just about anything; just try
-                // JSON-serializing the value, then deserializing it into the
-                // desired type.
+                // Legacy unencrypted format could be just about anything; just
+                // try JSON-serializing the value, then
+                // deserializing it into the desired type.
                 //
-                // Note that the stored data was actually encoded by JSON-serializing it, and
-                // then deserializing the JSON into Javascript objects — so, for
+                // Note that the stored data was actually encoded by
+                // JSON-serializing it, and then deserializing
+                // the JSON into Javascript objects — so, for
                 // example, `HashMap`s are converted into Javascript Objects
                 // (whose keys are always strings) rather than Maps (whose keys
-                // can be other things). `serde_wasm_bindgen::from_value` will complain about
-                // such things. The correct thing to do is to go *back* to JSON
-                // and then deserialize into Rust again, which is what `JsValue::into_serde`
-                // does.
+                // can be other things). `serde_wasm_bindgen::from_value` will
+                // complain about such things. The correct thing
+                // to do is to go *back* to JSON
+                // and then deserialize into Rust again, which is what
+                // `JsValue::into_serde` does.
                 Ok(value.into_serde()?)
             }
         }
@@ -333,7 +340,8 @@ impl SafeEncodeSerializer {
         &self,
         value: MaybeEncrypted,
     ) -> Result<T, CryptoStoreError> {
-        // First extract the plaintext JSON, either by decrypting or un-base64-ing.
+        // First extract the plaintext JSON, either by decrypting or
+        // un-base64-ing.
         let plaintext = Zeroizing::new(match (&self.store_cipher, value) {
             (Some(cipher), MaybeEncrypted::Encrypted(enc)) => {
                 cipher.decrypt_value_base64_data(enc).map_err(CryptoStoreError::backend)?
@@ -409,8 +417,8 @@ mod tests {
         let data = serde_json::to_vec(&data).unwrap();
         let serialized = JsValue::from_serde(&data).unwrap();
 
-        // Now, try deserializing with `deserialize_value`, and check we get the right
-        // thing.
+        // Now, try deserializing with `deserialize_value`, and check we get the
+        // right thing.
         let serializer = SafeEncodeSerializer::new(Some(Arc::new(cipher)));
         let deserialized: TestStruct =
             serializer.deserialize_value(serialized).expect("could not deserialize");

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -164,30 +164,31 @@ pub async fn upgrade_inner_db(
 ) -> Result<Database> {
     let mut db = Database::open(name).await?;
 
-    // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
-    // works with an unsigned integer.
+    // Even if the web-sys bindings expose the version as a f64, the IndexedDB
+    // API works with an unsigned integer.
     // See <https://github.com/rustwasm/wasm-bindgen/issues/1149>
     let mut old_version = db.version() as u32;
 
     if old_version < CURRENT_DB_VERSION {
-        // This is a hack, we need to open the database a first time to get the current
-        // version.
-        // The indexed_db_futures crate doesn't let us access the transaction so we
-        // can't migrate data inside the `onupgradeneeded` callback. Instead we see if
-        // we need to migrate some data before the upgrade, then let the store process
-        // the upgrade.
+        // This is a hack, we need to open the database a first time to get the
+        // current version.
+        // The indexed_db_futures crate doesn't let us access the transaction so
+        // we can't migrate data inside the `onupgradeneeded` callback.
+        // Instead we see if we need to migrate some data before the
+        // upgrade, then let the store process the upgrade.
         // See <https://github.com/Alorel/rust-indexed-db/issues/20>
         let has_store_cipher = store_cipher.is_some();
 
-        // Inside the `onupgradeneeded` callback we would know whether it's a new DB
-        // because the old version would be set to 0, here it is already set to 1 so we
-        // check if the stores exist.
+        // Inside the `onupgradeneeded` callback we would know whether it's a
+        // new DB because the old version would be set to 0, here it is
+        // already set to 1 so we check if the stores exist.
         if old_version == 1 && db.object_store_names().next().is_none() {
             old_version = 0;
         }
 
-        // Upgrades to v1 and v2 (re)create empty stores, while the other upgrades
-        // change data that is already in the stores, so we use exclusive branches here.
+        // Upgrades to v1 and v2 (re)create empty stores, while the other
+        // upgrades change data that is already in the stores, so we use
+        // exclusive branches here.
         if old_version == 0 {
             let migration = OngoingMigration {
                 create_stores: ALL_STORES.iter().copied().collect(),
@@ -264,8 +265,9 @@ pub async fn upgrade_inner_db(
             .with_on_upgrade_needed(
                 move |evt: VersionChangeEvent, _: &Transaction<'_>| -> Result<(), Error> {
                     // Sanity check.
-                    // There should be no upgrade needed since the database should have already been
-                    // upgraded to the latest version.
+                    // There should be no upgrade needed since the database
+                    // should have already been upgraded to
+                    // the latest version.
                     panic!(
                         "Opening database that was not fully upgraded: \
                      DB version: {}; latest version: {CURRENT_DB_VERSION}",
@@ -584,8 +586,8 @@ async fn migrate_to_v5(db: Database, store_cipher: Option<&StoreCipher>) -> Resu
 
 /// Remove the old user IDs stores and populate the new ones.
 async fn migrate_to_v6(db: Database, store_cipher: Option<&StoreCipher>) -> Result<Database> {
-    // We only have joined and invited user IDs in the old store, so instead we will
-    // use the room member events to populate the new store.
+    // We only have joined and invited user IDs in the old store, so instead we
+    // will use the room member events to populate the new store.
     let tx = db
         .transaction([
             keys::ROOM_STATE,

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1543,11 +1543,12 @@ impl_state_store!({
     }
 
     async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
-        // All the stores which use a RoomId as their key (and nothing additional).
+        // All the stores which use a RoomId as their key (and nothing
+        // additional).
         let direct_stores = [keys::ROOM_INFOS, keys::ROOM_SEND_QUEUE, keys::DEPENDENT_SEND_QUEUE];
 
-        // All the stores which use a RoomId as the first part of their key, but may
-        // have some additional data in the key.
+        // All the stores which use a RoomId as the first part of their key, but
+        // may have some additional data in the key.
         let prefixed_stores = [
             keys::PROFILES,
             keys::DISPLAY_NAMES,
@@ -1616,8 +1617,8 @@ impl_state_store!({
 
         let obj = tx.object_store(keys::ROOM_SEND_QUEUE)?;
 
-        // We store an encoded vector of the queued requests, with their transaction
-        // ids.
+        // We store an encoded vector of the queued requests, with their
+        // transaction ids.
 
         // Reload the previous vector for this room, or create an empty one.
         let prev = obj.get(&encoded_key).await?;
@@ -1663,8 +1664,8 @@ impl_state_store!({
 
         let obj = tx.object_store(keys::ROOM_SEND_QUEUE)?;
 
-        // We store an encoded vector of the queued requests, with their transaction
-        // ids.
+        // We store an encoded vector of the queued requests, with their
+        // transaction ids.
 
         // Reload the previous vector for this room, or create an empty one.
         let prev = obj.get(&encoded_key).await?;
@@ -1708,8 +1709,8 @@ impl_state_store!({
 
         let obj = tx.object_store(keys::ROOM_SEND_QUEUE)?;
 
-        // We store an encoded vector of the queued requests, with their transaction
-        // ids.
+        // We store an encoded vector of the queued requests, with their
+        // transaction ids.
 
         // Reload the previous vector for this room.
         if let Some(val) = obj.get(&encoded_key).await? {
@@ -1734,8 +1735,8 @@ impl_state_store!({
     async fn load_send_queue_requests(&self, room_id: &RoomId) -> Result<Vec<QueuedRequest>> {
         let encoded_key = self.encode_key(keys::ROOM_SEND_QUEUE, room_id);
 
-        // We store an encoded vector of the queued requests, with their transaction
-        // ids.
+        // We store an encoded vector of the queued requests, with their
+        // transaction ids.
         let prev = self
             .inner
             .transaction(keys::ROOM_SEND_QUEUE)
@@ -2014,7 +2015,8 @@ impl_state_store!({
                 let previous: PersistedThreadSubscription =
                     self.deserialize_value(&previous_value)?;
 
-                // If the previous status is the same as the new one, don't do anything.
+                // If the previous status is the same as the new one, don't do
+                // anything.
                 if new == previous {
                     continue;
                 }

--- a/crates/matrix-sdk-search/src/index/mod.rs
+++ b/crates/matrix-sdk-search/src/index/mod.rs
@@ -89,7 +89,8 @@ impl IndexableEvent {
         // by multiplying by 1_000_000 [1]. If the number of milliseconds is too
         // big, the multiplication will overflow.
         //
-        // To avoid this panic, we cap the number of milliseconds to a maximum value.
+        // To avoid this panic, we cap the number of milliseconds to a maximum
+        // value.
         //
         // [1]: https://github.com/quickwit-oss/tantivy/blob/31ca1a8ba290b425f871d2e2384592045ec01b8d/common/src/datetime.rs#L62-L67
         if let Some(timestamp) = &mut timestamp {
@@ -294,10 +295,11 @@ impl RoomIndex {
             self.uncommitted_removes.insert(event);
         }
 
-        // Uncommitted documents added in this same batch also get deleted by the
-        // term above, so reconcile them too. Otherwise `contains` would still
-        // report them as present and a subsequent re-add (e.g. from an edit)
-        // would be wrongly skipped, leaving the document deleted.
+        // Uncommitted documents added in this same batch also get deleted by
+        // the term above, so reconcile them too. Otherwise `contains`
+        // would still report them as present and a subsequent re-add
+        // (e.g. from an edit) would be wrongly skipped, leaving the
+        // document deleted.
         let uncommitted: Vec<_> = self
             .uncommitted_adds
             .iter()
@@ -804,8 +806,9 @@ mod tests {
         let edit = to_indexable(&edit);
 
         // An original and its edit arriving in the same batch produce an `Add`
-        // and an `Edit` of the same document. The `Edit`'s removal must not drop
-        // the document added earlier in the same uncommitted batch.
+        // and an `Edit` of the same document. The `Edit`'s removal must not
+        // drop the document added earlier in the same uncommitted
+        // batch.
         index.bulk_execute(vec![
             RoomIndexOperation::Add(edit.clone()),
             RoomIndexOperation::Edit(original_id.to_owned(), edit),

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -205,10 +205,10 @@ impl SqliteCryptoStore {
     ) -> Result<InboundGroupSession> {
         let mut pickle: PickledInboundGroupSession = self.deserialize_value(&value)?;
 
-        // The `backed_up` SQL column is the source of truth, because we update it
-        // inside `mark_inbound_group_sessions_as_backed_up` and don't update
-        // the pickled value inside the `data` column (until now, when we are puling it
-        // out of the DB).
+        // The `backed_up` SQL column is the source of truth, because we update
+        // it inside `mark_inbound_group_sessions_as_backed_up` and
+        // don't update the pickled value inside the `data` column
+        // (until now, when we are puling it out of the DB).
         pickle.backed_up = backed_up;
 
         Ok(InboundGroupSession::from_pickle(pickle)?)
@@ -216,8 +216,8 @@ impl SqliteCryptoStore {
 
     fn deserialize_key_request(&self, value: &[u8], sent_out: bool) -> Result<GossipRequest> {
         let mut request: GossipRequest = self.deserialize_value(value)?;
-        // sent_out SQL column is source of truth, sent_out field in serialized value
-        // needed for other stores though
+        // sent_out SQL column is source of truth, sent_out field in serialized
+        // value needed for other stores though
         request.sent_out = sent_out;
         Ok(request)
     }
@@ -275,8 +275,9 @@ pub(crate) async fn initialize_store(conn: &SqliteAsyncConn, version: u8) -> Res
 
     if version < 1 {
         debug!("Creating database");
-        // First turn on WAL mode, this can't be done in the transaction, it fails with
-        // the error message: "cannot change into wal mode from within a transaction".
+        // First turn on WAL mode, this can't be done in the transaction, it
+        // fails with the error message: "cannot change into wal mode
+        // from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/crypto_store/001_init.sql"))?;
@@ -859,8 +860,9 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
                 move |mut stmt| {
                     let sender_data_type = sender_data_type as u8;
 
-                    // If we are not provided with an `after_session_id`, use a key which will sort
-                    // before all real keys: the empty string.
+                    // If we are not provided with an `after_session_id`, use a
+                    // key which will sort before all real
+                    // keys: the empty string.
                     let after_session_id = after_session_id.unwrap_or(Key::Plain(Vec::new()));
 
                     stmt.query(named_params! {
@@ -893,8 +895,9 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
         }
 
         self.chunk_large_query_over(session_ids, None, move |txn, session_ids| {
-            // Safety: host parameters are not generated using any user input except the
-            // number of session IDs, so it is safe from injection.
+            // Safety: host parameters are not generated using any user input
+            // except the number of session IDs, so it is safe from
+            // injection.
             let query = format!(
                 "UPDATE inbound_group_session SET backed_up = TRUE where session_id IN ({})",
                 session_ids.host_parameters()
@@ -1140,10 +1143,11 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn save_pending_changes(&self, changes: PendingChanges) -> Result<()> {
-        // Serialize calls to `save_pending_changes`; there are multiple await points
-        // below, and we're pickling data as we go, so we don't want to
-        // invalidate data we've previously read and overwrite it in the store.
-        // TODO: #2000 should make this lock go away, or change its shape.
+        // Serialize calls to `save_pending_changes`; there are multiple await
+        // points below, and we're pickling data as we go, so we don't
+        // want to invalidate data we've previously read and overwrite
+        // it in the store. TODO: #2000 should make this lock go away,
+        // or change its shape.
         let _guard = self.save_changes_lock.lock().await;
 
         let pickled_account = if let Some(account) = changes.account {
@@ -1170,10 +1174,11 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn save_changes(&self, changes: Changes) -> Result<()> {
-        // Serialize calls to `save_changes`; there are multiple await points below, and
-        // we're pickling data as we go, so we don't want to invalidate data
-        // we've previously read and overwrite it in the store.
-        // TODO: #2000 should make this lock go away, or change its shape.
+        // Serialize calls to `save_changes`; there are multiple await points
+        // below, and we're pickling data as we go, so we don't want to
+        // invalidate data we've previously read and overwrite it in the
+        // store. TODO: #2000 should make this lock go away, or change
+        // its shape.
         let _guard = self.save_changes_lock.lock().await;
 
         let pickled_private_identity =
@@ -1346,7 +1351,8 @@ impl CryptoStore for SqliteCryptoStore {
         sessions: Vec<InboundGroupSession>,
         backed_up_to_version: Option<&str>,
     ) -> matrix_sdk_crypto::store::Result<(), Self::Error> {
-        // Sanity-check that the data in the sessions corresponds to backed_up_version
+        // Sanity-check that the data in the sessions corresponds to
+        // backed_up_version
         sessions.iter().for_each(|s| {
             let backed_up = s.backed_up();
             if backed_up != backed_up_to_version.is_some() {
@@ -1358,8 +1364,8 @@ impl CryptoStore for SqliteCryptoStore {
             }
         });
 
-        // Currently, this store doesn't save the backup version separately, so this
-        // just delegates to save_changes.
+        // Currently, this store doesn't save the backup version separately, so
+        // this just delegates to save_changes.
         self.save_changes(Changes { inbound_group_sessions: sessions, ..Changes::default() }).await
     }
 
@@ -1939,7 +1945,8 @@ mod tests {
         let tmpdir = tempdir().unwrap();
         let destination = tmpdir.path().join(db_name);
 
-        // Copy the test database to the tempdir so our test runs are idempotent.
+        // Copy the test database to the tempdir so our test runs are
+        // idempotent.
         std::fs::copy(&database_path, destination).unwrap();
 
         tmpdir

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -436,8 +436,8 @@ impl TransactionExtForLinkedChunks for Transaction<'_> {
         linked_chunk_id: &Key,
         chunk_id: ChunkIdentifier,
     ) -> Result<Gap> {
-        // There's at most one row for it in the database, so a call to `query_one` is
-        // sufficient.
+        // There's at most one row for it in the database, so a call to
+        // `query_one` is sufficient.
         let encoded_prev_token: Vec<u8> = self.query_one(
             "SELECT prev_token FROM gap_chunks WHERE chunk_id = ? AND linked_chunk_id = ?",
             (chunk_id.index(), &linked_chunk_id),
@@ -480,8 +480,9 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
 
     if version < 1 {
         debug!("Creating database");
-        // First turn on WAL mode, this can't be done in the transaction, it fails with
-        // the error message: "cannot change into wal mode from within a transaction".
+        // First turn on WAL mode, this can't be done in the transaction, it
+        // fails with the error message: "cannot change into wal mode
+        // from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/event_cache_store/001_init.sql"))?;
@@ -581,8 +582,8 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
         .await?;
 
         if version >= 1 {
-            // Defragment the DB and optimize its size on the filesystem now that we removed
-            // the media cache.
+            // Defragment the DB and optimize its size on the filesystem now
+            // that we removed the media cache.
             conn.vacuum().await?;
         }
     }
@@ -737,8 +738,8 @@ impl EventCacheStore for SqliteEventCacheStore {
             self.encryption.encode_room_id(keys::EVENTS, linked_chunk_id.room_id());
         let encryption = self.encryption.clone();
 
-        // Use a single transaction throughout this function, so that either all updates
-        // work, or none is taken into account.
+        // Use a single transaction throughout this function, so that either all
+        // updates work, or none is taken into account.
         with_immediate_transaction(self, move |txn| {
             for update in updates {
                 match update {
@@ -1164,8 +1165,9 @@ impl EventCacheStore for SqliteEventCacheStore {
         self.read()
             .await?
             .with_transaction(move |txn| -> Result<_> {
-                // We want to collect the metadata about each chunk (id, next, previous), and
-                // for event chunks, the number of events in it. For gaps, the
+                // We want to collect the metadata about each chunk (id, next,
+                // previous), and for event chunks, the number
+                // of events in it. For gaps, the
                 // number of events is 0, by convention.
                 //
                 // We've tried different strategies over time:
@@ -1179,16 +1181,18 @@ impl EventCacheStore for SqliteEventCacheStore {
                 //   https://github.com/matrix-org/matrix-rust-sdk/pull/5411.
                 //
                 // The current solution is to run two queries:
-                // - one to get each chunk and its number of events, by doing a single `SELECT`
-                //   query over the `event_chunks` table, grouping by chunk ids. This gives us a
-                //   list of `(chunk_id, num_events)` pairs, which can be transformed into a
+                // - one to get each chunk and its number of events, by doing a
+                //   single `SELECT` query over the `event_chunks` table,
+                //   grouping by chunk ids. This gives us a list of `(chunk_id,
+                //   num_events)` pairs, which can be transformed into a
                 //   hashmap.
-                // - one to get each chunk's metadata (id, previous, next, type) from the
-                //   database with a `SELECT`, and then use the hashmap to get the number of
-                //   events.
+                // - one to get each chunk's metadata (id, previous, next, type)
+                //   from the database with a `SELECT`, and then use the hashmap
+                //   to get the number of events.
                 //
-                // This strategy minimizes the number of queries to the database, and keeps them
-                // super simple, while doing a bit more processing here, which is much faster.
+                // This strategy minimizes the number of queries to the
+                // database, and keeps them super simple, while
+                // doing a bit more processing here, which is much faster.
 
                 let num_events_by_chunk_ids = txn
                     .prepare(
@@ -1223,10 +1227,12 @@ impl EventCacheStore for SqliteEventCacheStore {
                 .map(|data| -> Result<_> {
                     let (id, previous, next, chunk_type) = data?;
 
-                    // Note: since a gap has 0 events, an alternative could be to *not* retrieve
-                    // the chunk type, and just let the hashmap lookup fail for gaps. However,
-                    // benchmarking shows that this is slightly slower than matching the chunk
-                    // type (around 1%, so in the realm of noise), so we keep the explicit
+                    // Note: since a gap has 0 events, an alternative could be
+                    // to *not* retrieve the chunk type, and
+                    // just let the hashmap lookup fail for gaps. However,
+                    // benchmarking shows that this is slightly slower than
+                    // matching the chunk type (around 1%,
+                    // so in the realm of noise), so we keep the explicit
                     // check instead.
                     let num_items = if chunk_type == CHUNK_TYPE_GAP_TYPE_STRING {
                         0
@@ -1403,8 +1409,8 @@ impl EventCacheStore for SqliteEventCacheStore {
             self.encryption.encode_linked_chunk(keys::LINKED_CHUNKS, &linked_chunk_id);
         let encryption = self.encryption.clone();
 
-        // First off, try by selecting the thread info. It's the most common case. If it
-        // doesn't exist, create an empty one.
+        // First off, try by selecting the thread info. It's the most common
+        // case. If it doesn't exist, create an empty one.
         //
         // We do that with 2 transactions.
         let maybe_thread_info = self
@@ -1492,7 +1498,8 @@ impl EventCacheStore for SqliteEventCacheStore {
                         // Remove all the chunks, and let cascading do its job.
                         txn.execute("DELETE FROM linked_chunks", ())?;
 
-                        // Also clear all the events' contents, and let cascading do its job.
+                        // Also clear all the events' contents, and let
+                        // cascading do its job.
                         txn.execute("DELETE FROM events", ())?;
 
                         Ok(())
@@ -1555,9 +1562,10 @@ impl EventCacheStore for SqliteEventCacheStore {
     ) -> Result<Vec<(OwnedEventId, Position)>, Self::Error> {
         let _timer = timer!("method");
 
-        // If there's no events for which we want to check duplicates, we can return
-        // early. It's not only an optimization to do so: it's required, otherwise the
-        // `host_parameters` call below will panic.
+        // If there's no events for which we want to check duplicates, we can
+        // return early. It's not only an optimization to do so: it's
+        // required, otherwise the `host_parameters` call below will
+        // panic.
         if event_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1632,8 +1640,10 @@ impl EventCacheStore for SqliteEventCacheStore {
                             let (duplicated_hashed_event_id, chunk_identifier, index) =
                                 duplicated_event?;
 
-                            // The event ID is encoded in the database. We can't decode it. However,
-                            // we can find the original event ID with the `event_ids` parameter of
+                            // The event ID is encoded in the database. We can't
+                            // decode it. However,
+                            // we can find the original event ID with the
+                            // `event_ids` parameter of
                             // this method by comparing the encoded event ID!
                             let Some(duplicated_event_id) = event_ids_and_hashed_event_ids
                                 .iter()
@@ -1859,8 +1869,9 @@ fn find_event_relations_transaction(
             let (event, chunk_id, index): (Vec<u8>, Option<u64>, _) = result?;
             let event = encryption.decode_event(&event)?;
 
-            // Only build the position if both the chunk_id and position were present; in
-            // theory, they should either be present at the same time, or not at all.
+            // Only build the position if both the chunk_id and position were
+            // present; in theory, they should either be present at
+            // the same time, or not at all.
             let pos = chunk_id
                 .zip(index)
                 .map(|(chunk_id, index)| Position::new(ChunkIdentifier::new(chunk_id), index));
@@ -1882,10 +1893,10 @@ fn find_event_relations_transaction(
             host_parameters(filters.len())
         );
 
-        // First the filters need to be stringified; because `.to_sql()` will borrow
-        // from them, they also need to be stringified onto the stack, so as to
-        // get a stable address (to avoid returning a temporary reference in the
-        // map closure below).
+        // First the filters need to be stringified; because `.to_sql()` will
+        // borrow from them, they also need to be stringified onto the
+        // stack, so as to get a stable address (to avoid returning a
+        // temporary reference in the map closure below).
         let filter_strings: Vec<_> = filters.iter().map(|f| f.to_string()).collect();
         let filters_params: Vec<_> = filter_strings
             .iter()
@@ -1940,9 +1951,9 @@ async fn with_immediate_transaction<
     this.write()
         .await?
         .interact(move |conn| -> Result<T, Error> {
-            // Start the transaction in IMMEDIATE mode since all updates may cause writes,
-            // to avoid read transactions upgrading to write mode and causing
-            // SQLITE_BUSY errors. See also: https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
+            // Start the transaction in IMMEDIATE mode since all updates may
+            // cause writes, to avoid read transactions upgrading to
+            // write mode and causing SQLITE_BUSY errors. See also: https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
             conn.set_transaction_behavior(TransactionBehavior::Immediate);
 
             let code = || -> Result<T, Error> {
@@ -1954,8 +1965,9 @@ async fn with_immediate_transaction<
 
             let res = code();
 
-            // Reset the transaction behavior to use Deferred, after this transaction has
-            // been run, whether it was successful or not.
+            // Reset the transaction behavior to use Deferred, after this
+            // transaction has been run, whether it was successful
+            // or not.
             conn.set_transaction_behavior(TransactionBehavior::Deferred);
 
             res
@@ -2113,8 +2125,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Check that the gaps match those set up in the corresponding integration test
-        // above
+        // Check that the gaps match those set up in the corresponding
+        // integration test above
         assert_eq!(gaps, vec![42, 44]);
     }
 
@@ -2183,8 +2195,8 @@ mod tests {
         let room_id = *DEFAULT_TEST_ROOM_ID;
         let linked_chunk_id = LinkedChunkId::Room(room_id);
 
-        // Trigger a violation of the unique constraint on the (room id, chunk id)
-        // couple.
+        // Trigger a violation of the unique constraint on the (room id, chunk
+        // id) couple.
         let err = store
             .handle_linked_chunk_updates(
                 linked_chunk_id,
@@ -2209,9 +2221,9 @@ mod tests {
             assert_matches!(err.sqlite_error_code(), Some(rusqlite::ErrorCode::ConstraintViolation));
         });
 
-        // If the updates have been handled transactionally, then no new chunks should
-        // have been added; failure of the second update leads to the first one being
-        // rolled back.
+        // If the updates have been handled transactionally, then no new chunks
+        // should have been added; failure of the second update leads to
+        // the first one being rolled back.
         let chunks = store.load_all_chunks(linked_chunk_id).await.unwrap();
         assert!(chunks.is_empty());
     }
@@ -2305,7 +2317,8 @@ mod encrypted_tests {
             .await
             .expect("We should be able to attempt to find event relations");
 
-        // Ensure that we only got the single related event the first room contains.
+        // Ensure that we only got the single related event the first room
+        // contains.
         similar_asserts::assert_eq!(
             results.len(),
             1,

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -272,8 +272,9 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
 
     if version < 1 {
         debug!("Creating database");
-        // First turn on WAL mode, this can't be done in the transaction, it fails with
-        // the error message: "cannot change into wal mode from within a transaction".
+        // First turn on WAL mode, this can't be done in the transaction, it
+        // fails with the error message: "cannot change into wal mode
+        // from within a transaction".
         conn.execute_batch("PRAGMA journal_mode = wal;").await?;
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/media_store/001_init.sql"))?;
@@ -547,8 +548,8 @@ impl MediaStoreInner for SqliteMediaStore {
         let data = conn
             .with_transaction::<_, rusqlite::Error, _>(move |txn| {
                 // Update the last access.
-                // We need to do this first so the transaction is in write mode right away.
-                // See: https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions
+                // We need to do this first so the transaction is in write mode
+                // right away. See: https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions
                 txn.execute(
                     "UPDATE media SET last_access = ? WHERE uri = ? AND format = ?",
                     (timestamp, &uri, &format),
@@ -607,10 +608,12 @@ impl MediaStoreInner for SqliteMediaStore {
                     }
                 }
 
-                // Finally, if the cache size is too big, remove old items until it fits.
+                // Finally, if the cache size is too big, remove old items until
+                // it fits.
                 if let Some(max_cache_size) = policy.max_cache_size {
-                    // i64 is the integer type used by SQLite, use it here to avoid usize overflow
-                    // during the conversion of the result.
+                    // i64 is the integer type used by SQLite, use it here to
+                    // avoid usize overflow during the
+                    // conversion of the result.
                     let cache_size = txn
                         .query_row(
                             "SELECT sum(length(data)) FROM media WHERE ignore_policy IS FALSE",
@@ -622,9 +625,11 @@ impl MediaStoreInner for SqliteMediaStore {
                         )?
                         .unwrap_or_default();
 
-                    // If the cache size is overflowing or bigger than max cache size, clean up.
+                    // If the cache size is overflowing or bigger than max cache
+                    // size, clean up.
                     if cache_size > max_cache_size {
-                        // Get the sizes of the media contents ordered by last access.
+                        // Get the sizes of the media contents ordered by last
+                        // access.
                         let mut cached_stmt = txn.prepare_cached(
                             "SELECT rowid, length(data) FROM media \
                              WHERE ignore_policy IS FALSE ORDER BY last_access DESC",
@@ -658,8 +663,10 @@ impl MediaStoreInner for SqliteMediaStore {
                                 }
                                 Some(acc) => accumulated_items_size = acc,
                                 None => {
-                                    // The accumulated size is overflowing but the setting cannot be
-                                    // bigger than usize::MAX, we can stop accumulating.
+                                    // The accumulated size is overflowing but
+                                    // the setting cannot be
+                                    // bigger than usize::MAX, we can stop
+                                    // accumulating.
                                     limit_reached = true;
                                     rows_to_remove.push(row_id);
                                 }
@@ -794,8 +801,8 @@ mod tests {
             .await
             .expect("adding file failed");
 
-        // Since the precision of the timestamp is in seconds, wait so the timestamps
-        // differ.
+        // Since the precision of the timestamp is in seconds, wait so the
+        // timestamps differ.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         media_store
@@ -814,8 +821,8 @@ mod tests {
         assert_eq!(contents[0], thumbnail_content, "thumbnail is not last access");
         assert_eq!(contents[1], content, "file is not second-to-last access");
 
-        // Since the precision of the timestamp is in seconds, wait so the timestamps
-        // differ.
+        // Since the precision of the timestamp is in seconds, wait so the
+        // timestamps differ.
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         // Access the file so its last access is more recent.

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -432,8 +432,9 @@ impl SqliteStateStore {
         if from < 12 {
             debug!("Upgrading database to version 12");
             // Defragment the DB and optimize its size on the filesystem.
-            // This should have been run in the migration for version 7, to reduce the size
-            // of the DB as we removed the media cache.
+            // This should have been run in the migration for version 7, to
+            // reduce the size of the DB as we removed the media
+            // cache.
             conn.vacuum().await?;
             conn.set_kv("version", vec![12]).await?;
         }
@@ -620,8 +621,9 @@ impl EncryptableStore for SqliteStateStore {
 
 /// Initialize the database.
 async fn init(conn: &SqliteAsyncConn) -> Result<()> {
-    // First turn on WAL mode, this can't be done in the transaction, it fails with
-    // the error message: "cannot change into wal mode from within a transaction".
+    // First turn on WAL mode, this can't be done in the transaction, it fails
+    // with the error message: "cannot change into wal mode from within a
+    // transaction".
     conn.execute_batch("PRAGMA journal_mode = wal;").await?;
     conn.with_transaction(|txn| {
         txn.execute_batch(include_str!("../migrations/state_store/001_init.sql"))?;
@@ -1858,15 +1860,17 @@ impl StateStore for SqliteStateStore {
         let mut names_map = display_names
             .iter()
             .flat_map(|display_name| {
-                // We encode the display name as the `raw_str()` and the normalized string.
+                // We encode the display name as the `raw_str()` and the
+                // normalized string.
                 //
                 // This is for compatibility reasons since:
-                //  1. Previously "Alice" and "alice" were considered to be distinct display
-                //     names, while we now consider them to be the same so we need to merge the
-                //     previously distinct buckets of user IDs.
-                //  2. We can't do a migration to merge the previously distinct buckets of user
-                //     IDs since the display names itself are hashed before they are persisted
-                //     in the store.
+                //  1. Previously "Alice" and "alice" were considered to be
+                //     distinct display names, while we now consider them to be
+                //     the same so we need to merge the previously distinct
+                //     buckets of user IDs.
+                //  2. We can't do a migration to merge the previously distinct
+                //     buckets of user IDs since the display names itself are
+                //     hashed before they are persisted in the store.
                 let raw =
                     (self.encode_key(keys::DISPLAY_NAME, display_name.as_raw_str()), display_name);
                 let normalized = display_name.as_normalized_str().map(|normalized| {
@@ -1927,8 +1931,8 @@ impl StateStore for SqliteStateStore {
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
         let room_id = self.encode_key(keys::RECEIPT, room_id);
         let receipt_type = self.encode_key(keys::RECEIPT, receipt_type.to_string());
-        // We cannot have a NULL primary key so we rely on serialization instead of the
-        // string representation.
+        // We cannot have a NULL primary key so we rely on serialization instead
+        // of the string representation.
         let receipt_thread =
             self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(receipt_thread)?);
         let user_id = self.encode_key(keys::RECEIPT, user_id);
@@ -1952,8 +1956,8 @@ impl StateStore for SqliteStateStore {
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
         let room_id = self.encode_key(keys::RECEIPT, room_id);
         let receipt_type = self.encode_key(keys::RECEIPT, receipt_type.to_string());
-        // We cannot have a NULL primary key so we rely on serialization instead of the
-        // string representation.
+        // We cannot have a NULL primary key so we rely on serialization instead
+        // of the string representation.
         let receipt_thread =
             self.encode_key(keys::RECEIPT, rmp_serde::to_vec_named(receipt_thread)?);
         let event_id = self.encode_key(keys::RECEIPT, event_id);
@@ -2059,10 +2063,11 @@ impl StateStore for SqliteStateStore {
         let room_id_value = self.serialize_value(&room_id.to_owned())?;
 
         let content = self.serialize_json(&content)?;
-        // The transaction id is used both as a key (in remove/update) and a value (as
-        // it's useful for the callers), so we keep it as is, and neither hash
-        // it (with encode_key) or encrypt it (through serialize_value). After
-        // all, it carries no personal information, so this is considered fine.
+        // The transaction id is used both as a key (in remove/update) and a
+        // value (as it's useful for the callers), so we keep it as is,
+        // and neither hash it (with encode_key) or encrypt it (through
+        // serialize_value). After all, it carries no personal
+        // information, so this is considered fine.
 
         let created_at_ts: u64 = created_at.0.into();
         self.write()
@@ -2083,8 +2088,8 @@ impl StateStore for SqliteStateStore {
         let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
 
         let content = self.serialize_json(&content)?;
-        // See comment in [`Self::save_send_queue_request`] to understand why the
-        // transaction id is neither encrypted or hashed.
+        // See comment in [`Self::save_send_queue_request`] to understand why
+        // the transaction id is neither encrypted or hashed.
         let transaction_id = transaction_id.to_string();
 
         let num_updated = self.write()
@@ -2127,9 +2132,10 @@ impl StateStore for SqliteStateStore {
     ) -> Result<Vec<QueuedRequest>, Self::Error> {
         let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
 
-        // Note: ROWID is always present and is an auto-incremented integer counter. We
-        // want to maintain the insertion order, so we can sort using it.
-        // Note 2: transaction_id is not encoded, see why in `save_send_queue_request`.
+        // Note: ROWID is always present and is an auto-incremented integer
+        // counter. We want to maintain the insertion order, so we can
+        // sort using it. Note 2: transaction_id is not encoded, see why
+        // in `save_send_queue_request`.
         let res: Vec<(String, Vec<u8>, Option<Vec<u8>>, usize, Option<u64>)> = self
             .read()
             .await?
@@ -2174,7 +2180,8 @@ impl StateStore for SqliteStateStore {
         // See comment in `save_send_queue_request`.
         let transaction_id = transaction_id.to_string();
 
-        // Serialize the error to json bytes (encrypted if option is enabled) if set.
+        // Serialize the error to json bytes (encrypted if option is enabled) if
+        // set.
         let error_value = error.map(|e| self.serialize_value(&e)).transpose()?;
 
         self.write()
@@ -2187,9 +2194,10 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn load_rooms_with_unsent_requests(&self) -> Result<Vec<OwnedRoomId>, Self::Error> {
-        // If the values were not encrypted, we could use `SELECT DISTINCT` here, but we
-        // have to manually do the deduplication: indeed, for all X, encrypt(X)
-        // != encrypted(X), since we use a nonce in the encryption process.
+        // If the values were not encrypted, we could use `SELECT DISTINCT`
+        // here, but we have to manually do the deduplication: indeed,
+        // for all X, encrypt(X) != encrypted(X), since we use a nonce
+        // in the encryption process.
 
         let res: Vec<Vec<u8>> = self
             .read()
@@ -2199,8 +2207,8 @@ impl StateStore for SqliteStateStore {
             })
             .await?;
 
-        // So we collect the results into a `BTreeSet` to perform the deduplication, and
-        // then rejigger that into a vector.
+        // So we collect the results into a `BTreeSet` to perform the
+        // deduplication, and then rejigger that into a vector.
         Ok(res
             .into_iter()
             .map(|entry| self.deserialize_value(&entry))
@@ -2331,7 +2339,8 @@ impl StateStore for SqliteStateStore {
     ) -> Result<Vec<DependentQueuedRequest>> {
         let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
 
-        // Note: transaction_id is not encoded, see why in `save_send_queue_request`.
+        // Note: transaction_id is not encoded, see why in
+        // `save_send_queue_request`.
         let res: Vec<(String, String, Option<Vec<u8>>, Vec<u8>, Option<u64>)> = self
             .read()
             .await?
@@ -2979,8 +2988,8 @@ mod migration_tests {
             .unwrap();
         }
 
-        // This transparently migrates to the latest version, which clears up all
-        // requests and dependent requests.
+        // This transparently migrates to the latest version, which clears up
+        // all requests and dependent requests.
         let store = SqliteStateStore::open(path, Some(SECRET)).await.unwrap();
 
         let requests = store.load_send_queue_requests(room_id).await.unwrap();

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -229,7 +229,8 @@ pub(crate) trait SqliteAsyncConnExt {
             return Err(error.into());
         } else {
             trace!("VACUUM complete");
-            // Once vacuumed, truncate the WAL file again to purge the copied DB contents.
+            // Once vacuumed, truncate the WAL file again to purge the copied DB
+            // contents.
             self.wal_checkpoint().await;
         }
 

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -289,8 +289,9 @@ impl StoreCipher {
     /// # anyhow::Ok(()) };
     /// ```
     pub fn import(passphrase: &str, encrypted: &[u8]) -> Result<Self, Error> {
-        // Our old export format used serde_json for the serialization format. Let's
-        // first try the new format and if that fails, try the old one.
+        // Our old export format used serde_json for the serialization format.
+        // Let's first try the new format and if that fails, try the old
+        // one.
         let encrypted: EncryptedStoreCipher =
             if let Ok(deserialized) = rmp_serde::from_slice(encrypted) {
                 deserialized
@@ -344,15 +345,16 @@ impl StoreCipher {
 
         let mut key = match &encrypted.kdf_info {
             KdfInfo::None => {
-                // We used to be able to call this method only with a 32-byte array. If we call
-                // this method with a smaller key and the `None` KDF info, then there's a
+                // We used to be able to call this method only with a 32-byte
+                // array. If we call this method with a smaller
+                // key and the `None` KDF info, then there's a
                 // mismatch between how the export was used.
                 if key.len() != 32 {
                     return Err(Error::KdfMismatch);
                 }
 
-                // To avoid borrower issues between the two branches we copy the key here to
-                // take ownership over it.
+                // To avoid borrower issues between the two branches we copy the
+                // key here to take ownership over it.
                 let mut key_copy = Box::new([0u8; 32]);
                 key_copy.copy_from_slice(key);
 
@@ -946,8 +948,8 @@ mod tests {
 
         assert_eq!(value, decrypted_value);
 
-        // Can't use assert matches here since we don't have a Debug implementation for
-        // StoreCipher.
+        // Can't use assert matches here since we don't have a Debug
+        // implementation for StoreCipher.
         match StoreCipher::import_with_key(&[0u8; 32], &encrypted) {
             Err(Error::KdfMismatch) => {}
             _ => panic!(

--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -75,9 +75,10 @@ impl EncryptionSyncService {
         client: Client,
         poll_and_network_timeouts: Option<(Duration, Duration)>,
     ) -> Result<Self, Error> {
-        // Make sure to use the same `conn_id` and caching store identifier, whichever
-        // process is running this sliding sync. There must be at most one
-        // sliding sync instance that enables the e2ee and to-device extensions.
+        // Make sure to use the same `conn_id` and caching store identifier,
+        // whichever process is running this sliding sync. There must be
+        // at most one sliding sync instance that enables the e2ee and
+        // to-device extensions.
         let mut builder = client
             .sliding_sync("encryption")
             .map_err(Error::SlidingSync)?
@@ -96,7 +97,8 @@ impl EncryptionSyncService {
         if let CrossProcessLockConfig::MultiProcess { holder_name } =
             client.cross_process_lock_config()
         {
-            // Gently try to enable the cross-process lock on behalf of the user.
+            // Gently try to enable the cross-process lock on behalf of the
+            // user.
             match client.encryption().enable_cross_process_store_lock(holder_name.clone()).await {
                 Ok(()) | Err(matrix_sdk::Error::BadCryptoStoreState) => {
                     // Ignore; we've already set the crypto store lock to
@@ -138,14 +140,15 @@ impl EncryptionSyncService {
             let mut lock_guard =
                 self.client.encryption().try_lock_store_once().await.map_err(Error::LockError)?;
 
-            // Try to take the lock at the beginning; if it's busy, that means that another
-            // process already holds onto it, and as such we won't try to run the
-            // encryption sync loop at all (because we expect the other process to
-            // do so).
+            // Try to take the lock at the beginning; if it's busy, that means
+            // that another process already holds onto it, and as
+            // such we won't try to run the encryption sync loop at
+            // all (because we expect the other process to do so).
 
             if lock_guard.is_none() {
-                // If we can't acquire the cross-process lock on the first attempt,
-                // that means the main process is running, or its lease hasn't expired
+                // If we can't acquire the cross-process lock on the first
+                // attempt, that means the main process is
+                // running, or its lease hasn't expired
                 // yet. In case it's the latter, wait a bit and retry.
                 tracing::debug!(
                     "Lock was already taken, and we're not the main loop; retrying in {}ms...",
@@ -177,8 +180,9 @@ impl EncryptionSyncService {
         for _ in 0..num_iterations {
             match sync.next().await {
                 Some(Ok(update_summary)) => {
-                    // This API is only concerned with the e2ee and to-device extensions.
-                    // Warn if anything weird has been received from the homeserver.
+                    // This API is only concerned with the e2ee and to-device
+                    // extensions. Warn if anything weird
+                    // has been received from the homeserver.
                     if !update_summary.lists.is_empty() {
                         debug!(?update_summary.lists, "unexpected non-empty list of lists in encryption sync API");
                     }
@@ -225,8 +229,9 @@ impl EncryptionSyncService {
             loop {
                 match self.next_sync_with_lock(&mut sync).await? {
                     Some(Ok(update_summary)) => {
-                        // This API is only concerned with the e2ee and to-device extensions.
-                        // Warn if anything weird has been received from the homeserver.
+                        // This API is only concerned with the e2ee and
+                        // to-device extensions. Warn if
+                        // anything weird has been received from the homeserver.
                         if !update_summary.lists.is_empty() {
                             debug!(?update_summary.lists, "unexpected non-empty list of lists in encryption sync API");
                         }
@@ -277,8 +282,9 @@ impl EncryptionSyncService {
     ///
     /// This will unlock the cross-process lock, if taken.
     pub(crate) fn stop_sync(&self) -> Result<(), Error> {
-        // Stopping the sync loop will cause the next `next()` call to return `None`, so
-        // this will also release the cross-process lock automatically.
+        // Stopping the sync loop will cause the next `next()` call to return
+        // `None`, so this will also release the cross-process lock
+        // automatically.
         self.sliding_sync.stop_sync().map_err(Error::SlidingSync)?;
 
         Ok(())

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -119,7 +119,8 @@ impl NotificationClient {
         parent_client: Client,
         process_setup: NotificationProcessSetup,
     ) -> Result<Self, Error> {
-        // Only create the lock id if cross process lock is needed (multiple processes)
+        // Only create the lock id if cross process lock is needed (multiple
+        // processes)
         let cross_process_store_config = match process_setup {
             NotificationProcessSetup::MultipleProcesses => {
                 CrossProcessLockConfig::multi_process(Self::LOCK_ID)
@@ -236,18 +237,21 @@ impl NotificationClient {
         // The message is still encrypted, and the client is configured to retry
         // decryption.
         //
-        // Spawn an `EncryptionSync` that runs two iterations of the sliding sync loop:
-        // - the first iteration allows to get SS events as well as send e2ee requests.
-        // - the second one let the SS homeserver forward events triggered by the
-        //   sending of e2ee requests.
+        // Spawn an `EncryptionSync` that runs two iterations of the sliding
+        // sync loop:
+        // - the first iteration allows to get SS events as well as send e2ee
+        //   requests.
+        // - the second one let the SS homeserver forward events triggered by
+        //   the sending of e2ee requests.
         //
         // Keep timeouts small for both, since we might be short on time.
 
         let push_ctx = room.push_context().await?;
         let sync_permit_guard = match &self.process_setup {
             NotificationProcessSetup::MultipleProcesses => {
-                // We're running on our own process, dedicated for notifications. In that case,
-                // create a dummy sync permit; we're guaranteed there's at most one since we've
+                // We're running on our own process, dedicated for
+                // notifications. In that case, create a dummy
+                // sync permit; we're guaranteed there's at most one since we've
                 // acquired the `encryption_sync_mutex' lock here.
                 let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
                 sync_permit.lock_owned().await
@@ -257,14 +261,16 @@ impl NotificationClient {
                 if let Some(permit_guard) = sync_service.try_get_encryption_sync_permit() {
                     permit_guard
                 } else {
-                    // There's already a sync service active, thus the encryption sync is already
-                    // running elsewhere. As a matter of fact, if the event was encrypted, that
-                    // means we were racing against the encryption sync. Wait a bit, attempt to
+                    // There's already a sync service active, thus the
+                    // encryption sync is already
+                    // running elsewhere. As a matter of fact, if the event was
+                    // encrypted, that means we were racing
+                    // against the encryption sync. Wait a bit, attempt to
                     // decrypt, and carry on.
 
                     // We repeat the sleep 3 times at most, each iteration we
-                    // double the amount of time waited, so overall we may wait up to 7 times this
-                    // amount.
+                    // double the amount of time waited, so overall we may wait
+                    // up to 7 times this amount.
                     let mut wait = 200;
 
                     debug!("Encryption sync running in background");
@@ -274,7 +280,8 @@ impl NotificationClient {
                         sleep(Duration::from_millis(wait)).await;
 
                         // Note: We specify the cast type in case the
-                        // `experimental-encrypted-state-events` feature is enabled, which provides
+                        // `experimental-encrypted-state-events` feature is
+                        // enabled, which provides
                         // multiple cast implementations.
                         let new_event = room
                             .decrypt_event(
@@ -302,7 +309,8 @@ impl NotificationClient {
                         }
                     }
 
-                    // We couldn't decrypt the event after waiting a few times, abort.
+                    // We couldn't decrypt the event after waiting a few times,
+                    // abort.
                     debug!("Timeout waiting for the encryption sync to decrypt notification.");
                     return Ok(None);
                 }
@@ -315,9 +323,9 @@ impl NotificationClient {
         )
         .await;
 
-        // Just log out errors, but don't have them abort the notification processing:
-        // an undecrypted notification is still better than no
-        // notifications.
+        // Just log out errors, but don't have them abort the notification
+        // processing: an undecrypted notification is still better than
+        // no notifications.
 
         match encryption_sync {
             Ok(sync) => match sync.run_fixed_iterations(2, sync_permit_guard).await {
@@ -381,8 +389,8 @@ impl NotificationClient {
         requests: &[NotificationItemsRequest],
     ) -> Result<BTreeMap<OwnedEventId, (OwnedRoomId, Option<RawNotificationEvent>)>, Error> {
         const MAX_SLIDING_SYNC_ATTEMPTS: u64 = 3;
-        // Serialize all the calls to this method by taking a lock at the beginning,
-        // that will be dropped later.
+        // Serialize all the calls to this method by taking a lock at the
+        // beginning, that will be dropped later.
         let _guard = self.notification_sync_mutex.lock().await;
 
         // Set up a sliding sync that only subscribes to the room that had the
@@ -413,9 +421,9 @@ impl NotificationClient {
 
                         let room_id = request.room_id.clone();
 
-                        // found it! There shouldn't be a previous event before, but if
-                        // there is, that should be ok to
-                        // just replace it.
+                        // found it! There shouldn't be a previous event before,
+                        // but if there is, that should
+                        // be ok to just replace it.
                         handler_raw_notification.lock().unwrap().insert(
                             event_id.to_owned(),
                             (room_id, Some(RawNotificationEvent::Timeline(raw))),
@@ -450,8 +458,9 @@ impl NotificationClient {
 
                 trace!("received a stripped room member event");
 
-                // Try to match the event by event_id, as it's the most precise. In theory, we
-                // shouldn't receive it, so that's a first attempt.
+                // Try to match the event by event_id, as it's the most precise.
+                // In theory, we shouldn't receive it, so that's
+                // a first attempt.
                 match &raw.get_field::<OwnedEventId>("event_id") {
                     Ok(Some(event_id)) => {
                         let request =
@@ -461,9 +470,9 @@ impl NotificationClient {
                         }
                         let room_id = request.unwrap().room_id.clone();
 
-                        // found it! There shouldn't be a previous event before, but if
-                        // there is, that should be ok to
-                        // just replace it.
+                        // found it! There shouldn't be a previous event before,
+                        // but if there is, that should
+                        // be ok to just replace it.
                         handler_raw_notifications.lock().unwrap().insert(
                             event_id.to_owned(),
                             (room_id, Some(RawNotificationEvent::Invite(raw))),
@@ -478,14 +487,16 @@ impl NotificationClient {
                     }
                 }
 
-                // Try to match the event by membership and state_key for the current user.
+                // Try to match the event by membership and state_key for the
+                // current user.
                 if deserialized.content.membership == MembershipState::Invite
                     && deserialized.state_key == user_id
                 {
                     trace!("found an invite event for the current user");
-                    // This could be it! There might be several of these following each other, so
-                    // assume it's the latest one (in sync ordering), and override a previous one if
-                    // present.
+                    // This could be it! There might be several of these
+                    // following each other, so assume it's
+                    // the latest one (in sync ordering), and override a
+                    // previous one if present.
                     handler_raw_invites
                         .lock()
                         .unwrap()
@@ -565,10 +576,11 @@ impl NotificationClient {
                 expected {expected_event_count} total",
             );
 
-            // We can stop looking once we've received the expected number of events from
-            // the sync. Since we can receive only events or invites for rooms but not both,
-            // and we're not taking into account invites from not subscribed rooms, this
-            // check should be accurate.
+            // We can stop looking once we've received the expected number of
+            // events from the sync. Since we can receive only
+            // events or invites for rooms but not both,
+            // and we're not taking into account invites from not subscribed
+            // rooms, this check should be accurate.
             if event_count + invite_count == expected_event_count {
                 // We got the events.
                 break;
@@ -681,7 +693,8 @@ impl NotificationClient {
         let mut batch_result = BatchNotificationFetchingResult::new();
 
         for (event_id, (room_id, raw_event)) in raw_events.into_iter() {
-            // At this point it should have been added by the sync, if it's not, give up.
+            // At this point it should have been added by the sync, if it's not,
+            // give up.
             let Some(room) = self.client.get_room(&room_id) else { return Err(Error::UnknownRoom) };
 
             let Some(raw_event) = raw_event else {
@@ -707,7 +720,8 @@ impl NotificationClient {
                         continue;
                     }
 
-                    // Timeline events may be encrypted, so make sure they get decrypted first.
+                    // Timeline events may be encrypted, so make sure they get
+                    // decrypted first.
                     match self.retry_decryption(&room, timeline_event).await {
                         Ok(Some(timeline_event)) => {
                             let push_actions = timeline_event.push_actions().map(ToOwned::to_owned);
@@ -718,8 +732,10 @@ impl NotificationClient {
                         }
 
                         Ok(None) => {
-                            // The event was either not encrypted in the first place, or we
-                            // couldn't decrypt it after retrying. Use the raw event as is.
+                            // The event was either not encrypted in the first
+                            // place, or we couldn't
+                            // decrypt it after retrying. Use the raw event as
+                            // is.
                             match room.event_push_actions(timeline_event).await {
                                 Ok(push_actions) => (raw_event.clone(), push_actions),
                                 Err(err) => {
@@ -738,7 +754,8 @@ impl NotificationClient {
                 }
 
                 RawNotificationEvent::Invite(invite_event) => {
-                    // Invite events can't be encrypted, so they should be in clear text.
+                    // Invite events can't be encrypted, so they should be in
+                    // clear text.
                     match room.event_push_actions(invite_event).await {
                         Ok(push_actions) => {
                             (RawNotificationEvent::Invite(invite_event.clone()), push_actions)
@@ -824,8 +841,8 @@ fn is_event_encrypted(event_type: TimelineEventType) -> bool {
 }
 
 fn is_event_redacted(event: &AnySyncTimelineEvent) -> bool {
-    // Check if the event is a message-like event but has no original content (i.e.,
-    // redacted)
+    // Check if the event is a message-like event but has no original content
+    // (i.e., redacted)
     match event {
         AnySyncTimelineEvent::MessageLike(msg) => msg.is_redacted(),
         _ => false,
@@ -1182,8 +1199,8 @@ mod tests {
                 .await
                 .expect("Could not create a notification client");
 
-        // Check we don't receive the invite for a different room, even if it was
-        // included in the sync response
+        // Check we don't receive the invite for a different room, even if it
+        // was included in the sync response
         let event_id = owned_event_id!("$a:b.c");
         let result = notification_client
             .try_sliding_sync(&[NotificationItemsRequest {

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/category.rs
@@ -166,18 +166,18 @@ mod tests {
             .build()
             .await;
 
-        // The room has 2 members, but it has no direct targets, so it should not be
-        // considered a `People` room.
+        // The room has 2 members, but it has no direct targets, so it should
+        // not be considered a `People` room.
         let room = setup_room(&client, &server, 0, 2).await;
         assert!(matches(&room, RoomCategory::People).not());
 
-        // The room has 2 members, but it has several direct targets, so it should not
-        // be considered a `People` room.
+        // The room has 2 members, but it has several direct targets, so it
+        // should not be considered a `People` room.
         let room = setup_room(&client, &server, 42, 2).await;
         assert!(matches(&room, RoomCategory::People).not());
 
-        // The room has 2 members and a single target, so it should be considered a
-        // `People` room.
+        // The room has 2 members and a single target, so it should be
+        // considered a `People` room.
         let room = setup_room(&client, &server, 1, 2).await;
         assert!(matches(&room, RoomCategory::People));
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -205,10 +205,11 @@ impl RoomListService {
         }
 
         if share_pos {
-            // The e2ee extensions aren't enabled in this sliding sync instance, and this is
-            // the only one that could be used from a different process. So it's
-            // fine to enable position sharing (i.e. reloading it from disk),
-            // since it's always exclusively owned by the current process.
+            // The e2ee extensions aren't enabled in this sliding sync instance,
+            // and this is the only one that could be used from a
+            // different process. So it's fine to enable position
+            // sharing (i.e. reloading it from disk), since it's
+            // always exclusively owned by the current process.
             debug!("Enabling `share_pos` for the room list sliding sync");
             builder = builder.share_pos();
         }
@@ -237,8 +238,10 @@ impl RoomListService {
                         is_invite: None,
                     })))
                     .requires_timeout(move |request_generator| {
-                        // We want Sliding Sync to apply the poll + network timeout —i.e. to do the
-                        // long-polling— in some particular cases. Let's define them.
+                        // We want Sliding Sync to apply the poll + network
+                        // timeout —i.e. to do the
+                        // long-polling— in some particular cases. Let's define
+                        // them.
                         match observable_state.get() {
                             // These are the states where we want an immediate response from the
                             // server, with no long-polling.
@@ -381,10 +384,10 @@ impl RoomListService {
 
         // Usually, when the session expires, it leads the state to be `Error`,
         // thus some actions (like refreshing the lists) are executed. However,
-        // if the sync loop has been stopped manually, the state is `Terminated`, and
-        // when the session is forced to expire, the state remains `Terminated`, thus
-        // the actions aren't executed as expected. Consequently, let's update the
-        // state.
+        // if the sync loop has been stopped manually, the state is
+        // `Terminated`, and when the session is forced to expire, the
+        // state remains `Terminated`, thus the actions aren't executed
+        // as expected. Consequently, let's update the state.
         if let State::Terminated { from } = self.state_machine.get() {
             self.state_machine.set(State::Error { from });
         }
@@ -483,7 +486,8 @@ impl RoomListService {
     /// [listen_to_room]: matrix_sdk::latest_events::LatestEvents::listen_to_room
     /// [`LatestEventValue`]: matrix_sdk::latest_events::LatestEventValue
     pub async fn set_room_subscriptions(&self, room_ids: &[&RoomId]) {
-        // Read the state before the await: the state machine can drift meanwhile.
+        // Read the state before the await: the state machine can drift
+        // meanwhile.
         let cancel_in_flight_request = self.must_cancel_in_flight_request();
 
         self.listen_to_latest_events(room_ids).await;
@@ -507,7 +511,8 @@ impl RoomListService {
     /// Contrary to [`Self::set_room_subscriptions`], the members of every room
     /// of `room_ids` are marked as missing, so that they are re-fetched.
     pub async fn reset_and_add_room_subscriptions(&self, room_ids: &[&RoomId]) {
-        // Read the state before the await: the state machine can drift meanwhile.
+        // Read the state before the await: the state machine can drift
+        // meanwhile.
         let cancel_in_flight_request = self.must_cancel_in_flight_request();
 
         self.listen_to_latest_events(room_ids).await;

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -80,8 +80,9 @@ impl RoomList {
                 .spawn_infinite_task("room_list::loading_state_task", async move {
                     pin_mut!(room_list_service_state);
 
-                    // As soon as `RoomListService` changes its state, if it isn't
-                    // `Terminated` nor `Error`, we know we have fetched something,
+                    // As soon as `RoomListService` changes its state, if it
+                    // isn't `Terminated` nor `Error`, we
+                    // know we have fetched something,
                     // so the room list is loaded.
                     while let Some(state) = room_list_service_state.next().await {
                         use State::*;
@@ -97,7 +98,8 @@ impl RoomList {
 
                     loading_state.set(RoomListLoadingState::Loaded { maximum_number_of_rooms });
 
-                    // Wait for updates on the maximum number of rooms to update again.
+                    // Wait for updates on the maximum number of rooms to update
+                    // again.
                     let mut maximum_number_of_rooms_stream =
                         sliding_sync_list.maximum_number_of_rooms_stream();
 
@@ -362,9 +364,10 @@ impl RoomListDynamicEntriesController {
         let limit = self.limit.get();
 
         if limit < max {
-            // With this logic, it is possible that `limit` becomes greater than `max` if
-            // `max - limit < page_size`, and that's perfectly fine. It's OK to have a
-            // `limit` greater than `max`, but it's not OK to increase the limit
+            // With this logic, it is possible that `limit` becomes greater than
+            // `max` if `max - limit < page_size`, and that's
+            // perfectly fine. It's OK to have a `limit` greater
+            // than `max`, but it's not OK to increase the limit
             // indefinitely.
             self.limit.set_if_not_eq(limit + self.page_size);
         }

--- a/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/sorters/recency.rs
@@ -62,9 +62,9 @@ type Score = u64;
 fn extract_scores(left: &RoomListItem, right: &RoomListItem) -> (Option<Score>, Option<Score>) {
     // Warning 1.
     //
-    // Be careful. This method is called **a lot** in the context of a sorter. Using
-    // `Room::latest_event` would be dramatic as it returns a clone of the
-    // `LatestEventValue`. It's better to use the more specific method
+    // Be careful. This method is called **a lot** in the context of a sorter.
+    // Using `Room::latest_event` would be dramatic as it returns a clone of
+    // the `LatestEventValue`. It's better to use the more specific method
     // `Room::latest_event_timestamp`, where the value is cached in
     // `RoomListItem::cached_latest_event_timestamp`.
 
@@ -74,12 +74,12 @@ fn extract_scores(left: &RoomListItem, right: &RoomListItem) -> (Option<Score>, 
     // must always be the same while sorting the rooms. Thus, the following
     // rules must apply:
     //
-    // - Nominal case: Two rooms with a latest event can be compared together based
-    //   on their latest event's timestamp,
-    // - Case #1: If a room has a latest event, but the other doesn't have one, the
-    //   first room has a score but the other doesn't have one,
-    // - Case #2: If none of the room has a latest event, we fallback to the recency
-    //   stamp for both rooms.
+    // - Nominal case: Two rooms with a latest event can be compared together
+    //   based on their latest event's timestamp,
+    // - Case #1: If a room has a latest event, but the other doesn't have one,
+    //   the first room has a score but the other doesn't have one,
+    // - Case #2: If none of the room has a latest event, we fallback to the
+    //   recency stamp for both rooms.
     //
     // The most important aspect is: if room returns its latest event's
     // timestamp or its recency stamp, _once_, it must return it every time
@@ -202,7 +202,8 @@ mod tests {
 
         // `room_a` has `None`, `room_b` has something else.
         //
-        // One of the room has a latest event, so the recency stamp MUST BE IGNORED.
+        // One of the room has a latest event, so the recency stamp MUST BE
+        // IGNORED.
         {
             set_latest_event_value(&mut room_a, none()).await;
             set_latest_event_value(&mut room_b, remote(3)).await;
@@ -212,7 +213,8 @@ mod tests {
 
         // `room_b` has `None`, `room_a` has something else.
         //
-        // One of the room has a latest event, so the recency stamp MUST BE IGNORED.
+        // One of the room has a latest event, so the recency stamp MUST BE
+        // IGNORED.
         {
             set_latest_event_value(&mut room_a, remote(3)).await;
             set_latest_event_value(&mut room_b, none()).await;
@@ -317,9 +319,9 @@ mod tests {
         }
     }
 
-    // Property tests to ensure that our comparison implementation for the `Score`
-    // is total[1]. If it wasn't so, a call to `sort_by()` with the given
-    // `cmp()` method could panic.
+    // Property tests to ensure that our comparison implementation for the
+    // `Score` is total[1]. If it wasn't so, a call to `sort_by()` with the
+    // given `cmp()` method could panic.
     //
     // [1]: https://en.wikipedia.org/wiki/Total_order
     proptest! {

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -128,8 +128,9 @@ impl StateMachine {
             }
 
             Running => {
-                // We haven't changed the state for a while, we go back to `Recovering` to avoid
-                // requesting potentially large data. See `Self::last_state_update` to learn
+                // We haven't changed the state for a while, we go back to
+                // `Recovering` to avoid requesting potentially
+                // large data. See `Self::last_state_update` to learn
                 // the details.
                 if self.last_state_update_time.lock().unwrap().elapsed() > self.state_lifespan {
                     set_all_rooms_to_selective_sync_mode(sliding_sync).await?;

--- a/crates/matrix-sdk-ui/src/search_service.rs
+++ b/crates/matrix-sdk-ui/src/search_service.rs
@@ -278,7 +278,8 @@ mod tests {
         pin_mut!(results_stream);
         assert_pending!(results_stream);
 
-        // The next page is empty, so the end is reached and nothing more is emitted.
+        // The next page is empty, so the end is reached and nothing more is
+        // emitted.
         search.paginate().await.unwrap();
 
         assert_pending!(results_stream);
@@ -328,10 +329,12 @@ mod tests {
         pin_mut!(results_stream);
         assert_pending!(results_stream);
 
-        // Changing the query clears the previous results and loads the new ones.
+        // Changing the query clears the previous results and loads the new
+        // ones.
         search.set_query("banana".to_owned()).await.unwrap();
 
-        // The subscriber observes the clear followed by the new page in one batch.
+        // The subscriber observes the clear followed by the new page in one
+        // batch.
         assert_next_matches!(results_stream, diffs => {
             assert_let!([VectorDiff::Clear, VectorDiff::Append { values }] = diffs.as_slice());
             assert_eq!(values.len(), 1);

--- a/crates/matrix-sdk-ui/src/spaces/mod.rs
+++ b/crates/matrix-sdk-ui/src/spaces/mod.rs
@@ -194,7 +194,8 @@ impl SpaceService {
             })
             .abort_on_drop();
 
-        // Make sure to also update the currently joined spaces for the initial values.
+        // Make sure to also update the currently joined spaces for the initial
+        // values.
         let (spaces, filters, graph) = Self::build_space_state(&client).await;
         Self::update_space_state_if_needed(
             Vector::from(spaces),
@@ -419,9 +420,9 @@ impl SpaceService {
             // Redacting state is a "weird" thing to do, so send {} instead.
             // https://github.com/matrix-org/matrix-spec/issues/2252
             //
-            // Specifically, "The redaction of the state doesn't participate in state
-            // resolution so behaves quite differently from e.g. sending an empty form of
-            // that state events".
+            // Specifically, "The redaction of the state doesn't participate in
+            // state resolution so behaves quite differently from
+            // e.g. sending an empty form of that state events".
             space_room
                 .send_state_event_raw("m.space.child", child_id.as_str(), serde_json::json!({}))
                 .await
@@ -512,8 +513,8 @@ impl SpaceService {
         // And also store `m.space.child` ordering info for later use
         let mut space_child_states = HashMap::<OwnedRoomId, SpaceRoomChildState>::new();
 
-        // Iterate over all joined spaces and populate the graph with edges based
-        // on `m.space.parent` and `m.space.child` state events.
+        // Iterate over all joined spaces and populate the graph with edges
+        // based on `m.space.parent` and `m.space.child` state events.
         for space in joined_spaces.iter() {
             graph.add_node(space.room_id().to_owned());
 
@@ -853,8 +854,8 @@ mod tests {
             )
             .await;
 
-        // Build the `SpaceService` and expect the room to show up with no updates
-        // pending
+        // Build the `SpaceService` and expect the room to show up with no
+        // updates pending
 
         let space_service = SpaceService::new(client.clone()).await;
 
@@ -1156,7 +1157,8 @@ mod tests {
 
     #[async_test]
     async fn test_editable_spaces() {
-        // Given a space hierarchy where the user is admin of some spaces and subspaces.
+        // Given a space hierarchy where the user is admin of some spaces and
+        // subspaces.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
@@ -1366,7 +1368,8 @@ mod tests {
 
     #[async_test]
     async fn test_add_child_to_space_without_space_admin() {
-        // Given a space and child room where the user is a regular member of both.
+        // Given a space and child room where the user is a regular member of
+        // both.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
@@ -1410,15 +1413,15 @@ mod tests {
         let result =
             space_service.add_child_to_space(child_id.to_owned(), space_id.to_owned()).await;
 
-        // Then the operation fails when trying to set the space child event and the
-        // parent event is not attempted.
+        // Then the operation fails when trying to set the space child event and
+        // the parent event is not attempted.
         assert!(result.is_err());
     }
 
     #[async_test]
     async fn test_add_child_to_space_without_child_admin() {
-        // Given a space and child room where the user is admin of the space but not of
-        // the child.
+        // Given a space and child room where the user is admin of the space but
+        // not of the child.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
@@ -1464,8 +1467,8 @@ mod tests {
             space_service.add_child_to_space(child_id.to_owned(), space_id.to_owned()).await;
 
         error!("result: {:?}", result);
-        // Then the operation succeeds in setting the space child event and the parent
-        // event is not attempted.
+        // Then the operation succeeds in setting the space child event and the
+        // parent event is not attempted.
         assert!(result.is_ok());
     }
 
@@ -1568,14 +1571,15 @@ mod tests {
         let result =
             space_service.remove_child_from_space(child_id.to_owned(), parent_id.to_owned()).await;
 
-        // Then the child event is removed successfully and the parent event removal is
-        // not attempted.
+        // Then the child event is removed successfully and the parent event
+        // removal is not attempted.
         assert!(result.is_ok());
     }
 
     #[async_test]
     async fn test_remove_child_from_space_without_child_event() {
-        // Given a space with a child where the space's m.space.child event wasn't set.
+        // Given a space with a child where the space's m.space.child event
+        // wasn't set.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
@@ -1620,14 +1624,15 @@ mod tests {
         let result =
             space_service.remove_child_from_space(child_id.to_owned(), parent_id.to_owned()).await;
 
-        // Then the parent event is removed successfully and the child event removal is
-        // not attempted.
+        // Then the parent event is removed successfully and the child event
+        // removal is not attempted.
         assert!(result.is_ok());
     }
 
     #[async_test]
     async fn test_remove_unknown_child_from_space() {
-        // Given a space with a child room that is unknown (not in the client store).
+        // Given a space with a child room that is unknown (not in the client
+        // store).
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let user_id = client.user_id().unwrap();
@@ -1637,7 +1642,8 @@ mod tests {
 
         let space_child_event_id = event_id!("$1");
         server.mock_set_space_child().ok(space_child_event_id.to_owned()).expect(1).mount().await;
-        // The parent event should not be attempted since the child room is unknown.
+        // The parent event should not be attempted since the child room is
+        // unknown.
         server.mock_set_space_parent().unauthorized().expect(0).mount().await;
 
         let parent_id = room_id!("!parent_space:example.org");
@@ -1669,8 +1675,9 @@ mod tests {
             .remove_child_from_space(unknown_child_id.to_owned(), parent_id.to_owned())
             .await;
 
-        // Then the operation succeeds: the child event is removed from the space,
-        // and the parent event removal is skipped since the child room is unknown.
+        // Then the operation succeeds: the child event is removed from the
+        // space, and the parent event removal is skipped since the
+        // child room is unknown.
         assert!(result.is_ok());
     }
 
@@ -1697,8 +1704,8 @@ mod tests {
             )
             .await;
 
-        // Build the `SpaceService` and expect the room to show up with no updates
-        // pending
+        // Build the `SpaceService` and expect the room to show up with no
+        // updates pending
         let space_service = SpaceService::new(client.clone()).await;
 
         let (initial_values, joined_spaces_subscriber) =

--- a/crates/matrix-sdk-ui/src/spaces/room.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room.rs
@@ -248,8 +248,8 @@ mod tests {
             Ordering::Greater
         );
 
-        // Rooms without an order provided through the `children_state` should be
-        // sorted by their `m.space.child` `origin_server_ts`
+        // Rooms without an order provided through the `children_state` should
+        // be sorted by their `m.space.child` `origin_server_ts`
         assert_eq!(
             SpaceRoom::compare_rooms(
                 (

--- a/crates/matrix-sdk-ui/src/spaces/room_list.rs
+++ b/crates/matrix-sdk-ui/src/spaces/room_list.rs
@@ -294,8 +294,9 @@ impl SpaceRoomList {
                     None => PaginationToken::HitEnd,
                 };
 
-                // The space is part of the /hierarchy response. Partition the room array
-                // so we can use its details but also filter it out of the room list
+                // The space is part of the /hierarchy response. Partition the
+                // room array so we can use its details but also
+                // filter it out of the room list
                 let (space, children): (Vec<_>, Vec<_>) =
                     result.rooms.into_iter().partition(|f| f.summary.room_id == self.space_id);
 
@@ -463,7 +464,8 @@ mod tests {
 
         let room_list = space_service.space_room_list(parent_space_id.to_owned()).await;
 
-        // The space parent is known to the client and should be populated accordingly
+        // The space parent is known to the client and should be populated
+        // accordingly
         assert_let!(Some(parent_space) = room_list.space());
         assert_eq!(parent_space.children_count, 2);
 
@@ -661,7 +663,8 @@ mod tests {
 
         let room_list = space_service.space_room_list(parent_space_id.to_owned()).await;
 
-        // The parent space is known to the client and should be populated accordingly
+        // The parent space is known to the client and should be populated
+        // accordingly
         assert_let!(Some(parent_space) = room_list.space());
         assert_eq!(parent_space.children_count, 2);
     }
@@ -796,7 +799,8 @@ mod tests {
         let (_, rooms_subscriber) = room_list.subscribe_to_room_updates().await;
         pin_mut!(rooms_subscriber);
 
-        // Mock a /hierarchy response where one child is suggested and the other is not.
+        // Mock a /hierarchy response where one child is suggested and the other
+        // is not.
         let children_state = vec![
             json!({
                 "type": "m.space.child",
@@ -879,7 +883,8 @@ mod tests {
     async fn test_room_list_sorting() {
         let mut children_state = HashMap::<OwnedRoomId, HierarchySpaceChildEvent>::new();
 
-        // Rooms not present in the `children_state` should be sorted by their room ID
+        // Rooms not present in the `children_state` should be sorted by their
+        // room ID
         assert_eq!(
             SpaceRoomList::compare_rooms(
                 &make_space_room(owned_room_id!("!Luana:a.b"), None, None, &mut children_state),
@@ -898,8 +903,8 @@ mod tests {
             Ordering::Greater
         );
 
-        // Rooms without an order provided through the `children_state` should be
-        // sorted by their `m.space.child` `origin_server_ts`
+        // Rooms without an order provided through the `children_state` should
+        // be sorted by their `m.space.child` `origin_server_ts`
         assert_eq!(
             SpaceRoomList::compare_rooms(
                 &make_space_room(owned_room_id!("!Luana:a.b"), None, Some(1), &mut children_state),

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -163,12 +163,13 @@ impl SyncTaskSupervisor {
 
         let wait_for_termination_report = async {
             loop {
-                // Since we didn't empty the channel when entering the offline mode in fear that
-                // we might miss a report with the
-                // `TerminationOrigin::Supervisor` origin and the channel might contain stale
-                // reports from one of the sync services, in case both of them have sent a
-                // report, let's ignore all reports we receive from the sync
-                // services.
+                // Since we didn't empty the channel when entering the offline
+                // mode in fear that we might miss a report with
+                // the `TerminationOrigin::Supervisor` origin
+                // and the channel might contain stale
+                // reports from one of the sync services, in case both of them
+                // have sent a report, let's ignore all reports
+                // we receive from the sync services.
                 let report =
                     receiver.recv().await.unwrap_or_else(TerminationReport::supervisor_error);
 
@@ -185,20 +186,24 @@ impl SyncTaskSupervisor {
 
         let wait_to_be_online = async move {
             loop {
-                // Encountering network failures when sending a request which has with no retry
-                // limit set in the `RequestConfig` are treated as permanent failures and our
+                // Encountering network failures when sending a request which
+                // has with no retry limit set in the
+                // `RequestConfig` are treated as permanent failures and our
                 // exponential backoff doesn't kick in.
                 //
-                // Let's set a retry limit so network failures are retried as well.
+                // Let's set a retry limit so network failures are retried as
+                // well.
                 let request_config = RequestConfig::default().retry_limit(5);
 
-                // We're in an infinite loop, but our request sending already has an exponential
-                // backoff set up. This will kick in for any request errors that we consider to
-                // be transient. Common network errors (timeouts, DNS failures) or any server
-                // error in the 5xx range of HTTP errors are considered to be transient.
+                // We're in an infinite loop, but our request sending already
+                // has an exponential backoff set up. This will
+                // kick in for any request errors that we consider to
+                // be transient. Common network errors (timeouts, DNS failures)
+                // or any server error in the 5xx range of HTTP
+                // errors are considered to be transient.
                 //
-                // Still, as a precaution, we're going to sleep here for a while in the Error
-                // case.
+                // Still, as a precaution, we're going to sleep here for a while
+                // in the Error case.
                 match client.fetch_server_versions(Some(request_config)).await {
                     Ok(_) => break,
                     Err(_) => sleep(Duration::from_millis(100)).await,
@@ -236,13 +241,14 @@ impl SyncTaskSupervisor {
         let state = inner.state.clone();
         let termination_sender = sender.clone();
 
-        // When we first start, and don't use offline mode, we want to acquire the sync
-        // permit before we enter a future that might be polled at a later time,
-        // this means that the permit will be acquired as soon as this future,
-        // the one the `spawn_supervisor_task` function creates, is awaited.
+        // When we first start, and don't use offline mode, we want to acquire
+        // the sync permit before we enter a future that might be polled
+        // at a later time, this means that the permit will be acquired
+        // as soon as this future, the one the `spawn_supervisor_task`
+        // function creates, is awaited.
         //
-        // In other words, once `sync_service.start().await` is finished, the permit
-        // will be in the acquired state.
+        // In other words, once `sync_service.start().await` is finished, the
+        // permit will be in the acquired state.
         let mut sync_permit_guard =
             MaybeAcquiredPermit::Acquired(encryption_sync_permit.clone().lock_owned().await);
 
@@ -266,20 +272,22 @@ impl SyncTaskSupervisor {
                     report
                 } else {
                     info!("internal channel has been closed?");
-                    // We should still stop the child tasks in the unlikely scenario that our
-                    // receiver died.
+                    // We should still stop the child tasks in the unlikely
+                    // scenario that our receiver died.
                     TerminationReport::supervisor_error()
                 };
 
-                // If one service failed, make sure to request stopping the other one.
+                // If one service failed, make sure to request stopping the
+                // other one.
                 let (stop_room_list, stop_encryption) = match &report.origin {
                     TerminationOrigin::EncryptionSync => (true, false),
                     TerminationOrigin::RoomList => (false, true),
                     TerminationOrigin::Supervisor => (true, true),
                 };
 
-                // Stop both services, and wait for the streams to properly finish: at some
-                // point they'll return `None` and will exit their infinite loops, and their
+                // Stop both services, and wait for the streams to properly
+                // finish: at some point they'll return `None`
+                // and will exit their infinite loops, and their
                 // tasks will gracefully terminate.
 
                 if stop_room_list {
@@ -449,9 +457,11 @@ impl SyncTaskSupervisor {
         match self.termination_sender.send(TerminationReport::supervisor()).await {
             Ok(_) => {
                 let _ = self.task.await.inspect_err(|err| {
-                    // A `JoinError` indicates that the task was already dead, either because it got
-                    // cancelled or because it panicked. We only cancel the task in the Err branch
-                    // below and the task shouldn't be able to panic.
+                    // A `JoinError` indicates that the task was already dead,
+                    // either because it got cancelled or
+                    // because it panicked. We only cancel the task in the Err
+                    // branch below and the task shouldn't
+                    // be able to panic.
                     //
                     // So let's log an error and return.
                     error!("The supervisor task has stopped unexpectedly: {err:?}");
@@ -459,8 +469,9 @@ impl SyncTaskSupervisor {
             }
             Err(err) => {
                 error!("Couldn't send the termination report to the supervisor task: {err}");
-                // Let's abort the task if it won't shut down properly, otherwise we would have
-                // left it as a detached task.
+                // Let's abort the task if it won't shut down properly,
+                // otherwise we would have left it as a detached
+                // task.
                 self.task.abort();
             }
         }
@@ -512,7 +523,8 @@ impl SyncServiceInner {
     async fn stop(&mut self) {
         trace!("pausing sync service");
 
-        // Remove the supervisor from our state and request the tasks to be shutdown.
+        // Remove the supervisor from our state and request the tasks to be
+        // shutdown.
         if let Some(supervisor) = self.supervisor.take() {
             supervisor.shutdown().await;
         } else {
@@ -629,7 +641,8 @@ impl SyncService {
     pub async fn start(&self) {
         let mut inner = self.inner.lock().await;
 
-        // Only (re)start the tasks if it's stopped or if we're in the offline mode.
+        // Only (re)start the tasks if it's stopped or if we're in the offline
+        // mode.
         match inner.state.get() {
             // If we're already running, there's nothing to do.
             State::Running => {}
@@ -675,8 +688,8 @@ impl SyncService {
     /// the sessions on the server as well.
     #[instrument(skip_all)]
     pub async fn expire_sessions(&self) {
-        // First, stop the sync service if it was running; it's a no-op if it was
-        // already stopped.
+        // First, stop the sync service if it was running; it's a no-op if it
+        // was already stopped.
         self.stop().await;
 
         // Expire the room list sync session.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -163,7 +163,8 @@ impl TimelineBuilder {
     pub async fn build(self) -> Result<Timeline, Error> {
         let Self { room, settings, unable_to_decrypt_hook, focus, internal_id_prefix } = self;
 
-        // Subscribe the event cache to sync responses, in case we hadn't done it yet.
+        // Subscribe the event cache to sync responses, in case we hadn't done
+        // it yet.
         let client = room.client();
         let event_cache = client.event_cache();
         event_cache.subscribe()?;
@@ -302,9 +303,10 @@ impl TimelineBuilder {
         };
 
         if has_events {
-            // The events we're injecting might be encrypted events, but we might
-            // have received the room key to decrypt them while nobody was listening to the
-            // `m.room_key` event, let's retry now.
+            // The events we're injecting might be encrypted events, but we
+            // might have received the room key to decrypt them
+            // while nobody was listening to the `m.room_key` event,
+            // let's retry now.
             timeline.retry_decryption_for_all_events().await;
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/aggregations.rs
@@ -294,7 +294,8 @@ impl Aggregation {
 
                 let previous_reaction = reactions.get(key).and_then(|by_user| by_user.get(sender));
 
-                // If the reaction was already added to the item, we don't need to add it back.
+                // If the reaction was already added to the item, we don't need
+                // to add it back.
                 //
                 // Search for a previous reaction that would be equivalent.
 
@@ -433,7 +434,8 @@ impl Aggregation {
                     let by_user = reactions.get_mut(key);
                     if let Some(by_user) = by_user {
                         by_user.swap_remove(sender);
-                        // If this was the last reaction, remove the entire map for this key.
+                        // If this was the last reaction, remove the entire map
+                        // for this key.
                         if by_user.is_empty() {
                             reactions.swap_remove(key);
                         }
@@ -547,16 +549,16 @@ impl Aggregations {
     /// Add a given aggregation that relates to the [`TimelineItemContent`]
     /// identified by the given [`TimelineEventItemId`].
     pub fn add(&mut self, related_to: TimelineEventItemId, aggregation: Aggregation) {
-        // If the aggregation is a redaction, it invalidates all the other aggregations;
-        // remove them.
+        // If the aggregation is a redaction, it invalidates all the other
+        // aggregations; remove them.
         if matches!(aggregation.kind, AggregationKind::Redaction { .. }) {
             for agg in self.related_events.remove(&related_to).unwrap_or_default() {
                 self.inverted_map.remove(&agg.own_id);
             }
         }
 
-        // If there was any redaction among the current aggregation, adding a new one
-        // should be a noop.
+        // If there was any redaction among the current aggregation, adding a
+        // new one should be a noop.
         if let Some(previous_aggregations) = self.related_events.get(&related_to)
             && previous_aggregations
                 .iter()
@@ -567,18 +569,19 @@ impl Aggregations {
 
         self.inverted_map.insert(aggregation.own_id.clone(), related_to.clone());
 
-        // We can have 3 different states for the same aggregation in related_events, in
-        // chronological order:
+        // We can have 3 different states for the same aggregation in
+        // related_events, in chronological order:
         //
         // 1. The local echo with a transaction ID.
-        // 2. The local echo with the event ID returned by the server after sending the
-        //    event.
+        // 2. The local echo with the event ID returned by the server after
+        //    sending the event.
         // 3. The remote echo received via sync.
         //
-        // The transition from states 1 to 2 is handled in `mark_aggregation_as_sent()`.
-        // So here we need to handle the transition from states 2 to 3. We need to
-        // replace the local echo by the remote echo, which might have more data, like
-        // the raw JSON.
+        // The transition from states 1 to 2 is handled in
+        // `mark_aggregation_as_sent()`. So here we need to handle the
+        // transition from states 2 to 3. We need to replace the local
+        // echo by the remote echo, which might have more data, like the
+        // raw JSON.
         let related_events = self.related_events.entry(related_to).or_default();
         if let Some(pos) = related_events.iter().position(|agg| agg.own_id == aggregation.own_id) {
             related_events.remove(pos);
@@ -611,8 +614,8 @@ impl Aggregations {
                 .position(|agg| agg.own_id == *aggregation_id)
                 .map(|idx| aggregations.remove(idx));
 
-            // If this was the last aggregation, remove the entry in the `related_events`
-            // mapping.
+            // If this was the last aggregation, remove the entry in the
+            // `related_events` mapping.
             if aggregations.is_empty() {
                 self.related_events.remove(found);
             }
@@ -645,7 +648,8 @@ impl Aggregations {
                     warn!("error when unapplying aggregation: {err}");
                 }
                 ApplyAggregationResult::Edit => {
-                    // This edit has been removed; try to find another that still applies.
+                    // This edit has been removed; try to find another that
+                    // still applies.
                     if let Some(aggregations) = self.related_events.get(found) {
                         if resolve_edits(aggregations, items, &mut cowed) {
                             items.replace(
@@ -734,7 +738,8 @@ impl Aggregations {
 
         // Update the aggregations in the `related_events` field.
         if let Some(aggregations) = self.related_events.remove(&from) {
-            // Update the inverted mappings (from aggregation's id, to the new target id).
+            // Update the inverted mappings (from aggregation's id, to the new
+            // target id).
             for a in &aggregations {
                 if let Some(prev_target) = self.inverted_map.remove(&a.own_id) {
                     debug_assert_eq!(prev_target, from);
@@ -783,7 +788,8 @@ impl Aggregations {
                 }
 
                 AggregationKind::Redaction { is_local } => {
-                    // Mark the redaction as being remote and apply it (irreversibly).
+                    // Mark the redaction as being remote and apply it
+                    // (irreversibly).
                     *is_local = false;
 
                     let found = found.clone();
@@ -791,8 +797,8 @@ impl Aggregations {
                 }
 
                 AggregationKind::Reaction { reaction_status, .. } => {
-                    // Mark the reaction as becoming remote, and signal that update to the
-                    // caller.
+                    // Mark the reaction as becoming remote, and signal that
+                    // update to the caller.
                     *reaction_status = ReactionStatus::RemoteToRemote(event_id);
 
                     let found = found.clone();
@@ -821,10 +827,10 @@ fn resolve_edits(
     items: &ObservableItemsTransaction<'_>,
     event: &mut Cow<'_, EventTimelineItem>,
 ) -> bool {
-    // A tuple of the best edit, if we have found one and a boolean indicating if
-    // the edit is coming from a local echo. If it's from a local echo, we can't
-    // validate it as we don't have a raw JSON, but this isn't that important as
-    // we're sure we won't send ourselves invalid edits.
+    // A tuple of the best edit, if we have found one and a boolean indicating
+    // if the edit is coming from a local echo. If it's from a local echo,
+    // we can't validate it as we don't have a raw JSON, but this isn't that
+    // important as we're sure we won't send ourselves invalid edits.
     let mut best_edit: Option<(PendingEdit, bool)> = None;
     let mut best_edit_pos = None;
 
@@ -832,21 +838,24 @@ fn resolve_edits(
         if let AggregationKind::Edit(pending_edit) = &a.kind {
             match &a.own_id {
                 TimelineEventItemId::TransactionId(_) => {
-                    // A local echo is always the most recent edit: use this one.
+                    // A local echo is always the most recent edit: use this
+                    // one.
                     best_edit = Some((pending_edit.clone(), true));
                     break;
                 }
 
                 TimelineEventItemId::EventId(event_id) => {
                     if let Some(best_edit_pos) = &mut best_edit_pos {
-                        // Find the position of the timeline owning the edit: either the bundled
-                        // item owner if this was a bundled edit, or the edit event itself.
+                        // Find the position of the timeline owning the edit:
+                        // either the bundled item owner
+                        // if this was a bundled edit, or the edit event itself.
                         let pos = items.position_by_event_id(
                             pending_edit.bundled_item_owner.as_ref().unwrap_or(event_id),
                         );
 
                         if let Some(pos) = pos {
-                            // If the edit is more recent (higher index) than the previous best
+                            // If the edit is more recent (higher index) than
+                            // the previous best
                             // edit we knew about, use this one.
                             if pos > *best_edit_pos {
                                 best_edit = Some((pending_edit.clone(), false));
@@ -856,17 +865,19 @@ fn resolve_edits(
                         } else {
                             trace!(edit_id = ?a.own_id, "couldn't find timeline meta for edit event");
 
-                            // The edit event isn't in the timeline, so it might be a bundled
-                            // edit. In this case, record it as the best edit if and only if
-                            // there wasn't any other.
+                            // The edit event isn't in the timeline, so it might
+                            // be a bundled edit. In
+                            // this case, record it as the best edit if and only
+                            // if there wasn't any
+                            // other.
                             if best_edit.is_none() {
                                 best_edit = Some((pending_edit.clone(), false));
                                 trace!(?best_edit_pos, edit_id = ?a.own_id, "found bundled edit");
                             }
                         }
                     } else {
-                        // There wasn't any best edit yet, so record this one as being it, with
-                        // its position.
+                        // There wasn't any best edit yet, so record this one as
+                        // being it, with its position.
                         best_edit = Some((pending_edit.clone(), false));
                         best_edit_pos = items.position_by_event_id(event_id);
                         trace!(?best_edit_pos, edit_id = ?a.own_id, "first best edit");
@@ -895,8 +906,8 @@ fn edit_item(
     // We can receive edits from a local echo, i.e. the edit wasn't yet received
     // from the homeserver.
     //
-    // Before we send an edit we check that the event is allowed to be edited and
-    // that the replacement content is allowed.
+    // Before we send an edit we check that the event is allowed to be edited
+    // and that the replacement content is allowed.
     //
     // We don't have yet a full JSON of the event, so we can't do the validation
     // here.

--- a/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/decryption_retry_task.rs
@@ -184,7 +184,8 @@ mod tests {
         let timeline = vector![decrypted_event("session1")];
         // When we ask what to retry
         let answer = compute_redecryption_candidates(&timeline);
-        // Then we don't need to decrypt anything, but we do refetch the encryption info
+        // Then we don't need to decrypt anything, but we do refetch the
+        // encryption info
         assert!(answer.0.is_empty());
         assert_eq!(answer.1.first().map(|s| s.as_str()), Some("session1"));
     }

--- a/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/metadata.rs
@@ -180,13 +180,14 @@ impl TimelineMetadata {
     }
 
     pub(super) fn clear(&mut self) {
-        // Note: we don't clear the next internal id to avoid bad cases of stale unique
-        // ids across timeline clears.
+        // Note: we don't clear the next internal id to avoid bad cases of stale
+        // unique ids across timeline clears.
         self.aggregations.clear();
         self.replies.clear();
         self.fully_read_event = None;
-        // We forgot about the fully read marker right above, so wait for a new one
-        // before attempting to update it for each new timeline item.
+        // We forgot about the fully read marker right above, so wait for a new
+        // one before attempting to update it for each new timeline
+        // item.
         self.has_up_to_date_read_marker_item = true;
         self.read_receipts.clear();
     }
@@ -206,8 +207,9 @@ impl TimelineMetadata {
             return Some(RelativePosition::Same);
         }
 
-        // We can make early returns here because we know all events since the end of
-        // the timeline, so the first event encountered is the oldest one.
+        // We can make early returns here because we know all events since the
+        // end of the timeline, so the first event encountered is the
+        // oldest one.
         for event_meta in all_remote_events.iter().rev() {
             if event_meta.event_id == event_a {
                 return Some(RelativePosition::Before);
@@ -259,8 +261,8 @@ impl TimelineMetadata {
         });
 
         if let Some(fully_read_event_idx) = &mut fully_read_event_idx {
-            // The item at position `i` is the first item that's fully read, we're about to
-            // insert a read marker just after it.
+            // The item at position `i` is the first item that's fully read,
+            // we're about to insert a read marker just after it.
             //
             // Do another forward pass to skip all the events we've sent too.
 
@@ -275,15 +277,18 @@ impl TimelineMetadata {
                 });
 
             if let Some(next) = next {
-                // `next` point to the first item that's not sent by us, so the *previous* of
-                // next is the right place where to insert the fully read marker.
+                // `next` point to the first item that's not sent by us, so the
+                // *previous* of next is the right place where
+                // to insert the fully read marker.
                 *fully_read_event_idx = next.wrapping_sub(1);
             } else {
-                // There's no event after the read marker that's not sent by us, i.e. the full
-                // timeline has been read: the fully read marker goes to the end, even after the
+                // There's no event after the read marker that's not sent by us,
+                // i.e. the full timeline has been read: the
+                // fully read marker goes to the end, even after the
                 // local timeline items.
                 //
-                // TODO (@hywan): Should we introduce a `items.position_of_last_remote()` to
+                // TODO (@hywan): Should we introduce a
+                // `items.position_of_last_remote()` to
                 // insert before the local timeline items?
                 *fully_read_event_idx = items.len().wrapping_sub(1);
             }
@@ -291,28 +296,31 @@ impl TimelineMetadata {
 
         match (read_marker_idx, fully_read_event_idx) {
             (None, None) => {
-                // We didn't have a previous read marker, and we didn't find the fully-read
-                // event in the timeline items. Don't do anything, and retry on
-                // the next event we add.
+                // We didn't have a previous read marker, and we didn't find the
+                // fully-read event in the timeline items. Don't
+                // do anything, and retry on the next event we
+                // add.
                 self.has_up_to_date_read_marker_item = false;
             }
 
             (None, Some(idx)) => {
-                // Only insert the read marker if it is not at the end of the timeline.
+                // Only insert the read marker if it is not at the end of the
+                // timeline.
                 if idx + 1 < items.len() {
                     let idx = idx + 1;
                     items.insert(idx, TimelineItem::read_marker(), None);
                     self.has_up_to_date_read_marker_item = true;
                 } else {
-                    // The next event might require a read marker to be inserted at the current
-                    // end.
+                    // The next event might require a read marker to be inserted
+                    // at the current end.
                     self.has_up_to_date_read_marker_item = false;
                 }
             }
 
             (Some(_), None) => {
-                // We didn't find the timeline item containing the event referred to by the read
-                // marker. Retry next time we get a new event.
+                // We didn't find the timeline item containing the event
+                // referred to by the read marker. Retry next
+                // time we get a new event.
                 self.has_up_to_date_read_marker_item = false;
             }
 
@@ -320,7 +328,8 @@ impl TimelineMetadata {
                 if from >= to {
                     // The read marker can't move backwards.
                     if from + 1 == items.len() {
-                        // The read marker has nothing after it. An item disappeared; remove it.
+                        // The read marker has nothing after it. An item
+                        // disappeared; remove it.
                         items.remove(from);
                     }
                     self.has_up_to_date_read_marker_item = true;
@@ -330,11 +339,14 @@ impl TimelineMetadata {
                 let prev_len = items.len();
                 let read_marker = items.remove(from);
 
-                // Only insert the read marker if it is not at the end of the timeline.
+                // Only insert the read marker if it is not at the end of the
+                // timeline.
                 if to + 1 < prev_len {
-                    // Since the fully-read event's index was shifted to the left
-                    // by one position by the remove call above, insert the fully-
-                    // read marker at its previous position, rather than that + 1
+                    // Since the fully-read event's index was shifted to the
+                    // left by one position by the remove
+                    // call above, insert the fully-
+                    // read marker at its previous position, rather than that +
+                    // 1
                     items.insert(to, read_marker, None);
                     self.has_up_to_date_read_marker_item = true;
                 } else {
@@ -515,14 +527,17 @@ impl TimelineMetadata {
                 thread_root = Some(thread.event_id);
 
                 if is_thread_focus && thread.is_falling_back {
-                    // In general, a threaded event is marked as a response to the previous message
-                    // in the thread, to maintain backwards compatibility with clients not
+                    // In general, a threaded event is marked as a response to
+                    // the previous message in the thread,
+                    // to maintain backwards compatibility with clients not
                     // supporting threads.
                     //
-                    // But we can have actual replies to other in-thread events. The
-                    // `is_falling_back` bool helps distinguishing both use cases.
+                    // But we can have actual replies to other in-thread events.
+                    // The `is_falling_back` bool helps
+                    // distinguishing both use cases.
                     //
-                    // If this timeline is thread-focused, we only mark non-falling-back replies as
+                    // If this timeline is thread-focused, we only mark
+                    // non-falling-back replies as
                     // actual in-thread replies.
                     None
                 } else {

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -282,12 +282,13 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, rules: &RoomVersionRul
     match event {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomRedaction(ev)) => {
             if ev.redacts(&rules.redaction).is_some() {
-                // This is a redaction of an existing message, we'll only update the previous
-                // message and not render a new entry.
+                // This is a redaction of an existing message, we'll only update
+                // the previous message and not render a new
+                // entry.
                 false
             } else {
-                // This is a redacted entry, that we'll show only if the redacted entity wasn't
-                // a reaction.
+                // This is a redacted entry, that we'll show only if the
+                // redacted entity wasn't a reaction.
                 ev.event_type() != MessageLikeEventType::Reaction
             }
         }
@@ -295,8 +296,8 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, rules: &RoomVersionRul
         AnySyncTimelineEvent::MessageLike(msg) => {
             match msg.original_content() {
                 None => {
-                    // This is a redacted entry, that we'll show only if the redacted entity wasn't
-                    // a reaction.
+                    // This is a redacted entry, that we'll show only if the
+                    // redacted entity wasn't a reaction.
                     msg.event_type() != MessageLikeEventType::Reaction
                 }
 
@@ -472,8 +473,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
         };
 
         if room_info.get().encryption_state().is_encrypted() {
-            // If the room was already encrypted, it won't toggle to unencrypted, so we can
-            // shut down this task early.
+            // If the room was already encrypted, it won't toggle to
+            // unencrypted, so we can shut down this task early.
             mark_encrypted().await;
             return;
         }
@@ -481,8 +482,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
         while let Some(info) = room_info.next().await {
             if info.encryption_state().is_encrypted() {
                 mark_encrypted().await;
-                // Once the room is encrypted, it cannot switch back to unencrypted, so our work
-                // here is done.
+                // Once the room is encrypted, it cannot switch back to
+                // unencrypted, so our work here is done.
                 break;
             }
         }
@@ -601,8 +602,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
                 TimelineItemHandle::Remote(event_id) => {
                     // Add a reaction through the room data provider.
-                    // No need to reflect the effect locally, since the local echo handling will
-                    // take care of it.
+                    // No need to reflect the effect locally, since the local
+                    // echo handling will take care of it.
                     trace!("adding a reaction to a remote echo");
                     let annotation = Annotation::new(event_id.to_owned(), key.to_owned());
                     self.room_data_provider
@@ -618,7 +619,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             ReactionStatus::LocalToLocal(send_reaction_handle) => {
                 if let Some(handle) = send_reaction_handle {
                     if !handle.abort().await.map_err(|err| Error::SendQueueError(err.into()))? {
-                        // Impossible state: the reaction has moved from local to echo under our
+                        // Impossible state: the reaction has moved from local
+                        // to echo under our
                         // feet, but the timeline was supposed to be locked!
                         warn!("unexpectedly unable to abort sending of local reaction");
                     }
@@ -628,12 +630,14 @@ impl<P: RoomDataProvider> TimelineController<P> {
             }
 
             ReactionStatus::LocalToRemote(send_handle) => {
-                // No need to reflect the change ourselves, since handling the discard of the
-                // local echo will take care of it.
+                // No need to reflect the change ourselves, since handling the
+                // discard of the local echo will take care of
+                // it.
                 trace!("aborting send of the previous reaction that was a local echo");
                 if let Some(handle) = send_handle {
                     if !handle.abort().await.map_err(|err| Error::SendQueueError(err.into()))? {
-                        // Impossible state: the reaction has moved from local to echo under our
+                        // Impossible state: the reaction has moved from local
+                        // to echo under our
                         // feet, but the timeline was supposed to be locked!
                         warn!("unexpectedly unable to abort sending of local reaction");
                     }
@@ -643,7 +647,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             }
 
             ReactionStatus::RemoteToRemote(event_id) => {
-                // Assume the redaction will work; we'll re-add the reaction if it didn't.
+                // Assume the redaction will work; we'll re-add the reaction if
+                // it didn't.
                 let Some(annotated_event_id) =
                     item.as_remote().map(|event_item| event_item.event_id.clone())
                 else {
@@ -767,11 +772,12 @@ impl<P: RoomDataProvider> TimelineController<P> {
                 .await;
         }
 
-        // Replace the events if either the current event list or the new one aren't
-        // empty.
+        // Replace the events if either the current event list or the new one
+        // aren't empty.
         // Previously we just had to check the new one wasn't empty because
-        // we did a clear operation before so the current one would always be empty, but
-        // now we may want to replace a populated timeline with an empty one.
+        // we did a clear operation before so the current one would always be
+        // empty, but now we may want to replace a populated timeline
+        // with an empty one.
         let mut events = events.into_iter().peekable();
         if !state.items.is_empty() || events.peek().is_some() {
             state
@@ -810,7 +816,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
         let mut state = self.state.write().await;
         let mut txn = state.transaction();
 
-        // Store the current active call info in metadata for new RtcNotification items
+        // Store the current active call info in metadata for new
+        // RtcNotification items
         txn.meta.active_call = maybe_active_call.clone();
 
         if let Some(existing_event_id) = &txn.meta.active_rtc_notification_event_id {
@@ -895,8 +902,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
         let new_event_id: Option<&EventId> =
             as_variant!(&send_state, EventSendState::Sent { event_id } => event_id);
 
-        // The local echoes are always at the end of the timeline, we must first make
-        // sure the remote echo hasn't showed up yet.
+        // The local echoes are always at the end of the timeline, we must first
+        // make sure the remote echo hasn't showed up yet.
         if rfind_event_item(&txn.items, |it| {
             new_event_id.is_some() && it.event_id() == new_event_id && it.as_remote().is_some()
         })
@@ -935,8 +942,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
         let Some((idx, item)) = result else {
             // Event wasn't found as a standalone item.
             //
-            // If it was just sent, try to find if it matches a corresponding aggregation,
-            // and mark it as sent in that case.
+            // If it was just sent, try to find if it matches a corresponding
+            // aggregation, and mark it as sent in that case.
             if let Some(new_event_id) = new_event_id {
                 if txn.meta.aggregations.mark_aggregation_as_sent(
                     txn_id.to_owned(),
@@ -967,8 +974,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             error!(?existing_event_id, ?new_event_id, "Local echo already marked as sent");
         }
 
-        // If the event has just been marked as sent, update the aggregations mapping to
-        // take that into account.
+        // If the event has just been marked as sent, update the aggregations
+        // mapping to take that into account.
         if let Some(new_event_id) = new_event_id {
             txn.meta.aggregations.mark_target_as_sent(txn_id.to_owned(), new_event_id.to_owned());
         }
@@ -989,8 +996,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
             txn.items.remove(idx);
 
-            // A read marker or a date divider may have been inserted before the local echo.
-            // Ensure both are up to date.
+            // A read marker or a date divider may have been inserted before the
+            // local echo. Ensure both are up to date.
             let mut adjuster = DateDividerAdjuster::new(self.settings.date_divider_mode.clone());
             adjuster.run(&mut txn.items, &mut txn.meta);
 
@@ -1002,8 +1009,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             return true;
         }
 
-        // Avoid multiple mutable and immutable borrows of the lock guard by explicitly
-        // dereferencing it once.
+        // Avoid multiple mutable and immutable borrows of the lock guard by
+        // explicitly dereferencing it once.
         let mut txn = state.transaction();
 
         // Look if this was a local aggregation.
@@ -1014,7 +1021,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             Ok(val) => val,
             Err(err) => {
                 warn!("error when discarding local echo for an aggregation: {err}");
-                // The aggregation has been found, it's just that we couldn't discard it.
+                // The aggregation has been found, it's just that we couldn't
+                // discard it.
                 true
             }
         };
@@ -1032,9 +1040,10 @@ impl<P: RoomDataProvider> TimelineController<P> {
         content: AnyMessageLikeEventContent,
     ) -> bool {
         let AnyMessageLikeEventContent::RoomMessage(content) = content else {
-            // Ideally, we'd support replacing local echoes for a reaction, etc., but
-            // handling RoomMessage should be sufficient in most cases. Worst
-            // case, the local echo will be sent Soon™ and we'll get another chance at
+            // Ideally, we'd support replacing local echoes for a reaction,
+            // etc., but handling RoomMessage should be sufficient
+            // in most cases. Worst case, the local echo will be
+            // sent Soon™ and we'll get another chance at
             // editing the event then.
             warn!("Replacing a local echo for a non-RoomMessage-like event NYI");
             return false;
@@ -1050,8 +1059,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
             return false;
         };
 
-        // Reuse the previous local echo's state, but reset the send state to not sent
-        // (per API contract).
+        // Reuse the previous local echo's state, but reset the send state to
+        // not sent (per API contract).
         let ti_kind = {
             let Some(prev_local_item) = prev_item.as_local() else {
                 warn!("We looked for a local item, but it transitioned as remote??");
@@ -1079,8 +1088,8 @@ impl<P: RoomDataProvider> TimelineController<P> {
 
         txn.items.replace(idx, new_item);
 
-        // This doesn't change the original sending time, so there's no need to adjust
-        // date dividers.
+        // This doesn't change the original sending time, so there's no need to
+        // adjust date dividers.
 
         txn.commit();
 
@@ -1467,7 +1476,8 @@ impl TimelineController {
                 match event_cache.pagination().status().get() {
                     PaginationStatus::Idle { hit_timeline_start } => {
                         if hit_timeline_start {
-                            // Eagerly insert the timeline start item, since pagination claims
+                            // Eagerly insert the timeline start item, since
+                            // pagination claims
                             // we've already hit the timeline start.
                             self.insert_timeline_start_if_missing().await;
                         }
@@ -1489,8 +1499,9 @@ impl TimelineController {
 
                 let has_events = !events.is_empty();
 
-                // Ask the cache for the thread root, if it managed to extract one or decided
-                // that the target event was the thread root.
+                // Ask the cache for the thread root, if it managed to extract
+                // one or decided that the target event was the
+                // thread root.
                 if let Some(thread_root) = event_cache.thread_root().await? {
                     focus_thread_root.get_or_init(|| thread_root);
                 }
@@ -1580,9 +1591,9 @@ impl TimelineController {
         let (events, subscriber) = event_cache.subscribe().await?;
         let has_events = !events.is_empty();
 
-        // For each event, we also need to find the related events, as they don't
-        // include the thread relationship, they won't be included in
-        // the initial list of events.
+        // For each event, we also need to find the related events, as they
+        // don't include the thread relationship, they won't be included
+        // in the initial list of events.
         let mut related_events = Vector::new();
         for event_id in events.iter().filter_map(|event| event.event_id()) {
             if let Some((_original, related)) =
@@ -1649,8 +1660,8 @@ impl TimelineController {
         )
         .await?;
 
-        // We need to be sure to have the latest position of the event as it might have
-        // changed while waiting for the request.
+        // We need to be sure to have the latest position of the event as it
+        // might have changed while waiting for the request.
         let mut state = self.state.write().await;
         let (index, item) = rfind_event_by_id(&state.items, &remote_item.event_id)
             .ok_or(Error::EventNotInTimeline(TimelineEventItemId::EventId(event_id.to_owned())))?;
@@ -1673,8 +1684,8 @@ impl TimelineController {
             return Ok(());
         };
 
-        // Now that we've received the content of the replied-to event, replace the
-        // replied-to content in the item with it.
+        // Now that we've received the content of the replied-to event, replace
+        // the replied-to content in the item with it.
         trace!("Updating in-reply-to details");
         let internal_id = item.internal_id.to_owned();
         let mut item = item.clone();
@@ -1733,8 +1744,8 @@ impl TimelineController {
         let room = self.room();
         let all_remote_events = state.items.all_remote_events();
 
-        // Resolve the event the receipt should target, redirecting away from the
-        // user's own events for read receipts.
+        // Resolve the event the receipt should target, redirecting away from
+        // the user's own events for read receipts.
         let target_event_id = match receipt_type {
             SendReceiptType::Read | SendReceiptType::ReadPrivate => {
                 let is_own_event = all_remote_events
@@ -1828,7 +1839,8 @@ impl TimelineController {
             _ => None,
         };
 
-        // Don't send anything if the resolved event isn't more recent than that.
+        // Don't send anything if the resolved event isn't more recent than
+        // that.
         if let Some(previous_event_id) = previous_event_id {
             trace!(%previous_event_id, "found a previous receipt");
             if let Some(relative_pos) = TimelineMetadata::compare_events_positions(
@@ -1841,8 +1853,8 @@ impl TimelineController {
             }
         }
 
-        // No previous receipt was found (or it's an unknown one): let the server
-        // handle it.
+        // No previous receipt was found (or it's an unknown one): let the
+        // server handle it.
         SendReceiptDecision::SendTo(target_event_id)
     }
 
@@ -1854,7 +1866,8 @@ impl TimelineController {
             TimelineFocusKind::Thread { .. } => false,
             TimelineFocusKind::Live { hide_threaded_events, .. } => *hide_threaded_events,
             TimelineFocusKind::Event { .. } => {
-                // For event-focused timelines, filtering is handled in the event cache layer.
+                // For event-focused timelines, filtering is handled in the
+                // event cache layer.
                 false
             }
             TimelineFocusKind::PinnedEvents { .. } => true,
@@ -1867,14 +1880,17 @@ impl TimelineController {
             .rev()
             .filter_map(|event_meta| {
                 if !filter_out_thread_events {
-                    // For an unthreaded timeline, the last event is always the latest event.
+                    // For an unthreaded timeline, the last event is always the
+                    // latest event.
                     Some(event_meta.event_id.clone())
                 } else if event_meta.thread_root_id.is_none() {
-                    // For the main-thread timeline, only non-threaded events are valid candidates
-                    // for the latest event.
+                    // For the main-thread timeline, only non-threaded events
+                    // are valid candidates for the latest
+                    // event.
                     //
-                    // But! An event could be an aggregation that relate to an in-thread
-                    // event. In this case, it's not a valid latest event.
+                    // But! An event could be an aggregation that relate to an
+                    // in-thread event. In this case, it's
+                    // not a valid latest event.
                     if let Some(TimelineEventItemId::EventId(target_event_id)) =
                         state.meta.aggregations.is_aggregation_of(&TimelineEventItemId::EventId(
                             event_meta.event_id.clone(),
@@ -1883,16 +1899,19 @@ impl TimelineController {
                             state.items.all_remote_events().get_by_event_id(target_event_id)
                         && target_meta.thread_root_id.is_some()
                     {
-                        // This event is an aggregation of an in-thread event, so skip it.
+                        // This event is an aggregation of an in-thread event,
+                        // so skip it.
                         None
                     } else {
-                        // Not in a thread, and not the aggregation of an in-thread event, so it's
+                        // Not in a thread, and not the aggregation of an
+                        // in-thread event, so it's
                         // a valid candidate for the latest event.
                         Some(event_meta.event_id.clone())
                     }
                 } else {
-                    // An in-thread event, when we're filtering out threaded events, is never a
-                    // valid candidate for the latest event.
+                    // An in-thread event, when we're filtering out threaded
+                    // events, is never a valid candidate
+                    // for the latest event.
                     None
                 }
             })
@@ -1924,9 +1943,10 @@ impl TimelineController {
             PaginationStatus::Idle { hit_timeline_start } => {
                 if hit_timeline_start {
                     let state = self.state.read().await;
-                    // If the skip count is greater than 0, it means that a subsequent pagination
-                    // could return more items, so pretend we didn't get the information that the
-                    // timeline start was hit.
+                    // If the skip count is greater than 0, it means that a
+                    // subsequent pagination could return
+                    // more items, so pretend we didn't get the information that
+                    // the timeline start was hit.
                     if state.meta.subscriber_skip_count.get() > 0 {
                         return PaginationStatus::Idle { hit_timeline_start: false };
                     }
@@ -1978,8 +1998,8 @@ async fn fetch_replied_to_event<P: RoomDataProvider>(
         return Ok(details);
     }
 
-    // Replace the item with a new timeline item that has the fetching status of the
-    // replied-to event to pending.
+    // Replace the item with a new timeline item that has the fetching status of
+    // the replied-to event to pending.
     trace!("Setting in-reply-to details to pending");
     let in_reply_to_details =
         InReplyToDetails { event_id: in_reply_to.to_owned(), event: TimelineDetails::Pending };

--- a/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/observable_items.rs
@@ -1148,7 +1148,8 @@ mod observable_items_tests {
         }
 
         // Timeline item with a remote event, but late.
-        // I don't know if this case is possible in reality, but let's be robust.
+        // I don't know if this case is possible in reality, but let's be
+        // robust.
         transaction.insert(3, item("$ev2"), Some(2));
 
         assert_mapping! {
@@ -1961,8 +1962,9 @@ impl AllRemoteEvents {
 
     /// Get the position of an event in the events array by its ID.
     pub fn position_by_event_id(&self, event_id: &EventId) -> Option<usize> {
-        // Reverse the iterator to start looking at the end. Since this will give us the
-        // "reverse" position, reverse the index after finding the event.
+        // Reverse the iterator to start looking at the end. Since this will
+        // give us the "reverse" position, reverse the index after
+        // finding the event.
         self.0
             .iter()
             .enumerate()
@@ -1974,12 +1976,13 @@ impl AllRemoteEvents {
     /// greater than `new_timeline_item_index`.
     fn increment_all_timeline_item_index_after(&mut self, new_timeline_item_index: usize) {
         // Traverse items from back to front because:
-        // - if `new_timeline_item_index` is 0, we need to shift all items anyways, so
-        //   all items must be traversed,
-        // - otherwise, it's unlikely we want to traverse all items: the item has been
-        //   either inserted or pushed back, so there is no need to traverse the first
-        //   items; we can also break the iteration as soon as all timeline item index
-        //   after `new_timeline_item_index` has been updated.
+        // - if `new_timeline_item_index` is 0, we need to shift all items
+        //   anyways, so all items must be traversed,
+        // - otherwise, it's unlikely we want to traverse all items: the item
+        //   has been either inserted or pushed back, so there is no need to
+        //   traverse the first items; we can also break the iteration as soon
+        //   as all timeline item index after `new_timeline_item_index` has been
+        //   updated.
         for event_meta in self.0.iter_mut().rev() {
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 if *timeline_item_index >= new_timeline_item_index {
@@ -1996,12 +1999,13 @@ impl AllRemoteEvents {
     /// `removed_timeline_item_index`.
     fn decrement_all_timeline_item_index_after(&mut self, removed_timeline_item_index: usize) {
         // Traverse items from back to front because:
-        // - if `new_timeline_item_index` is 0, we need to shift all items anyways, so
-        //   all items must be traversed,
-        // - otherwise, it's unlikely we want to traverse all items: the item has been
-        //   either inserted or pushed back, so there is no need to traverse the first
-        //   items; we can also break the iteration as soon as all timeline item index
-        //   after `new_timeline_item_index` has been updated.
+        // - if `new_timeline_item_index` is 0, we need to shift all items
+        //   anyways, so all items must be traversed,
+        // - otherwise, it's unlikely we want to traverse all items: the item
+        //   has been either inserted or pushed back, so there is no need to
+        //   traverse the first items; we can also break the iteration as soon
+        //   as all timeline item index after `new_timeline_item_index` has been
+        //   updated.
         for event_meta in self.0.iter_mut().rev() {
             if let Some(timeline_item_index) = event_meta.timeline_item_index.as_mut() {
                 if *timeline_item_index > removed_timeline_item_index {
@@ -2197,9 +2201,9 @@ mod all_remote_events_tests {
         // Push back with a `timeline_item_index`.
         events.push_back(event_meta("$ev2", Some(1)));
 
-        // Push back with a `timeline_item_index` pointing to a timeline item that is
-        // not the last one. Is it possible in practise? Normally not, but let's test
-        // it anyway.
+        // Push back with a `timeline_item_index` pointing to a timeline item
+        // that is not the last one. Is it possible in practise?
+        // Normally not, but let's test it anyway.
         events.push_back(event_meta("$ev3", Some(1)));
 
         assert_events!(

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -149,8 +149,8 @@ impl ReadReceiptsState {
                 old_receipt_pos = Some(pos);
             }
 
-            // The receipt should appear on the first visible event that can show read
-            // receipts.
+            // The receipt should appear on the first visible event that can
+            // show read receipts.
             if old_receipt_pos.is_some()
                 && old_item_event_id.is_none()
                 && event.visible
@@ -164,8 +164,8 @@ impl ReadReceiptsState {
                 new_receipt_pos = Some(pos);
             }
 
-            // The receipt should appear on the first visible event that can show read
-            // receipts.
+            // The receipt should appear on the first visible event that can
+            // show read receipts.
             if new_receipt_pos.is_some()
                 && new_item_event_id.is_none()
                 && event.visible
@@ -184,8 +184,9 @@ impl ReadReceiptsState {
         // Check if the old receipt is more recent than the new receipt.
         if let Some(old_receipt_pos) = old_receipt_pos {
             let Some(new_receipt_pos) = new_receipt_pos else {
-                // The old receipt is more recent since we can't find the new receipt in the
-                // timeline and we supposedly have all events since the end of the timeline.
+                // The old receipt is more recent since we can't find the new
+                // receipt in the timeline and we supposedly
+                // have all events since the end of the timeline.
                 if !is_own_user_id {
                     trace!(
                         "we had a previous read receipt, but couldn't find the event \
@@ -205,13 +206,13 @@ impl ReadReceiptsState {
         }
 
         // The new receipt is deemed more recent from now on because:
-        // - If old_receipt_pos is Some, we already checked all the cases where it
-        //   wouldn't be more recent.
+        // - If old_receipt_pos is Some, we already checked all the cases where
+        //   it wouldn't be more recent.
         // - If both old_receipt_pos and new_receipt_pos are None, they are both
-        //   explicit read receipts so the server should only send us a more recent
-        //   receipt.
-        // - If old_receipt_pos is None and new_receipt_pos is Some, the new receipt is
-        //   more recent because it has a place in the timeline.
+        //   explicit read receipts so the server should only send us a more
+        //   recent receipt.
+        // - If old_receipt_pos is None and new_receipt_pos is Some, the new
+        //   receipt is more recent because it has a place in the timeline.
 
         if !is_own_user_id {
             trace!(
@@ -330,8 +331,8 @@ impl ReadReceiptsState {
         // after an event that holds hidden read receipts, then we should steal
         // them from it.
         //
-        // Find the event, go past it, and keep a reference to the previous rendered
-        // timeline item, if any.
+        // Find the event, go past it, and keep a reference to the previous
+        // rendered timeline item, if any.
         let Some(current_event_index) = timeline_items.position_by_event_id(event_id) else {
             warn!("Could not find event {event_id} in timeline");
             return all_receipts;
@@ -344,15 +345,15 @@ impl ReadReceiptsState {
 
         // Ok, the event we're searching for is the last item in our list.
         //
-        // Let's just clone the event ID and copy the index to avoid double borrow of
-        // the `events_iter`.
+        // Let's just clone the event ID and copy the index to avoid double
+        // borrow of the `events_iter`.
         let prev_event_and_item_index = previous_events_that_can_show_read_receipts
             .last()
             .map(|(event_id, index)| (event_id.clone(), index));
 
-        // Include receipts from the following events that are hidden or can't show
-        // read receipts until the next event that is visible and can show read
-        // receipts.
+        // Include receipts from the following events that are hidden or can't
+        // show read receipts until the next event that is visible and
+        // can show read receipts.
 
         // Start by creating an iterator from the following event, if possible.
         let next_events_iter =
@@ -369,12 +370,13 @@ impl ReadReceiptsState {
             }
         }
 
-        // Steal hidden receipts from the previous timeline item, if it carried them.
+        // Steal hidden receipts from the previous timeline item, if it carried
+        // them.
         if let Some((prev_event_id, prev_item_index)) = prev_event_and_item_index {
             let prev_item = &timeline_items[prev_item_index];
-            // Technically, we could unwrap the `as_event()`, because this is a rendered
-            // item for an event in all_remote_events, but this extra check is
-            // cheap.
+            // Technically, we could unwrap the `as_event()`, because this is a
+            // rendered item for an event in all_remote_events, but
+            // this extra check is cheap.
             if let Some(remote_prev_item) = prev_item.as_event() {
                 let prev_receipts = remote_prev_item.read_receipts().clone();
                 for (user_id, _) in &hidden {
@@ -564,20 +566,25 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                 for (user_id, receipt) in receipts {
                     if matches!(own_receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
                     {
-                        // If the own receipt thread is unthreaded or main, we maintain maximal
-                        // compatibility with clients using either unthreaded or main-thread read
-                        // receipts by allowing both here.
+                        // If the own receipt thread is unthreaded or main, we
+                        // maintain maximal
+                        // compatibility with clients using either unthreaded or
+                        // main-thread read receipts by
+                        // allowing both here.
                         match receipt.thread {
                             ReceiptThread::Unthreaded | ReceiptThread::Main => {
                                 // Processing happens below.
                             }
 
                             ReceiptThread::Thread(thread_root) => {
-                                // Special processing for threads: try to find a timeline item for
-                                // the root, and update its thread summary, if the receipt is for
+                                // Special processing for threads: try to find a
+                                // timeline item for
+                                // the root, and update its thread summary, if
+                                // the receipt is for
                                 // ourselves.
                                 //
-                                // TODO: This is temporary code, and should be removed when #4113 is
+                                // TODO: This is temporary code, and should be
+                                // removed when #4113 is
                                 // done.
                                 if user_id == self.meta.own_user_id
                                     && let Some((item_pos, item)) =
@@ -593,7 +600,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                                     let TimelineItemContent::MsgLike(msglike) =
                                         &mut new_item.content
                                     else {
-                                        // Only MsgLike items have a thread summary.
+                                        // Only MsgLike items have a thread
+                                        // summary.
                                         continue;
                                     };
 
@@ -602,7 +610,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                                         continue;
                                     };
 
-                                    // Assume read receipts only move forward, at the moment.
+                                    // Assume read receipts only move forward,
+                                    // at the moment.
                                     if receipt_type == ReceiptType::Read {
                                         thread_summary.public_read_receipt_event_id =
                                             Some(event_id.clone());
@@ -610,7 +619,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                                         thread_summary.private_read_receipt_event_id =
                                             Some(event_id.clone());
                                     } else {
-                                        // We don't know this receipt type; skip it.
+                                        // We don't know this receipt type; skip
+                                        // it.
                                         continue;
                                     }
 
@@ -618,7 +628,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                                         .replace(item_pos, TimelineItem::new(new_item, item_id));
                                 }
 
-                                // Couldn't find an item for this new read receipt; process the
+                                // Couldn't find an item for this new read
+                                // receipt; process the
                                 // next receipt.
                                 continue;
                             }
@@ -629,7 +640,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
                             }
                         }
                     } else if own_receipt_thread != receipt.thread {
-                        // Otherwise, we only keep the receipts of the same thread kind.
+                        // Otherwise, we only keep the receipts of the same
+                        // thread kind.
                         continue;
                     }
 
@@ -665,9 +677,10 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
 
         let receipts = if matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
         {
-            // If the requested receipt thread is unthreaded or main, we maintain maximal
-            // compatibility with clients using either unthreaded or main-thread read
-            // receipts by allowing both here.
+            // If the requested receipt thread is unthreaded or main, we
+            // maintain maximal compatibility with clients using
+            // either unthreaded or main-thread read receipts by
+            // allowing both here.
 
             // First, load the main receipts.
             let mut main_receipts =
@@ -677,14 +690,15 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
             let unthreaded_receipts =
                 room_data_provider.load_event_receipts(event_id, &ReceiptThread::Unthreaded).await;
 
-            // We can safely extend both here: if a key is already set, then that means that
-            // the user has the unthreaded and main receipt on the main event,
-            // which is fine, and something we display as the one user receipt.
+            // We can safely extend both here: if a key is already set, then
+            // that means that the user has the unthreaded and main
+            // receipt on the main event, which is fine, and
+            // something we display as the one user receipt.
             main_receipts.extend(unthreaded_receipts);
             main_receipts
         } else {
-            // In all other cases, return what's requested, and only that (threaded
-            // receipts).
+            // In all other cases, return what's requested, and only that
+            // (threaded receipts).
             room_data_provider.load_event_receipts(event_id, &receipt_thread).await
         };
 
@@ -723,7 +737,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
         timestamp: Option<MilliSecondsSinceUnixEpoch>,
     ) {
         let (Some(user_id), Some(timestamp)) = (sender, timestamp) else {
-            // We cannot add a read receipt if we do not know the user or the timestamp.
+            // We cannot add a read receipt if we do not know the user or the
+            // timestamp.
             return;
         };
 
@@ -863,9 +878,9 @@ impl<P: RoomDataProvider> TimelineState<P> {
             )
             .await;
 
-        // Let's assume that a private read receipt should be more recent than a public
-        // read receipt (otherwise there's no point in the private read receipt),
-        // and use it as the default.
+        // Let's assume that a private read receipt should be more recent than a
+        // public read receipt (otherwise there's no point in the
+        // private read receipt), and use it as the default.
         match TimelineMetadata::compare_optional_receipts(
             public_read_receipt.as_ref(),
             private_read_receipt.as_ref(),
@@ -883,15 +898,15 @@ impl<P: RoomDataProvider> TimelineState<P> {
         &self,
         user_id: &UserId,
     ) -> Option<OwnedEventId> {
-        // We only need to use the local map, since receipts for known events are
-        // already loaded from the store.
+        // We only need to use the local map, since receipts for known events
+        // are already loaded from the store.
         let public_read_receipt = self.meta.read_receipts.get_latest(user_id, &ReceiptType::Read);
         let private_read_receipt =
             self.meta.read_receipts.get_latest(user_id, &ReceiptType::ReadPrivate);
 
-        // Let's assume that a private read receipt should be more recent than a public
-        // read receipt, otherwise there's no point in the private read receipt,
-        // and use it as default.
+        // Let's assume that a private read receipt should be more recent than a
+        // public read receipt, otherwise there's no point in the
+        // private read receipt, and use it as default.
         let (latest_receipt_id, _) = match TimelineMetadata::compare_optional_receipts(
             public_read_receipt,
             private_read_receipt,
@@ -941,8 +956,9 @@ impl TimelineMetadata {
         }
 
         if receipt_thread == ReceiptThread::Unthreaded {
-            // Maintain compatibility with clients using either the unthreaded and main read
-            // receipts, and try to find the most recent one.
+            // Maintain compatibility with clients using either the unthreaded
+            // and main read receipts, and try to find the most
+            // recent one.
             let unthreaded_read_receipt = room_data_provider
                 .load_user_receipt(receipt_type.clone(), &ReceiptThread::Unthreaded, user_id)
                 .await;
@@ -951,8 +967,8 @@ impl TimelineMetadata {
                 .load_user_receipt(receipt_type.clone(), &ReceiptThread::Main, user_id)
                 .await;
 
-            // Let's use the unthreaded read receipt as default, since it's the one we
-            // should be using.
+            // Let's use the unthreaded read receipt as default, since it's the
+            // one we should be using.
             match Self::compare_optional_receipts(
                 main_thread_read_receipt.as_ref(),
                 unthreaded_read_receipt.as_ref(),
@@ -963,9 +979,10 @@ impl TimelineMetadata {
                 _ => unreachable!(),
             }
         } else {
-            // In all the other cases, use the thread's read receipt. A main-thread receipt
-            // in particular will use this code path, and not be compatible with
-            // an unthreaded read receipt.
+            // In all the other cases, use the thread's read receipt. A
+            // main-thread receipt in particular will use this code
+            // path, and not be compatible with an unthreaded read
+            // receipt.
             room_data_provider
                 .load_user_receipt(receipt_type.clone(), &receipt_thread, user_id)
                 .await

--- a/crates/matrix-sdk-ui/src/timeline/controller/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state.rs
@@ -177,7 +177,8 @@ impl<P: RoomDataProvider> TimelineState<P> {
                 thread_root.as_ref().is_some_and(|r| r == root_event_id)
             }
             TimelineFocusKind::Event { .. } | TimelineFocusKind::PinnedEvents { .. } => {
-                // Don't add new items to these timelines; aggregations are added independently
+                // Don't add new items to these timelines; aggregations are
+                // added independently
                 // of the `should_add_new_items` value.
                 false
             }
@@ -250,8 +251,8 @@ impl<P: RoomDataProvider> TimelineState<P> {
     }
 
     pub(super) fn mark_all_events_as_encrypted(&mut self) {
-        // When this transaction finishes, all items in the timeline will be emitted
-        // again with the updated encryption value.
+        // When this transaction finishes, all items in the timeline will be
+        // emitted again with the updated encryption value.
         let mut txn = self.transaction();
         txn.mark_all_events_as_encrypted();
         txn.commit();

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -384,24 +384,33 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     {
                         // FIXME: This branch is a complete hackjob.
                         //
-                        // The reason being is that this branch is here to handle UTD -> Decrypted
-                        // event remplacements for focused timelines. But this transition should
-                        // naturally happen the same way it happens for unfocused timelines.
+                        // The reason being is that this branch is here to
+                        // handle UTD -> Decrypted event
+                        // remplacements for focused timelines. But this
+                        // transition should
+                        // naturally happen the same way it happens for
+                        // unfocused timelines.
                         //
-                        // Why it doesn't work here? Because the event cache fires out a
-                        // VectorDiff::Set with an index that matches to the cache's view of the
-                        // timeline, which is unfiltered, while the focused timeline will only show
+                        // Why it doesn't work here? Because the event cache
+                        // fires out a VectorDiff::Set
+                        // with an index that matches to the cache's view of the
+                        // timeline, which is unfiltered, while the focused
+                        // timeline will only show
                         // i.e. pinned events.
                         //
                         // The `test_pinned_events_are_decrypted_after_recovering` integration test
-                        // showcases this. The event cache fires out the `Set` with an index of 7,
-                        // but the timeline with the PinnedEvents focus has only 4 items.
+                        // showcases this. The event cache fires out the `Set`
+                        // with an index of 7,
+                        // but the timeline with the PinnedEvents focus has only
+                        // 4 items.
                         //
-                        // This hackjob continues in the `handle_remote_aggregation()` method as we
-                        // can't just handle any `TimelineAction::AddItem` due to:
-                        //  https://github.com/matrix-org/matrix-rust-sdk/pull/4645
+                        // This hackjob continues in the
+                        // `handle_remote_aggregation()` method as we
+                        // can't just handle any `TimelineAction::AddItem` due
+                        // to:  https://github.com/matrix-org/matrix-rust-sdk/pull/4645
                         //
-                        // Doing so breaks the `test_new_pinned_events_are_not_added_on_sync` test.
+                        // Doing so breaks the
+                        // `test_new_pinned_events_are_not_added_on_sync` test.
                         //
                         // Relevant issue: https://github.com/matrix-org/matrix-rust-sdk/issues/5954.
                         self.handle_remote_aggregation(
@@ -513,13 +522,15 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
         match &self.focus {
             TimelineFocusKind::PinnedEvents { .. } => {
-                // The pinned events timeline only receives updates for, well, pinned events.
+                // The pinned events timeline only receives updates for, well,
+                // pinned events.
                 true
             }
 
             TimelineFocusKind::Event { .. } => {
-                // For event-focused timelines, thread filtering is now handled in the
-                // event cache layer. We accept all events from pagination.
+                // For event-focused timelines, thread filtering is now handled
+                // in the event cache layer. We accept all
+                // events from pagination.
 
                 // Retrieve the origin of the event.
                 let origin = match position {
@@ -542,13 +553,14 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             }
 
             TimelineFocusKind::Live { hide_threaded_events, .. } => {
-                // If the timeline's filtering out in-thread events, don't add items for
-                // threaded events.
+                // If the timeline's filtering out in-thread events, don't add
+                // items for threaded events.
                 thread_root.is_none() || !hide_threaded_events
             }
 
             TimelineFocusKind::Thread { root_event_id, .. } => {
-                // Add new items only for the thread root and the thread replies.
+                // Add new items only for the thread root and the thread
+                // replies.
                 event.event_id() == root_event_id
                     || thread_root.as_ref().is_some_and(|r| r == root_event_id)
             }
@@ -594,12 +606,12 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     )> {
         let state_key: Option<String> = raw.get_field("state_key").ok().flatten();
 
-        // A state event is an event that has a state key. Note that the two branches
-        // differ because the inferred return type for `get_field` is different
-        // in each case.
+        // A state event is an event that has a state key. Note that the two
+        // branches differ because the inferred return type for
+        // `get_field` is different in each case.
         //
-        // If this was a state event but it didn't include a state_key, we'll assume it
-        // was a msg-like, because we can't do much more.
+        // If this was a state event but it didn't include a state_key, we'll
+        // assume it was a msg-like, because we can't do much more.
         let event_type = if let Some(state_key) = state_key {
             raw.get_field("type")
                 .ok()
@@ -611,7 +623,8 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
         let event_id: Option<OwnedEventId> = raw.get_field("event_id").ok().flatten();
         let Some(event_id) = event_id else {
-            // If the event doesn't even have an event ID, we can't do anything with it.
+            // If the event doesn't even have an event ID, we can't do anything
+            // with it.
             warn!(
                 ?event_type,
                 "Failed to deserialize timeline event (with no ID): {deserialization_error}"
@@ -627,8 +640,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             (Some(sender), Some(origin_server_ts), Some(event_type))
                 if settings.add_failed_to_parse =>
             {
-                // We have sufficient information to show an item in the timeline, and we've
-                // been requested to show it, let's do it.
+                // We have sufficient information to show an item in the
+                // timeline, and we've been requested to show
+                // it, let's do it.
                 #[derive(serde::Deserialize)]
                 struct Unsigned {
                     transaction_id: Option<OwnedTransactionId>,
@@ -640,8 +654,8 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     .flatten()
                     .and_then(|unsigned| unsigned.transaction_id);
 
-                // The event can be partially deserialized, and it is allowed to be added to
-                // the timeline.
+                // The event can be partially deserialized, and it is allowed to
+                // be added to the timeline.
                 Some((
                     event_id,
                     sender,
@@ -655,8 +669,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             }
 
             (sender, origin_server_ts, event_type) => {
-                // We either lack information for rendering an item, or we've been requested not
-                // to show it. Save it into the metadata and return.
+                // We either lack information for rendering an item, or we've
+                // been requested not to show it. Save it into
+                // the metadata and return.
                 warn!(
                     ?event_type,
                     ?event_id,
@@ -679,8 +694,8 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         }
     }
 
-    // Attempt to load a thread's latest reply as an embedded timeline item, either
-    // using the event cache or the storage.
+    // Attempt to load a thread's latest reply as an embedded timeline item,
+    // either using the event cache or the storage.
     #[instrument(skip(self, room_data_provider))]
     async fn fetch_latest_thread_reply(
         &mut self,
@@ -717,13 +732,14 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             return (None, None);
         }
 
-        // Load the public and private read receipts for the user, in the thread. In the
-        // future, we might move this code in the event cache, so that read
-        // receipt handling happens there instead.
+        // Load the public and private read receipts for the user, in the
+        // thread. In the future, we might move this code in the event
+        // cache, so that read receipt handling happens there instead.
 
-        // As an exception to handle the latest "implicit" read receipt (which is the
-        // latest event sent by the user): if the latest event has been sent by
-        // the current user, then we consider that as a read receipt.
+        // As an exception to handle the latest "implicit" read receipt (which
+        // is the latest event sent by the user): if the latest event
+        // has been sent by the current user, then we consider that as a
+        // read receipt.
         #[allow(clippy::collapsible_if)] // clippy has poor taste
         if let Some(ref latest_reply) = summary.latest_reply {
             if let Ok(event) = RoomDataProvider::load_event(room_data_provider, latest_reply)
@@ -945,10 +961,11 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 },
                 should_add_new_items: should_add,
             };
-            // A recycled timeline ID carries the TimelineUniqueId from a previously
-            // removed item (see VectorDiff::Remove), so that when the same event is
-            // re-added in the same diff batch the UI sees a stable identifier.
-            // It is only applicable when the event produces a single AddItem action;
+            // A recycled timeline ID carries the TimelineUniqueId from a
+            // previously removed item (see VectorDiff::Remove), so
+            // that when the same event is re-added in the same diff
+            // batch the UI sees a stable identifier. It is only
+            // applicable when the event produces a single AddItem action;
             // with multiple actions (e.g. beacon replace) there
             // is no single item to associate it with, so it's safe to ignore.
             let recycled_timeline_id = recycled_timeline_id.filter(|_| timeline_actions.len() == 1);
@@ -991,10 +1008,11 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
         // We need to be careful here.
         //
-        // We must first remove the timeline item, which will update the mapping between
-        // remote events and timeline items. Removing the timeline item will “unlink”
-        // this mapping as the remote event will be updated to map to nothing. Only
-        // after that, we can remove the remote event. Doing this in the other order
+        // We must first remove the timeline item, which will update the mapping
+        // between remote events and timeline items. Removing the
+        // timeline item will “unlink” this mapping as the remote event
+        // will be updated to map to nothing. Only after that, we can
+        // remove the remote event. Doing this in the other order
         // will update the mapping twice, and will result in a corrupted state.
 
         let mut recycled_timeline_id = None;
@@ -1022,7 +1040,8 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         // `VectorDiff::Clear` should be much more efficient to process for
         // subscribers.
         if self.items.has_local() {
-            // Remove all remote events and virtual items that aren't date dividers.
+            // Remove all remote events and virtual items that aren't date
+            // dividers.
             self.items.for_each(|entry| {
                 if entry.is_remote_event()
                     || entry.as_virtual().is_some_and(|vitem| match vitem {
@@ -1125,8 +1144,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     event.can_show_read_receipts = event_meta.can_show_read_receipts;
 
                     if settings.track_read_receipts.is_enabled() {
-                        // Since the event's visibility changed, we need to update the read
-                        // receipts of the previous visible event.
+                        // Since the event's visibility changed, we need to
+                        // update the read receipts of
+                        // the previous visible event.
                         self.maybe_update_read_receipts_of_prev_event(&event_meta.event_id);
                     }
                 }
@@ -1166,7 +1186,8 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                 let mut cloned_event = event.clone();
                 cloned_event.is_room_encrypted = true;
 
-                // Replace the existing item with a new version with the right encryption flag
+                // Replace the existing item with a new version with the right
+                // encryption flag
                 let item = item.with_kind(cloned_event);
                 self.items.replace(idx, item);
             }

--- a/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/date_dividers.rs
@@ -120,11 +120,12 @@ impl DateDividerAdjuster {
         // `Remove(i)` followed by a `Replace((i+1) -1)`, which wouldn't do what
         // we want, if running in reverse order.
         //
-        // Also note that we can remove a few items at position J, then later decide to
-        // replace/remove an item (in `handle_event`) at position I, with I<J. That
-        // would break the above invariant (that operations happen in
-        // non-decreasing order of the indices), so we must record the insert
-        // position for an operation related to the previous item.
+        // Also note that we can remove a few items at position J, then later
+        // decide to replace/remove an item (in `handle_event`) at
+        // position I, with I<J. That would break the above invariant
+        // (that operations happen in non-decreasing order of the
+        // indices), so we must record the insert position for an
+        // operation related to the previous item.
 
         let mut prev_item: Option<PrevItemDesc<'_>> = None;
         let mut latest_event_ts = None;
@@ -132,8 +133,8 @@ impl DateDividerAdjuster {
         for (i, item) in items.iter_remotes_and_locals_regions() {
             match item.kind() {
                 TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(ts)) => {
-                    // Record what the last alive item pair is only if we haven't removed the date
-                    // divider.
+                    // Record what the last alive item pair is only if we
+                    // haven't removed the date divider.
                     if !self.handle_date_divider(i, *ts, prev_item.as_ref().map(|desc| desc.item)) {
                         prev_item = Some(PrevItemDesc {
                             item_index: i,
@@ -160,13 +161,13 @@ impl DateDividerAdjuster {
             }
         }
 
-        // Also chase trailing date dividers explicitly, by iterating from the end to
-        // the start. Since they wouldn't be the prev_item of anything, we
-        // wouldn't analyze them in the previous loop.
+        // Also chase trailing date dividers explicitly, by iterating from the
+        // end to the start. Since they wouldn't be the prev_item of
+        // anything, we wouldn't analyze them in the previous loop.
         for (i, item) in items.iter_remotes_and_locals_regions().rev() {
             if item.is_date_divider() {
-                // The item is a trailing date divider: remove it, if it wasn't already
-                // scheduled for deletion.
+                // The item is a trailing date divider: remove it, if it wasn't
+                // already scheduled for deletion.
                 if !self
                     .ops
                     .iter()
@@ -174,8 +175,9 @@ impl DateDividerAdjuster {
                 {
                     trace!("removing trailing date divider @ {i}");
 
-                    // Find the index at which to insert the removal operation. It must be before
-                    // any other operation on a bigger index, to maintain the
+                    // Find the index at which to insert the removal operation.
+                    // It must be before any other operation
+                    // on a bigger index, to maintain the
                     // non-decreasing invariant.
                     let index =
                         self.ops.iter().position(|op| op.index() > i).unwrap_or(self.ops.len());
@@ -190,8 +192,8 @@ impl DateDividerAdjuster {
             }
         }
 
-        // Only record the initial state if we've enabled the trace log level, and not
-        // otherwise.
+        // Only record the initial state if we've enabled the trace log level,
+        // and not otherwise.
         let initial_state = if event_enabled!(Level::TRACE) {
             Some(
                 items
@@ -226,8 +228,8 @@ impl DateDividerAdjuster {
         prev_item: Option<&Arc<TimelineItem>>,
     ) -> bool {
         let Some(prev_item) = prev_item else {
-            // No interesting item prior to the date divider: it must be the first one,
-            // nothing to do.
+            // No interesting item prior to the date divider: it must be the
+            // first one, nothing to do.
             return false;
         };
 
@@ -235,8 +237,8 @@ impl DateDividerAdjuster {
             TimelineItemKind::Event(event) => {
                 // This date divider is preceded by an event.
                 if self.is_same_date_divider_group_as(event.timestamp(), ts) {
-                    // The event has the same date as the date divider: remove the current date
-                    // divider.
+                    // The event has the same date as the date divider: remove
+                    // the current date divider.
                     trace!("removing date divider following event with same timestamp @ {i}");
                     self.ops.push(DateDividerOperation::Remove(i));
                     return true;
@@ -245,7 +247,8 @@ impl DateDividerAdjuster {
 
             TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(_)) => {
                 trace!("removing duplicate date divider @ {i}");
-                // This date divider is preceded by another one: remove the current one.
+                // This date divider is preceded by another one: remove the
+                // current one.
                 self.ops.push(DateDividerOperation::Remove(i));
                 return true;
             }
@@ -268,8 +271,8 @@ impl DateDividerAdjuster {
         latest_event_ts: Option<MilliSecondsSinceUnixEpoch>,
     ) {
         let Some(PrevItemDesc { item_index, insert_op_at, item }) = prev_item_desc else {
-            // The event was the first item, so there wasn't any date divider before it:
-            // insert one.
+            // The event was the first item, so there wasn't any date divider
+            // before it: insert one.
             trace!("inserting the first date divider @ {}", i);
             self.ops.push(DateDividerOperation::Insert(i, ts));
             return;
@@ -277,8 +280,8 @@ impl DateDividerAdjuster {
 
         match item.kind() {
             TimelineItemKind::Event(prev_event) => {
-                // The event is preceded by another event. If they're not the same date,
-                // insert a date divider.
+                // The event is preceded by another event. If they're not the
+                // same date, insert a date divider.
                 let prev_ts = prev_event.timestamp();
 
                 if !self.is_same_date_divider_group_as(prev_ts, ts) {
@@ -295,12 +298,13 @@ impl DateDividerAdjuster {
 
                 // The event is preceded by a date divider.
                 if timestamp_to_date(*prev_ts) != event_date {
-                    // The date divider is wrong. Should we replace it with the correct value, or
-                    // remove it entirely?
+                    // The date divider is wrong. Should we replace it with the
+                    // correct value, or remove it entirely?
                     if let Some(last_event_ts) = latest_event_ts
                         && timestamp_to_date(last_event_ts) == event_date
                     {
-                        // There's a previous event with the same date: remove the divider.
+                        // There's a previous event with the same date: remove
+                        // the divider.
                         trace!(
                             "removed date divider @ {item_index} between two events \
                                  that have the same date"
@@ -309,8 +313,8 @@ impl DateDividerAdjuster {
                         return;
                     }
 
-                    // There's no previous event or there's one with a different date: replace
-                    // the current divider.
+                    // There's no previous event or there's one with a different
+                    // date: replace the current divider.
                     trace!("replacing date divider @ {item_index} with new timestamp from event");
                     self.ops.insert(insert_op_at, DateDividerOperation::Replace(item_index, ts));
                 }
@@ -406,17 +410,20 @@ impl DateDividerAdjuster {
         };
 
         // Assert invariants.
-        // 1. The timeline starts with a date divider, if it's not only virtual items.
+        // 1. The timeline starts with a date divider, if it's not only virtual
+        //    items.
         {
             let mut i = items.first_remotes_region_index();
             while let Some(item) = items.get(i) {
                 if let Some(virt) = item.as_virtual() {
                     if matches!(virt, VirtualTimelineItem::DateDivider(_)) {
-                        // We found a date divider among the first virtual items: stop here.
+                        // We found a date divider among the first virtual
+                        // items: stop here.
                         break;
                     }
                 } else {
-                    // We found an event, but we didn't have a date divider: report an error.
+                    // We found an event, but we didn't have a date divider:
+                    // report an error.
                     report.errors.push(DateDividerInsertError::FirstItemNotDateDivider);
                     break;
                 }
@@ -464,7 +471,8 @@ impl DateDividerAdjuster {
                         );
                     }
 
-                    // There is a date divider before us, and it's the same date as our timestamp.
+                    // There is a date divider before us, and it's the same date
+                    // as our timestamp.
                     if let Some(prev_ts) = prev_date_divider_ts {
                         if !self.is_same_date_divider_group_as(prev_ts, ts) {
                             report.errors.push(
@@ -496,8 +504,8 @@ impl DateDividerAdjuster {
             }
         }
 
-        // 5. If there was a read marker at the beginning, there should be one at the
-        //    end.
+        // 5. If there was a read marker at the beginning, there should be one
+        //    at the end.
         if let Some(state) = &report.initial_state
             && state.iter().any(|item| item.is_read_marker())
             && !report

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -273,7 +273,8 @@ impl TimelineAction {
                             &unable_to_decrypt_info,
                         );
 
-                        // Let the hook know that we ran into an unable-to-decrypt that is added to
+                        // Let the hook know that we ran into an
+                        // unable-to-decrypt that is added to
                         // the timeline.
                         if let Some(hook) = unable_to_decrypt_hook_manager {
                             hook.on_utd(
@@ -291,10 +292,12 @@ impl TimelineAction {
                             )),
                         ))]
                     } else {
-                        // If we get here, it means that some part of the code has created a
-                        // `TimelineEvent` containing an `m.room.encrypted` event without
-                        // decrypting it. Possibly this means that encryption has not been
-                        // configured. We treat it the same as any other message-like event.
+                        // If we get here, it means that some part of the code
+                        // has created a `TimelineEvent`
+                        // containing an `m.room.encrypted` event without
+                        // decrypting it. Possibly this means that encryption
+                        // has not been configured. We
+                        // treat it the same as any other message-like event.
                         vec![Self::from_content(
                             AnyMessageLikeEventContent::RoomEncrypted(content),
                             in_reply_to,
@@ -336,10 +339,12 @@ impl TimelineAction {
                 },
                 AnySyncStateEvent::BeaconInfo(ev) => match ev {
                     SyncStateEvent::Original(ev) => {
-                        // Check the `live` field directly, not `is_live()` which
-                        // considers timeout. We want to create a timeline item for any
-                        // beacon_info that was started as live, regardless of whether
-                        // the timeout has since expired.
+                        // Check the `live` field directly, not `is_live()`
+                        // which considers timeout. We
+                        // want to create a timeline item for any
+                        // beacon_info that was started as live, regardless of
+                        // whether the timeout has since
+                        // expired.
                         if ev.content.live {
                             let add_item_action =
                                 Self::add_item(TimelineItemContent::MsgLike(MsgLikeContent {
@@ -372,8 +377,10 @@ impl TimelineAction {
                             actions.extend(handle_aggregation_action);
                             actions
                         } else {
-                            // A non-live beacon_info is a stop event: it should update the
-                            // existing live item from the same sender rather than creating a
+                            // A non-live beacon_info is a stop event: it should
+                            // update the
+                            // existing live item from the same sender rather
+                            // than creating a
                             // new timeline item.
                             let event_id = ev.event_id.clone();
                             vec![Self::HandleAggregation {
@@ -752,7 +759,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             aggregation,
             &self.meta.room_version_rules,
         ) {
-            // Update all events that replied to this message with the edited content.
+            // Update all events that replied to this message with the edited
+            // content.
             Self::maybe_update_responses(
                 self.meta,
                 self.items,
@@ -858,8 +866,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         let aggregation = Aggregation::new(own_id, AggregationKind::BeaconStop { content });
 
         let Some(target_event_id) = target_event_id else {
-            // The live start item hasn't arrived yet (or the content doesn't match).
-            // Stash the stop so it can be applied when the matching start item arrives.
+            // The live start item hasn't arrived yet (or the content doesn't
+            // match). Stash the stop so it can be applied when the
+            // matching start item arrives.
             trace!(
                 "no matching live beacon_info item found for {sender}; \
                  stashing stop event to apply when the start item arrives"
@@ -910,8 +919,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
         // If it's an aggregation that's being redacted, handle it here.
         if self.handle_aggregation_redaction(redacted.clone()) {
-            // When we have raw timeline items, we should not return here anymore, as we
-            // might need to redact the raw item as well.
+            // When we have raw timeline items, we should not return here
+            // anymore, as we might need to redact the raw item as
+            // well.
             return;
         }
 
@@ -932,8 +942,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             &self.meta.room_version_rules,
         );
 
-        // Even if the redacted event wasn't in the timeline, we can always update
-        // responses with a placeholder "redacted" embedded item.
+        // Even if the redacted event wasn't in the timeline, we can always
+        // update responses with a placeholder "redacted" embedded item.
         let embedded_event = EmbeddedEvent {
             content: TimelineItemContent::MsgLike(MsgLikeContent::redacted()),
             sender: self.ctx.sender.clone(),
@@ -1121,7 +1131,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 let all_remote_events = self.items.all_remote_events();
                 let event_index = *event_index;
 
-                // Look for the closest `timeline_item_index` at the left of `event_index`.
+                // Look for the closest `timeline_item_index` at the left of
+                // `event_index`.
                 let timeline_item_index = all_remote_events
                     .range(0..=event_index)
                     .rev()
@@ -1129,16 +1140,17 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     // The new `timeline_item_index` is the previous + 1.
                     .map(|timeline_item_index| timeline_item_index + 1);
 
-                // No index? Look for the closest `timeline_item_index` at the right of
-                // `event_index`.
+                // No index? Look for the closest `timeline_item_index` at the
+                // right of `event_index`.
                 let timeline_item_index = timeline_item_index.or_else(|| {
                     all_remote_events
                         .range(event_index + 1..)
                         .find_map(|event_meta| event_meta.timeline_item_index)
                 });
 
-                // Still no index? Well, it means there is no existing `timeline_item_index`
-                // so we are inserting at the last non-local item position as a fallback.
+                // Still no index? Well, it means there is no existing
+                // `timeline_item_index` so we are inserting at
+                // the last non-local item position as a fallback.
                 let timeline_item_index = timeline_item_index.unwrap_or_else(|| {
                     self.items
                         .iter_remotes_region()
@@ -1147,7 +1159,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                             timeline_item.as_event().map(|_| timeline_item_index + 1)
                         })
                         .unwrap_or_else(|| {
-                            // There is no remote timeline item, so we could insert at the start of
+                            // There is no remote timeline item, so we could
+                            // insert at the start of
                             // the remotes region.
                             self.items.first_remotes_region_index()
                         })
@@ -1183,8 +1196,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         timeline_item.as_event().map(|_| timeline_item_index + 1)
                     })
                     .unwrap_or_else(|| {
-                        // There is no remote timeline item, so we could insert at the start of
-                        // the remotes region.
+                        // There is no remote timeline item, so we could insert
+                        // at the start of the remotes
+                        // region.
                         self.items.first_remotes_region_index()
                     });
 
@@ -1201,11 +1215,13 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         Some(0)
                     });
 
-                // Try to keep precise insertion semantics here, in this exact order:
+                // Try to keep precise insertion semantics here, in this exact
+                // order:
                 //
-                // * _push back_ when the new item is inserted after all items (the assumption
-                // being that this is the hot path, because most of the time new events
-                // come from the sync),
+                // * _push back_ when the new item is inserted after all items
+                //   (the assumption
+                // being that this is the hot path, because most of the time new
+                // events come from the sync),
                 // * _push front_ when the new item is inserted at index 0,
                 // * _insert_ otherwise.
 
@@ -1229,10 +1245,12 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 position: TimelineItemPosition::UpdateAt { timeline_item_index: idx },
                 ..
             } => {
-                // The event cache redacts the raw event independently of the aggregations
-                // system, which reaches us here as an `UpdateAt`. If the item is already
-                // redacted (via the aggregations system, applied earlier in the diff batch),
-                // skip it to avoid a spurious duplicate update.
+                // The event cache redacts the raw event independently of the
+                // aggregations system, which reaches us here as
+                // an `UpdateAt`. If the item is already
+                // redacted (via the aggregations system, applied earlier in the
+                // diff batch), skip it to avoid a spurious
+                // duplicate update.
                 let already_redacted = item.content().is_redacted()
                     && self.items[*idx]
                         .as_event()
@@ -1243,7 +1261,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 } else {
                     trace!("Updating timeline item at position {idx}");
 
-                    // Update all events that replied to this previously encrypted message.
+                    // Update all events that replied to this previously
+                    // encrypted message.
                     Self::maybe_update_responses(
                         self.meta,
                         self.items,
@@ -1281,12 +1300,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             // Is this the same as previously?
             if let Some(prev_event_id) = &self.meta.active_rtc_notification_event_id {
                 if Some(prev_event_id.as_ref()) == last_notification.event_id() {
-                    // then no changes, the newest rtc_notification event have not change
+                    // then no changes, the newest rtc_notification event have
+                    // not change
                     return;
                 }
 
                 // They are different, clean the old event
-                // Find the previous notification item and clear its active_members
+                // Find the previous notification item and clear its
+                // active_members
                 if let Some((idx, prev_item)) =
                     rfind_event_item(self.items, |it: &EventTimelineItem| {
                         it.event_id() == Some(prev_event_id)
@@ -1335,8 +1356,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 let new_timeline_item = TimelineItem::new(updated_event_item, internal_id);
                 self.items.replace(idx, new_timeline_item);
 
-                // Update the active_rtc_notification_event_id so that this event gets any new
-                // updates of call membership
+                // Update the active_rtc_notification_event_id so that this
+                // event gets any new updates of call membership
                 self.meta.active_rtc_notification_event_id =
                     last_notification.event_id().map(ToOwned::to_owned);
             }
@@ -1356,7 +1377,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         transaction_id: Option<&TransactionId>,
         recycled_timeline_id: Option<TimelineUniqueId>,
     ) -> Arc<TimelineItem> {
-        // Detect a local timeline item that matches `event_id` or `transaction_id`.
+        // Detect a local timeline item that matches `event_id` or
+        // `transaction_id`.
         if let Some((local_timeline_item_index, local_timeline_item)) = items
             // Iterate the locals region.
             .iter_locals_region()
@@ -1372,8 +1394,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     // A duplicate local event timeline item has been found!
                     Some((nth, event_timeline_item))
                 } else {
-                    // This local event timeline is not the one we are looking for. Continue our
-                    // search.
+                    // This local event timeline is not the one we are looking
+                    // for. Continue our search.
                     None
                 }
             })
@@ -1391,7 +1413,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             let recycled = items.remove(local_timeline_item_index);
             TimelineItem::new(new_item, recycled.internal_id.clone())
         } else {
-            // We haven't found a matching local item to recycle; create a new item.
+            // We haven't found a matching local item to recycle; create a new
+            // item.
             meta.new_timeline_item_with_internal_id(new_item, recycled_timeline_id)
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -246,7 +246,8 @@ impl TimelineItemContent {
                 None
             }
             [_, _, ..] => {
-                // There is no meaningful single content to extract in that case.
+                // There is no meaningful single content to extract in that
+                // case.
                 warn!("Ignoring event that produced multiple timeline actions");
                 None
             }
@@ -851,7 +852,8 @@ impl AnyOtherStateEventContentChange {
     /// `AnyStateEventContentChange`.
     ///
     /// Panics if the event content does not match one of the variants.
-    // This could be a `From` implementation but we don't want it in the public API.
+    // This could be a `From` implementation but we don't want it in the public
+    // API.
     pub(crate) fn with_event_content(content: AnyStateEventContentChange) -> Self {
         let event_type = content.event_type();
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/pinned_events.rs
@@ -42,8 +42,9 @@ impl From<&StateEventContentChange<RoomPinnedEventsEventContent>> for RoomPinned
                         let mut still_pinned: HashSet<&OwnedEventId> =
                             HashSet::from_iter(old_pinned);
 
-                        // Newly added elements will be kept in new_pinned, previous ones in
-                        // still_pinned instead
+                        // Newly added elements will be kept in new_pinned,
+                        // previous ones in still_pinned
+                        // instead
                         still_pinned.retain(|item| new_pinned.remove(item));
 
                         let added = !new_pinned.is_empty();
@@ -59,12 +60,13 @@ impl From<&StateEventContentChange<RoomPinnedEventsEventContent>> for RoomPinned
                             RoomPinnedEventsChange::Changed
                         }
                     } else {
-                        // We don't know the previous state, so let's assume a generic change
+                        // We don't know the previous state, so let's assume a
+                        // generic change
                         RoomPinnedEventsChange::Changed
                     }
                 } else {
-                    // If there is no previous content we can assume the first pinned event id was
-                    // just added
+                    // If there is no previous content we can assume the first
+                    // pinned event id was just added
                     RoomPinnedEventsChange::Added
                 }
             }
@@ -161,8 +163,9 @@ mod tests {
 
     #[test]
     fn pinned_events_content_with_no_changes_returns_changed() {
-        // Returning Changed is counter-intuitive, but it makes no sense to display in
-        // the timeline 'UserFoo didn't change anything in the pinned events'
+        // Returning Changed is counter-intuitive, but it makes no sense to
+        // display in the timeline 'UserFoo didn't change anything in
+        // the pinned events'
 
         let content = StateEventContentChange::Original {
             content: RoomPinnedEventsEventContent::new(vec![

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/reply.rs
@@ -144,8 +144,9 @@ impl EmbeddedEvent {
             [TimelineAction::HandleAggregation { kind, .. }] => {
                 // As an exception, edits are allowed to be embedded events.
 
-                // For an embedded event, we don't need to fill a few fields; it's in an
-                // embedded view context, so there's no strong need to show all detailed
+                // For an embedded event, we don't need to fill a few fields;
+                // it's in an embedded view context, so there's
+                // no strong need to show all detailed
                 // information about it.
                 let reactions = Default::default();
                 let thread_root = None;
@@ -178,7 +179,8 @@ impl EmbeddedEvent {
                     }
 
                     _ => {
-                        // The event can't be represented as a standalone timeline item.
+                        // The event can't be represented as a standalone
+                        // timeline item.
                         warn!("embedded event is an aggregation: {}", kind.debug_string());
                         None
                     }
@@ -198,9 +200,11 @@ impl EmbeddedEvent {
                 Ok(None)
             }
             [_, _, ..] => {
-                // Multiple actions can happen e.g. when a beacon_info with prev_content
-                // is replied to: it produces both an AddItem and a HandleAggregation.
-                // There is no meaningful single content to extract in that case.
+                // Multiple actions can happen e.g. when a beacon_info with
+                // prev_content is replied to: it produces both
+                // an AddItem and a HandleAggregation.
+                // There is no meaningful single content to extract in that
+                // case.
                 warn!("Ignoring embedded event that produced multiple timeline actions");
                 Ok(None)
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -334,8 +334,8 @@ impl EventTimelineItem {
 
     /// Flag indicating this timeline item can be edited by the current user.
     pub fn is_editable(&self) -> bool {
-        // Steps here should be in sync with [`EventTimelineItem::edit_info`] and
-        // [`Timeline::edit_poll`].
+        // Steps here should be in sync with [`EventTimelineItem::edit_info`]
+        // and [`Timeline::edit_poll`].
 
         if !self.is_own() {
             // In theory could work, but it's hard to compute locally.
@@ -397,8 +397,9 @@ impl EventTimelineItem {
         }
 
         // A live-location item originates from a `beacon_info` *state* event,
-        // which cannot be encrypted (except with `experimental-encrypted-state-events`
-        // flag). The actual location updates (`beacon` message-like events)
+        // which cannot be encrypted (except with
+        // `experimental-encrypted-state-events` flag). The actual
+        // location updates (`beacon` message-like events)
         // *are* encrypted.
         //
         // When there are no beacons yet we return `None` (the state event
@@ -446,8 +447,9 @@ impl EventTimelineItem {
         } else if self.content.is_message() {
             true
         } else if self.content().as_live_location_state().is_some() {
-            // Live location sharing session (MSC3489) events are state events, not always
-            // displayed in a timeline, so can't be replied to.
+            // Live location sharing session (MSC3489) events are state events,
+            // not always displayed in a timeline, so can't be
+            // replied to.
             false
         } else {
             self.latest_json().is_some()

--- a/crates/matrix-sdk-ui/src/timeline/latest_event.rs
+++ b/crates/matrix-sdk-ui/src/timeline/latest_event.rs
@@ -160,8 +160,8 @@ impl LatestEventValue {
                     },
 
                     TimelineAction::HandleAggregation { kind, .. } => {
-                        // Add some debug logging here to help diagnose issues with the latest
-                        // event.
+                        // Add some debug logging here to help diagnose issues
+                        // with the latest event.
                         trace!("latest event is an aggregation: {}", kind.debug_string());
                         Self::None
                     }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -375,8 +375,8 @@ impl Timeline {
         mut content: AnyMessageLikeEventContent,
         extra_content: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> Result<SendHandle, Error> {
-        // If this is a room event we're sending in a threaded timeline, we add the
-        // thread relation ourselves.
+        // If this is a room event we're sending in a threaded timeline, we add
+        // the thread relation ourselves.
         if content.relation().is_none()
             && let Some(reply) = self.infer_reply(None).await
         {
@@ -500,8 +500,9 @@ impl Timeline {
     /// automatically fills the [`Reply`] information based on the current
     /// timeline focus.
     pub(crate) async fn infer_reply(&self, in_reply_to: Option<OwnedEventId>) -> Option<Reply> {
-        // If there's a replied-to event id, the reply is pretty straightforward, and we
-        // should only infer the `EnforceThread` based on the current focus.
+        // If there's a replied-to event id, the reply is pretty
+        // straightforward, and we should only infer the `EnforceThread`
+        // based on the current focus.
         if let Some(in_reply_to) = in_reply_to {
             let enforce_thread = if self.controller.is_threaded() {
                 EnforceThread::Threaded(ReplyWithinThread::Yes)
@@ -517,14 +518,15 @@ impl Timeline {
 
         let thread_root = self.controller.thread_root()?;
 
-        // The latest event id is used for the reply-to fallback, for clients which
-        // don't handle threads. It should be correctly set to the latest
-        // event in the thread, which the timeline instance might or might
-        // not know about; in this case, we do a best effort of filling it, and resort
-        // to using the thread root if we don't know about any event.
+        // The latest event id is used for the reply-to fallback, for clients
+        // which don't handle threads. It should be correctly set to the
+        // latest event in the thread, which the timeline instance might
+        // or might not know about; in this case, we do a best effort of
+        // filling it, and resort to using the thread root if we don't
+        // know about any event.
         //
-        // Note: we could trigger a back-pagination if the timeline is empty, and wait
-        // for the results, if the timeline is too often empty.
+        // Note: we could trigger a back-pagination if the timeline is empty,
+        // and wait for the results, if the timeline is too often empty.
 
         let latest_event_id = self
             .controller
@@ -578,7 +580,8 @@ impl Timeline {
                 let new_content: AnyMessageLikeEventContent = match new_content {
                     EditedContent::RoomMessage(message) => {
                         if item.content.is_message() {
-                            // The replacement becomes the pending event itself, so restore its
+                            // The replacement becomes the pending event itself,
+                            // so restore its
                             // relations, which the payload can't carry by type.
                             AnyMessageLikeEventContent::RoomMessage(
                                 message.with_relation(item.content.relation()),
@@ -741,8 +744,9 @@ impl Timeline {
                 Ok(())
             }
             TimelineItemHandle::Local(handle) => {
-                // Forward the reason: if the local echo was being sent and the send wins the
-                // race, the server-side redaction that materializes the abort carries it.
+                // Forward the reason: if the local echo was being sent and the
+                // send wins the race, the server-side redaction
+                // that materializes the abort carries it.
                 if !handle
                     .abort_with_reason(reason.map(ToOwned::to_owned))
                     .await

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -37,12 +37,15 @@ impl super::Timeline {
                         );
                     }
                     None => {
-                        // We could adjust the skip count to a lower value, while passing the
-                        // requested number of events. We *may* have reached the start of the
-                        // timeline, but since we're fulfilling the caller's request, assume it's
-                        // not the case and return false here. A subsequent call will go to the
-                        // `Some()` arm of this match, and cause a call to the event cache's
-                        // pagination.
+                        // We could adjust the skip count to a lower value,
+                        // while passing the
+                        // requested number of events. We *may* have reached the
+                        // start of the timeline, but
+                        // since we're fulfilling the caller's request, assume
+                        // it's not the case and return
+                        // false here. A subsequent call will go to the
+                        // `Some()` arm of this match, and cause a call to the
+                        // event cache's pagination.
                         return Ok(false);
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/subscriber.rs
+++ b/crates/matrix-sdk-ui/src/timeline/subscriber.rs
@@ -143,8 +143,9 @@ pub mod skip {
 
             // Initial states: no items are present.
             if previous_number_of_items == 0 {
-                // Adjust the count to provide a maximum number of initial items. We want to
-                // skip the first items until we get a certain number of items to display.
+                // Adjust the count to provide a maximum number of initial
+                // items. We want to skip the first items until
+                // we get a certain number of items to display.
                 //
                 // | `next_number_of_items` | `MAX…` | output | will display |
                 // |------------------------|--------|--------|--------------|
@@ -156,13 +157,16 @@ pub mod skip {
             }
             // Not the initial state: there are items.
             else {
-                // There are less items than before. Shift to the left `count` by the difference
-                // between `previous_number_of_items` and `next_number_of_items` to keep the
-                // same number of items in the stream as much as possible.
+                // There are less items than before. Shift to the left `count`
+                // by the difference
+                // between `previous_number_of_items` and `next_number_of_items`
+                // to keep the same number of items in the
+                // stream as much as possible.
                 //
-                // This is not a backwards pagination, it cannot “go below 0”, however this is
-                // necessary to handle the case where the timeline is cleared and
-                // the number of items becomes 0 for example.
+                // This is not a backwards pagination, it cannot “go below 0”,
+                // however this is necessary to handle the case
+                // where the timeline is cleared and the number
+                // of items becomes 0 for example.
                 if next_number_of_items < previous_number_of_items {
                     current_count.saturating_sub(previous_number_of_items - next_number_of_items)
                 }
@@ -194,8 +198,9 @@ pub mod skip {
         ) -> (usize, Option<usize>) {
             let current_count = self.count.get();
 
-            // We skip the values from the start of the timeline; paginating backwards means
-            // we have to reduce the count until reaching 0.
+            // We skip the values from the start of the timeline; paginating
+            // backwards means we have to reduce the count until
+            // reaching 0.
             //
             // | `current_count` | `page_size` | output         |
             // |-----------------|-------------|----------------|
@@ -205,9 +210,10 @@ pub mod skip {
             // | 0               | 20          | (0, Some(20))  |
             //                                    ^  ^^^^^^^^
             //                                    |  |
-            //                                    |  it needs 20 items to fulfill the
-            //                                    |  page size
-            //                                    count becomes 0
+            //                                    |  it needs 20 items to
+            // fulfill the                                    |
+            // page size                                    count
+            // becomes 0
             //
             if current_count >= page_size {
                 (current_count - page_size, None)
@@ -225,12 +231,14 @@ pub mod skip {
         ///
         /// [`Skip`]: eyeball_im_util::vector::Skip
         #[allow(unused)] // this is not used yet because only a live timeline is using it, but as soon as
-        // other kind of timelines will use it, we would need it, it's better to have
-        // this in case of; everything is tested, the logic is made more robust.
+        // other kind of timelines will use it, we would need it, it's better to
+        // have this in case of; everything is tested, the logic is made
+        // more robust.
         pub fn compute_next_when_paginating_forwards(&self, _page_size: usize) -> usize {
-            // Nothing to do, the count remains unchanged as we skip the first values, not
-            // the last values; paginating forwards will add items at the end, not at the
-            // start of the timeline.
+            // Nothing to do, the count remains unchanged as we skip the first
+            // values, not the last values; paginating forwards will
+            // add items at the end, not at the start of the
+            // timeline.
             self.count.get()
         }
 
@@ -268,8 +276,8 @@ pub mod skip {
             assert_eq!(count, 0);
             skip_count.count.set(count);
 
-            // Add 5 new items. The count stays at 0 because we don't want to skip the
-            // previous items.
+            // Add 5 new items. The count stays at 0 because we don't want to
+            // skip the previous items.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items + 5;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
@@ -284,15 +292,17 @@ pub mod skip {
             assert_eq!(count, 0);
             skip_count.count.set(count);
 
-            // Remove a certain number of items. The count stays at 0 because it was
-            // previously 0, no items are skipped, nothing to adjust.
+            // Remove a certain number of items. The count stays at 0 because it
+            // was previously 0, no items are skipped, nothing to
+            // adjust.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items - 4;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
             assert_eq!(count, 0);
             skip_count.count.set(count);
 
-            // Remove all items. The count goes to 0 (regardless it was 0 before).
+            // Remove all items. The count goes to 0 (regardless it was 0
+            // before).
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = 0;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
@@ -310,8 +320,8 @@ pub mod skip {
             assert_eq!(count, 10);
             skip_count.count.set(count);
 
-            // Add 5 new items. The count stays at 10 because we don't want to skip the
-            // previous items.
+            // Add 5 new items. The count stays at 10 because we don't want to
+            // skip the previous items.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items + 5;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
@@ -326,15 +336,16 @@ pub mod skip {
             assert_eq!(count, 10);
             skip_count.count.set(count);
 
-            // Remove a certain number of items. The count is reduced by 5 so that the same
-            // number of items are presented.
+            // Remove a certain number of items. The count is reduced by 5 so
+            // that the same number of items are presented.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items - 4;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
             assert_eq!(count, 6);
             skip_count.count.set(count);
 
-            // Remove all items. The count goes to 0 (regardless it was 6 before).
+            // Remove all items. The count goes to 0 (regardless it was 6
+            // before).
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = 0;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
@@ -352,8 +363,8 @@ pub mod skip {
             assert_eq!(count, 0);
             skip_count.count.set(count);
 
-            // Add 30 new items. The count stays at 0 because we don't want to skip the
-            // previous items.
+            // Add 30 new items. The count stays at 0 because we don't want to
+            // skip the previous items.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items + 30;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);
@@ -389,14 +400,16 @@ pub mod skip {
 
             let page_size = 20;
 
-            // Paginate backwards. The count shifts by `page_size`, and the page is full.
+            // Paginate backwards. The count shifts by `page_size`, and the page
+            // is full.
             let (count, needs) = skip_count.compute_next_when_paginating_backwards(page_size);
             assert_eq!(count, 10);
             assert_eq!(needs, None);
             skip_count.count.set(count);
 
-            // Paginate backwards. The count shifts by `page_size` but reaches 0 before the
-            // page becomes full. It needs 10 more items to fulfill the page.
+            // Paginate backwards. The count shifts by `page_size` but reaches 0
+            // before the page becomes full. It needs 10 more items
+            // to fulfill the page.
             let (count, needs) = skip_count.compute_next_when_paginating_backwards(page_size);
             assert_eq!(count, 0);
             assert_eq!(needs, Some(10));
@@ -413,8 +426,8 @@ pub mod skip {
             assert_eq!(count, 0);
             skip_count.count.set(count);
 
-            // Add 30 new items. The count stays at 0 because we don't want to skip the
-            // previous items.
+            // Add 30 new items. The count stays at 0 because we don't want to
+            // skip the previous items.
             let previous_number_of_items = next_number_of_items;
             let next_number_of_items = previous_number_of_items + 30;
             let count = skip_count.compute_next(previous_number_of_items, next_number_of_items);

--- a/crates/matrix-sdk-ui/src/timeline/tasks.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tasks.rs
@@ -58,9 +58,10 @@ pub(in crate::timeline) async fn pinned_events_task(
             Err(RecvError::Lagged(num_skipped)) => {
                 warn!(num_skipped, "Lagged behind pinned-event cache updates, resetting timeline");
 
-                // The updates might have lagged, but the room event cache might have
-                // events, so retrieve them and add them back again to the timeline,
-                // after clearing it.
+                // The updates might have lagged, but the room event cache might
+                // have events, so retrieve them and add them
+                // back again to the timeline, after clearing
+                // it.
                 let (initial_events, _) = match pinned_events_cache.subscribe().await {
                     Ok(initial_events) => initial_events,
                     Err(err) => {
@@ -116,9 +117,10 @@ pub(in crate::timeline) async fn event_focused_task(
             Err(RecvError::Lagged(num_skipped)) => {
                 warn!(num_skipped, "Lagged behind focused-event cache updates, resetting timeline");
 
-                // The updates might have lagged, but the room event cache might have
-                // events, so retrieve them and add them back again to the timeline,
-                // after clearing it.
+                // The updates might have lagged, but the room event cache might
+                // have events, so retrieve them and add them
+                // back again to the timeline, after clearing
+                // it.
                 let Ok((initial_events, _)) = event_cache.subscribe().await else {
                     error!("Failed to subscribe to the event-focused cache");
                     break;
@@ -208,9 +210,10 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
             Err(RecvError::Lagged(num_skipped)) => {
                 warn!(num_skipped, "Lagged behind event cache updates, resetting timeline");
 
-                // The updates might have lagged, but the room event cache might have
-                // events, so retrieve them and add them back again to the timeline,
-                // after clearing it.
+                // The updates might have lagged, but the room event cache might
+                // have events, so retrieve them and add them
+                // back again to the timeline, after clearing
+                // it.
                 let initial_events = match room_event_cache.events().await {
                     Ok(initial_events) => initial_events,
                     Err(err) => {
@@ -249,7 +252,8 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
                 if matches!(timeline_focus, TimelineFocus::Live { .. }) {
                     timeline_controller.handle_remote_events_with_diffs(diffs, origin).await;
                 } else if matches!(timeline_focus, TimelineFocus::Event { .. }) {
-                    // Only handle the remote aggregation for an event-focused timeline.
+                    // Only handle the remote aggregation for an event-focused
+                    // timeline.
                     timeline_controller.handle_remote_aggregations(diffs, origin).await;
                 }
 
@@ -261,7 +265,8 @@ pub(in crate::timeline) async fn room_event_cache_updates_task(
             RoomEventCacheUpdate::AddEphemeralEvents { events } => {
                 trace!("Received new ephemeral events from sync.");
 
-                // TODO: ephemeral (read receipts) should be handled by the event cache (#4113).
+                // TODO: ephemeral (read receipts) should be handled by the
+                // event cache (#4113).
                 timeline_controller.handle_ephemeral_events(events).await;
             }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -221,8 +221,8 @@ async fn test_room_member() {
     assert_matches!(profile.avatar_url_change(), Some(_));
 
     {
-        // No avatar or display name in the new room member event content, but it's
-        // possible to get the previous one using the getters.
+        // No avatar or display name in the new room member event content, but
+        // it's possible to get the previous one using the getters.
         timeline
             .handle_live_event(
                 f.member(&ALICE).membership(MembershipState::Leave).previous(
@@ -359,7 +359,8 @@ async fn test_internal_id_reuse() {
     assert_eq!(event3.as_event().unwrap().sender(), *CAROL);
     assert_eq!(event3.unique_id().0, "2");
 
-    // Then, handle a deduplication (removal then reinsertion of the same event).
+    // Then, handle a deduplication (removal then reinsertion of the same
+    // event).
     timeline
         .controller
         .handle_remote_events_with_diffs(
@@ -659,7 +660,7 @@ async fn test_latest_event_id_in_main_timeline() {
     assert_eq!(items.len(), 1);
     assert_let!(Some(latest_event_id) = timeline.controller.latest_event_id().await);
 
-    // But the latest event in the live timeline is still the reaction, since the
-    // threaded event is not part of the live timeline
+    // But the latest event in the live timeline is still the reaction, since
+    // the threaded event is not part of the live timeline
     assert_eq!(reaction_event_id, latest_event_id);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -65,8 +65,8 @@ async fn test_remote_echo_full_trip() {
         assert!(date_divider.is_date_divider());
     }
 
-    // Scenario 2: The local event has not been sent to the server successfully, it
-    // has failed. In this case, there is no event ID.
+    // Scenario 2: The local event has not been sent to the server successfully,
+    // it has failed. In this case, there is no event ID.
     {
         let error = Arc::new(matrix_sdk::Error::SendQueueWedgeError(Box::new(
             QueueWedgeError::GenericApiError { msg: "this is a test".to_owned() },
@@ -89,8 +89,8 @@ async fn test_remote_echo_full_trip() {
         assert_eq!(*item.unique_id(), id);
     }
 
-    // Scenario 3: The local event has been sent successfully to the server and an
-    // event ID has been received as part of the server's response.
+    // Scenario 3: The local event has been sent successfully to the server and
+    // an event ID has been received as part of the server's response.
     let event_id = event_id!("$W6mZSLWMmfuQQ9jhZWeTxFIM");
     let timestamp = {
         timeline
@@ -110,8 +110,8 @@ async fn test_remote_echo_full_trip() {
         event_item.timestamp()
     };
 
-    // Now, a sync has been run against the server, and an event with the same ID
-    // comes in.
+    // Now, a sync has been run against the server, and an event with the same
+    // ID comes in.
     timeline
         .handle_live_event(
             timeline
@@ -207,8 +207,9 @@ async fn test_date_divider_removed_after_local_echo_disappeared() {
     assert!(items[1].is_remote_event());
 
     // Add a local echo.
-    // It's not possible to synthesize `LocalEcho`s because they require forging a
-    // `SendHandle`, which is a bit involved. Instead, use handle_local_event.
+    // It's not possible to synthesize `LocalEcho`s because they require forging
+    // a `SendHandle`, which is a bit involved. Instead, use
+    // handle_local_event.
     let txn_id =
         timeline.handle_local_event(RoomMessageEventContent::text_plain("local echo").into()).await;
 
@@ -249,8 +250,8 @@ async fn test_no_read_marker_with_local_echo() {
 
     let f = &timeline.factory;
 
-    // Use `replace_with_initial_remote_events` which initializes the read marker;
-    // other methods don't, by default.
+    // Use `replace_with_initial_remote_events` which initializes the read
+    // marker; other methods don't, by default.
     timeline
         .controller
         .replace_with_initial_remote_events(
@@ -270,8 +271,9 @@ async fn test_no_read_marker_with_local_echo() {
     assert!(items[1].is_remote_event());
 
     // Add a local echo.
-    // It's not possible to synthesize `LocalEcho`s because they require forging a
-    // `SendHandle`, which is a bit involved. Instead, use handle_local_event.
+    // It's not possible to synthesize `LocalEcho`s because they require forging
+    // a `SendHandle`, which is a bit involved. Instead, use
+    // handle_local_event.
     let txn_id =
         timeline.handle_local_event(RoomMessageEventContent::text_plain("local echo").into()).await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -267,8 +267,8 @@ async fn test_false_positive_late_decryption_regression() {
     sleep(Duration::from_millis(200)).await;
 
     // Simulate a retry decryption.
-    // Due to the regression this was marking the event as successfully decrypted on
-    // retry
+    // Due to the regression this was marking the event as successfully
+    // decrypted on retry
     timeline
         .controller
         .retry_event_decryption(Some(iter::once(SESSION_ID.to_owned()).collect()))
@@ -281,8 +281,8 @@ async fn test_false_positive_late_decryption_regression() {
     {
         let utds = hook.utds.lock().unwrap();
         assert_eq!(utds.len(), 1);
-        // This is the main thing we're testing: if this wasn't identified as a definite
-        // UTD, this would be `Some(..)`.
+        // This is the main thing we're testing: if this wasn't identified as a
+        // definite UTD, this would be `Some(..)`.
         assert!(utds[0].time_to_decrypt.is_none());
     }
 }
@@ -407,7 +407,8 @@ async fn test_retry_edit_decryption() {
     // Then first, the first item gets decrypted on its own
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 0, .. });
 
-    // And second, they get resolved into a single event after the edit is decrypted
+    // And second, they get resolved into a single event after the edit is
+    // decrypted
     assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 0, value } => value);
     let item =
         assert_next_matches_with_timeout!(stream, VectorDiff::Set { index: 0, value } => value);
@@ -465,8 +466,8 @@ async fn test_retry_edit_and_more() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut stream) = timeline.subscribe_filter_map(|e| e.as_event().cloned()).await;
 
-    // Given the timeline contains an event and an edit of that event, and another
-    // event, all UTD.
+    // Given the timeline contains an event and an edit of that event, and
+    // another event, all UTD.
 
     let event = event_factory
         .event(encrypted_message(
@@ -568,8 +569,8 @@ async fn test_retry_edit_and_more() {
 
     let items = timeline.items().await;
 
-    // We're left with 3 items, the zeroth one is the date divider and the next two
-    // are the messages.
+    // We're left with 3 items, the zeroth one is the date divider and the next
+    // two are the messages.
     assert!(items[0].is_date_divider());
     assert_eq!(items.len(), 3);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -480,7 +480,8 @@ async fn test_event_filter_exclude_membership_changes() {
         )
         .await;
 
-    // The timeline should contain everything except for the invite and join events
+    // The timeline should contain everything except for the invite and join
+    // events
     let event_items: Vec<Arc<TimelineItem>> = timeline.get_event_items().await;
     let num_text_message_items = event_items.iter().filter(is_text_message_item).count();
     let num_room_name_items = event_items.iter().filter(is_room_name_item).count();
@@ -533,8 +534,8 @@ async fn test_event_filter_exclude_profile_changes() {
         )
         .await;
 
-    // The timeline should contain everything except for the display name and avatar
-    // URL changes
+    // The timeline should contain everything except for the display name and
+    // avatar URL changes
     let event_items: Vec<Arc<TimelineItem>> = timeline.get_event_items().await;
     let num_text_message_items = event_items.iter().filter(is_text_message_item).count();
     let num_room_name_items = event_items.iter().filter(is_room_name_item).count();
@@ -653,8 +654,8 @@ async fn test_event_filter_can_exclude_only_join_and_leave_membership_changes() 
     let num_room_topic_items = event_items.iter().filter(is_room_topic_item).count();
     let num_membership_change_items = event_items.iter().filter(is_membership_change_item).count();
     let num_profile_change_items = event_items.iter().filter(is_profile_change_item).count();
-    // 2 profile changes + 1 text message + 1 room name + 1 room topic + 1 invited
-    // membership change
+    // 2 profile changes + 1 text message + 1 room name + 1 room topic + 1
+    // invited membership change
     assert_eq!(event_items.len(), 6);
     assert_eq!(num_text_message_items, 1);
     assert_eq!(num_room_name_items, 1);

--- a/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/live_location.rs
@@ -412,7 +412,8 @@ async fn test_beacon_stop_updates_existing_item() {
 
     // The existing item is updated — a Set diff, not a PushBack.
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
-    // The original start item is updated — its event_id remains the start event.
+    // The original start item is updated — its event_id remains the start
+    // event.
     assert_eq!(item.event_id().unwrap(), start_id);
     assert!(
         !item.content().as_live_location_state().unwrap().is_live(),
@@ -525,7 +526,8 @@ async fn test_beacon_stop_before_start_is_applied_later() {
         )
         .await;
 
-    // The item should appear already stopped — a single PushBack, no follow-up Set.
+    // The item should appear already stopped — a single PushBack, no follow-up
+    // Set.
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_eq!(item.event_id().unwrap(), start_id, "the item should carry the start event's ID");
     assert!(
@@ -550,7 +552,8 @@ async fn test_pending_beacon_stop_not_applied_to_different_session() {
 
     // Use the current time as base for session B.
     // Session A's timestamp doesn't matter since its stop will be discarded.
-    // Session B needs a recent timestamp so is_live() doesn't fail due to timeout.
+    // Session B needs a recent timestamp so is_live() doesn't fail due to
+    // timeout.
     let old_session_ts = MilliSecondsSinceUnixEpoch(uint!(1)); // Old session (past)
     let new_session_ts = MilliSecondsSinceUnixEpoch::now(); // New session (now)
 
@@ -902,7 +905,8 @@ async fn test_local_reaction_on_live_location_item() {
     // Receive the remote echo from sync.
     timeline.handle_live_event(timeline.factory.reaction(beacon_id, "👍").sender(&ALICE)).await;
 
-    // The item is updated once more — now the reaction is a confirmed remote echo.
+    // The item is updated once more — now the reaction is a confirmed remote
+    // echo.
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
     assert!(item.content().as_live_location_state().is_some());
     let reactions = item.content().reactions().unwrap();

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -273,8 +273,8 @@ async fn send_first_message(
 
 #[async_test]
 async fn test_reinserted_item_keeps_reactions() {
-    // This test checks that after deduplicating events, the reactions attached to
-    // the deduplicated event are not lost.
+    // This test checks that after deduplicating events, the reactions attached
+    // to the deduplicated event are not lost.
     let timeline = TestTimeline::new().await;
     let f = &timeline.factory;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -709,7 +709,8 @@ async fn test_implicit_read_receipt_before_explicit_read_receipt() {
     // Test a timeline in this order:
     // 1. $alice_event: sent by alice, has no explicit read receipts.
     // 2. $bob_event: sent by bob, has no explicit read receipts.
-    // 3. $carol_event: sent by carol, has the explicit read receipts of all users.
+    // 3. $carol_event: sent by carol, has the explicit read receipts of all
+    //    users.
     let room_id = room_id!("!room:localhost");
     let alice_event_id = owned_event_id!("$alice_event");
     let bob_event_id = owned_event_id!("$bob_event");

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -255,8 +255,8 @@ async fn test_local_and_remote_echo_of_redaction() {
     );
     assert!(original_json.is_some());
 
-    // Now redact the message. We first emit the local echo of the redaction event.
-    // The timeline event should be marked as being under redaction.
+    // Now redact the message. We first emit the local echo of the redaction
+    // event. The timeline event should be marked as being under redaction.
     timeline.handle_local_redaction(event_id.clone()).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
     assert!(item.content().is_redacted());
@@ -267,8 +267,8 @@ async fn test_local_and_remote_echo_of_redaction() {
     );
     assert!(original_json.is_none());
 
-    // Then comes the remote echo of the redaction event. The timeline event should
-    // now be redacted.
+    // Then comes the remote echo of the redaction event. The timeline event
+    // should now be redacted.
     timeline.handle_live_event(f.redaction(&event_id).sender(&ALICE)).await;
     let item = assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
     assert!(item.content().is_redacted());

--- a/crates/matrix-sdk-ui/src/timeline/tests/rtc.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/rtc.rs
@@ -118,10 +118,10 @@ async fn test_rtc_members_update_last_only() {
         .await;
 
     // ===========
-    // ASSERT: As per requirement only the latest notification item in the timeline
-    // should have the active call info. So ensure the oldest notification item
-    // is cleared and that the new one has the previously known info
-    // ===========
+    // ASSERT: As per requirement only the latest notification item in the
+    // timeline should have the active call info. So ensure the oldest
+    // notification item is cleared and that the new one has the previously
+    // known info ===========
 
     // The notification is first added
     assert_next_matches!(

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -82,8 +82,8 @@ async fn test_date_divider() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     item.as_event().unwrap();
 
-    // The other events are in the past so a local event always creates a new date
-    // divider.
+    // The other events are in the past so a local event always creates a new
+    // date divider.
     let date_divider =
         assert_next_matches!(stream, VectorDiff::Insert { index: 5, value } => value);
     assert!(date_divider.is_date_divider());
@@ -128,8 +128,8 @@ async fn test_update_read_marker() {
 
     timeline.controller.handle_fully_read_marker(event_id2.clone()).await;
 
-    // The read marker is removed but not reinserted, because it cannot be added at
-    // the end.
+    // The read marker is removed but not reinserted, because it cannot be added
+    // at the end.
     // Timeline: [date-divider, A, B].
     //                            ^-- fully read
     assert_next_matches!(stream, VectorDiff::Remove { index: 2 });
@@ -146,8 +146,8 @@ async fn test_update_read_marker() {
     let marker = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
     assert!(marker.is_read_marker());
 
-    // Nothing should happen if the fully read event is set back to an older event
-    // sent by another user.
+    // Nothing should happen if the fully read event is set back to an older
+    // event sent by another user.
     timeline.controller.handle_fully_read_marker(event_id1).await;
     assert!(stream.next().now_or_never().is_none());
 
@@ -178,8 +178,8 @@ async fn test_update_read_marker() {
     let marker = assert_next_matches!(stream, VectorDiff::Insert { index: 4, value } => value);
     assert!(marker.is_read_marker());
 
-    // If the current user sends an event afterwards, the read marker doesn't move.
-    // Timeline: [date-divider, A, B, C, read-marker, D, E].
+    // If the current user sends an event afterwards, the read marker doesn't
+    // move. Timeline: [date-divider, A, B, C, read-marker, D, E].
     //                  fully read --^
     timeline.handle_live_event(f.text_msg("E").sender(&own_user)).await;
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -211,9 +211,9 @@ async fn test_update_read_marker() {
 
     assert!(stream.next().now_or_never().is_none());
 
-    // But when it's another user who sent the event, then we get a read marker just
-    // before their message. It is the first message that's both after the
-    // fully-read event and not sent by us.
+    // But when it's another user who sent the event, then we get a read marker
+    // just before their message. It is the first message that's both after
+    // the fully-read event and not sent by us.
     //
     // Timeline: [date-divider, A, B, C, D, E, F, G, H].
     //                     fully read --^
@@ -221,8 +221,8 @@ async fn test_update_read_marker() {
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     item.as_event().unwrap();
 
-    //                                     [our own]              v-- sent by Bob
-    // Timeline: [date-divider, A, B, C, D,  E, F, G, read-marker, H].
+    //                                     [our own]              v-- sent by
+    // Bob Timeline: [date-divider, A, B, C, D,  E, F, G, read-marker, H].
     //                     fully read --^
     let marker = assert_next_matches!(stream, VectorDiff::Insert { index: 8, value } => value);
     assert!(marker.is_read_marker());

--- a/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
+++ b/crates/matrix-sdk-ui/src/timeline/thread_list_service.rs
@@ -273,7 +273,8 @@ impl ThreadListService {
 
         let mut pagination_token = self.token.lock().await;
 
-        // Build the options for this page, using the current token if we have one.
+        // Build the options for this page, using the current token if we have
+        // one.
         let from = match &*pagination_token {
             PaginationToken::HasMore(token) => Some(token.clone()),
             _ => None,
@@ -283,7 +284,8 @@ impl ThreadListService {
 
         match self.load_thread_list(opts).await {
             Ok(thread_list) => {
-                // Update the pagination token based on whether there are more pages.
+                // Update the pagination token based on whether there are more
+                // pages.
                 *pagination_token = match &thread_list.prev_batch_token {
                     Some(token) => PaginationToken::HasMore(token.clone()),
                     None => PaginationToken::HitEnd,
@@ -405,7 +407,8 @@ impl ThreadListService {
                 let new_events = Self::collect_events_from_diffs(timeline_diffs.diffs);
 
                 for event in new_events {
-                    // Check if this event has a thread relation pointing to a known root.
+                    // Check if this event has a thread relation pointing to a
+                    // known root.
                     let Some(thread_root) = extract_thread_root(event.raw()) else { continue };
 
                     // Find the position of this thread root in our list.
@@ -415,12 +418,14 @@ impl ThreadListService {
                     };
 
                     if let Some(index) = position {
-                        // Build the latest event representation from the raw event.
+                        // Build the latest event representation from the raw
+                        // event.
                         if let Some(latest_event) = Self::build_event(room, event).await {
                             let mut guard = items.lock();
 
-                            // Re-check the position — the vector may have changed while
-                            // we were awaiting the profile lookup above.
+                            // Re-check the position — the vector may have
+                            // changed while we were
+                            // awaiting the profile lookup above.
                             if index < guard.len()
                                 && guard[index].root_event.event_id == thread_root
                             {

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -233,12 +233,12 @@ impl UtdHookManager {
         sender_user_id: &UserId,
     ) {
         trace!(%event_id, "UtdHookManager: Observed UTD");
-        // Hold the lock on `reported_utds` throughout, to avoid races with other
-        // threads.
+        // Hold the lock on `reported_utds` throughout, to avoid races with
+        // other threads.
         let mut reported_utds_lock = self.reported_utds.lock().await;
 
-        // Check if this, or a previous instance of UtdHookManager, has already reported
-        // this UTD, and bail out if not.
+        // Check if this, or a previous instance of UtdHookManager, has already
+        // reported this UTD, and bail out if not.
         if reported_utds_lock.contains(event_id) {
             return;
         }
@@ -290,21 +290,23 @@ impl UtdHookManager {
         let client = self.client.clone();
         let owned_event_id = event_id.to_owned();
 
-        // Spawn a task that will wait for the given delay, and maybe call the parent
-        // hook then.
+        // Spawn a task that will wait for the given delay, and maybe call the
+        // parent hook then.
         let handle = self.client.task_monitor().spawn_finite_task("utd_hook", async move {
             // Wait for the given delay.
             sleep(max_delay).await;
 
-            // Make sure we take out the lock on `reported_utds` before removing the entry
-            // from `pending_delayed`, to ensure we don't race against another call to
-            // `on_utd` (which could otherwise see that the entry has been
-            // removed from `pending_delayed` but not yet added to
+            // Make sure we take out the lock on `reported_utds` before removing
+            // the entry from `pending_delayed`, to ensure we don't
+            // race against another call to `on_utd` (which could
+            // otherwise see that the entry has been removed from
+            // `pending_delayed` but not yet added to
             // `reported_utds`).
             let mut reported_utds_lock = reported_utds.lock().await;
 
-            // Remove the task from the outstanding set. But if it's already been removed,
-            // it's been decrypted since the task was added!
+            // Remove the task from the outstanding set. But if it's already
+            // been removed, it's been decrypted since the task was
+            // added!
             let pending_report = pending_delayed.lock().unwrap().remove(&owned_event_id);
             if let Some(pending_report) = pending_report {
                 Self::report_utd(
@@ -331,13 +333,14 @@ impl UtdHookManager {
     /// before, it has no effect.
     pub(crate) async fn on_late_decrypt(&self, event_id: &EventId) {
         trace!(%event_id, "UtdHookManager: On late decrypt");
-        // Hold the lock on `reported_utds` throughout, to avoid races with other
-        // threads.
+        // Hold the lock on `reported_utds` throughout, to avoid races with
+        // other threads.
         let mut reported_utds_lock = self.reported_utds.lock().await;
 
-        // Only let the parent hook know about the late decryption if the event is
-        // a pending UTD. If so, remove the event from the pending list —
-        // doing so will cause the reporting task to no-op if it runs.
+        // Only let the parent hook know about the late decryption if the event
+        // is a pending UTD. If so, remove the event from the pending
+        // list — doing so will cause the reporting task to no-op if it
+        // runs.
         let Some(pending_utd_report) = self.pending_delayed.lock().unwrap().remove(event_id) else {
             trace!(%event_id, "UtdHookManager: received a late decrypt report for an unknown utd");
             return;
@@ -384,14 +387,16 @@ impl Drop for UtdHookManager {
     fn drop(&mut self) {
         // Cancel all the outstanding delayed tasks to report UTDs.
         //
-        // Here, we don't take the lock on `reported_utd`s (indeed, we can't, since
-        // `reported_utds` has an async mutex, and `drop` has to be sync), but
-        // that's ok. We can't race against `on_utd` or `on_late_decrypt`, since
-        // they both have `&self` references which mean `drop` can't be called.
-        // We *could* race against one of the actual tasks to report
-        // UTDs, but that's ok too: either the report task will bail out when it sees
-        // the entry has been removed from `pending_delayed` (which is fine), or the
-        // report task will successfully report the UTD (which is fine).
+        // Here, we don't take the lock on `reported_utd`s (indeed, we can't,
+        // since `reported_utds` has an async mutex, and `drop` has to
+        // be sync), but that's ok. We can't race against `on_utd` or
+        // `on_late_decrypt`, since they both have `&self` references
+        // which mean `drop` can't be called. We *could* race against
+        // one of the actual tasks to report UTDs, but that's ok too:
+        // either the report task will bail out when it sees
+        // the entry has been removed from `pending_delayed` (which is fine), or
+        // the report task will successfully report the UTD (which is
+        // fine).
         let mut pending_delayed = self.pending_delayed.lock().unwrap();
         for (_, pending_utd_report) in pending_delayed.drain() {
             pending_utd_report.report_task.abort();
@@ -426,7 +431,8 @@ mod tests {
         // And I wrap with the UtdHookManager,
         let wrapper = UtdHookManager::new(hook.clone(), logged_in_client(None).await);
 
-        // And I call the `on_utd` method multiple times, sometimes on the same event,
+        // And I call the `on_utd` method multiple times, sometimes on the same
+        // event,
         let event_timestamp = MilliSecondsSinceUnixEpoch::now();
         let sender_user = user_id!("@example2:localhost");
         let federated_user = user_id!("@example2:example.com");
@@ -450,8 +456,8 @@ mod tests {
             assert!(utds[1].time_to_decrypt.is_none());
             assert!(utds[2].time_to_decrypt.is_none());
 
-            // event_local_age_millis should be a small positive number, because the
-            // timestamp we used was after we created the device
+            // event_local_age_millis should be a small positive number, because
+            // the timestamp we used was after we created the device
             let utd_local_age = utds[0].event_local_age_millis;
             assert!(utd_local_age >= 0);
             assert!(utd_local_age <= 1000);
@@ -466,8 +472,8 @@ mod tests {
 
     #[async_test]
     async fn test_deduplicates_utds_from_previous_session() {
-        // Use a single client for both hooks, so that both hooks are backed by the same
-        // memorystore.
+        // Use a single client for both hooks, so that both hooks are backed by
+        // the same memorystore.
         let client = no_retry_test_client(None).await;
 
         // Dummy hook 1, with the first UtdHookManager
@@ -510,7 +516,8 @@ mod tests {
             let mut wrapper = UtdHookManager::new(hook.clone(), client.clone());
             wrapper.reload_from_store().await.unwrap();
 
-            // Call it with more events, some of which match the previous instance
+            // Call it with more events, some of which match the previous
+            // instance
             wrapper
                 .on_utd(
                     event_id!("$1"),
@@ -539,8 +546,8 @@ mod tests {
     /// session, are reported in the next session.
     #[async_test]
     async fn test_does_not_deduplicate_late_utds_from_previous_session() {
-        // Use a single client for both hooks, so that both hooks are backed by the same
-        // memorystore.
+        // Use a single client for both hooks, so that both hooks are backed by
+        // the same memorystore.
         let client = no_retry_test_client(None).await;
 
         // Dummy hook 1, with the first UtdHookManager
@@ -599,8 +606,8 @@ mod tests {
         // And I wrap with the UtdHookManager,
         let wrapper = UtdHookManager::new(hook.clone(), no_retry_test_client(None).await);
 
-        // And I call the `on_late_decrypt` method before the event had been marked as
-        // utd,
+        // And I call the `on_late_decrypt` method before the event had been
+        // marked as utd,
         wrapper.on_late_decrypt(event_id!("$1")).await;
 
         // Then nothing is registered in the parent hook.
@@ -653,8 +660,8 @@ mod tests {
         // If I create a dummy hook,
         let hook = Arc::new(Dummy::default());
 
-        // And I wrap with the UtdHookManager, configured to delay reporting after 2
-        // seconds.
+        // And I wrap with the UtdHookManager, configured to delay reporting
+        // after 2 seconds.
         let wrapper = UtdHookManager::new(hook.clone(), no_retry_test_client(None).await)
             .with_max_delay(Duration::from_secs(2));
 
@@ -678,7 +685,8 @@ mod tests {
         assert!(hook.utds.lock().unwrap().is_empty());
         assert_eq!(wrapper.pending_delayed.lock().unwrap().len(), 1);
 
-        // But if I wait just a bit more, then it's getting notified as a definite UTD.
+        // But if I wait just a bit more, then it's getting notified as a
+        // definite UTD.
         sleep(Duration::from_millis(1500)).await;
 
         {
@@ -697,8 +705,8 @@ mod tests {
         // If I create a dummy hook,
         let hook = Arc::new(Dummy::default());
 
-        // And I wrap with the UtdHookManager, configured to delay reporting after 2
-        // seconds.
+        // And I wrap with the UtdHookManager, configured to delay reporting
+        // after 2 seconds.
         let wrapper = UtdHookManager::new(hook.clone(), no_retry_test_client(None).await)
             .with_max_delay(Duration::from_secs(2));
 

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -60,8 +60,8 @@ async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
         },
     };
 
-    // The request then passes the `pos`ition marker to the next request, as usual
-    // in sliding sync.
+    // The request then passes the `pos`ition marker to the next request, as
+    // usual in sliding sync.
     sliding_sync_then_assert_request_and_fake_response! {
         [server, stream]
         assert request >= {
@@ -160,7 +160,8 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -278,8 +279,8 @@ async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<
     let stream = encryption_sync.sync(sync_permit_guard);
     pin_mut!(stream);
 
-    // First iteration fills the whole request; server responds with the to-device
-    // token that should remembered.
+    // First iteration fills the whole request; server responds with the
+    // to-device token that should remembered.
     sliding_sync_then_assert_request_and_fake_response! {
         [server, stream]
         assert request = {
@@ -328,9 +329,9 @@ async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<
         },
     };
 
-    // This encryption sync now conceptually goes to sleep, and another encryption
-    // sync starts in another process, runs a sync and changes the to-device
-    // token cached on disk.
+    // This encryption sync now conceptually goes to sleep, and another
+    // encryption sync starts in another process, runs a sync and changes
+    // the to-device token cached on disk.
     if let Some(olm_machine) = &*client.olm_machine_for_testing().await {
         olm_machine
             .store()

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -77,8 +77,8 @@ async fn test_notification_client_with_context() {
         .mount()
         .await;
 
-    // The encryption state is also fetched to figure whether the room is encrypted
-    // or not.
+    // The encryption state is also fetched to figure whether the room is
+    // encrypted or not.
     server.mock_room_state_encryption().plain().mount().await;
 
     let item = notification_client.get_notification_with_context(room_id, event_id).await.unwrap();
@@ -240,8 +240,8 @@ async fn test_unsubscribed_threads_get_notifications() {
     let process_setup = NotificationProcessSetup::SingleProcess { sync_service };
     let notification_client = NotificationClient::new(client.clone(), process_setup).await.unwrap();
 
-    // For a thread with an unknown subscription status (note: we're not mocking the
-    // get endpoint, since 404 is equivalent to no thread status),
+    // For a thread with an unknown subscription status (note: we're not mocking
+    // the get endpoint, since 404 is equivalent to no thread status),
     let thread_root = event_id!("$thread_root");
 
     let sender_member_event =
@@ -296,7 +296,8 @@ async fn test_unsubscribed_threads_get_notifications() {
             .mount()
             .await;
 
-        // I do get a notification about it, because it's not technically in the thread.
+        // I do get a notification about it, because it's not technically in the
+        // thread.
         let item =
             notification_client.get_notification_with_context(room_id, thread_root).await.unwrap();
         assert_matches!(item, NotificationStatus::Event(..));
@@ -385,7 +386,8 @@ async fn test_notification_client_sliding_sync() {
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -578,7 +580,8 @@ async fn test_notification_client_sliding_sync_invites() {
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -723,7 +726,8 @@ async fn test_notification_client_sliding_sync_invites_with_event_id() {
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -872,7 +876,8 @@ async fn test_notification_client_mixed() {
             let sender_member_event = sender_member_event.clone();
             move |request: &Request| {
                 let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-                // Repeat the transaction id in the response, to validate sticky parameters.
+                // Repeat the transaction id in the response, to validate sticky
+                // parameters.
                 let mut pos = pos.lock().unwrap();
                 *pos += 1;
                 let pos_as_str = (*pos).to_string();
@@ -920,8 +925,8 @@ async fn test_notification_client_mixed() {
         .mount()
         .await;
 
-    // The encryption state is also fetched to figure whether the room is encrypted
-    // or not.
+    // The encryption state is also fetched to figure whether the room is
+    // encrypted or not.
     server.mock_room_state_encryption().plain().mount().await;
 
     let dummy_sync_service = Arc::new(SyncService::builder(client.clone()).build().await.unwrap());
@@ -1041,7 +1046,8 @@ async fn test_notification_client_sliding_sync_filters_out_events_from_ignored_u
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -1116,13 +1122,14 @@ async fn test_notification_client_context_filters_out_events_from_ignored_users(
 
     server.sync_joined_room(&client, room_id).await;
 
-    // Add mock for sliding sync so we get the ignored user list from its account
-    // data
+    // Add mock for sliding sync so we get the ignored user list from its
+    // account data
     let pos = Mutex::new(0);
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = pos.lock().unwrap();
             *pos += 1;
             let pos_as_str = (*pos).to_string();
@@ -1175,8 +1182,8 @@ async fn test_notification_client_context_filters_out_events_from_ignored_users(
         }])
         .await;
 
-    // If the event is not found even though there was a mocked response for it, it
-    // was discarded as expected.
+    // If the event is not found even though there was a mocked response for it,
+    // it was discarded as expected.
     let result =
         notification_client.get_notification_with_context(room_id, event_id).await.unwrap();
 
@@ -1249,8 +1256,8 @@ async fn test_notification_room_display_name_excludes_service_members() {
         .mount()
         .await;
 
-    // Check that the notification we get with sliding sync shows the correct room
-    // name
+    // Check that the notification we get with sliding sync shows the correct
+    // room name
     let notification_client =
         NotificationClient::new(client.clone(), process_setup.clone()).await.unwrap();
     assert_let!(

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1250,7 +1250,8 @@ async fn test_loading_states() -> Result<(), Error> {
         // Wait on Tokio to run all the tasks. Necessary only when testing.
         yield_now().await;
 
-        // There is a loading state update because the number of rooms has been updated.
+        // There is a loading state update because the number of rooms has been
+        // updated.
         assert_next_matches!(
             all_rooms_loading_state,
             RoomListLoadingState::Loaded { maximum_number_of_rooms: Some(12) }
@@ -1297,7 +1298,8 @@ async fn test_loading_states() -> Result<(), Error> {
         let sync = room_list.sync();
         pin_mut!(sync);
 
-        // The loading state is loaded! Indeed, there is data loaded from the cache.
+        // The loading state is loaded! Indeed, there is data loaded from the
+        // cache.
         assert_next_matches!(
             all_rooms_loading_state,
             RoomListLoadingState::Loaded { maximum_number_of_rooms: Some(12) }
@@ -1390,8 +1392,8 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
         },
     };
 
-    // Ensure the dynamic entries' stream is pending because there is no filter set
-    // yet.
+    // Ensure the dynamic entries' stream is pending because there is no filter
+    // set yet.
     assert_pending!(dynamic_entries_stream);
 
     // Now, let's define a filter.
@@ -1858,8 +1860,8 @@ async fn test_room_sorting() -> Result<(), Error> {
         },
     };
 
-    // Ensure the dynamic entries' stream is pending because there is no filter set
-    // yet.
+    // Ensure the dynamic entries' stream is pending because there is no filter
+    // set yet.
     assert_pending!(stream);
 
     // Now, let's define a filter.
@@ -2197,8 +2199,8 @@ async fn test_room() -> Result<(), Error> {
     // Room has not received a name from sliding sync, then it's calculated.
     assert_eq!(room1.cached_display_name(), Some(RoomDisplayName::Empty));
 
-    // Room has not received an avatar from sliding sync, then it's calculated, but
-    // there is nothing to calculate from, so there is no URL.
+    // Room has not received an avatar from sliding sync, then it's calculated,
+    // but there is nothing to calculate from, so there is no URL.
     assert_eq!(room1.avatar_url(), None);
 
     sync_then_assert_request_and_fake_response! {
@@ -2664,7 +2666,8 @@ async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
 
     room_list.reset_and_add_room_subscriptions(&[room_id_0, room_id_1]).await;
 
-    // `set_room_subscriptions` would have kept the members of `room_id_1` synced.
+    // `set_room_subscriptions` would have kept the members of `room_id_1`
+    // synced.
     assert!(!room_1.are_members_synced());
 
     sync_then_assert_request_and_fake_response! {
@@ -2967,9 +2970,9 @@ async fn test_room_latest_event() -> Result<(), Error> {
     let room = room_list.room(room_id)?;
     let timeline = room.timeline_builder().build().await.unwrap();
 
-    // We could subscribe to the room —with `RoomList::set_room_subscriptions`— to
-    // automatically listen to the latest event updates, but we will do it
-    // manually here (so that we can ignore the subscription thingies).
+    // We could subscribe to the room —with `RoomList::set_room_subscriptions`—
+    // to automatically listen to the latest event updates, but we will do
+    // it manually here (so that we can ignore the subscription thingies).
     let latest_events = client.latest_events().await;
     latest_events.listen_to_room(room_id).await.unwrap();
 
@@ -3051,8 +3054,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 1.
         {
-            // The state transitions into `Init`. The `SyncIndicator` stays in `Hide` as
-            // nothing is happening yet.
+            // The state transitions into `Init`. The `SyncIndicator` stays in
+            // `Hide` as nothing is happening yet.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Hide,
@@ -3064,8 +3067,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 2.
         {
-            // The state transitions into `SettingUp`. The `SyncIndicator` must be `Show` as
-            // the service has now been started.
+            // The state transitions into `SettingUp`. The `SyncIndicator` must
+            // be `Show` as the service has now been started.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Show,
@@ -3077,7 +3080,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 3.
         {
-            // The state transitions into `Running`. The `SyncIndicator` must be `Hide`.
+            // The state transitions into `Running`. The `SyncIndicator` must be
+            // `Hide`.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Hide,
@@ -3089,7 +3093,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 4.
         {
-            // The state transitions into `Error`. The `SyncIndicator` must be `Show`.
+            // The state transitions into `Error`. The `SyncIndicator` must be
+            // `Show`.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Show,
@@ -3101,7 +3106,8 @@ async fn test_sync_indicator() -> Result<(), Error> {
 
         // Request 5.
         {
-            // The state transitions into `Recovering`. The `SyncIndicator` must be `Hide`.
+            // The state transitions into `Recovering`. The `SyncIndicator` must
+            // be `Hide`.
             assert_next_sync_indicator!(
                 sync_indicator,
                 SyncIndicator::Hide,
@@ -3235,7 +3241,8 @@ async fn test_multiple_timeline_init() {
         .await;
 
     let task = {
-        // Get a RoomListService::Room, initialize the timeline, start a pagination.
+        // Get a RoomListService::Room, initialize the timeline, start a
+        // pagination.
         let room = room_list.room(room_id).unwrap();
 
         let timeline = room.timeline_builder().build().await.unwrap();
@@ -3259,8 +3266,9 @@ async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_i
     let server = MatrixMockServer::new().await;
 
     {
-        // The first time, don't advertise support for MSC4306; the extension will NOT
-        // enabled in this case, despite the client requesting it.
+        // The first time, don't advertise support for MSC4306; the extension
+        // will NOT enabled in this case, despite the client requesting
+        // it.
         server
             .mock_versions()
             .ok()

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -40,7 +40,8 @@ async fn setup_mocking_sliding_sync_server(
     Mock::given(SlidingSyncMatcher)
         .respond_with(move |request: &Request| {
             let partial_request: PartialSlidingSyncRequest = request.body_json().unwrap();
-            // Repeat the transaction id in the response, to validate sticky parameters.
+            // Repeat the transaction id in the response, to validate sticky
+            // parameters.
             let mut pos = match partial_request.conn_id.as_deref() {
                 Some("encryption") => encryption_pos.lock().unwrap(),
                 Some("room-list") => room_pos.lock().unwrap(),
@@ -140,7 +141,8 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
     );
     assert!(latest_room_list_pos.is_some());
 
-    // Now reset the server, wait for a bit that it doesn't receive extra requests.
+    // Now reset the server, wait for a bit that it doesn't receive extra
+    // requests.
     drop(guard);
     server.reset().await;
     let _guard =
@@ -150,8 +152,8 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
 
     assert!(server.received_requests().await.unwrap().is_empty());
 
-    // When restarting and waiting a bit, the server gets new requests, starting at
-    // the same position than just before being stopped.
+    // When restarting and waiting a bit, the server gets new requests, starting
+    // at the same position than just before being stopped.
     sync_service.start().await;
     assert_next_matches!(state_stream, State::Running);
     assert!(sync_service.is_supervisor_running().await);
@@ -176,8 +178,9 @@ async fn test_sync_service_state() -> anyhow::Result<()> {
                 num_encryption_sync_requests += 1;
             } else if conn_id == "room-list" {
                 if num_room_list_requests == 0 {
-                    // Either it's the same pos, or it's the next one if the request could be
-                    // processed by the client.
+                    // Either it's the same pos, or it's the next one if the
+                    // request could be processed by the
+                    // client.
                     let mut current_pos = None;
                     for (key, val) in request.url.query_pairs() {
                         if key == "pos" {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/decryption.rs
@@ -70,8 +70,9 @@ async fn test_an_utd_from_the_event_cache_as_an_initial_item_is_decrypted() {
         //
         // 1. a chunk of 1 item
         //
-        // The item is an encrypted event! It has been stored before having a chance to
-        // be decrypted. Damn. We want to see if decryption will trigger automatically.
+        // The item is an encrypted event! It has been stored before having a
+        // chance to be decrypted. Damn. We want to see if decryption
+        // will trigger automatically.
         event_cache_store
             .as_clean()
             .unwrap()
@@ -210,9 +211,9 @@ async fn test_an_utd_from_the_event_cache_as_a_paginated_item_is_decrypted() {
         // 1. a chunk of 1 item
         // 2. a chunk of 1 item
         //
-        // The older item is an encrypted event! It has been stored before having a
-        // chance to be decrypted. Damn. We want to see if decryption will trigger
-        // automatically.
+        // The older item is an encrypted event! It has been stored before
+        // having a chance to be decrypted. Damn. We want to see if
+        // decryption will trigger automatically.
         event_cache_store
             .as_clean()
             .unwrap()
@@ -316,8 +317,8 @@ async fn test_an_utd_from_the_event_cache_as_a_paginated_item_is_decrypted() {
     // Now we can paginate to load the UTD!
     let reached_start = timeline.paginate_backwards(1).await.unwrap();
 
-    // We have reached the start of the timeline. Not really part of this test, but
-    // let's test everything :-).
+    // We have reached the start of the timeline. Not really part of this test,
+    // but let's test everything :-).
     assert!(reached_start);
 
     assert_next_matches_with_timeout!(updates_stream, 250, updates => {
@@ -328,8 +329,8 @@ async fn test_an_utd_from_the_event_cache_as_a_paginated_item_is_decrypted() {
         });
     });
 
-    // Now, let's look at the updates. We must observe an update reflecting the UTD
-    // has entered the `Timeline`.
+    // Now, let's look at the updates. We must observe an update reflecting the
+    // UTD has entered the `Timeline`.
     assert_next_matches_with_timeout!(updates_stream, 250, updates => {
         assert_eq!(updates.len(), 2, "Expecting 2 updates from the `Timeline`");
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -110,7 +110,8 @@ async fn test_echo() {
         )
         .await;
 
-    // The Event Cache deduplicates the first event, but we receive a second one.
+    // The Event Cache deduplicates the first event, but we receive a second
+    // one.
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 5);
 
@@ -146,8 +147,8 @@ async fn test_retry_failed() {
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
-    // When trying to send an event, return with a 500 error, which is interpreted
-    // as a transient error.
+    // When trying to send an event, return with a 500 error, which is
+    // interpreted as a transient error.
     let scoped_faulty_send = server.mock_room_send().error500().expect(3).mount_as_scoped().await;
 
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -222,9 +222,9 @@ async fn test_edit_local_echo() {
 
     assert_pending!(timeline_stream);
 
-    // Set up the success response before editing, since edit causes an immediate
-    // retry (the room's send queue is not blocked, since the one event it couldn't
-    // send failed in an unrecoverable way).
+    // Set up the success response before editing, since edit causes an
+    // immediate retry (the room's send queue is not blocked, since the one
+    // event it couldn't send failed in an unrecoverable way).
     drop(mounted_send);
     server.mock_room_send().ok(event_id!("$1")).mount().await;
 
@@ -285,7 +285,8 @@ async fn test_edit_local_echo_keeps_thread_relation() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    // The first send attempt fails unrecoverably, so the local echo stays editable.
+    // The first send attempt fails unrecoverably, so the local echo stays
+    // editable.
     let mounted_send =
         server.mock_room_send().error_too_large().mock_once().mount_as_scoped().await;
 
@@ -312,8 +313,8 @@ async fn test_edit_local_echo_keeps_thread_relation() {
         Some(EventSendState::SendingFailed { .. })
     );
 
-    // Editing with bare, relation-free content works, and the retried send keeps
-    // the thread relation.
+    // Editing with bare, relation-free content works, and the retried send
+    // keeps the thread relation.
     drop(mounted_send);
     server.mock_room_send().ok(event_id!("$1")).mock_once().mount().await;
 
@@ -341,7 +342,8 @@ async fn test_edit_local_echo_keeps_thread_relation() {
 
     sleep(Duration::from_millis(500)).await;
 
-    // The event went out with the edited body *and* its original thread relation.
+    // The event went out with the edited body *and* its original thread
+    // relation.
     let requests = server.server().received_requests().await.unwrap();
     let sent = requests
         .iter()
@@ -760,9 +762,9 @@ async fn test_edit_local_echo_with_unsupported_content() {
 
     assert_pending!(timeline_stream);
 
-    // Set up the success response before editing, since edit causes an immediate
-    // retry (the room's send queue is not blocked, since the one event it couldn't
-    // send failed in an unrecoverable way).
+    // Set up the success response before editing, since edit causes an
+    // immediate retry (the room's send queue is not blocked, since the one
+    // event it couldn't send failed in an unrecoverable way).
     drop(mounted_send);
     server.mock_room_send().ok(event_id!("$1")).mount().await;
 
@@ -773,7 +775,8 @@ async fn test_edit_local_echo_with_unsupported_content() {
         new_content: poll_content_block.clone(),
     };
 
-    // Let's edit the local echo (message) with an unsupported type (poll start).
+    // Let's edit the local echo (message) with an unsupported type (poll
+    // start).
     let edit_err = timeline.edit(&item.identifier(), poll_start_content).await.unwrap_err();
 
     // We couldn't edit the local echo, since their content types didn't match
@@ -794,7 +797,8 @@ async fn test_edit_local_echo_with_unsupported_content() {
     let item = item.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::NotSentYet { progress: None }));
 
-    // Let's edit the local echo (poll start) with an unsupported type (message).
+    // Let's edit the local echo (poll start) with an unsupported type
+    // (message).
     let edit_err = timeline
         .edit(
             &item.identifier(),

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -289,7 +289,8 @@ async fn test_focused_timeline_local_echoes() {
     sleep(Duration::from_millis(100)).await;
     assert_pending!(timeline_stream);
 
-    // Add a reaction to the focused event, which will cause a local echo to happen.
+    // Add a reaction to the focused event, which will cause a local echo to
+    // happen.
     timeline.toggle_reaction(&event_item.identifier(), "✨").await.unwrap();
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
@@ -449,7 +450,8 @@ async fn test_focused_timeline_handles_threaded_event() {
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
-    // The new item loaded is inserted at the start, just after the date divider.
+    // The new item loaded is inserted at the start, just after the date
+    // divider.
     assert_let!(VectorDiff::Insert { index: 1, value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Prev");
 
@@ -483,8 +485,8 @@ async fn test_focused_timeline_handles_threaded_event() {
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
-    // Same as before, the previous event is inserted at the front, after the date
-    // divider.
+    // Same as before, the previous event is inserted at the front, after the
+    // date divider.
     assert_let!(VectorDiff::Insert { index: 1, value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Root");
 
@@ -702,8 +704,8 @@ async fn test_focused_timeline_handles_other_thread_event_when_forcing_threaded_
     assert!(items[0].is_date_divider());
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "Ho");
 
-    // We paginate backwards once and hit the start of the thread which will trigger
-    // an /event request for the thread root.
+    // We paginate backwards once and hit the start of the thread which will
+    // trigger an /event request for the thread root.
     server
         .mock_room_relations()
         .match_from("prev_token")
@@ -859,7 +861,8 @@ async fn test_focused_timeline_filters_out_threaded_events() {
     // Only the non-threaded event is inserted at the start.
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
     assert_eq!(timeline_updates.len(), 1);
-    // The new item loaded is inserted at the start, just after the date divider.
+    // The new item loaded is inserted at the start, just after the date
+    // divider.
     assert_let!(VectorDiff::Insert { index: 1, value: item } = &timeline_updates[0]);
     assert_eq!(item.as_event().unwrap().content().as_message().unwrap().body(), "Prev no thread");
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/media.rs
@@ -330,7 +330,8 @@ async fn test_send_attachment_from_bytes() -> TestResult {
             assert_let!(MessageType::File(file) = msg.msgtype());
             assert_let!(MediaSource::Plain(uri) = &file.source);
 
-            // Check if the upload finished and the URI now refers to the final MXC URI.
+            // Check if the upload finished and the URI now refers to the final
+            // MXC URI.
             if progress.current == progress.total && *uri == "mxc://sdk.rs/media" {
                 break;
             }
@@ -422,8 +423,8 @@ async fn test_send_media_with_thumbnail() -> TestResult {
         assert_let!(MessageType::Image(content) = msg.msgtype());
         assert_eq!(content.filename(), "image.png");
 
-        // At the moment, it's stored in the media cache store, so its media source
-        // references a local URI.
+        // At the moment, it's stored in the media cache store, so its media
+        // source references a local URI.
         assert_let!(MediaSource::Plain(uri) = &content.source);
         assert!(uri.to_string().contains("localhost"));
 
@@ -433,7 +434,8 @@ async fn test_send_media_with_thumbnail() -> TestResult {
         assert!(uri.to_string().contains("localhost"));
 
         let thumbnail = media_info.thumbnail_info.as_ref().unwrap();
-        // Sanity checks, although we're not quite interested in these values here.
+        // Sanity checks, although we're not quite interested in these values
+        // here.
         assert_eq!(thumbnail.height.unwrap(), uint!(13));
         assert_eq!(thumbnail.width.unwrap(), uint!(37));
         assert_eq!(thumbnail.size.unwrap(), uint!(42));
@@ -507,7 +509,8 @@ async fn test_send_media_with_thumbnail() -> TestResult {
         );
         assert_let!(Some(msg) = item.content().as_message());
 
-        // Message is an image, as intended, and both MXC URIs are not local anymore.
+        // Message is an image, as intended, and both MXC URIs are not local
+        // anymore.
         assert_let!(MessageType::Image(content) = msg.msgtype());
         assert_eq!(content.filename(), "image.png");
 
@@ -538,9 +541,9 @@ async fn test_send_media_with_thumbnail() -> TestResult {
         );
         assert_eq!(thumbnail_uri.to_string(), "mxc://sdk.rs/thumbnail");
 
-        // Now, getting the thumbnail should be a cache hit and not require an extra
-        // endpoint to be set up; the test will fail with a 404 error if there's
-        // a cache miss.
+        // Now, getting the thumbnail should be a cache hit and not require an
+        // extra endpoint to be set up; the test will fail with a 404
+        // error if there's a cache miss.
         let use_cache = true;
         let retrieved_thumbnail_data = client
             .media()
@@ -556,8 +559,8 @@ async fn test_send_media_with_thumbnail() -> TestResult {
         // And the thumbnail data matches what we've sent.
         assert_eq!(retrieved_thumbnail_data, thumbnail_data);
 
-        // Another way to get the thumbnail data is to request a thumbnail with the same
-        // sizes as the ones we've sent during the upload.
+        // Another way to get the thumbnail data is to request a thumbnail with
+        // the same sizes as the ones we've sent during the upload.
         let retrieved_thumbnail_data = client
             .media()
             .get_media_content(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -91,8 +91,8 @@ async fn test_timeline_is_threaded() {
     }
 
     {
-        // An event-focused timeline, focused on a non-thread event, isn't threaded when
-        // no context is requested.
+        // An event-focused timeline, focused on a non-thread event, isn't
+        // threaded when no context is requested.
         let f = EventFactory::new();
         let event_id = event_id!("$target1");
         let event =
@@ -118,8 +118,8 @@ async fn test_timeline_is_threaded() {
     }
 
     {
-        // But an event-focused timeline, focused on an in-thread event, is threaded
-        // when no context is requested \o/
+        // But an event-focused timeline, focused on an in-thread event, is
+        // threaded when no context is requested \o/
         let f = EventFactory::new();
         let thread_root = event_id!("$thread_root");
         let event_id = event_id!("$target2");
@@ -184,7 +184,8 @@ async fn test_timeline_is_threaded() {
     }
 
     {
-        // An event-focused timeline, focused on a non-thread event, isn't threaded.
+        // An event-focused timeline, focused on a non-thread event, isn't
+        // threaded.
         let f = EventFactory::new();
         let event = f
             .text_msg("hello world")
@@ -212,7 +213,8 @@ async fn test_timeline_is_threaded() {
     }
 
     {
-        // But an event-focused timeline, focused on an in-thread event, is threaded \o/
+        // But an event-focused timeline, focused on an in-thread event, is
+        // threaded \o/
         let f = EventFactory::new();
         let thread_root = event_id!("$thread_root");
         let event = f
@@ -243,7 +245,8 @@ async fn test_timeline_is_threaded() {
     }
 
     {
-        // An event-focused timeline, focused on a thread root, is also threaded \o/
+        // An event-focused timeline, focused on a thread root, is also threaded
+        // \o/
         let f = EventFactory::new();
         let event = f
             .text_msg("hey to you too")
@@ -543,8 +546,8 @@ async fn test_redact_local_sent_message() {
 
     assert_pending!(timeline_stream);
 
-    // Mock the redaction response for the event we just sent. Ensure it's called
-    // once.
+    // Mock the redaction response for the event we just sent. Ensure it's
+    // called once.
     server.mock_room_redact().ok(event_id!("$redaction_event_id")).mock_once().mount().await;
 
     // Let's redact the local echo with the remote handle.
@@ -759,8 +762,8 @@ async fn test_duplicate_maintains_correct_order() {
     let content = items[1].as_event().unwrap().content().as_message().unwrap().body();
     assert_eq!(content, "C");
 
-    // We receive multiple events, and C is now the last one (because we supposedly
-    // increased the timeline limit).
+    // We receive multiple events, and C is now the last one (because we
+    // supposedly increased the timeline limit).
     server
         .sync_room(
             &client,
@@ -831,8 +834,8 @@ async fn test_timeline_without_encryption_can_update() {
         .await;
 
     // Previously this would have panicked.
-    // We're creating a timeline without read receipts tracking to check only the
-    // encryption changes.
+    // We're creating a timeline without read receipts tracking to check only
+    // the encryption changes.
     let timeline = TimelineBuilder::new(&room).build().await.unwrap();
 
     let (items, mut stream) = timeline.subscribe().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -196,7 +196,8 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
         .ok(RoomMessagesResponseTemplate::default().events({
             // Return 30 events in this pagination.
             let mut events = Vec::new();
-            // Invert indices, so that in the event cache they end ordered from $0 to $29.
+            // Invert indices, so that in the event cache they end ordered from
+            // $0 to $29.
             for i in (0..30).rev() {
                 events.push(
                     f.text_msg(format!("hello world {i}"))
@@ -237,8 +238,8 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
     }
 
     // After the loop, the last index that's been peeked is 2*17+1 == 35.
-    // These three happen differently, because we're getting closer to the initial
-    // maximum skip count value.
+    // These three happen differently, because we're getting closer to the
+    // initial maximum skip count value.
     {
         assert_let!(VectorDiff::PushBack { value: message } = &timeline_updates[36]);
         let event_item = message.as_event().unwrap();
@@ -265,8 +266,8 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
     assert_pending!(timeline_stream);
     assert_next_eq!(back_pagination_status, PaginationStatus::Idle { hit_timeline_start: false });
 
-    // If we back-paginate again, we'd get all the previous items, by adjusting the
-    // skip count, but not hitting network.
+    // If we back-paginate again, we'd get all the previous items, by adjusting
+    // the skip count, but not hitting network.
     timeline.paginate_backwards(30).await.unwrap();
 
     assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
@@ -310,8 +311,8 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
     let (initial_pagination_status2, mut back_pagination_status2) =
         timeline2.live_back_pagination_status().await.unwrap();
 
-    // …so a caller must have the information that we haven't hit the timeline start
-    // yet.
+    // …so a caller must have the information that we haven't hit the timeline
+    // start yet.
     assert_eq!(initial_pagination_status2, PaginationStatus::Idle { hit_timeline_start: false });
 
     // A small pagination should only update the skip count.
@@ -326,8 +327,8 @@ async fn test_skip_count_is_taken_into_account_in_pagination_status() {
         value.as_event().unwrap();
     }
 
-    // A final pagination will get all the timeline items, as well as the timeline
-    // start.
+    // A final pagination will get all the timeline items, as well as the
+    // timeline start.
     let hit_start = timeline2.paginate_backwards(20).await.unwrap();
     assert!(hit_start);
 
@@ -356,8 +357,8 @@ async fn test_back_pagination_highlighted() {
     let client = server.client_builder().build().await;
 
     let f = EventFactory::new().sender(user_id!("@example:localhost"));
-    // We need the member event and power levels locally so the push rules processor
-    // works.
+    // We need the member event and power levels locally so the push rules
+    // processor works.
     let room = server
         .sync_room(
             &client,
@@ -581,9 +582,10 @@ async fn test_timeline_reset_while_paginating() {
         .await;
 
     // The pagination with the first token will be hit twice:
-    // - first, before the sync response comes, then the gap is stored in the cache.
-    // - second, after all other gaps have been resolved, we get back to resolving
-    //   this one.
+    // - first, before the sync response comes, then the gap is stored in the
+    //   cache.
+    // - second, after all other gaps have been resolved, we get back to
+    //   resolving this one.
     server
         .mock_room_messages()
         .match_from("pagination_1")
@@ -670,8 +672,8 @@ async fn test_timeline_reset_while_paginating() {
 
         let (status, _) = timeline.live_back_pagination_status().await.unwrap();
 
-        // Timeline start reached because second pagination response contains no end
-        // field.
+        // Timeline start reached because second pagination response contains no
+        // end field.
         assert_eq!(status, PaginationStatus::Idle { hit_timeline_start: true });
     };
 
@@ -686,8 +688,8 @@ async fn test_timeline_reset_while_paginating() {
     // field.
     assert!(hit_start);
 
-    // No events in back-pagination responses, start of timeline + date divider +
-    // all events from the previous syncs are present.
+    // No events in back-pagination responses, start of timeline + date divider
+    // + all events from the previous syncs are present.
     assert_eq!(timeline.items().await.len(), 4);
 
     // Make sure both pagination mocks were called.
@@ -1018,8 +1020,8 @@ async fn test_back_pagination_aborted() {
     // The spawned task should finish with a cancellation.
     assert!(paginate.await.unwrap_err().is_cancelled());
 
-    // But since the pagination task is owned by the event cache, it continues in
-    // the background.
+    // But since the pagination task is owned by the event cache, it continues
+    // in the background.
     assert_let_timeout!(
         Duration::from_secs(2),
         Some(PaginationStatus::Idle { hit_timeline_start }) = back_pagination_status.next()
@@ -1146,8 +1148,8 @@ async fn test_lazy_back_pagination() {
 
         assert!(hit_end_of_timeline.not());
 
-        // Oh, 5 new items, without even hitting the network because the timeline
-        // already has these!
+        // Oh, 5 new items, without even hitting the network because the
+        // timeline already has these!
         assert_timeline_stream! {
             [timeline_stream]
             prepend "$ev9";
@@ -1176,8 +1178,8 @@ async fn test_lazy_back_pagination() {
     }
 
     // This time, let's run another backwards pagination of 6 items. 2 items are
-    // from in-memory events, 1 item is a virtual item, and 3 will be created from
-    // events fetched from the network.
+    // from in-memory events, 1 item is a virtual item, and 3 will be created
+    // from events fetched from the network.
     {
         let network_pagination = mock_server
             .mock_room_messages()
@@ -1208,10 +1210,11 @@ async fn test_lazy_back_pagination() {
             prepend "$ev0";
             prepend --- date divider ---;
         };
-        // And 3 other items representing the events received from the network backwards
-        // pagination.
+        // And 3 other items representing the events received from the network
+        // backwards pagination.
         //
-        // They are inserted after the date divider, hence the indices 1, 2 and 3.
+        // They are inserted after the date divider, hence the indices 1, 2 and
+        // 3.
         assert_timeline_stream! {
             [timeline_stream]
             insert[1] "$ev102";
@@ -1224,9 +1227,9 @@ async fn test_lazy_back_pagination() {
         drop(network_pagination);
     }
 
-    // Finally, let's run a last backwards pagination of 5 items, fully hitting the
-    // network, but 2 will be returned because the beginning of the timeline is
-    // reached.
+    // Finally, let's run a last backwards pagination of 5 items, fully hitting
+    // the network, but 2 will be returned because the beginning of the
+    // timeline is reached.
     {
         let network_pagination = mock_server
             .mock_room_messages()
@@ -1248,8 +1251,8 @@ async fn test_lazy_back_pagination() {
 
         let hit_end_of_timeline = timeline.paginate_backwards(5).await.unwrap();
 
-        // There was no previous-batch token in the previous /messages response, so
-        // we've hit the start of the timeline.
+        // There was no previous-batch token in the previous /messages response,
+        // so we've hit the start of the timeline.
         assert!(hit_end_of_timeline);
 
         // The start of the timeline is inserted as its own timeline update.
@@ -1397,9 +1400,9 @@ async fn test_timeline_start_properly_inserted_when_created() {
         assert_pending!(stream);
     }
 
-    // Create a new timeline while this one is alive (so that the room event cache
-    // doesn't unload the linked chunk), and make sure it contains the timeline
-    // start as soon as possible.
+    // Create a new timeline while this one is alive (so that the room event
+    // cache doesn't unload the linked chunk), and make sure it contains the
+    // timeline start as soon as possible.
     let timeline2 = room.timeline().await.unwrap();
 
     let (items, mut stream2) = timeline2.subscribe().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pinned_event.rs
@@ -61,8 +61,8 @@ async fn test_new_pinned_events_are_not_added_on_sync() {
         .mount()
         .await;
 
-    // Load initial timeline items: a `m.room.pinned_events` with events $1 and $2
-    // pinned
+    // Load initial timeline items: a `m.room.pinned_events` with events $1 and
+    // $2 pinned
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1", "$2"])
         .mock_and_sync(&client, &server)
@@ -91,8 +91,8 @@ async fn test_new_pinned_events_are_not_added_on_sync() {
     assert_eq!(items[1].as_event().unwrap().content().as_message().unwrap().body(), "in the end");
     assert_pending!(timeline_stream);
 
-    // Load new pinned event contents from sync, $2 was pinned but wasn't available
-    // before
+    // Load new pinned event contents from sync, $2 was pinned but wasn't
+    // available before
     let event_2 = f
         .text_msg("pinned message!")
         .event_id(event_id!("$2"))
@@ -105,8 +105,8 @@ async fn test_new_pinned_events_are_not_added_on_sync() {
         .await
         .expect("Room should be synced");
 
-    // Event $2 was received through sync, but it wasn't added to the pinned event
-    // timeline.
+    // Event $2 was received through sync, but it wasn't added to the pinned
+    // event timeline.
     assert_pending!(timeline_stream);
 }
 
@@ -139,7 +139,8 @@ async fn test_pinned_event_with_reaction() {
         .mount()
         .await;
 
-    // Load initial timeline items: a `m.room.pinned_events` with event $1 pinned
+    // Load initial timeline items: a `m.room.pinned_events` with event $1
+    // pinned
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1"])
         .mock_and_sync(&client, &server)
@@ -218,7 +219,8 @@ async fn test_pinned_event_with_paginated_reactions() {
         .mount()
         .await;
 
-    // Load initial timeline items: a `m.room.pinned_events` with event $1 pinned
+    // Load initial timeline items: a `m.room.pinned_events` with event $1
+    // pinned
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1"])
         .mock_and_sync(&client, &server)
@@ -441,8 +443,8 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
         .mount()
         .await;
 
-    // Load initial timeline items: a `m.room.pinned_events` with event $1 and $2
-    // pinned
+    // Load initial timeline items: a `m.room.pinned_events` with event $1 and
+    // $2 pinned
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1", "$2"])
         .mock_and_sync(&client, &server)
@@ -476,8 +478,8 @@ async fn test_cached_events_are_kept_for_different_room_instances() {
     drop(timeline);
     drop(room);
 
-    // Set up a sync response with only the pinned event ids and no events, so if
-    // they exist later we know they come from the cache
+    // Set up a sync response with only the pinned event ids and no events, so
+    // if they exist later we know they come from the cache
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1", "$2"])
         .mock_and_sync(&client, &server)
@@ -504,8 +506,9 @@ async fn test_pinned_timeline_with_pinned_event_ids_and_empty_result_fails() {
     let client = server.client_builder().build().await;
     let room_id = room_id!("!test:localhost");
 
-    // Load initial timeline items: a `m.room.pinned_events` with event $1 and $2
-    // pinned, but they're not available neither in the cache nor in the HS
+    // Load initial timeline items: a `m.room.pinned_events` with event $1 and
+    // $2 pinned, but they're not available neither in the cache nor in the
+    // HS
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1", "$2"])
         .mock_and_sync(&client, &server)
@@ -701,8 +704,8 @@ async fn test_edited_events_are_reflected_in_sync() {
         .mount()
         .await;
 
-    // Load initial timeline items: a text message and a `m.room.pinned_events` with
-    // event $1.
+    // Load initial timeline items: a text message and a `m.room.pinned_events`
+    // with event $1.
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec!["$1"])
         .mock_and_sync(&client, &server)
@@ -791,8 +794,8 @@ async fn test_redacted_events_are_reflected_in_sync() {
         .mount()
         .await;
 
-    // Load initial timeline items: a text message and a `m.room.pinned_events` with
-    // event $1
+    // Load initial timeline items: a text message and a `m.room.pinned_events`
+    // with event $1
     let room = PinnedEventsSync::new(room_id)
         .with_pinned_event_ids(vec![pinned_event_id.as_str()])
         .mock_and_sync(&client, &server)
@@ -903,8 +906,8 @@ async fn test_ensure_max_concurrency_is_observed() {
     // Abort handle to stop requests from being processed.
     handle.abort();
 
-    // The real check happens here, based on the `max_concurrent_requests` expected
-    // value set above for the mock endpoint.
+    // The real check happens here, based on the `max_concurrent_requests`
+    // expected value set above for the mock endpoint.
     server.server().verify().await;
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -36,9 +36,10 @@ async fn test_user_profile_after_being_banned() {
     let room = server.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
-    // Build a simple timeline with Bob joining the room, Alice accepting an invite,
-    // sending some messages, and then getting banned by Bob. Alice's profile should
-    // be unavailable after the ban, while Bob's profile should be unaffected.
+    // Build a simple timeline with Bob joining the room, Alice accepting an
+    // invite, sending some messages, and then getting banned by Bob.
+    // Alice's profile should be unavailable after the ban, while Bob's
+    // profile should be unaffected.
     server
         .sync_room(
             &client,
@@ -107,8 +108,9 @@ async fn test_user_profile_after_leaving() {
     let room = server.sync_joined_room(&client, &DEFAULT_TEST_ROOM_ID).await;
     let timeline = Arc::new(room.timeline().await.unwrap());
 
-    // Build a simple timeline with Bob joining the room, Alice accepting an invite
-    // and sending a message, Bob sending a message, and Alice leaving
+    // Build a simple timeline with Bob joining the room, Alice accepting an
+    // invite and sending a message, Bob sending a message, and Alice
+    // leaving
     server
         .sync_room(
             &client,
@@ -146,8 +148,8 @@ async fn test_user_profile_after_leaving() {
     // Date divider + 5 events
     assert_eq!(timeline_items.len(), 6);
 
-    // Alice's profile, and therefore display name, should be still available after
-    // she left the room.
+    // Alice's profile, and therefore display name, should be still available
+    // after she left the room.
     let alice_event = timeline_items[4].as_event().unwrap();
     let alice_profile = alice_event.sender_profile();
     // Was this event sent by Alice?

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -106,8 +106,8 @@ async fn test_retry_order() {
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
-    // When trying to send an event, return with a 500 error, which is interpreted
-    // as a transient error.
+    // When trying to send an event, return with a 500 error, which is
+    // interpreted as a transient error.
     let scoped_faulty_send = server.mock_room_send().error500().expect(3).mount_as_scoped().await;
 
     // Send two messages without mocking the server response.
@@ -191,8 +191,8 @@ async fn test_reloaded_failed_local_echoes_are_marked_as_failed() {
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
-    // When trying to send an event, return with a 413 error, which is interpreted
-    // as a permanent error.
+    // When trying to send an event, return with a 413 error, which is
+    // interpreted as a permanent error.
     server.mock_room_send().error_too_large().expect(1).mount().await;
 
     // Sending an event will respond with a 500, resulting in a failed-to-send
@@ -262,8 +262,9 @@ async fn test_clear_with_echoes() {
 
         timeline.send(RoomMessageEventContent::text_plain("Send failure").into()).await.unwrap();
 
-        // Wait for the first message to fail. Don't use time, but listen for the first
-        // timeline item diff to get back signalling the error.
+        // Wait for the first message to fail. Don't use time, but listen for
+        // the first timeline item diff to get back signalling the
+        // error.
 
         assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
         // 2 updates: date divider and local echo.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/reactions.rs
@@ -26,8 +26,8 @@ use tokio::time::sleep;
 
 #[async_test]
 async fn test_abort_before_being_sent() {
-    // This test checks that a reaction could be aborted *before* or *while* it's
-    // being sent by the send queue.
+    // This test checks that a reaction could be aborted *before* or *while*
+    // it's being sent by the send queue.
 
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
@@ -71,7 +71,8 @@ async fn test_abort_before_being_sent() {
 
     // Now we try to add two reactions to this message…
 
-    // Mock the send endpoint with a delay, to give us time to abort the sending.
+    // Mock the send endpoint with a delay, to give us time to abort the
+    // sending.
     server
         .mock_room_send()
         .ok_with_delay(event_id!("$2"), Duration::from_millis(150))
@@ -134,8 +135,8 @@ async fn test_abort_before_being_sent() {
         assert_pending!(stream);
     }
 
-    // Then we remove the first one; because it was being sent, it should lead to a
-    // redaction event.
+    // Then we remove the first one; because it was being sent, it should lead
+    // to a redaction event.
     timeline.toggle_reaction(&item_id, "👍").await.unwrap();
 
     {
@@ -154,8 +155,8 @@ async fn test_abort_before_being_sent() {
         assert_pending!(stream);
     }
 
-    // But because the first one was being sent, this one won't and the local echo
-    // could be discarded.
+    // But because the first one was being sent, this one won't and the local
+    // echo could be discarded.
     timeline.toggle_reaction(&item_id, "🥰").await.unwrap();
 
     {
@@ -187,8 +188,8 @@ async fn test_abort_before_being_sent() {
 
 #[async_test]
 async fn test_redact_failed() {
-    // This test checks that if a reaction redaction failed, then we re-insert the
-    // reaction after displaying it was removed.
+    // This test checks that if a reaction redaction failed, then we re-insert
+    // the reaction after displaying it was removed.
 
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
@@ -264,8 +265,8 @@ async fn test_redact_failed() {
 
 #[async_test]
 async fn test_local_reaction_to_local_echo() {
-    // This test checks that if a reaction redaction failed, then we re-insert the
-    // reaction after displaying it was removed.
+    // This test checks that if a reaction redaction failed, then we re-insert
+    // the reaction after displaying it was removed.
 
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
@@ -364,8 +365,8 @@ async fn test_local_reaction_to_local_echo() {
         assert_pending!(stream);
     }
 
-    // Remove second reaction. It's immediately removed, since it was a local echo,
-    // and it wasn't being sent.
+    // Remove second reaction. It's immediately removed, since it was a local
+    // echo, and it wasn't being sent.
     timeline.toggle_reaction(&item_id, key2).await.unwrap();
 
     {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -1040,7 +1040,8 @@ async fn test_send_single_receipt_with_unread_flag() {
             .unwrap();
     }
 
-    // Unthreaded receipts on unknown events are set and the unread flag is unset.
+    // Unthreaded receipts on unknown events are set and the unread flag is
+    // unset.
     {
         let _guards = (
             server
@@ -1086,8 +1087,8 @@ async fn test_send_single_receipt_with_unread_flag() {
             .unwrap();
     }
 
-    // Threaded receipt with unknown previous receipt is sent, but the unread flag
-    // is not unset.
+    // Threaded receipt with unknown previous receipt is sent, but the unread
+    // flag is not unset.
     {
         let _guard = server
             .mock_send_receipt(CreateReceiptType::Read)
@@ -1164,8 +1165,8 @@ async fn test_mark_as_read() {
         .await
         .unwrap();
 
-    // Then no request is actually sent, because the event forming the timeline item
-    // (the message) is known as read.
+    // Then no request is actually sent, because the event forming the timeline
+    // item (the message) is known as read.
     assert!(has_sent.not());
 
     server.mock_send_receipt(CreateReceiptType::Read).ok().mock_once().mount().await;
@@ -1198,8 +1199,8 @@ async fn test_mark_as_read_after_own_reply() {
     let own_user_id = client.user_id().unwrap();
     let alice_event_id = event_id!("$alice_event_id");
 
-    // Alice sends a message, the user replies. The user's reply is the latest event
-    // and but the homeserver has no receipt for Alice's message.
+    // Alice sends a message, the user replies. The user's reply is the latest
+    // event and but the homeserver has no receipt for Alice's message.
     let f = EventFactory::new();
     server
         .sync_room(
@@ -1225,9 +1226,9 @@ async fn test_mark_as_read_after_own_reply() {
         .await;
 
     // Marking the room as read still sends a receipt (for Alice's message, the
-    // latest event not sent by the user) instead of being suppressed by the user's
-    // implicit receipt. This is required to allow the server to re-compute the
-    // push/badge count.
+    // latest event not sent by the user) instead of being suppressed by the
+    // user's implicit receipt. This is required to allow the server to
+    // re-compute the push/badge count.
     let has_sent = timeline.mark_as_read(CreateReceiptType::Read).await.unwrap();
     assert!(has_sent);
 }
@@ -1266,8 +1267,9 @@ async fn test_mark_as_read_with_only_own_events() {
         )
         .await;
 
-    // With no other user's event to point at, the receipt falls back to the user's
-    // own latest event so a lingering server-side push/badge count can be reset.
+    // With no other user's event to point at, the receipt falls back to the
+    // user's own latest event so a lingering server-side push/badge count
+    // can be reset.
     server
         .mock_send_receipt(CreateReceiptType::Read)
         .match_event_id(event_id!("$second"))
@@ -1301,8 +1303,8 @@ async fn test_send_read_receipt_redirects_from_own_event() {
     let alice_event_id = event_id!("$alice_event_id");
     let own_event_id = event_id!("$own_event_id");
 
-    // Alice sends a message, then the user replies. The homeserver has no receipt
-    // for either yet.
+    // Alice sends a message, then the user replies. The homeserver has no
+    // receipt for either yet.
     let f = EventFactory::new();
     server
         .sync_room(
@@ -1551,7 +1553,8 @@ async fn test_mark_as_read_with_unread_flag() {
             .mount_as_scoped()
             .await;
 
-        // When I mark the room as read by sending a read receipt to the latest event,
+        // When I mark the room as read by sending a read receipt to the latest
+        // event,
         let has_sent = timeline.mark_as_read(CreateReceiptType::Read).await.unwrap();
 
         // The receipt is sent and the unread flag was unset.
@@ -1583,7 +1586,8 @@ async fn test_mark_as_read_with_unread_flag() {
             .mount_as_scoped()
             .await;
 
-        // When I mark the room as read by sending a read receipt to the latest event,
+        // When I mark the room as read by sending a read receipt to the latest
+        // event,
         let has_sent = timeline.mark_as_read(CreateReceiptType::Read).await.unwrap();
 
         // The receipt is not sent but the unread flag was unset.
@@ -1794,8 +1798,8 @@ async fn test_send_multiple_receipts_with_unread_flag() {
         timeline.send_multiple_receipts(first_receipts).await.unwrap();
     }
 
-    // Receipts with unknown previous receipts are always sent, and the unread flag
-    // is unset.
+    // Receipts with unknown previous receipts are always sent, and the unread
+    // flag is unset.
     {
         let _read_markers_guard =
             server.mock_send_read_markers().ok().expect(1).mount_as_scoped().await;
@@ -2020,16 +2024,17 @@ async fn test_no_duplicate_receipt_after_backpagination() {
 
         let receipts = &event1.read_receipts();
 
-        // Carol has explicitly seen ev3, which is after Bob's event, so there shouldn't
-        // be a receipt for them here.
+        // Carol has explicitly seen ev3, which is after Bob's event, so there
+        // shouldn't be a receipt for them here.
         assert!(receipts.get(*CAROL).is_none());
 
-        // Alice has seen this event, being the sender; but Alice has also sent an edit
-        // after Bob's message, so Alice must not have a read receipt here.
+        // Alice has seen this event, being the sender; but Alice has also sent
+        // an edit after Bob's message, so Alice must not have a read
+        // receipt here.
         assert!(receipts.get(*ALICE).is_none());
 
-        // And Bob has seen the original, but posted something after it, so no receipt
-        // for Bob either.
+        // And Bob has seen the original, but posted something after it, so no
+        // receipt for Bob either.
         assert!(receipts.get(*BOB).is_none());
 
         // In other words, no receipts here.
@@ -2053,9 +2058,9 @@ async fn test_no_duplicate_receipt_after_backpagination() {
 
 #[async_test]
 async fn test_no_duplicate_receipt_after_backpagination_with_message_like_events_tracking() {
-    // Regression test for a duplicate read receipt that only manifests when read
-    // receipts are tracked in `TimelineReadReceiptTracking::MessageLikeEvents`
-    // mode.
+    // Regression test for a duplicate read receipt that only manifests when
+    // read receipts are tracked in
+    // `TimelineReadReceiptTracking::MessageLikeEvents` mode.
     //
     // In that mode a state event is *rendered* (`visible == true`) but *cannot
     // hold a read receipt* (`can_show_read_receipts == false`).
@@ -2082,9 +2087,10 @@ async fn test_no_duplicate_receipt_after_backpagination_with_message_like_events
     //    Carol
     //
     // $4 is hidden and at the end, so Carol's receipt must land on the
-    // most recent event that can show read receipts, that is $3. Crucially, $3 is
-    // immediately preceded by the state event $2, which is rendered but cannot
-    // carry receipts — so the receipt-holder to reconcile against is $1, not $2.
+    // most recent event that can show read receipts, that is $3. Crucially, $3
+    // is immediately preceded by the state event $2, which is rendered but
+    // cannot carry receipts — so the receipt-holder to reconcile against is
+    // $1, not $2.
 
     let eid1 = event_id!("$1_alice_message");
     let eid2 = event_id!("$2_bob_state_event");

--- a/crates/matrix-sdk-ui/tests/integration/timeline/redecryption.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/redecryption.rs
@@ -83,9 +83,9 @@ async fn test_redecryption(
 
     let bob_room = bob.get_room(room_id).expect("Bob should have access to the invited room");
 
-    // Alice will send a single event to the room, but this will trigger a to-device
-    // message containing the room key to be sent as well. We capture both the event
-    // and the to-device message.
+    // Alice will send a single event to the room, but this will trigger a
+    // to-device message containing the room key to be sent as well. We
+    // capture both the event and the to-device message.
 
     let event_id = event_id!("$some_id");
     let (event_receiver, mock) =

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -1242,10 +1242,10 @@ async fn test_send_reply_enforce_thread_is_reply() {
 
 #[async_test]
 async fn test_send_reply_with_event_id_that_is_redacted() {
-    // This test checks if is possible to reply to a redacted event that is not in
-    // the timeline. The event id will go through a process where the event is
-    // fetched and the content will be extracted and deserialised to be used in
-    // the reply.
+    // This test checks if is possible to reply to a redacted event that is not
+    // in the timeline. The event id will go through a process where the
+    // event is fetched and the content will be extracted and deserialised
+    // to be used in the reply.
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().build().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/rtc.rs
@@ -429,8 +429,8 @@ async fn test_only_update_notification_after_it_has_been_marked_as_last() {
         )
         .await;
 
-    // Ensure that the existing notification timeline item has no info about the new
-    // call
+    // Ensure that the existing notification timeline item has no info about the
+    // new call
     assert_let_timeout!(Some(_timeline_updates) = timeline_stream.next());
 
     let items = timeline.items().await;
@@ -493,8 +493,8 @@ async fn test_only_update_notification_after_it_has_been_marked_as_last() {
             notification.content()
     );
 
-    // If there is a new membership, then this is a new call, should not update the
-    // old notification
+    // If there is a new membership, then this is a new call, should not update
+    // the old notification
 
     server
         .sync_room(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -719,7 +719,8 @@ async fn test_timeline_refreshes_sender_profile_on_global_profile_update() -> Re
     assert_let!(TimelineDetails::Ready(profile) = alice_message.sender_profile());
     assert!(profile.status.is_none(), "The status should be unset before the profile update.");
 
-    // A sync carrying only a global profiles update for Alice with a new status.
+    // A sync carrying only a global profiles update for Alice with a new
+    // status.
     receive_response! {
         [server.server(), stream]
         {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -136,7 +136,8 @@ async fn test_event_filter() {
     // The implicit read receipt of Alice is moving from Alice's message...
     assert_let!(VectorDiff::Set { index: 1, value: first } = &timeline_updates[1]);
     assert_eq!(first.as_event().unwrap().read_receipts().len(), 0, "no more implicit read receipt");
-    // … to Alice's edit. But since this item isn't visible, it's lost in the weeds!
+    // … to Alice's edit. But since this item isn't visible, it's lost in the
+    // weeds!
 
     // The edit is applied to the first event.
     assert_let!(VectorDiff::Set { index: 1, value: first } = &timeline_updates[2]);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -180,8 +180,8 @@ async fn test_thread_backpagination() {
         assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
         let event_item = value.as_event().unwrap();
         assert_eq!(event_item.content().as_message().unwrap().body(), "Threaded event 3");
-        // In a threaded timeline, threads aren't using the reply fallback, unless
-        // they're an actual reply to another thread event.
+        // In a threaded timeline, threads aren't using the reply fallback,
+        // unless they're an actual reply to another thread event.
         assert_matches!(event_item.content().in_reply_to(), None);
     }
 
@@ -189,8 +189,8 @@ async fn test_thread_backpagination() {
         assert_let!(VectorDiff::PushBack { value } = &timeline_updates[1]);
         let event_item = value.as_event().unwrap();
         assert_eq!(event_item.content().as_message().unwrap().body(), "Threaded event 4");
-        // But this one is an actual reply to another thread event, so it has the
-        // replied-to event correctly set.
+        // But this one is an actual reply to another thread event, so it has
+        // the replied-to event correctly set.
         assert_eq!(event_item.content().in_reply_to().unwrap().event_id, event_id!("$2"));
     }
 
@@ -484,9 +484,9 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
 
     // The timeline sees the reply.
     //
-    // TODO: maybe we should include the thread summaries if and only if the live
-    // timeline is configured to exclude thread replies, aka, it requires
-    // thread-focused timelines to consult the thread replies.
+    // TODO: maybe we should include the thread summaries if and only if the
+    // live timeline is configured to exclude thread replies, aka, it
+    // requires thread-focused timelines to consult the thread replies.
     assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
@@ -501,8 +501,8 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
     assert_let!(TimelineDetails::Ready(replied_to_event) = replied_to_details);
     assert!(replied_to_event.content.thread_summary().is_none());
 
-    // Since the replied-to item (the thread root) has been updated, all replies get
-    // updated too, including the item we just pushed.
+    // Since the replied-to item (the thread root) has been updated, all replies
+    // get updated too, including the item we just pushed.
     assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[1]);
     let event_item = value.as_event().unwrap();
     assert_eq!(event_item.event_id().unwrap(), reply_event_id);
@@ -517,7 +517,8 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
     assert_eq!(event_item.event_id().unwrap(), thread_event_id);
     assert!(event_item.content().thread_root().is_none());
 
-    // The thread summary contains the detailed information about the latest event.
+    // The thread summary contains the detailed information about the latest
+    // event.
     assert_let!(Some(summary) = event_item.content().thread_summary());
     assert!(summary.latest_event.is_ready());
     assert_let!(TimelineDetails::Ready(latest_event) = summary.latest_event);
@@ -562,8 +563,8 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
     assert!(event_item.content().thread_summary().is_none());
     assert_eq!(event_item.content().thread_root().as_deref(), Some(thread_event_id));
 
-    // Then the first thread reply is updated with the up-to-date thread summary in
-    // the replied-to event.
+    // Then the first thread reply is updated with the up-to-date thread summary
+    // in the replied-to event.
     assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[2]);
     let event_item = value.as_event().unwrap();
     assert_eq!(event_item.event_id().unwrap(), reply_event_id);
@@ -599,9 +600,9 @@ async fn test_new_thread_reply_causes_thread_summary_update() {
 
 #[async_test]
 async fn test_thread_msg_edit_reflects_in_summary() {
-    // A new message edit of a threaded reply received in sync (but after we already
-    // had a thread) will cause the thread root's thread summary to be updated
-    // with the latest content.
+    // A new message edit of a threaded reply received in sync (but after we
+    // already had a thread) will cause the thread root's thread summary to
+    // be updated with the latest content.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -619,8 +620,8 @@ async fn test_thread_msg_edit_reflects_in_summary() {
     let (initial_items, mut stream) = timeline.subscribe().await;
     assert!(initial_items.is_empty());
 
-    // Start with a message (with no bundled thread info), and a threaded reply to
-    // it.
+    // Start with a message (with no bundled thread info), and a threaded reply
+    // to it.
     let f = EventFactory::new().room(room_id).sender(&ALICE);
     let thread_event_id = event_id!("$thread_root");
     let reply_event_id = event_id!("$thread_reply");
@@ -642,8 +643,9 @@ async fn test_thread_msg_edit_reflects_in_summary() {
         .await;
 
     assert_let_timeout!(Some(timeline_updates) = stream.next());
-    // Thread root + new implicit read receipt + new thread summary + day divider.
-    // TODO: could we optimize this, to have only a single timeline update?
+    // Thread root + new implicit read receipt + new thread summary + day
+    // divider. TODO: could we optimize this, to have only a single timeline
+    // update?
     assert_eq!(timeline_updates.len(), 4);
 
     // Sanity check the timeline diffs.
@@ -656,8 +658,8 @@ async fn test_thread_msg_edit_reflects_in_summary() {
         // And it only has the read receipt of its author.
         assert_eq!(event_item.read_receipts().len(), 1);
 
-        // Then, a read-receipt "set" because Bob having sent a reply means he's seen
-        // the thread root.
+        // Then, a read-receipt "set" because Bob having sent a reply means he's
+        // seen the thread root.
         assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
         let event_item = value.as_event().unwrap();
         assert_eq!(event_item.event_id().unwrap(), thread_event_id);
@@ -728,9 +730,9 @@ async fn test_thread_msg_edit_reflects_in_summary() {
 
 #[async_test]
 async fn test_thread_poll_edit_reflects_in_summary() {
-    // A new poll edit of a threaded reply received in sync (at the same time as the
-    // original poll) will cause the thread root's thread summary to be updated
-    // with the latest content.
+    // A new poll edit of a threaded reply received in sync (at the same time as
+    // the original poll) will cause the thread root's thread summary to be
+    // updated with the latest content.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -786,8 +788,9 @@ async fn test_thread_poll_edit_reflects_in_summary() {
         .await;
 
     assert_let_timeout!(Some(timeline_updates) = stream.next());
-    // Thread root + new implicit read receipt + new thread summary + day divider.
-    // TODO: could we optimize this, to have only a single timeline update?
+    // Thread root + new implicit read receipt + new thread summary + day
+    // divider. TODO: could we optimize this, to have only a single timeline
+    // update?
     assert_eq!(timeline_updates.len(), 4);
 
     assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
@@ -798,8 +801,8 @@ async fn test_thread_poll_edit_reflects_in_summary() {
     // And it only has the read receipt of its author.
     assert_eq!(event_item.read_receipts().len(), 1);
 
-    // Then, a read-receipt "set" because Bob having sent a reply means he's seen
-    // the thread root.
+    // Then, a read-receipt "set" because Bob having sent a reply means he's
+    // seen the thread root.
     assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
     let event_item = value.as_event().unwrap();
     assert_eq!(event_item.event_id().unwrap(), thread_event_id);
@@ -837,8 +840,8 @@ async fn test_thread_poll_edit_reflects_in_summary() {
 async fn test_thread_filtering_for_sync() {
     // Make sure that:
     // - a live timeline that shows threaded events will show them
-    // - a live timeline that hides threaded events *will* hide them (and only keep
-    //   the summary)
+    // - a live timeline that hides threaded events *will* hide them (and only
+    //   keep the summary)
     // - a thread timeline will show the threaded events
 
     let server = MatrixMockServer::new().await;
@@ -946,8 +949,9 @@ async fn test_thread_filtering_for_sync() {
         assert_let!(VectorDiff::PushFront { value } = &timeline_updates[3]);
         assert!(value.is_date_divider());
 
-        // The thread event is a reply (because of the reply fallback), and since its
-        // replied-to timeline item has been updated, it also gets updated.
+        // The thread event is a reply (because of the reply fallback), and
+        // since its replied-to timeline item has been updated, it also
+        // gets updated.
         assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[4]);
         assert_eq!(
             value.as_event().unwrap().content().as_message().unwrap().body(),
@@ -961,8 +965,8 @@ async fn test_thread_filtering_for_sync() {
         assert_pending!(timeline_stream);
     }
 
-    // The threaded timeline should only contain the thread root and the threaded
-    // event.
+    // The threaded timeline should only contain the thread root and the
+    // threaded event.
     {
         assert_let_timeout!(Some(timeline_updates) = thread_timeline_stream.next());
         assert_eq!(timeline_updates.len(), 4);
@@ -993,8 +997,8 @@ async fn test_thread_filtering_for_sync() {
 
 #[async_test]
 async fn test_thread_timeline_gets_related_events_from_sync() {
-    // If a thread timeline receives a sync event related to an in-thread event, it
-    // gets updated.
+    // If a thread timeline receives a sync event related to an in-thread event,
+    // it gets updated.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -1046,8 +1050,9 @@ async fn test_thread_timeline_gets_related_events_from_sync() {
 
     assert_pending!(stream);
 
-    // When we get a reaction for the in-thread event, from sync, the timeline gets
-    // updated, even though the reaction doesn't mention the thread directly.
+    // When we get a reaction for the in-thread event, from sync, the timeline
+    // gets updated, even though the reaction doesn't mention the thread
+    // directly.
     server
         .sync_room(
             &client,
@@ -1063,7 +1068,8 @@ async fn test_thread_timeline_gets_related_events_from_sync() {
     assert_eq!(event_item.event_id().unwrap(), threaded_event_id);
     assert!(event_item.content().reactions().unwrap().is_empty().not());
 
-    // If I open another timeline on the same thread, I still see the related event.
+    // If I open another timeline on the same thread, I still see the related
+    // event.
     let other_timeline = room
         .timeline_builder()
         .with_focus(TimelineFocus::Thread { root_event_id: thread_root_event_id })
@@ -1185,13 +1191,13 @@ async fn test_thread_timeline_gets_local_echoes() {
         assert_let!(Some(Relation::Thread(thread)) = event.content.relates_to.clone());
         assert_eq!(thread.event_id, thread_root_event_id);
         assert!(thread.is_falling_back);
-        // The reply-to fallback is set to the latest in-thread event, not the thread
-        // root.
+        // The reply-to fallback is set to the latest in-thread event, not the
+        // thread root.
         assert_eq!(thread.in_reply_to.unwrap().event_id, threaded_event_id);
     }
 
-    // If I send a reaction for the in-thread event, the timeline gets updated, even
-    // though the reaction doesn't mention the thread directly.
+    // If I send a reaction for the in-thread event, the timeline gets updated,
+    // even though the reaction doesn't mention the thread directly.
     server.mock_room_send().ok(event_id!("$reaction_id")).mock_once().mount().await;
     timeline.toggle_reaction(&event_item.identifier(), "👍").await.unwrap();
 
@@ -1207,8 +1213,8 @@ async fn test_thread_timeline_gets_local_echoes() {
     assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert!(!timeline_updates.is_empty());
 
-    // Sometimes, a double `VectorDiff::Set` is received because of another update.
-    // Let's make the test reliable.
+    // Sometimes, a double `VectorDiff::Set` is received because of another
+    // update. Let's make the test reliable.
     for timeline_update in timeline_updates {
         assert_let!(VectorDiff::Set { index: 2, value } = timeline_update);
         let event_item = value.as_event().unwrap();
@@ -1222,9 +1228,9 @@ async fn test_thread_timeline_gets_local_echoes() {
 
 #[async_test]
 async fn test_thread_timeline_can_send_edit() {
-    // If I send an edit to a threaded timeline, it just works (aka the system to
-    // set the threaded relationship doesn't kick in, since there's already a
-    // relationship).
+    // If I send an edit to a threaded timeline, it just works (aka the system
+    // to set the threaded relationship doesn't kick in, since there's
+    // already a relationship).
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -1307,8 +1313,8 @@ async fn test_thread_timeline_can_send_edit() {
 
 #[async_test]
 async fn test_send_sticker_thread() {
-    // If I send a sticker to a threaded timeline, it just works (aka the system to
-    // set the threaded relationship does kick in).
+    // If I send a sticker to a threaded timeline, it just works (aka the system
+    // to set the threaded relationship does kick in).
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -1469,8 +1475,8 @@ async fn test_send_poll_thread() {
 
 #[async_test]
 async fn test_sending_read_receipt_with_no_events_doesnt_unset_read_flag() {
-    // If a thread timeline has no events, then marking it as read doesn't unset the
-    // unread flag on the room.
+    // If a thread timeline has no events, then marking it as read doesn't unset
+    // the unread flag on the room.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -1499,8 +1505,9 @@ async fn test_sending_read_receipt_with_no_events_doesnt_unset_read_flag() {
     assert_pending!(stream);
 
     // Try to mark the timeline as read.
-    // This should not unset the unread flag on the room (if it tried to do so, the
-    // test would fail with a 404, because the endpoint hasn't been set).
+    // This should not unset the unread flag on the room (if it tried to do so,
+    // the test would fail with a 404, because the endpoint hasn't been
+    // set).
     let marked_as_read = timeline.mark_as_read(SendReceiptType::Read).await.unwrap();
     assert!(marked_as_read.not());
 }
@@ -1567,7 +1574,8 @@ async fn test_read_receipts() {
     // Second event has Alice's implicit read receipt, third event has Bob's
     // implicit read receipt.
     {
-        // Alice's event gets pushed back, first, with its own implicit read receipt.
+        // Alice's event gets pushed back, first, with its own implicit read
+        // receipt.
         assert_let!(VectorDiff::PushBack { value } = &timeline_updates[0]);
         let ev0 = value.as_event().unwrap();
         assert_eq!(ev0.event_id(), Some(event_id!("$1")));
@@ -1575,8 +1583,8 @@ async fn test_read_receipts() {
         assert_eq!(rr.len(), 1);
         assert_eq!(rr[*ALICE].thread, receipt_thread);
 
-        // But then, as we're about to push another event from Alice, its read receipt
-        // disappears from the first event.
+        // But then, as we're about to push another event from Alice, its read
+        // receipt disappears from the first event.
         // XXX wouldn't it be nice that we didn't have this update?
         assert_let!(VectorDiff::Set { index: 0, value } = &timeline_updates[1]);
         let ev0 = value.as_event().unwrap();
@@ -1606,8 +1614,8 @@ async fn test_read_receipts() {
     // Receive a read receipt update:
     // - an explicit read receipt for Alice on $3, which will move their read
     //   receipt to the latest event.
-    // - an explicit read receipt for Bob on $3, which will not do anything (because
-    //   of the implicit read receipt)
+    // - an explicit read receipt for Bob on $3, which will not do anything
+    //   (because of the implicit read receipt)
     server
         .sync_room(
             &client,
@@ -1658,8 +1666,8 @@ async fn test_initial_read_receipts_are_correctly_populated() {
 
     // Start with a room that has an event with some initial read receipts.
     //
-    // It is sync'd *before* the timeline is created, so the timeline will have to
-    // load the receipts from the store.
+    // It is sync'd *before* the timeline is created, so the timeline will have
+    // to load the receipts from the store.
     let f = EventFactory::new();
     let room = server
         .sync_room(
@@ -1721,8 +1729,8 @@ async fn test_initial_read_receipts_compatibility_mode() {
 
     // Start with a room that has an event with some initial read receipts.
     //
-    // It is sync'd *before* the timeline is created, so the timeline will have to
-    // load the receipts from the store.
+    // It is sync'd *before* the timeline is created, so the timeline will have
+    // to load the receipts from the store.
     let f = EventFactory::new();
     let room = server
         .sync_room(
@@ -1787,8 +1795,8 @@ async fn test_initial_read_receipts_compatibility_mode() {
 
 #[async_test]
 async fn test_send_read_receipts() {
-    // Threaded read receipts can be sent from a thread timeline. Trying to send a
-    // read receipt on an event that had one is a no-op.
+    // Threaded read receipts can be sent from a thread timeline. Trying to send
+    // a read receipt on an event that had one is a no-op.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -1849,8 +1857,8 @@ async fn test_send_read_receipts() {
 
     let (mut initial_items, mut stream) = timeline.subscribe().await;
 
-    // Either the initial timeline is not empty, or it will soon receive an update
-    // from the event cache.
+    // Either the initial timeline is not empty, or it will soon receive an
+    // update from the event cache.
     if initial_items.is_empty() {
         assert_let_timeout!(Some(timeline_updates) = stream.next());
         for up in timeline_updates {
@@ -1858,16 +1866,16 @@ async fn test_send_read_receipts() {
         }
     }
 
-    // Now that the timeline is populated, we can check the initial read receipts.
-    // Note: 0 is the index of the date divider.
+    // Now that the timeline is populated, we can check the initial read
+    // receipts. Note: 0 is the index of the date divider.
     let ev = initial_items[1].as_event().unwrap();
     assert_eq!(ev.event_id(), Some(event_id!("$1")));
     let rr = ev.read_receipts();
     assert_eq!(rr.len(), 1);
     assert_eq!(rr[*ALICE].thread, receipt_thread);
 
-    // The timeline doesn't include the read receipt for the current user, but this
-    // is where it would be, if it did.
+    // The timeline doesn't include the read receipt for the current user, but
+    // this is where it would be, if it did.
     let ev = initial_items[2].as_event().unwrap();
     assert_eq!(ev.event_id(), Some(event_id!("$2")));
     assert!(ev.read_receipts().is_empty());
@@ -1887,14 +1895,14 @@ async fn test_send_read_receipts() {
     assert_eq!(rr.len(), 1);
     assert_eq!(rr[*BOB].thread, receipt_thread);
 
-    // `$1` is already covered by the user's real read receipt, so sending one there
-    // is a no-op.
+    // `$1` is already covered by the user's real read receipt, so sending one
+    // there is a no-op.
     let did_send =
         timeline.send_single_receipt(SendReceiptType::Read, owned_event_id!("$1")).await.unwrap();
     assert!(did_send.not());
 
-    // `$2` is the user's own event with their receipt is directly before it. Also a
-    // no-op.
+    // `$2` is the user's own event with their receipt is directly before it.
+    // Also a no-op.
     let did_send =
         timeline.send_single_receipt(SendReceiptType::Read, owned_event_id!("$2")).await.unwrap();
     assert!(did_send.not());
@@ -1929,8 +1937,8 @@ async fn test_send_read_receipts() {
             )
             .await;
 
-        // The timeline receives an update for the read receipt, but it won't move it,
-        // since it doesn't signal our own read receipt.
+        // The timeline receives an update for the read receipt, but it won't
+        // move it, since it doesn't signal our own read receipt.
         yield_now().await;
         assert_pending!(stream);
     }
@@ -1962,8 +1970,8 @@ async fn test_send_read_receipts() {
             )
             .await;
 
-        // The timeline receives an update for the read receipt, but it won't move it,
-        // since it doesn't signal our own read receipt.
+        // The timeline receives an update for the read receipt, but it won't
+        // move it, since it doesn't signal our own read receipt.
         yield_now().await;
         assert_pending!(stream);
     }
@@ -2047,8 +2055,9 @@ async fn test_send_read_receipt_moves_real_receipt_forward() {
 
 #[async_test]
 async fn test_send_read_receipt_with_only_own_events_is_a_no_op() {
-    // Sending a read receipt is a no-op when the target and everything before it
-    // are the user's own events, since a receipt is never sent to one of those.
+    // Sending a read receipt is a no-op when the target and everything before
+    // it are the user's own events, since a receipt is never sent to one of
+    // those.
 
     let server = MatrixMockServer::new().await;
     let client = client_with_threading_support(&server).await;
@@ -2094,8 +2103,8 @@ async fn test_send_read_receipt_with_only_own_events_is_a_no_op() {
         }
     }
 
-    // Both the user's latest event and the one before it are the user's, so both
-    // bail.
+    // Both the user's latest event and the one before it are the user's, so
+    // both bail.
     let did_send =
         timeline.send_single_receipt(SendReceiptType::Read, owned_event_id!("$2")).await.unwrap();
     assert!(did_send.not());
@@ -2265,14 +2274,14 @@ async fn test_redacted_replied_to_is_updated() {
     assert_let_timeout!(Some(timeline_updates) = stream.next());
     assert_eq!(timeline_updates.len(), 3);
 
-    // The first reply is being redacted by the `m.room.redaction` event the thread
-    // timeline receives.
+    // The first reply is being redacted by the `m.room.redaction` event the
+    // thread timeline receives.
     assert_let!(VectorDiff::Set { index: 1, value } = &timeline_updates[0]);
     let ev1 = value.as_event().unwrap();
     assert_eq!(ev1.event_id(), Some(first_reply));
 
-    // The second reply is being updated because the event it replies to has been
-    // updated.
+    // The second reply is being updated because the event it replies to has
+    // been updated.
     assert_let!(VectorDiff::Set { index: 2, value } = &timeline_updates[1]);
     let ev2 = value.as_event().unwrap();
     assert_eq!(ev2.event_id(), Some(second_reply));
@@ -2427,8 +2436,8 @@ async fn test_main_timeline_has_receipts_in_thread_summaries() {
         }
     }
 
-    // Let's take a look at the items, now that they've been loaded: there will be
-    // the day divider and the thread root itself.
+    // Let's take a look at the items, now that they've been loaded: there will
+    // be the day divider and the thread root itself.
     let items = timeline.items().await;
     assert_eq!(items.len(), 2);
 
@@ -2449,8 +2458,8 @@ async fn test_main_timeline_has_receipts_in_thread_summaries() {
     assert_eq!(summary.public_read_receipt_event_id.as_deref(), Some(latest_event_id));
     assert_eq!(summary.private_read_receipt_event_id, None);
 
-    // Now, a new read receipt is received for the same thread (we haven't received
-    // the thread event yet).
+    // Now, a new read receipt is received for the same thread (we haven't
+    // received the thread event yet).
     let new_latest_event_id = event_id!("$new_latest_event_id");
 
     server

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -148,9 +148,10 @@ impl Account {
             }
         }
 
-        // If name is `Some(_)`, this endpoint is the same as `set_profile_field`, but
-        // we still need to use it in case it is `None` and the server doesn't support
-        // the delete endpoint yet.
+        // If name is `Some(_)`, this endpoint is the same as
+        // `set_profile_field`, but we still need to use it in case it
+        // is `None` and the server doesn't support the delete endpoint
+        // yet.
         #[allow(deprecated)]
         let request =
             set_display_name::v3::Request::new(user_id.to_owned(), name.map(ToOwned::to_owned));
@@ -250,9 +251,10 @@ impl Account {
             }
         }
 
-        // If url is `Some(_)`, this endpoint is the same as `set_profile_field`, but
-        // we still need to use it in case it is `None` and the server doesn't support
-        // the delete endpoint yet.
+        // If url is `Some(_)`, this endpoint is the same as
+        // `set_profile_field`, but we still need to use it in case it
+        // is `None` and the server doesn't support the delete endpoint
+        // yet.
         #[allow(deprecated)]
         let request =
             set_avatar_url::v3::Request::new(user_id.to_owned(), url.map(ToOwned::to_owned));
@@ -561,8 +563,8 @@ impl Account {
         if let Err(error) =
             self.client.base_client().own_profile_updated(UserProfileUpdate::Updated(changes)).await
         {
-            // The homeserver has already accepted the changes at this point, so we
-            // only need to log the failure.
+            // The homeserver has already accepted the changes at this point, so
+            // we only need to log the failure.
             warn!(?error, "Failed to update the locally stored copy of our own profile");
         }
     }
@@ -1108,27 +1110,28 @@ impl Account {
     pub async fn mark_as_dm(&self, room_id: &RoomId, user_ids: &[OwnedUserId]) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
-        // This function does a read/update/store of an account data event stored on the
-        // homeserver. We first fetch the existing account data event, the event
-        // contains a map which gets updated by this method, finally we upload the
-        // modified event.
+        // This function does a read/update/store of an account data event
+        // stored on the homeserver. We first fetch the existing account
+        // data event, the event contains a map which gets updated by
+        // this method, finally we upload the modified event.
         //
-        // To prevent multiple calls to this method trying to update the map of DMs same
-        // time, and thus trampling on each other we introduce a lock which acts
-        // as a semaphore.
+        // To prevent multiple calls to this method trying to update the map of
+        // DMs same time, and thus trampling on each other we introduce
+        // a lock which acts as a semaphore.
         let _guard = self.client.locks().mark_as_dm_lock.lock().await;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the
         // existing `m.direct` event and append the room to the list of DMs we
         // have with this user.
 
-        // We are fetching the content from the server because we currently can't rely
-        // on `/sync` giving us the correct data in a timely manner.
+        // We are fetching the content from the server because we currently
+        // can't rely on `/sync` giving us the correct data in a timely
+        // manner.
         let raw_content = self.fetch_account_data_static::<DirectEventContent>().await?;
 
         let mut content = if let Some(raw_content) = raw_content {
-            // Log the error and pass it upwards if we fail to deserialize the m.direct
-            // event.
+            // Log the error and pass it upwards if we fail to deserialize the
+            // m.direct event.
             raw_content.deserialize().map_err(|err| {
                 error!("unable to deserialize m.direct event content; aborting request to mark {room_id} as dm: {err}");
                 err
@@ -1162,10 +1165,10 @@ impl Account {
 
         self.set_account_data(ignored_user_list).await?;
 
-        // In theory, we should also clear some caches here, because they may include
-        // events sent by the ignored user. In practice, we expect callers to
-        // take care of this, or subsystems to listen to user list changes and
-        // clear caches accordingly.
+        // In theory, we should also clear some caches here, because they may
+        // include events sent by the ignored user. In practice, we
+        // expect callers to take care of this, or subsystems to listen
+        // to user list changes and clear caches accordingly.
 
         Ok(())
     }
@@ -1302,8 +1305,8 @@ impl Account {
         ),
         Error,
     > {
-        // We need to create two observers, one for the stable event and one for the
-        // unstable and combine them into a single stream.
+        // We need to create two observers, one for the stable event and one for
+        // the unstable and combine them into a single stream.
         let first_observer = self
             .client
             .observe_events::<GlobalAccountDataEvent<MediaPreviewConfigEventContent>, ()>();
@@ -1356,8 +1359,8 @@ impl Account {
                 .map(Raw::cast)
         };
 
-        // We deserialize the content of the event, if is not found we return the
-        // default
+        // We deserialize the content of the event, if is not found we return
+        // the default
         let media_preview_config = media_preview_config.and_then(|value| value.deserialize().ok());
 
         Ok(media_preview_config)
@@ -1433,19 +1436,22 @@ impl Account {
         let index = recent_emojis.iter().position(|(unicode, _)| unicode == emoji);
 
         // Truncate to the max allowed size, which will remove any emojis that
-        // haven't been used in a very long time. This will also ease the pressure on
-        // `remove` and `insert` shifting lots of elements in the list
+        // haven't been used in a very long time. This will also ease the
+        // pressure on `remove` and `insert` shifting lots of elements
+        // in the list
         recent_emojis.truncate(MAX_RECENT_EMOJI_COUNT);
 
-        // Remove the emoji from the list if it was present and get it's `count` value
+        // Remove the emoji from the list if it was present and get it's `count`
+        // value
         let count = if let Some(index) = index { recent_emojis.remove(index).1 } else { uint!(0) };
 
-        // Insert the emoji with the updated count at the start of the list, so it's
-        // considered the most recently used emoji
+        // Insert the emoji with the updated count at the start of the list, so
+        // it's considered the most recently used emoji
         recent_emojis.insert(0, (emoji.to_owned(), count + uint!(1)));
 
-        // If the item was a new one, the list will now be `MAX_RECENT_EMOJI_COUNT` + 1,
-        // so truncate it again (this is a no-op if it already has the right size)
+        // If the item was a new one, the list will now be
+        // `MAX_RECENT_EMOJI_COUNT` + 1, so truncate it again (this is a
+        // no-op if it already has the right size)
         recent_emojis.truncate(MAX_RECENT_EMOJI_COUNT);
 
         let request = UpdateGlobalAccountDataRequest::new(
@@ -1488,9 +1494,9 @@ impl Account {
         };
 
         if let Some(content) = content {
-            // Sort by count, descending. For items with the same count, since they were
-            // previously ordered by recency in the list, more recent emojis will be
-            // returned first.
+            // Sort by count, descending. For items with the same count, since
+            // they were previously ordered by recency in the list,
+            // more recent emojis will be returned first.
             let sorted_emojis = content
                 .recent_emoji
                 .into_iter()
@@ -1629,7 +1635,8 @@ mod test_recent_emojis {
             .mount()
             .await;
 
-        // Now with a list of emojis longer than the max count, we fetch the emoji list
+        // Now with a list of emojis longer than the max count, we fetch the
+        // emoji list
         let recent_emojis = client.account().get_recent_emojis(true).await.expect("recent emojis");
 
         // It should only return until the max count
@@ -1648,8 +1655,8 @@ mod test_recent_emojis {
             list
         };
 
-        // Now if we add a new emoji that was not in the list, the last one in the list
-        // should be gone
+        // Now if we add a new emoji that was not in the list, the last one in
+        // the list should be gone
         server
             .mock_add_recent_emojis()
             .match_emojis_in_request_body(expected_updated_emoji_list)
@@ -1661,7 +1668,8 @@ mod test_recent_emojis {
 
         client.account().add_recent_emoji("50").await.expect("adding emoji");
 
-        // Do the same, but now with a new emoji that wasn't previously in the list
+        // Do the same, but now with a new emoji that wasn't previously in the
+        // list
         let expected_updated_emoji_list = {
             let mut list = long_emoji_list.clone();
             let item = (":D".to_owned(), uint!(1));

--- a/crates/matrix-sdk/src/authentication/matrix/mod.rs
+++ b/crates/matrix-sdk/src/authentication/matrix/mod.rs
@@ -518,7 +518,8 @@ impl MatrixAuth {
 
         let refresh_token_lock = &self.client.auth_ctx().refresh_token_lock;
         let Ok(mut guard) = refresh_token_lock.try_lock() else {
-            // Somebody else is also doing a token refresh; wait for it to finish first.
+            // Somebody else is also doing a token refresh; wait for it to
+            // finish first.
             return refresh_token_lock.lock().await.clone();
         };
 
@@ -778,8 +779,8 @@ impl MatrixAuth {
         room_load_settings: RoomLoadSettings,
         #[cfg(feature = "e2e-encryption")] login_info: Option<login::v3::LoginInfo>,
     ) -> Result<()> {
-        // This API doesn't have any data but by setting this variant we protect the
-        // user from using both authentication APIs at once.
+        // This API doesn't have any data but by setting this variant we protect
+        // the user from using both authentication APIs at once.
         self.client
             .auth_ctx()
             .auth_data

--- a/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/cross_process.rs
@@ -33,9 +33,9 @@ impl SessionHash {
             res.push('x');
         }
         for &c in &self.0 {
-            // We don't really care about little vs big endianness, since we only need a
-            // stable format, so we pick one: little endian (print high bits
-            // first).
+            // We don't really care about little vs big endianness, since we
+            // only need a stable format, so we pick one: little
+            // endian (print high bits first).
             res.push(CHARS[(c >> 4) as usize]);
             res.push(CHARS[(c & 0b1111) as usize]);
         }
@@ -79,13 +79,13 @@ impl CrossProcessRefreshManager {
     pub async fn spin_lock(
         &self,
     ) -> Result<CrossProcessRefreshLockGuard, CrossProcessRefreshLockError> {
-        // Acquire the intra-process mutex, to avoid multiple requests across threads in
-        // the current process.
+        // Acquire the intra-process mutex, to avoid multiple requests across
+        // threads in the current process.
         trace!("Waiting for intra-process lock...");
         let prev_hash = self.known_session_hash.clone().lock_owned().await;
 
-        // Acquire the cross-process mutex, to avoid multiple requests across different
-        // processus.
+        // Acquire the cross-process mutex, to avoid multiple requests across
+        // different processus.
         trace!("Waiting for inter-process lock...");
         let store_guard = self
             .store_lock
@@ -205,9 +205,10 @@ impl CrossProcessRefreshLockGuard {
         if let Some(db_hash) = &self.db_hash
             && new_hash != *db_hash
         {
-            // That should never happen, unless we got into an impossible situation!
-            // In this case, we assume the value returned by the callback is always
-            // correct, so override that in the database too.
+            // That should never happen, unless we got into an impossible
+            // situation! In this case, we assume the value returned
+            // by the callback is always correct, so override that
+            // in the database too.
             tracing::error!("error: DB and trusted disagree. Overriding in DB.");
             self.save_in_database(&new_hash).await?;
         }
@@ -356,8 +357,8 @@ mod tests {
         );
 
         {
-            // The cross process lock has been correctly updated, and the next attempt to
-            // take it won't result in a mismatch.
+            // The cross process lock has been correctly updated, and the next
+            // attempt to take it won't result in a mismatch.
             let xp_manager =
                 oauth.ctx().cross_process_token_refresh_manager.get().context("must have lock")?;
             let guard = xp_manager.spin_lock().await?;
@@ -372,8 +373,9 @@ mod tests {
 
     #[async_test]
     async fn test_refresh_access_token_twice() -> anyhow::Result<()> {
-        // This tests that refresh token works, and that it doesn't cause multiple token
-        // refreshes whenever one spawns two refreshes around the same time.
+        // This tests that refresh token works, and that it doesn't cause
+        // multiple token refreshes whenever one spawns two refreshes
+        // around the same time.
 
         let server = MatrixMockServer::new().await;
 
@@ -409,8 +411,8 @@ mod tests {
         }
 
         {
-            // The cross process lock has been correctly updated, and the next attempt to
-            // take it won't result in a mismatch.
+            // The cross process lock has been correctly updated, and the next
+            // attempt to take it won't result in a mismatch.
             let xp_manager =
                 oauth.ctx().cross_process_token_refresh_manager.get().context("must have lock")?;
             let guard = xp_manager.spin_lock().await?;
@@ -450,8 +452,8 @@ mod tests {
             .restore_session(mock_session(prev_tokens.clone()), RoomLoadSettings::default())
             .await?;
 
-        // Create a second client, without restoring it, to test that a token update
-        // before restoration doesn't cause new issues.
+        // Create a second client, without restoring it, to test that a token
+        // update before restoration doesn't cause new issues.
         let unrestored_client = server
             .client_builder()
             .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
@@ -462,8 +464,8 @@ mod tests {
         unrestored_oauth.enable_cross_process_refresh_lock("unrestored_client".to_owned()).await?;
 
         {
-            // Create a third client that will run a refresh while the others two are doing
-            // nothing.
+            // Create a third client that will run a refresh while the others
+            // two are doing nothing.
             let client3 = server
                 .client_builder()
                 .on_builder(|builder| builder.sqlite_store(&tmp_dir, None))
@@ -477,14 +479,14 @@ mod tests {
                 .restore_session(mock_session(prev_tokens.clone()), RoomLoadSettings::default())
                 .await?;
 
-            // Run a refresh in the second client; this will invalidate the tokens from the
-            // first token.
+            // Run a refresh in the second client; this will invalidate the
+            // tokens from the first token.
             oauth3.refresh_access_token().await?;
 
             assert_eq!(client3.session_tokens(), Some(next_tokens.clone()));
 
-            // Reading from the cross-process lock for the second client only shows the new
-            // tokens.
+            // Reading from the cross-process lock for the second client only
+            // shows the new tokens.
             let xp_manager =
                 oauth3.ctx().cross_process_token_refresh_manager.get().context("must have lock")?;
             let guard = xp_manager.spin_lock().await?;
@@ -495,7 +497,8 @@ mod tests {
         }
 
         {
-            // Restoring the client that was not restored yet will work Just Fine.
+            // Restoring the client that was not restored yet will work Just
+            // Fine.
             let oauth = unrestored_oauth;
 
             unrestored_client.set_session_callbacks(
@@ -525,8 +528,8 @@ mod tests {
         }
 
         {
-            // The cross process lock has been correctly updated, and the next attempt to
-            // take it will result in a mismatch.
+            // The cross process lock has been correctly updated, and the next
+            // attempt to take it will result in a mismatch.
             let xp_manager =
                 oauth.ctx().cross_process_token_refresh_manager.get().context("must have lock")?;
             let guard = xp_manager.spin_lock().await?;
@@ -595,8 +598,8 @@ mod tests {
         oauth.logout().await.unwrap();
 
         {
-            // The cross process lock has been correctly updated, and all the hashes are
-            // empty after a logout.
+            // The cross process lock has been correctly updated, and all the
+            // hashes are empty after a logout.
             let xp_manager =
                 oauth.ctx().cross_process_token_refresh_manager.get().context("must have lock")?;
             let guard = xp_manager.spin_lock().await?;
@@ -635,10 +638,11 @@ mod tests {
         let server = MatrixMockServer::new().await;
         let oauth_server = server.oauth();
 
-        // The token endpoint behaves like a rotating MAS. Only the first exchange
-        // succeeds and rotates the token: that one is the NSE's refresh, which the
-        // app is suspended through. Any later exchange presents the token that
-        // rotation consumed, and is rejected with `invalid_grant`.
+        // The token endpoint behaves like a rotating MAS. Only the first
+        // exchange succeeds and rotates the token: that one is the
+        // NSE's refresh, which the app is suspended through. Any later
+        // exchange presents the token that rotation consumed, and is
+        // rejected with `invalid_grant`.
         oauth_server
             .mock_token()
             .ok_with_tokens("1234", "ZYXWV") // == mock_session_tokens_with_refresh()
@@ -648,9 +652,9 @@ mod tests {
             .await;
         oauth_server.mock_token().invalid_grant().with_priority(2).mount().await;
 
-        // The app's (first) metadata request is delayed, to keep its refresh parked
-        // until after the NSE has rotated the token. The NSE's own request is
-        // answered immediately.
+        // The app's (first) metadata request is delayed, to keep its refresh
+        // parked until after the NSE has rotated the token. The NSE's
+        // own request is answered immediately.
         oauth_server
             .mock_server_metadata()
             .with_delay(Duration::from_secs(1))
@@ -661,8 +665,8 @@ mod tests {
             .await;
         oauth_server.mock_server_metadata().ok().with_priority(2).mount().await;
 
-        // The app and the NSE are two clients over one shared sqlite store, both
-        // restored with the same (prev) session.
+        // The app and the NSE are two clients over one shared sqlite store,
+        // both restored with the same (prev) session.
         let tmp_dir = tempfile::tempdir().unwrap();
 
         let app = server
@@ -705,13 +709,14 @@ mod tests {
         )
         .unwrap();
 
-        // Start the app's refresh; it takes the lock and then parks in the delayed
-        // `server_metadata()` request.
+        // Start the app's refresh; it takes the lock and then parks in the
+        // delayed `server_metadata()` request.
         let app_oauth = app.oauth();
         let app_refresh = tokio::spawn(async move { app_oauth.refresh_access_token().await });
 
-        // Wait until the app has actually issued that request — by then it holds the
-        // lock and, in the buggy ordering, has already captured the refresh token.
+        // Wait until the app has actually issued that request — by then it
+        // holds the lock and, in the buggy ordering, has already
+        // captured the refresh token.
         let mut waited = Duration::ZERO;
         while !server
             .received_requests()
@@ -725,17 +730,19 @@ mod tests {
             waited += Duration::from_millis(10);
         }
 
-        // "Suspend" the app: blocking the current-thread runtime freezes every task,
-        // including the one renewing the lease, so the 500ms lock lease lapses.
+        // "Suspend" the app: blocking the current-thread runtime freezes every
+        // task, including the one renewing the lease, so the 500ms lock
+        // lease lapses.
         thread::sleep(Duration::from_millis(700));
 
-        // The NSE steals the lapsed lock and refreshes, rotating prev -> next and
-        // consuming the prev token at the server.
+        // The NSE steals the lapsed lock and refreshes, rotating prev -> next
+        // and consuming the prev token at the server.
         nse.oauth().refresh_access_token().await.unwrap();
         assert_eq!(nse.session_tokens(), Some(mock_session_tokens_with_refresh()));
 
         // The app resumes when its metadata delay elapses. It must notice the
-        // rotation and recover, rather than exchange the token it captured earlier.
+        // rotation and recover, rather than exchange the token it captured
+        // earlier.
         let app_refresh = app_refresh.await.expect("the app refresh task shouldn't panic");
 
         assert!(

--- a/crates/matrix-sdk/src/authentication/oauth/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/mod.rs
@@ -317,8 +317,9 @@ impl OAuth {
         &self,
         lock_value: String,
     ) -> Result<(), OAuthError> {
-        // FIXME: it must be deferred only because we're using the crypto store and it's
-        // initialized only in `set_or_reload_session`, not if we use a dedicated store.
+        // FIXME: it must be deferred only because we're using the crypto store
+        // and it's initialized only in `set_or_reload_session`, not if
+        // we use a dedicated store.
         let mut lock = self.ctx().deferred_cross_process_lock_init.lock().await;
         if lock.is_some() {
             return Err(CrossProcessRefreshLockError::DuplicatedLock.into());
@@ -337,8 +338,8 @@ impl OAuth {
         let deferred_init_lock = self.ctx().deferred_cross_process_lock_init.lock().await;
 
         // Don't `take()` the value, so that subsequent calls to
-        // `enable_cross_process_refresh_lock` will keep on failing if we've enabled the
-        // lock at least once.
+        // `enable_cross_process_refresh_lock` will keep on failing if we've
+        // enabled the lock at least once.
         let Some(lock_value) = deferred_init_lock.as_ref() else {
             return;
         };
@@ -355,8 +356,8 @@ impl OAuth {
 
         let manager = CrossProcessRefreshManager::new(store.clone(), lock);
 
-        // This method is guarded with the `deferred_cross_process_lock_init` lock held,
-        // so this `set` can't be an error.
+        // This method is guarded with the `deferred_cross_process_lock_init`
+        // lock held, so this `set` can't be an error.
         let _ = self.ctx().cross_process_token_refresh_manager.set(manager);
     }
 
@@ -516,7 +517,8 @@ impl OAuth {
         let mut server_metadata_guard = match server_metadata_cache.refresh_lock.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                // There is already a refresh in progress, wait for it to finish.
+                // There is already a refresh in progress, wait for it to
+                // finish.
                 let guard = server_metadata_cache.refresh_lock.lock().await;
 
                 // Reuse the data if the request was successful.
@@ -675,8 +677,8 @@ impl OAuth {
         let registration_response =
             register_client(self.http_client(), registration_endpoint, client_metadata).await?;
 
-        // The format of the credentials changes according to the client metadata that
-        // was sent. Public clients only get a client ID.
+        // The format of the credentials changes according to the client
+        // metadata that was sent. Public clients only get a client ID.
         self.restore_registered_client(registration_response.client_id.clone());
 
         Ok(registration_response)
@@ -753,8 +755,8 @@ impl OAuth {
             .set(AuthData::OAuth(data))
             .expect("Client authentication data was already set");
 
-        // Initialize the cross-process locking by saving our tokens' hash into the
-        // database, if we've enabled the cross-process lock.
+        // Initialize the cross-process locking by saving our tokens' hash into
+        // the database, if we've enabled the cross-process lock.
 
         #[cfg(feature = "e2e-encryption")]
         if let Some(cross_process_lock) = self.ctx().cross_process_token_refresh_manager.get() {
@@ -765,12 +767,14 @@ impl OAuth {
                 .await
                 .map_err(|err| crate::Error::OAuth(Box::new(err.into())))?;
 
-            // After we got the lock, it's possible that our session doesn't match the one
-            // read from the database, because of a race: another process has
-            // refreshed the tokens while we were waiting for the lock.
+            // After we got the lock, it's possible that our session doesn't
+            // match the one read from the database, because of a
+            // race: another process has refreshed the tokens while
+            // we were waiting for the lock.
             //
-            // In that case, if there's a mismatch, we reload the session and update the
-            // hash. Otherwise, we save our hash into the database.
+            // In that case, if there's a mismatch, we reload the session and
+            // update the hash. Otherwise, we save our hash into the
+            // database.
 
             if guard.hash_mismatch {
                 Box::pin(self.handle_session_hash_mismatch(&mut guard))
@@ -1021,10 +1025,12 @@ impl OAuth {
             let mut cross_process_guard = cross_process_manager.spin_lock().await?;
 
             if cross_process_guard.hash_mismatch {
-                // At this point, we're finishing a login while another process had written
-                // something in the database. It's likely the information in the database is
-                // just outdated and wasn't properly updated, but display a warning, just in
-                // case this happens frequently.
+                // At this point, we're finishing a login while another process
+                // had written something in the database. It's
+                // likely the information in the database is
+                // just outdated and wasn't properly updated, but display a
+                // warning, just in case this happens
+                // frequently.
                 warn!("unexpected cross-process hash mismatch when finishing login (see comment)");
             }
 
@@ -1195,10 +1201,11 @@ impl OAuth {
 
         self.client.auth_ctx().set_session_tokens(tokens);
 
-        // Call the save_session_callback if set, while the optional lock is being held.
+        // Call the save_session_callback if set, while the optional lock is
+        // being held.
         if let Some(save_session_callback) = self.client.auth_ctx().save_session_callback.get() {
-            // Satisfies the save_session_callback invariant: set_session_tokens has
-            // been called just above.
+            // Satisfies the save_session_callback invariant: set_session_tokens
+            // has been called just above.
             tracing::debug!("call save_session_callback");
             if let Err(err) = save_session_callback(self.client.clone()) {
                 error!("when saving session after refresh: {err}");
@@ -1243,8 +1250,8 @@ impl OAuth {
 
         let Ok(mut refresh_status_guard) = refresh_status_lock else {
             debug!("another refresh is happening, waiting for result.");
-            // There's already a request to refresh happening in the same process. Wait for
-            // it to finish.
+            // There's already a request to refresh happening in the same
+            // process. Wait for it to finish.
             let res = client.auth_ctx().refresh_token_lock.lock().await.clone();
             debug!("other refresh is a {}", if res.is_ok() { "success" } else { "failure " });
             return res;
@@ -1252,14 +1259,16 @@ impl OAuth {
 
         debug!("no other refresh happening in background, starting.");
 
-        // Fetch the authorization server metadata *before* taking the cross-process
-        // lock, checking the session hash, or reading the refresh token. This request
-        // can stall for a long time when the OS suspends the process (e.g. iOS
-        // background suspension), and while suspended the lock lease lapses, which
-        // lets another process refresh and rotate the token. Doing it first means the
-        // lock and the hash check happen after the stall, so such a rotation is caught
-        // below as a hash mismatch instead of being exchanged while stale, which the
-        // server rejects with `invalid_grant` and signs the user out.
+        // Fetch the authorization server metadata *before* taking the
+        // cross-process lock, checking the session hash, or reading the
+        // refresh token. This request can stall for a long time when
+        // the OS suspends the process (e.g. iOS background suspension),
+        // and while suspended the lock lease lapses, which lets another
+        // process refresh and rotate the token. Doing it first means the
+        // lock and the hash check happen after the stall, so such a rotation is
+        // caught below as a hash mismatch instead of being exchanged
+        // while stale, which the server rejects with `invalid_grant`
+        // and signs the user out.
         let server_metadata = match self.server_metadata().await {
             Ok(metadata) => metadata,
             Err(err) => {
@@ -1295,8 +1304,9 @@ impl OAuth {
                     Box::pin(self.handle_session_hash_mismatch(&mut cross_process_guard))
                         .await
                         .map_err(|err| RefreshTokenError::OAuth(Arc::new(err.into())))?;
-                    // Optimistic exit: assume that the underlying process did update fast enough.
-                    // In the worst case, we'll do another refresh Soon™.
+                    // Optimistic exit: assume that the underlying process did
+                    // update fast enough. In the worst
+                    // case, we'll do another refresh Soon™.
                     tracing::info!("other process handled refresh for us, assuming success");
                     *refresh_status_guard = Ok(());
                     return Ok(());
@@ -1307,9 +1317,10 @@ impl OAuth {
                 None
             };
 
-        // Read the refresh token only now, after the hash check above, so we always
-        // exchange the token that is current in the store, never one that another
-        // process rotated out from under us while we were suspended.
+        // Read the refresh token only now, after the hash check above, so we
+        // always exchange the token that is current in the store, never
+        // one that another process rotated out from under us while we
+        // were suspended.
         let Some(session_tokens) = self.client.session_tokens() else {
             warn!("invalid state: missing session tokens");
             fail!(refresh_status_guard, RefreshTokenError::RefreshTokenRequired);
@@ -1320,9 +1331,10 @@ impl OAuth {
             fail!(refresh_status_guard, RefreshTokenError::RefreshTokenRequired);
         };
 
-        // Do not interrupt refresh access token requests and processing, by detaching
-        // the request sending and response processing.
-        // Make sure to keep the `refresh_status_guard` during the entire processing.
+        // Do not interrupt refresh access token requests and processing, by
+        // detaching the request sending and response processing.
+        // Make sure to keep the `refresh_status_guard` during the entire
+        // processing.
 
         let this = self.clone();
 
@@ -1821,8 +1833,8 @@ impl AuthorizationResponse {
     ///
     /// Returns an error if the query doesn't have the expected format.
     fn parse_query(query: &str) -> Result<Self, RedirectUriQueryParseError> {
-        // For some reason deserializing the enum with `serde(untagged)` doesn't work,
-        // so let's try both variants separately.
+        // For some reason deserializing the enum with `serde(untagged)` doesn't
+        // work, so let's try both variants separately.
         if let Ok(code) = serde_html_form::from_str(query) {
             return Ok(AuthorizationResponse::Success(code));
         }

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/grant.rs
@@ -61,12 +61,13 @@ async fn finish_login_grant<Q>(
     secrets_bundle: &SecretsBundle,
     state: &SharedObservable<GrantLoginProgress<Q>>,
 ) -> Result<(), QRCodeGrantLoginError> {
-    // The new device registers with the authorization server and sends it a device
-    // authorization authorization request.
+    // The new device registers with the authorization server and sends it a
+    // device authorization authorization request.
     // -- MSC4108 OAuth 2.0 login step 2
 
-    // We wait for the new device to send us the m.login.protocol message with the
-    // device authorization grant information. -- MSC4108 OAuth 2.0 login step 3
+    // We wait for the new device to send us the m.login.protocol message with
+    // the device authorization grant information. -- MSC4108 OAuth 2.0
+    // login step 3
     let (device_authorization_grant, protocol, device_id) = match channel.receive_json().await? {
         QrAuthMessage::LoginProtocol { device_authorization_grant, protocol, device_id } => {
             (device_authorization_grant, protocol, device_id)
@@ -140,8 +141,8 @@ async fn finish_login_grant<Q>(
             });
         }
     }
-    // We send the new device the m.login.protocol_accepted message to let it know
-    // that the consent process is in progress.
+    // We send the new device the m.login.protocol_accepted message to let it
+    // know that the consent process is in progress.
     // -- MSC4108 OAuth 2.0 login step 4 continued
     let message = QrAuthMessage::LoginProtocolAccepted;
     channel.send_json(&message).await?;
@@ -152,8 +153,8 @@ async fn finish_login_grant<Q>(
     // the user code displayed on the other device. -- MSC4108 OAuth 2.0 login
     // steps 5 & 6
 
-    // We wait for the new device to send us the m.login.success or m.login.failure
-    // message
+    // We wait for the new device to send us the m.login.success or
+    // m.login.failure message
     match channel.receive_json().await? {
         QrAuthMessage::LoginSuccess => (),
         QrAuthMessage::LoginFailure { reason, .. } => {
@@ -175,7 +176,8 @@ async fn finish_login_grant<Q>(
         if matches!(client.device_exists(device_id.clone().into()).await, Ok(true)) {
             break;
         } else {
-            // If the deadline hasn't yet passed, give it some time and retry the request.
+            // If the deadline hasn't yet passed, give it some time and retry
+            // the request.
             if Instant::now() < deadline {
                 matrix_sdk_common::sleep::sleep(Duration::from_millis(500)).await;
                 continue;
@@ -276,15 +278,16 @@ impl<'a> IntoFuture for GrantLoginWithScannedQrCode<'a> {
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            // Before we get here, the other device has created a new rendezvous session
-            // and presented a QR code which this device has scanned.
-            // -- MSC4108 Secure channel setup steps 1-3
+            // Before we get here, the other device has created a new rendezvous
+            // session and presented a QR code which this device has
+            // scanned. -- MSC4108 Secure channel setup steps 1-3
 
-            // First things first, export the secrets bundle and establish the secure
-            // channel. Since we're the one that scanned the QR code, we're
-            // certain that the secure channel is secure, under the assumption
-            // that we didn't scan the wrong QR code. -- MSC4108 Secure channel
-            // setup steps 3-5
+            // First things first, export the secrets bundle and establish the
+            // secure channel. Since we're the one that scanned the
+            // QR code, we're certain that the secure channel is
+            // secure, under the assumption that we didn't scan the
+            // wrong QR code. -- MSC4108 Secure channel setup steps
+            // 3-5
             let secrets_bundle = export_secrets_bundle(self.client).await?;
 
             let mut channel = EstablishedSecureChannel::from_qr_code(
@@ -294,19 +297,20 @@ impl<'a> IntoFuture for GrantLoginWithScannedQrCode<'a> {
             )
             .await?;
 
-            // The other side isn't yet sure that it's talking to the right device, show
-            // a check code so they can confirm.
+            // The other side isn't yet sure that it's talking to the right
+            // device, show a check code so they can confirm.
             // -- MSC4108 Secure channel setup step 6
             let check_code = channel.check_code().to_owned();
             self.state
                 .set(GrantLoginProgress::EstablishingSecureChannel(QrProgress { check_code }));
 
-            // The user now enters the checkcode on the other device which verifies it
-            // and will only continue requesting the login if the code matches.
-            // -- MSC4108 Secure channel setup step 7
+            // The user now enters the checkcode on the other device which
+            // verifies it and will only continue requesting the
+            // login if the code matches. -- MSC4108 Secure channel
+            // setup step 7
 
-            // Inform the other device about the available login protocols and the
-            // homeserver to use.
+            // Inform the other device about the available login protocols and
+            // the homeserver to use.
             // -- MSC4108 OAuth 2.0 login step 1
             let message = QrAuthMessage::LoginProtocols {
                 protocols: vec![LoginProtocolType::DeviceAuthorizationGrant],
@@ -366,30 +370,32 @@ impl<'a> IntoFuture for GrantLoginWithGeneratedQrCode<'a> {
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            // Create a new ephemeral key pair and a rendezvous session to grant a
-            // login with.
+            // Create a new ephemeral key pair and a rendezvous session to grant
+            // a login with.
             // -- MSC4108 Secure channel setup steps 1 & 2
             let homeserver_url = self.client.homeserver();
             let http_client = self.client.inner.http_client.clone();
             let secrets_bundle = export_secrets_bundle(self.client).await?;
             let channel = SecureChannel::reciprocate(http_client, &homeserver_url).await?;
 
-            // Extract the QR code data and emit an update so that the caller can
-            // present the QR code for scanning by the new device.
-            // -- MSC4108 Secure channel setup step 3
+            // Extract the QR code data and emit an update so that the caller
+            // can present the QR code for scanning by the new
+            // device. -- MSC4108 Secure channel setup step 3
             self.state.set(GrantLoginProgress::EstablishingSecureChannel(
                 GeneratedQrProgress::QrReady(channel.qr_code_data().clone()),
             ));
 
-            // Wait for the secure channel to connect. The other device now needs to scan
-            // the QR code and send us the LoginInitiateMessage which we respond to
+            // Wait for the secure channel to connect. The other device now
+            // needs to scan the QR code and send us the
+            // LoginInitiateMessage which we respond to
             // with the LoginOkMessage. -- MSC4108 step 4 & 5
             let channel = channel.connect().await?;
 
-            // The other device now needs to verify our message, compute the checkcode and
-            // display it. We emit a progress update to let the caller prompt the
-            // user to enter the checkcode and feed it back to us.
-            // -- MSC4108 Secure channel setup step 6
+            // The other device now needs to verify our message, compute the
+            // checkcode and display it. We emit a progress update
+            // to let the caller prompt the user to enter the
+            // checkcode and feed it back to us. -- MSC4108 Secure
+            // channel setup step 6
             let (tx, rx) = tokio::sync::oneshot::channel();
             self.state.set(GrantLoginProgress::EstablishingSecureChannel(
                 GeneratedQrProgress::QrScanned(CheckCodeSender::new(tx)),
@@ -400,10 +406,11 @@ impl<'a> IntoFuture for GrantLoginWithGeneratedQrCode<'a> {
             // -- MSC4108 Secure channel setup step 7
             let mut channel = channel.confirm(check_code)?;
 
-            // Since the QR code was generated on this existing device, the new device can
-            // derive the homeserver to use for logging in from the QR code and we
-            // don't need to send the m.login.protocols message.
-            // -- MSC4108 OAuth 2.0 login step 1
+            // Since the QR code was generated on this existing device, the new
+            // device can derive the homeserver to use for logging
+            // in from the QR code and we don't need to send the
+            // m.login.protocols message. -- MSC4108 OAuth 2.0 login
+            // step 1
 
             // Proceed with granting the login.
             // -- MSC4108 OAuth 2.0 login remaining steps
@@ -472,7 +479,8 @@ mod test {
         // Wait for Alice to produce the qr code.
         let qr_code_data = qr_code_rx.await.expect("Bob should receive the QR code");
 
-        // Use the QR code to establish the secure channel from the new client (Bob).
+        // Use the QR code to establish the secure channel from the new client
+        // (Bob).
         let mut bob = EstablishedSecureChannel::from_qr_code(
             reqwest::Client::new(),
             &qr_code_data,
@@ -501,13 +509,14 @@ mod test {
                 return;
             }
             BobBehaviour::InvalidJsonMessage => {
-                // Send invalid JSON that cannot be deserialized as QrAuthMessage.
+                // Send invalid JSON that cannot be deserialized as
+                // QrAuthMessage.
                 bob.send_json(serde_json::json!({"type": "m.login.bogus"})).await.unwrap();
                 return;
             }
             BobBehaviour::DeviceAlreadyExists => {
-                // Mock the endpoint for querying devices so that Alice thinks the device
-                // already exists.
+                // Mock the endpoint for querying devices so that Alice thinks
+                // the device already exists.
                 server
                     .as_ref()
                     .expect("Bob needs the server for DeviceAlreadyExists")
@@ -547,8 +556,8 @@ mod test {
                 };
                 bob.send_json(message).await.unwrap();
 
-                // Alice cancels while waiting for the authorization and should fail the login
-                // with the appropriate reason.
+                // Alice cancels while waiting for the authorization and should
+                // fail the login with the appropriate reason.
                 let message = bob
                     .receive_json()
                     .await
@@ -594,15 +603,16 @@ mod test {
                 return;
             }
             BobBehaviour::DeviceNotCreated => {
-                // Don't mock the endpoint for querying devices so that Alice cannot verify that
-                // we have logged in.
+                // Don't mock the endpoint for querying devices so that Alice
+                // cannot verify that we have logged in.
 
-                // Send the LoginSuccess message to claim that we have logged in.
+                // Send the LoginSuccess message to claim that we have logged
+                // in.
                 let message = QrAuthMessage::LoginSuccess;
                 bob.send_json(message).await.unwrap();
 
-                // Alice should eventually give up querying our device and fail the login with
-                // the appropriate reason.
+                // Alice should eventually give up querying our device and fail
+                // the login with the appropriate reason.
                 let message = bob
                     .receive_json()
                     .await
@@ -613,8 +623,8 @@ mod test {
                 return; // Exit.
             }
             _ => {
-                // Mock the endpoint for querying devices so that Alice thinks we have logged
-                // in.
+                // Mock the endpoint for querying devices so that Alice thinks
+                // we have logged in.
                 server
                     .as_ref()
                     .expect("Bob needs the server for HappyPath")
@@ -663,7 +673,8 @@ mod test {
         let channel =
             channel.connect().await.expect("Bob should be able to connect the secure channel");
 
-        // Wait for Alice to send us the checkcode and use it to verify the channel.
+        // Wait for Alice to send us the checkcode and use it to verify the
+        // channel.
         let check_code = check_code_rx.await.expect("Bob should receive the checkcode");
         let mut bob = channel
             .confirm(check_code)
@@ -697,13 +708,14 @@ mod test {
                 return;
             }
             BobBehaviour::InvalidJsonMessage => {
-                // Send invalid JSON that cannot be deserialized as QrAuthMessage.
+                // Send invalid JSON that cannot be deserialized as
+                // QrAuthMessage.
                 bob.send_json(serde_json::json!({"type": "m.login.bogus"})).await.unwrap();
                 return;
             }
             BobBehaviour::DeviceAlreadyExists => {
-                // Mock the endpoint for querying devices so that Alice thinks the device
-                // already exists.
+                // Mock the endpoint for querying devices so that Alice thinks
+                // the device already exists.
                 server
                     .as_ref()
                     .expect("Bob needs the MatrixMockServer")
@@ -743,8 +755,8 @@ mod test {
                 };
                 bob.send_json(message).await.unwrap();
 
-                // Alice cancels while waiting for the authorization and should fail the login
-                // with the appropriate reason.
+                // Alice cancels while waiting for the authorization and should
+                // fail the login with the appropriate reason.
                 let message = bob
                     .receive_json()
                     .await
@@ -790,15 +802,16 @@ mod test {
                 return;
             }
             BobBehaviour::DeviceNotCreated => {
-                // Don't mock the endpoint for querying devices so that Alice cannot verify that
-                // we have logged in.
+                // Don't mock the endpoint for querying devices so that Alice
+                // cannot verify that we have logged in.
 
-                // Send the LoginSuccess message to claim that we have logged in.
+                // Send the LoginSuccess message to claim that we have logged
+                // in.
                 let message = QrAuthMessage::LoginSuccess;
                 bob.send_json(message).await.unwrap();
 
-                // Alice should eventually give up querying our device and fail the login with
-                // the appropriate reason.
+                // Alice should eventually give up querying our device and fail
+                // the login with the appropriate reason.
                 let message = bob
                     .receive_json()
                     .await
@@ -809,8 +822,8 @@ mod test {
                 return; // Exit.
             }
             _ => {
-                // Mock the endpoint for querying devices so that Alice thinks we have logged
-                // in.
+                // Mock the endpoint for querying devices so that Alice thinks
+                // we have logged in.
                 server
                     .as_ref()
                     .expect("Bob needs the MatrixMockServer")
@@ -1022,7 +1035,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -1155,7 +1169,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -1408,7 +1423,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -1662,7 +1678,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -1921,7 +1938,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -2114,7 +2132,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -2317,7 +2336,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -2584,7 +2604,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -2870,7 +2891,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -3120,7 +3142,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await
@@ -3384,7 +3407,8 @@ mod test {
             .mount()
             .await;
 
-        // Create a secure channel on the new client (Bob) and extract the QR code.
+        // Create a secure channel on the new client (Bob) and extract the QR
+        // code.
         let client = HttpClient::new(reqwest::Client::new(), Default::default());
         let channel = SecureChannel::login(client, &rendezvous_server.homeserver_url)
             .await

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/login.rs
@@ -67,20 +67,20 @@ async fn finish_login<Q>(
     trace!("Registering the client with the OAuth 2.0 authorization server.");
     let server_metadata = register_client(&oauth, registration_data).await?;
 
-    // We want to use the Curve25519 public key for the device ID, so let's generate
-    // a new vodozemac `Account` now.
+    // We want to use the Curve25519 public key for the device ID, so let's
+    // generate a new vodozemac `Account` now.
     let account = vodozemac::olm::Account::new();
     let public_key = account.identity_keys().curve25519;
     let device_id = public_key;
 
-    // Let's tell the OAuth 2.0 authorization server that we want to log in using
-    // the device authorization grant described in [RFC8628](https://datatracker.ietf.org/doc/html/rfc8628).
+    // Let's tell the OAuth 2.0 authorization server that we want to log in
+    // using the device authorization grant described in [RFC8628](https://datatracker.ietf.org/doc/html/rfc8628).
     trace!("Requesting device authorization.");
     let auth_grant_response =
         request_device_authorization(&oauth, &server_metadata, device_id).await?;
 
-    // Now we need to inform the other device of the login protocols we picked and
-    // the URL they should use to log us in.
+    // Now we need to inform the other device of the login protocols we picked
+    // and the URL they should use to log us in.
     trace!("Letting the existing device know about the device authorization grant.");
     let message =
         QrAuthMessage::authorization_grant_login_protocol((&auth_grant_response).into(), device_id);
@@ -103,17 +103,17 @@ async fn finish_login<Q>(
     }
 
     // The OAuth 2.0 authorization server may or may not show this user code to
-    // double check that we're talking to the right server. Let us display this, so
-    // the other device can double check this as well.
+    // double check that we're talking to the right server. Let us display this,
+    // so the other device can double check this as well.
     let user_code = auth_grant_response.user_code();
     state.set(LoginProgress::WaitingForToken { user_code: user_code.secret().to_owned() });
 
-    // Let's now wait for the access token to be provided to use by the OAuth 2.0
-    // authorization server.
+    // Let's now wait for the access token to be provided to use by the OAuth
+    // 2.0 authorization server.
     trace!("Waiting for the OAuth 2.0 authorization server to give us the access token.");
     if let Err(e) = wait_for_tokens(&oauth, &server_metadata, &auth_grant_response).await {
-        // If we received an error, and it's one of the ones we should report to the
-        // other side, do so now.
+        // If we received an error, and it's one of the ones we should report to
+        // the other side, do so now.
         if let Some(e) = e.as_request_token_error() {
             match e {
                 DeviceCodeErrorResponseType::AccessDenied => {
@@ -134,8 +134,8 @@ async fn finish_login<Q>(
         return Err(e.into());
     }
 
-    // We only received an access token from the OAuth 2.0 authorization server, we
-    // have no clue who we are, so we need to figure out our user ID
+    // We only received an access token from the OAuth 2.0 authorization server,
+    // we have no clue who we are, so we need to figure out our user ID
     // now. TODO: This snippet is almost the same as the
     // OAuth::finish_login_method(), why is that method even a public
     // method and not called as part of the set session tokens method.
@@ -163,8 +163,8 @@ async fn finish_login<Q>(
     let message = QrAuthMessage::LoginSuccess;
     channel.send_json(&message).await?;
 
-    // Let's wait for the secrets bundle to be sent to us, otherwise we won't be a
-    // fully E2EE enabled device.
+    // Let's wait for the secrets bundle to be sent to us, otherwise we won't be
+    // a fully E2EE enabled device.
     trace!("Waiting for the secrets bundle.");
     let bundle = match channel.receive_json().await? {
         QrAuthMessage::LoginSecrets(bundle) => bundle,
@@ -181,12 +181,12 @@ async fn finish_login<Q>(
         }
     };
 
-    // Import the secrets bundle, this will allow us to sign the device keys with
-    // the master key when we upload them.
+    // Import the secrets bundle, this will allow us to sign the device keys
+    // with the master key when we upload them.
     client.encryption().import_secrets_bundle_impl(&bundle).await?;
 
-    // Upload the device keys, this will ensure that other devices see us as a fully
-    // verified device ass soon as this method returns.
+    // Upload the device keys, this will ensure that other devices see us as a
+    // fully verified device ass soon as this method returns.
     client
         .encryption()
         .ensure_device_keys_upload()
@@ -293,27 +293,28 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            // Before we get here, the other device has created a new rendezvous session
-            // and presented a QR code which this device has scanned.
-            // -- MSC4108 Secure channel setup steps 1-3
+            // Before we get here, the other device has created a new rendezvous
+            // session and presented a QR code which this device has
+            // scanned. -- MSC4108 Secure channel setup steps 1-3
 
-            // First things first, establish the secure channel. Since we're the one that
-            // scanned the QR code, we're certain that the secure channel is
-            // secure, under the assumption that we didn't scan the wrong QR code.
-            // -- MSC4108 Secure channel setup steps 3-5
+            // First things first, establish the secure channel. Since we're the
+            // one that scanned the QR code, we're certain that the
+            // secure channel is secure, under the assumption that
+            // we didn't scan the wrong QR code. -- MSC4108 Secure
+            // channel setup steps 3-5
             let channel = self.establish_secure_channel().await?;
 
             trace!("Established the secure channel.");
 
-            // The other side isn't yet sure that it's talking to the right device, show
-            // a check code so they can confirm.
+            // The other side isn't yet sure that it's talking to the right
+            // device, show a check code so they can confirm.
             // -- MSC4108 Secure channel setup step 6
             let check_code = channel.check_code().to_owned();
             self.state.set(LoginProgress::EstablishingSecureChannel(QrProgress { check_code }));
 
-            // The user now enters the checkcode on the other device which verifies it
-            // and will only facilitate the login if the code matches.
-            // -- MSC4108 Secure channel setup step 7
+            // The user now enters the checkcode on the other device which
+            // verifies it and will only facilitate the login if the
+            // code matches. -- MSC4108 Secure channel setup step 7
 
             // Now attempt to finish the login.
             // -- MSC4108 OAuth 2.0 login all steps
@@ -380,13 +381,13 @@ impl<'a> IntoFuture for LoginWithGeneratedQrCode<'a> {
 
             trace!("Established the secure channel.");
 
-            // Wait for the other device to send us the m.login.protocols message
-            // so that we can discover the homeserver to use for logging in.
-            // -- MSC4108 OAuth 2.0 login step 1
+            // Wait for the other device to send us the m.login.protocols
+            // message so that we can discover the homeserver to use
+            // for logging in. -- MSC4108 OAuth 2.0 login step 1
             let message = channel.receive_json().await?;
 
-            // Verify that the device authorization grant is supported and extract
-            // the homeserver URL.
+            // Verify that the device authorization grant is supported and
+            // extract the homeserver URL.
             let homeserver = match message {
                 QrAuthMessage::LoginProtocols { protocols, homeserver } => {
                     if !protocols.contains(&LoginProtocolType::DeviceAuthorizationGrant) {
@@ -415,8 +416,8 @@ impl<'a> IntoFuture for LoginWithGeneratedQrCode<'a> {
                 }
             };
 
-            // Change the login homeserver if it is different from the server hosting the
-            // secure channel.
+            // Change the login homeserver if it is different from the server
+            // hosting the secure channel.
             if self.client.homeserver() != homeserver {
                 self.client
                     .switch_homeserver_and_re_resolve_well_known(homeserver)
@@ -444,23 +445,23 @@ impl<'a> LoginWithGeneratedQrCode<'a> {
     ) -> Result<EstablishedSecureChannel, SecureChannelError> {
         let http_client = self.client.inner.http_client.clone();
 
-        // Create a new ephemeral key pair and a rendezvous session to request a login
-        // with.
+        // Create a new ephemeral key pair and a rendezvous session to request a
+        // login with.
         // -- MSC4108 Secure channel setup steps 1 & 2
         let secure_channel = SecureChannel::login(http_client, &self.client.homeserver()).await?;
 
-        // Extract the QR code data and emit a progress update so that the caller can
-        // present the QR code for scanning by the other device.
-        // -- MSC4108 Secure channel setup step 3
+        // Extract the QR code data and emit a progress update so that the
+        // caller can present the QR code for scanning by the other
+        // device. -- MSC4108 Secure channel setup step 3
         let qr_code_data = secure_channel.qr_code_data().clone();
         trace!("Generated QR code.");
         self.state.set(LoginProgress::EstablishingSecureChannel(GeneratedQrProgress::QrReady(
             qr_code_data,
         )));
 
-        // Wait for the secure channel to connect. The other device now needs to scan
-        // the QR code and send us the LoginInitiateMessage which we respond to
-        // with the LoginOkMessage. -- MSC4108 step 4 & 5
+        // Wait for the secure channel to connect. The other device now needs to
+        // scan the QR code and send us the LoginInitiateMessage which
+        // we respond to with the LoginOkMessage. -- MSC4108 step 4 & 5
         let channel = secure_channel.connect().await?;
 
         // The other device now verifies our message, computes the checkcode and
@@ -473,8 +474,8 @@ impl<'a> LoginWithGeneratedQrCode<'a> {
             CheckCodeSender::new(tx),
         )));
 
-        // Retrieve the entered checkcode and verify it to confirm that the channel is
-        // actually secure.
+        // Retrieve the entered checkcode and verify it to confirm that the
+        // channel is actually secure.
         // -- MSC4108 Secure channel setup step 7
         let check_code = rx.await.map_err(|_| SecureChannelError::CannotReceiveCheckCode)?;
         trace!("Received check code.");
@@ -684,8 +685,8 @@ mod test {
 
         trace!("Established the secure channel.");
 
-        // The other side isn't yet sure that it's talking to the right device, show
-        // a check code so they can confirm.
+        // The other side isn't yet sure that it's talking to the right device,
+        // show a check code so they can confirm.
         let check_code = channel.check_code();
 
         let check_code_sender =
@@ -776,8 +777,8 @@ mod test {
 
         let homeserver_url = rendezvous_server.homeserver_url.clone();
 
-        // Create Alice, the existing client, as a logged-in client. They will scan the
-        // QR code generated by Bob.
+        // Create Alice, the existing client, as a logged-in client. They will
+        // scan the QR code generated by Bob.
         let alice = server.client_builder().logged_in_with_oauth().build().await;
         assert!(alice.session_meta().is_some(), "Alice should be logged in");
 
@@ -885,8 +886,8 @@ mod test {
 
         let rendezvous_homeserver_url = rendezvous_server.homeserver_url.clone();
 
-        // Create Alice, the existing client, as a logged-in client. They will scan the
-        // QR code generated by Bob.
+        // Create Alice, the existing client, as a logged-in client. They will
+        // scan the QR code generated by Bob.
         let alice = login_server.client_builder().logged_in_with_oauth().build().await;
         assert!(alice.session_meta().is_some(), "Alice should be logged in");
 
@@ -908,7 +909,8 @@ mod test {
             QrCodeIntentData::Msc4108 { data: Msc4108IntentData::Login, .. }
         );
 
-        // Alice and Bob should have different homeservers configured at the start.
+        // Alice and Bob should have different homeservers configured at the
+        // start.
         let initial_server_url = initial_server.server().uri().parse().unwrap();
         assert_eq!(bob.homeserver(), initial_server_url);
         let login_server_url = login_server.server().uri().parse().unwrap();
@@ -1131,8 +1133,8 @@ mod test {
 
         let homeserver_url = rendezvous_server.homeserver_url.clone();
 
-        // Create Alice, the existing client, as a logged-in client. They will scan the
-        // QR code generated by Bob.
+        // Create Alice, the existing client, as a logged-in client. They will
+        // scan the QR code generated by Bob.
         let alice = server.client_builder().logged_in_with_oauth().build().await;
         assert!(alice.session_meta().is_some(), "Alice should be logged in");
 

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/rendezvous_channel/msc_4108.rs
@@ -143,8 +143,8 @@ impl Channel {
         client: HttpClient,
         rendezvous_url: &Url,
     ) -> Result<InboundChannelCreationResult, HttpError> {
-        // Receive the initial message, which should be empty. But we need the ETAG to
-        // fully establish the rendezvous channel.
+        // Receive the initial message, which should be empty. But we need the
+        // ETAG to fully establish the rendezvous channel.
         let response = Self::receive_message_impl(&client.inner, None, rendezvous_url).await?;
 
         let etag = response.etag.clone();
@@ -190,8 +190,8 @@ impl Channel {
         debug!("Response for the rendezvous sending request {response:?}");
 
         if status.is_success() {
-            // We successfully send out a message, get the ETAG and update our internal copy
-            // of the ETAG.
+            // We successfully send out a message, get the ETAG and update our
+            // internal copy of the ETAG.
             let etag = get_header(response.headers(), &ETAG)?;
             self.etag = etag;
 
@@ -284,7 +284,8 @@ impl Channel {
         let RendezvousGetResponse { status_code, etag, content_type, body, .. } =
             Self::receive_message_impl(&self.client.inner, etag, &self.rendezvous_url).await?;
 
-        // We received a response with an ETAG, put it into the copy of our etag.
+        // We received a response with an ETAG, put it into the copy of our
+        // etag.
         self.etag = etag;
 
         let message = RendezvousMessage {

--- a/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel/mod.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/qrcode/secure_channel/mod.rs
@@ -170,9 +170,10 @@ impl EstablishedSecureChannel {
 
             let client = HttpClient::new(client, RequestConfig::short_retry());
 
-            // Let's establish an outbound ECIES channel, the other side won't know that
-            // it's talking to us, the device that scanned the QR code, until it
-            // receives and successfully decrypts the initial message. We're here encrypting
+            // Let's establish an outbound ECIES channel, the other side won't
+            // know that it's talking to us, the device that scanned
+            // the QR code, until it receives and successfully
+            // decrypts the initial message. We're here encrypting
             // the `LOGIN_INITIATE_MESSAGE`.
             let (crypto_channel, encoded_message) = {
                 let ecies = Ecies::new();
@@ -184,9 +185,10 @@ impl EstablishedSecureChannel {
                 (ChannelType::Ecies(ecies), message.encode())
             };
 
-            // The other side has crated a rendezvous channel, we're going to connect to it
-            // and send this initial encrypted message through it. The initial message on
-            // the rendezvous channel will have an empty body, so we can just
+            // The other side has crated a rendezvous channel, we're going to
+            // connect to it and send this initial encrypted message
+            // through it. The initial message on the rendezvous
+            // channel will have an empty body, so we can just
             // drop it.
             let mut channel = match qr_code_data.intent_data() {
                 QrCodeIntentData::Msc4108 { rendezvous_url, .. } => {
@@ -204,16 +206,17 @@ impl EstablishedSecureChannel {
                      INITIATE message"
             );
 
-            // Now we're sending the encrypted message through the rendezvous channel to the
-            // other side.
+            // Now we're sending the encrypted message through the rendezvous
+            // channel to the other side.
             channel.send(encoded_message).await?;
 
             trace!("Waiting for the LOGIN OK message");
 
             let (response, channel) = match crypto_channel {
                 ChannelType::Ecies(ecies) => {
-                    // We can create our EstablishedSecureChannel struct now and use the
-                    // convenient helpers which transparently decrypt on receival.
+                    // We can create our EstablishedSecureChannel struct now and
+                    // use the convenient helpers which
+                    // transparently decrypt on receival.
                     let crypto_channel = EstablishedCryptoChannel::Ecies(ecies);
                     let mut channel = Self { channel, crypto_channel };
 

--- a/crates/matrix-sdk/src/authentication/oauth/tests.rs
+++ b/crates/matrix-sdk/src/authentication/oauth/tests.rs
@@ -103,8 +103,8 @@ async fn check_authorization_url(
                     "Expected Matrix API scope not found in scopes"
                 );
 
-                // Only check the device ID if we know it. If it's generated randomly we don't
-                // know it.
+                // Only check the device ID if we know it. If it's generated
+                // randomly we don't know it.
                 if let Some(device_id) = device_id {
                     let device_id_scope =
                         format!("urn:matrix:org.matrix.msc2967.client:device:{device_id}");
@@ -122,7 +122,8 @@ async fn check_authorization_url(
                 }
 
                 if let Some(additional_scopes) = &additional_scopes {
-                    // Check if the additional scopes are present in the actual scopes.
+                    // Check if the additional scopes are present in the actual
+                    // scopes.
                     let expected_len = 2 + additional_scopes.len();
                     assert_eq!(actual_scopes.len(), expected_len, "Expected {expected_len} scopes",);
 
@@ -394,7 +395,8 @@ async fn test_finish_login() -> anyhow::Result<()> {
     let client = server.client_builder().registered_with_oauth().build().await;
     let oauth = client.oauth();
 
-    // If the state is missing, then any attempt to finish authorizing will fail.
+    // If the state is missing, then any attempt to finish authorizing will
+    // fail.
     let res = oauth.finish_login(UrlOrQuery::Query("code=42&state=none".to_owned())).await;
 
     assert_matches!(
@@ -607,7 +609,8 @@ async fn test_insecure_clients() -> anyhow::Result<()> {
     ] {
         let oauth = client.oauth();
 
-        // Restore the previous session so we have an existing set of refresh tokens.
+        // Restore the previous session so we have an existing set of refresh
+        // tokens.
         oauth
             .restore_session(mock_session(prev_tokens.clone()), RoomLoadSettings::default())
             .await?;
@@ -674,8 +677,8 @@ async fn test_register_client() {
     assert_eq!(response.client_id.as_str(), "test_client_id");
 
     let auth_data = oauth.data().unwrap();
-    // There is a difference of ending slash between the strings so we parse them
-    // with `Url` which will normalize that.
+    // There is a difference of ending slash between the strings so we parse
+    // them with `Url` which will normalize that.
     assert_eq!(auth_data.client_id, response.client_id);
 }
 
@@ -711,7 +714,8 @@ async fn test_server_metadata_cache() {
     // Call the method to trigger a cache refresh background task.
     oauth.cached_server_metadata().await.expect("We should be able to fetch the server metadata");
 
-    // We wait for the task to finish, the endpoint should have been called again.
+    // We wait for the task to finish, the endpoint should have been called
+    // again.
     sleep(Duration::from_secs(1)).await;
     assert_matches!(client.inner.caches.server_metadata.value(), CachedValue::Cached(value) if !value.has_expired());
 }
@@ -748,8 +752,8 @@ async fn test_server_metadata_cache_refresh_lock() {
     sleep(Duration::from_millis(200)).await;
 
     // Spawn the second and third requests. The first that acquires a lock will
-    // retry the request and succeed, and the second one will read the value from
-    // the cache.
+    // retry the request and succeed, and the second one will read the value
+    // from the cache.
     let oauth_clone = oauth.clone();
     let second_request = spawn(async move { oauth_clone.server_metadata().await });
     let third_request = spawn(async move { oauth.server_metadata().await });

--- a/crates/matrix-sdk/src/client/builder/homeserver_config.rs
+++ b/crates/matrix-sdk/src/client/builder/homeserver_config.rs
@@ -78,9 +78,11 @@ impl HomeserverConfig {
             }
 
             Self::ServerName { server, protocol } => {
-                // The well-known is the only source of the homeserver URL here, so there is
-                // nothing we could fall back to. Assuming the server name *is* the homeserver
-                // would silently talk to the wrong host for any delegating deployment.
+                // The well-known is the only source of the homeserver URL here,
+                // so there is nothing we could fall back to.
+                // Assuming the server name *is* the homeserver
+                // would silently talk to the wrong host for any delegating
+                // deployment.
                 if well_known_lookup_disabled {
                     return Err(ClientBuildError::WellKnownLookupDisabled);
                 }
@@ -393,8 +395,8 @@ mod tests {
 
         mock_well_known_never_called(&server, &homeserver).await;
 
-        // A server name can only be resolved through the well-known, so this must fail
-        // rather than guess a homeserver.
+        // A server name can only be resolved through the well-known, so this
+        // must fail rather than guess a homeserver.
         let error = HomeserverConfig::ServerName {
             server: OwnedServerName::try_from(server.address().to_string()).unwrap(),
             protocol: UrlScheme::Http,
@@ -417,9 +419,10 @@ mod tests {
 
         mock_well_known_never_called(&server, &homeserver).await;
 
-        // The value points at a delegating server, not at a homeserver: with the
-        // well-known step skipped, the homeserver check is all that's left, and it
-        // fails since `server` doesn't answer `/_matrix/client/versions`.
+        // The value points at a delegating server, not at a homeserver: with
+        // the well-known step skipped, the homeserver check is all
+        // that's left, and it fails since `server` doesn't answer
+        // `/_matrix/client/versions`.
         let error = HomeserverConfig::ServerNameOrHomeserverUrl(server.uri().to_string())
             .discover(&http_client, true)
             .await
@@ -446,8 +449,9 @@ mod tests {
             .mount(&homeserver)
             .await;
 
-        // The value points at a homeserver, which the `/_matrix/client/versions` check
-        // proves, so this resolves without ever touching the well-known.
+        // The value points at a homeserver, which the
+        // `/_matrix/client/versions` check proves, so this resolves
+        // without ever touching the well-known.
         let result = HomeserverConfig::ServerNameOrHomeserverUrl(homeserver.uri().to_string())
             .discover(&http_client, true)
             .await

--- a/crates/matrix-sdk/src/client/builder/mod.rs
+++ b/crates/matrix-sdk/src/client/builder/mod.rs
@@ -1026,11 +1026,12 @@ pub(crate) mod tests {
         assert_matches!(sanitize_server_name("https://matrix.server.org/something"), Err(_))
     }
 
-    // Note: Due to a limitation of the http mocking library the following tests all
-    // supply an http:// url, to `server_name_or_homeserver_url` rather than the plain server name,
+    // Note: Due to a limitation of the http mocking library the following tests
+    // all supply an http:// url, to `server_name_or_homeserver_url` rather than the plain server name,
     // otherwise  the builder will prepend https:// and the request will fail. In practice, this
-    // isn't a problem as the builder first strips the scheme and then checks if the
-    // name is a valid server name, so it is a close enough approximation.
+    // isn't a problem as the builder first strips the scheme and then checks if
+    // the name is a valid server name, so it is a close enough
+    // approximation.
 
     #[async_test]
     async fn test_discovery_invalid_server() {
@@ -1061,8 +1062,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_discovery_web_server() {
-        // Given a random web server that isn't a Matrix homeserver or hosting the
-        // well-known file for one.
+        // Given a random web server that isn't a Matrix homeserver or hosting
+        // the well-known file for one.
         let server = MockServer::start().await;
         let mut builder = ClientBuilder::new();
 
@@ -1115,8 +1116,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_discovery_well_known_legacy() {
-        // Given a base server with a well-known file that points to a homeserver that
-        // doesn't support sliding sync.
+        // Given a base server with a well-known file that points to a
+        // homeserver that doesn't support sliding sync.
         let server = MockServer::start().await;
         let homeserver = make_mock_homeserver().await;
         let mut builder = ClientBuilder::new();
@@ -1134,7 +1135,8 @@ pub(crate) mod tests {
         let client = builder.build().await.unwrap();
 
         // Then a client should be built with native support for sliding sync.
-        // It's native support because it's the default. Nothing is checked here.
+        // It's native support because it's the default. Nothing is checked
+        // here.
         assert!(client.sliding_sync_version().is_native());
     }
 
@@ -1145,12 +1147,12 @@ pub(crate) mod tests {
             .server_name(&ServerName::parse("example.org").unwrap())
             .disable_well_known_lookup(true);
 
-        // When building it. Note that no mock server is involved: the whole point is
-        // that not a single request is made.
+        // When building it. Note that no mock server is involved: the whole
+        // point is that not a single request is made.
         let error = builder.build().await.unwrap_err();
 
-        // Then the operation should fail, rather than assume that the server name is
-        // also the homeserver.
+        // Then the operation should fail, rather than assume that the server
+        // name is also the homeserver.
         assert_matches!(error, ClientBuildError::WellKnownLookupDisabled);
 
         // And the same goes for its insecure counterpart.
@@ -1166,8 +1168,9 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_discovery_server_name_or_url_with_well_known_lookup_disabled() {
-        // Given a homeserver that also serves a well-known file, which must never be
-        // requested. `MockServer` verifies the expectation when it is dropped.
+        // Given a homeserver that also serves a well-known file, which must
+        // never be requested. `MockServer` verifies the expectation
+        // when it is dropped.
         let homeserver = make_mock_homeserver().await;
         Mock::given(method("GET"))
             .and(path("/.well-known/matrix/client"))
@@ -1194,8 +1197,9 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_homeserver_url_never_contacts_the_server_name() {
-        // Given a deployment where the server name serves a well-known that points to
-        // the underlying homeserver (hosted on an unrelated domain in this test).
+        // Given a deployment where the server name serves a well-known that
+        // points to the underlying homeserver (hosted on an unrelated
+        // domain in this test).
         let mock_server = MockServer::start().await;
         let address = *mock_server.address();
         let port = address.port();
@@ -1233,7 +1237,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        // Then homeserver should be the only host that was contacted while building.
+        // Then homeserver should be the only host that was contacted while
+        // building.
         let resolved_hosts = resolver.hosts.lock().unwrap();
         assert!(!resolved_hosts.is_empty(), "The homeserver should have been contacted");
         assert!(

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -100,7 +100,8 @@ where
             e: &HttpError,
             client: &Client,
         ) -> HttpResult<RetryRequest> {
-            // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token refresh.
+            // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token
+            // refresh.
             let Some(ErrorKind::UnknownToken(unknown_token_data)) = e.client_api_error_kind()
             else {
                 return Ok(RetryRequest::No);
@@ -108,7 +109,8 @@ where
 
             trace!("Token refresh: Unknown token error received.");
 
-            // If automatic token refresh isn't supported, there is nothing more to do.
+            // If automatic token refresh isn't supported, there is nothing more
+            // to do.
             if !client.inner.auth_ctx.handle_refresh_tokens {
                 trace!("Token refresh: Automatic refresh disabled.");
                 client.broadcast_unknown_token(unknown_token_data);
@@ -120,7 +122,8 @@ where
                 match &refresh_error {
                     RefreshTokenError::RefreshTokenRequired => {
                         trace!("Token refresh: The session doesn't have a refresh token.");
-                        // Refreshing access tokens is not supported by this `Session`, ignore.
+                        // Refreshing access tokens is not supported by this
+                        // `Session`, ignore.
                         client.broadcast_unknown_token(unknown_token_data);
                         Ok(RetryRequest::No)
                     }
@@ -136,7 +139,8 @@ where
                                     "Token refresh: OAuth 2.0 refresh_token rejected \
                                          with invalid grant"
                                 );
-                                // The refresh was denied, signal to sign out the user.
+                                // The refresh was denied, signal to sign out
+                                // the user.
                                 client.broadcast_unknown_token(unknown_token_data);
                             }
                             _ => {
@@ -150,8 +154,9 @@ where
 
                     _ => {
                         trace!("Token refresh: Token refresh failed.");
-                        // This isn't necessarily correct, but matches the behaviour when
-                        // implementing OAuth 2.0.
+                        // This isn't necessarily correct, but matches the
+                        // behaviour when implementing
+                        // OAuth 2.0.
                         client.broadcast_unknown_token(unknown_token_data);
                         Err(HttpError::RefreshToken(refresh_error))
                     }

--- a/crates/matrix-sdk/src/client/homeserver_capabilities.rs
+++ b/crates/matrix-sdk/src/client/homeserver_capabilities.rs
@@ -208,7 +208,8 @@ impl HomeserverCapabilities {
         let mut capabilities_guard = match capabilities_cache.refresh_lock.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                // There is already a refresh in progress, wait for it to finish.
+                // There is already a refresh in progress, wait for it to
+                // finish.
                 let guard = capabilities_cache.refresh_lock.lock().await;
 
                 if let Err(error) = guard.as_ref() {
@@ -223,7 +224,8 @@ impl HomeserverCapabilities {
                     return Ok(value.into_data());
                 }
 
-                // The data wasn't cached or has expired, we need to make another request.
+                // The data wasn't cached or has expired, we need to make
+                // another request.
                 guard
             }
         };
@@ -292,8 +294,8 @@ impl HomeserverCapabilities {
     /// [Matrix spec]: https://spec.matrix.org/latest/client-server-api/#mprofile_fields-capability
     async fn homeserver_supports_extended_profile_fields(&self) -> crate::Result<bool> {
         let supported_versions = self.client.supported_versions().await?;
-        // If the homeserver supports the endpoint to delete profile fields, it supports
-        // extended profile fields.
+        // If the homeserver supports the endpoint to delete profile fields, it
+        // supports extended profile fields.
         Ok(delete_profile_field::v3::Request::PATH_BUILDER.is_supported(&supported_versions))
     }
 }
@@ -358,8 +360,8 @@ mod tests {
             .mount()
             .await;
 
-        // Check the values we get are not updated without a refresh, they're loaded
-        // from the cache
+        // Check the values we get are not updated without a refresh, they're
+        // loaded from the cache
         assert!(capabilities.can_change_password().await.expect("checking capabilities failed"));
 
         // Do another refresh to make sure we get the updated values
@@ -393,8 +395,8 @@ mod tests {
         // Check the values we get are updated
         assert!(capabilities.can_change_displayname().await.expect("checking capabilities failed"));
 
-        // Now revert the previous mock so we can check we're getting the cached value
-        // instead of this one
+        // Now revert the previous mock so we can check we're getting the cached
+        // value instead of this one
         let mut expected_capabilities = Capabilities::default();
         let mut profile_fields = ProfileFieldsCapability::new(true);
         profile_fields.disallowed = Some(vec![ProfileFieldName::DisplayName]);
@@ -406,8 +408,8 @@ mod tests {
             .mount()
             .await;
 
-        // Check the values we get are not updated without a refresh, they're loaded
-        // from the cache
+        // Check the values we get are not updated without a refresh, they're
+        // loaded from the cache
         assert!(capabilities.can_change_displayname().await.expect("checking capabilities failed"));
 
         // Force an expiry of the data.
@@ -420,7 +422,8 @@ mod tests {
         // Call a method to trigger a cache refresh background task.
         capabilities.homeserver_capabilities_cached().await.unwrap().unwrap();
 
-        // We wait for the task to finish, the endpoint should have been called again.
+        // We wait for the task to finish, the endpoint should have been called
+        // again.
         sleep(Duration::from_secs(1)).await;
         assert_matches!(client.inner.caches.homeserver_capabilities.value(), CachedValue::Cached(value) if !value.has_expired());
     }
@@ -430,8 +433,8 @@ mod tests {
     async fn test_deprecated_profile_fields_capabilities() {
         let server = MatrixMockServer::new().await;
 
-        // The user can only set the display name but not the avatar url or extended
-        // profile fields.
+        // The user can only set the display name but not the avatar url or
+        // extended profile fields.
         let mut capabilities = Capabilities::new();
         capabilities.profile_fields.take();
         capabilities.set_displayname = SetDisplayNameCapability::new(true);
@@ -444,9 +447,9 @@ mod tests {
             .mount()
             .await;
 
-        // Client with Matrix 1.12 that did not support extended profile fields yet.
-        // Because there is no `m.profile_fields` capability, we rely on the legacy
-        // profile capabilities.
+        // Client with Matrix 1.12 that did not support extended profile fields
+        // yet. Because there is no `m.profile_fields` capability, we
+        // rely on the legacy profile capabilities.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -467,8 +470,8 @@ mod tests {
                 .enabled
         );
 
-        // Client with Matrix 1.16 that added support for extended profile fields, the
-        // deprecated profile capabilities are ignored.
+        // Client with Matrix 1.16 that added support for extended profile
+        // fields, the deprecated profile capabilities are ignored.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -509,9 +512,9 @@ mod tests {
             .mount()
             .await;
 
-        // Client with Matrix 1.12 that did not support extended profile fields yet.
-        // However, because there is an `m.profile_fields` capability, we still rely on
-        // it.
+        // Client with Matrix 1.12 that did not support extended profile fields
+        // yet. However, because there is an `m.profile_fields`
+        // capability, we still rely on it.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -532,8 +535,8 @@ mod tests {
                 .enabled
         );
 
-        // Client with Matrix 1.16 that added support for extended profile fields, only
-        // the `m.profile_fields` capability is used too.
+        // Client with Matrix 1.16 that added support for extended profile
+        // fields, only the `m.profile_fields` capability is used too.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -574,9 +577,9 @@ mod tests {
             .mount()
             .await;
 
-        // Client with Matrix 1.12 that did not support extended profile fields yet.
-        // However, because there is an `m.profile_fields` capability, we still rely on
-        // it.
+        // Client with Matrix 1.12 that did not support extended profile fields
+        // yet. However, because there is an `m.profile_fields`
+        // capability, we still rely on it.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -597,8 +600,8 @@ mod tests {
                 .enabled
         );
 
-        // Client with Matrix 1.16 that added support for extended profile fields, only
-        // the `m.profile_fields` capability is used too.
+        // Client with Matrix 1.16 that added support for extended profile
+        // fields, only the `m.profile_fields` capability is used too.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -641,9 +644,9 @@ mod tests {
             .mount()
             .await;
 
-        // Client with Matrix 1.12 that did not support extended profile fields yet.
-        // However, because there is an `m.profile_fields` capability, we still rely on
-        // it.
+        // Client with Matrix 1.12 that did not support extended profile fields
+        // yet. However, because there is an `m.profile_fields`
+        // capability, we still rely on it.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_12]).build().await;
         let capabilities_api = client.homeserver_capabilities();
@@ -664,8 +667,8 @@ mod tests {
                 .enabled
         );
 
-        // Client with Matrix 1.16 that added support for extended profile fields, only
-        // the `m.profile_fields` capability is used too.
+        // Client with Matrix 1.16 that added support for extended profile
+        // fields, only the `m.profile_fields` capability is used too.
         let client =
             server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
         let capabilities_api = client.homeserver_capabilities();

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1212,8 +1212,8 @@ impl Client {
         Ev: SyncEvent + DeserializeOwned + SendOutsideWasm + SyncOutsideWasm + 'static,
         Ctx: EventHandlerContext + SendOutsideWasm + SyncOutsideWasm + 'static,
     {
-        // The default value is `None`. It becomes `Some((Ev, Ctx))` once it has a
-        // new value.
+        // The default value is `None`. It becomes `Some((Ev, Ctx))` once it has
+        // a new value.
         let shared_observable = SharedObservable::new(None);
 
         ObservableEventHandler::new(
@@ -1490,11 +1490,12 @@ impl Client {
         };
 
         if let Some(room) = self.get_room(&room_id) {
-            // The cached data can only be trusted if the room state is joined or
-            // banned: for invite and knock rooms, no updates will be received
-            // for the rooms after the invite/knock action took place so we may
-            // have very out to date data for important fields such as
-            // `join_rule`. For left rooms, the homeserver should return the latest info.
+            // The cached data can only be trusted if the room state is joined
+            // or banned: for invite and knock rooms, no updates
+            // will be received for the rooms after the invite/knock
+            // action took place so we may have very out to date
+            // data for important fields such as `join_rule`. For
+            // left rooms, the homeserver should return the latest info.
             match room.state() {
                 RoomState::Joined | RoomState::Banned => {
                     return Ok(RoomPreview::from_known_room(&room).await);
@@ -1775,12 +1776,12 @@ impl Client {
             room.set_is_direct(true).await?;
         }
 
-        // If we joined following an invite, check if we had previously received a key
-        // bundle from the inviter, and import it if so.
+        // If we joined following an invite, check if we had previously received
+        // a key bundle from the inviter, and import it if so.
         //
-        // It's important that we only do this once `BaseClient::room_joined` has
-        // completed: see the notes on `BundleReceiverTask::handle_bundle` on avoiding a
-        // race.
+        // It's important that we only do this once `BaseClient::room_joined`
+        // has completed: see the notes on
+        // `BundleReceiverTask::handle_bundle` on avoiding a race.
         #[cfg(feature = "e2e-encryption")]
         if self.inner.enable_share_history_on_invite
             && let Some(inviter) =
@@ -1806,8 +1807,9 @@ impl Client {
     /// * `room_id` - The `RoomId` of the room to be joined.
     #[instrument(skip(self))]
     pub async fn join_room_by_id(&self, room_id: &RoomId) -> Result<Room> {
-        // See who invited us to this room, if anyone. Note we have to do this before
-        // making the `/join` request, otherwise we could race against the sync.
+        // See who invited us to this room, if anyone. Note we have to do this
+        // before making the `/join` request, otherwise we could race
+        // against the sync.
         let pre_join_info = self.prepare_join_room_by_id(room_id).await;
 
         let request = join_room_by_id::v3::Request::new(room_id.to_owned());
@@ -2199,11 +2201,13 @@ impl Client {
             if let Err(Some(ErrorKind::UnknownToken { .. })) =
                 result.as_ref().map_err(HttpError::client_api_error_kind)
             {
-                // If the access token is actually expired, mark it as expired and fallback to
-                // the unauthenticated request below.
+                // If the access token is actually expired, mark it as expired
+                // and fallback to the unauthenticated request
+                // below.
                 self.auth_ctx().set_access_token_expired(&access_token);
             } else {
-                // If the request succeeded or it's an other error, just stop now.
+                // If the request succeeded or it's an other error, just stop
+                // now.
                 return result;
             }
         }
@@ -2242,9 +2246,10 @@ impl Client {
         let homeserver = self.homeserver();
         let scheme = homeserver.scheme();
 
-        // Use the server name, either an explicit one or an implicit one taken from
-        // the user id: sometimes we'll have only the homeserver url available and no
-        // server name, but the server name can be extracted from the current user id.
+        // Use the server name, either an explicit one or an implicit one taken
+        // from the user id: sometimes we'll have only the homeserver
+        // url available and no server name, but the server name can be
+        // extracted from the current user id.
         let server_url = self
             .server()
             .map(|server| server.to_string())
@@ -2261,10 +2266,12 @@ impl Client {
             None
         };
 
-        // If we didn't get a well-known value yet, try with the homeserver url instead:
+        // If we didn't get a well-known value yet, try with the homeserver url
+        // instead:
         if response.is_none() {
-            // Sometimes people configure their well-known directly on the homeserver so use
-            // this as a fallback when the server name is unknown.
+            // Sometimes people configure their well-known directly on the
+            // homeserver so use this as a fallback when the server
+            // name is unknown.
             warn!(
                 "Fetching the well-known from the server name didn't work, using the homeserver url instead"
             );
@@ -2390,7 +2397,8 @@ impl Client {
         let mut supported_versions_guard = match cached_supported_versions.refresh_lock.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                // There is already a refresh in progress, wait for it to finish.
+                // There is already a refresh in progress, wait for it to
+                // finish.
                 let guard = cached_supported_versions.refresh_lock.lock().await;
 
                 if let Err(error) = guard.as_ref() {
@@ -2405,7 +2413,8 @@ impl Client {
                     return Ok(value.into_data());
                 }
 
-                // The data wasn't cached or has expired, we need to make another request.
+                // The data wasn't cached or has expired, we need to make
+                // another request.
                 guard
             }
         };
@@ -2507,8 +2516,8 @@ impl Client {
             return Ok(None);
         };
 
-        // Spawn a task to refresh the cache if it has expired and we have a valid
-        // access token.
+        // Spawn a task to refresh the cache if it has expired and we have a
+        // valid access token.
         if value.has_expired() && self.auth_ctx().has_valid_access_token() {
             debug!("spawning task to refresh supported versions cache");
 
@@ -2626,11 +2635,12 @@ impl Client {
         let _well_known_guard = match well_known_cache.refresh_lock.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                // There is already a refresh in progress, wait for it to finish.
+                // There is already a refresh in progress, wait for it to
+                // finish.
                 let guard = well_known_cache.refresh_lock.lock().await;
 
-                // A refresh can't fail because we ignore failures, so there shouldn't be an
-                // error in the refresh lock.
+                // A refresh can't fail because we ignore failures, so there
+                // shouldn't be an error in the refresh lock.
 
                 // Reuse the data if it was cached and it hasn't expired.
                 if let CachedValue::Cached(value) = well_known_cache.value()
@@ -2639,7 +2649,8 @@ impl Client {
                     return value.into_data();
                 }
 
-                // The data wasn't cached or has expired, we need to make another request.
+                // The data wasn't cached or has expired, we need to make
+                // another request.
                 guard
             }
         };
@@ -2770,8 +2781,8 @@ impl Client {
             return CachedValue::NotSet;
         };
 
-        // Spawn a task to refresh the cache if it has expired and we have a valid
-        // access token.
+        // Spawn a task to refresh the cache if it has expired and we have a
+        // valid access token.
         if value.has_expired() && self.auth_ctx().has_valid_access_token() {
             debug!("spawning task to refresh RTC transports cache");
 
@@ -2793,7 +2804,8 @@ impl Client {
         let mut refresh_guard = match cache.refresh_lock.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                // There is already a refresh in progress, wait for it to finish.
+                // There is already a refresh in progress, wait for it to
+                // finish.
                 let guard = cache.refresh_lock.lock().await;
 
                 if let Err(error) = guard.as_ref() {
@@ -2808,7 +2820,8 @@ impl Client {
                     return Ok(value.into_data());
                 }
 
-                // The data wasn't cached or has expired, we need to make another request.
+                // The data wasn't cached or has expired, we need to make
+                // another request.
                 guard
             }
         };
@@ -2820,11 +2833,13 @@ impl Client {
                 Ok(Some(transports))
             }
             Err(error) if error.is_endpoint_not_implemented() => {
-                // The homeserver doesn't implement the RTC transports endpoint. Cache
-                // `None` (with the normal TTL) so we don't hit the endpoint on every
-                // call; this self-heals after the TTL in case the homeserver is
-                // upgraded. `None` is kept distinct from `Some(vec![])` (a homeserver
-                // that advertises no transports) so callers can decide whether to fall
+                // The homeserver doesn't implement the RTC transports endpoint.
+                // Cache `None` (with the normal TTL) so we
+                // don't hit the endpoint on every call; this
+                // self-heals after the TTL in case the homeserver is
+                // upgraded. `None` is kept distinct from `Some(vec![])` (a
+                // homeserver that advertises no transports) so
+                // callers can decide whether to fall
                 // back to the well-known foci (see `Client::rtc_foci`).
                 debug!("homeserver does not implement the RTC transports endpoint");
                 *refresh_guard = Ok(());
@@ -2889,8 +2904,8 @@ impl Client {
             return Ok(Some(transports));
         }
 
-        // The homeserver doesn't implement the discovery endpoint or does not expose
-        // any transports, fall back to the well-known foci.
+        // The homeserver doesn't implement the discovery endpoint or does not
+        // expose any transports, fall back to the well-known foci.
         // `well_known` returns `None` when well-known discovery is
         // disabled, which correctly collapses into "nothing was discovered".
         Ok(self.well_known().await.map(|well_known| well_known.rtc_foci))
@@ -3727,7 +3742,8 @@ impl Client {
     /// This is async and fallible as it may use the network to retrieve the
     /// server supported features, if they aren't cached already.
     pub async fn enabled_thread_subscriptions(&self) -> Result<bool> {
-        // Check if the client is configured to support thread subscriptions first.
+        // Check if the client is configured to support thread subscriptions
+        // first.
         match self.base_client().threading_support {
             ThreadingSupport::Enabled { with_subscriptions: false }
             | ThreadingSupport::Disabled => return Ok(false),
@@ -4236,7 +4252,8 @@ pub(crate) mod tests {
             .mount()
             .await;
 
-        // The `/versions` is on the homeserver (e.g. `matrix-client.matrix.org`).
+        // The `/versions` is on the homeserver (e.g.
+        // `matrix-client.matrix.org`).
         homeserver.mock_versions().ok().mock_once().named("versions").mount().await;
 
         let client = Client::builder()
@@ -4270,14 +4287,14 @@ pub(crate) mod tests {
         assert_eq!(client.homeserver(), Url::parse(&homeserver_url).unwrap());
 
         let new_server = Url::parse("http://example.org").unwrap();
-        // Since we're explicitly setting the server to something else, like we might do
-        // during QR code login...
+        // Since we're explicitly setting the server to something else, like we
+        // might do during QR code login...
         client.set_homeserver(new_server.clone());
 
         // The new URL should be set in the homeserver field.
         assert_eq!(client.homeserver(), new_server);
-        // But the server field should be set to empty, since we didn't do any discovery
-        // now.
+        // But the server field should be set to empty, since we didn't do any
+        // discovery now.
         assert!(client.server().is_none())
     }
 
@@ -4475,7 +4492,8 @@ pub(crate) mod tests {
             [room_id!("!beta:localhost"), room_id!("!alpha:localhost")]
         );
 
-        // Tracking the first room yet again should move it to the front of the list
+        // Tracking the first room yet again should move it to the front of the
+        // list
         account.track_recently_visited_room(owned_room_id!("!alpha:localhost")).await.unwrap();
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 2);
         assert_eq!(
@@ -4610,7 +4628,8 @@ pub(crate) mod tests {
 
         drop(versions_mock);
 
-        // Now, reset the cache, and observe the endpoint being called again once.
+        // Now, reset the cache, and observe the endpoint being called again
+        // once.
         client.reset_supported_versions().await.unwrap();
 
         server.mock_versions().ok().expect(2).named("second versions mock").mount().await;
@@ -4630,7 +4649,8 @@ pub(crate) mod tests {
         // Call the method to trigger a cache refresh background task.
         client.supported_versions_cached().await.unwrap().unwrap();
 
-        // We wait for the task to finish, the endpoint should have been called again.
+        // We wait for the task to finish, the endpoint should have been called
+        // again.
         sleep(Duration::from_secs(1)).await;
         assert_matches!(client.inner.caches.supported_versions.value(), CachedValue::Cached(value) if !value.has_expired());
     }
@@ -4689,7 +4709,8 @@ pub(crate) mod tests {
 
         drop(well_known_mock);
 
-        // Now, reset the cache, and observe the endpoints being called again once.
+        // Now, reset the cache, and observe the endpoints being called again
+        // once.
         client.reset_well_known().await.unwrap();
 
         server.mock_well_known().ok().named("second well known mock").expect(2).mount().await;
@@ -4708,9 +4729,10 @@ pub(crate) mod tests {
         // Call the method again to trigger a cache refresh background task.
         client.well_known().await;
 
-        // We wait for the task to finish, the endpoint should have been called again.
-        // We need to wait a bit because the first requests using the server name of the
-        // user will fail, only the requests using the homeserver URL will succeed.
+        // We wait for the task to finish, the endpoint should have been called
+        // again. We need to wait a bit because the first requests using
+        // the server name of the user will fail, only the requests
+        // using the homeserver URL will succeed.
         sleep(Duration::from_secs(5)).await;
         assert_matches!(client.inner.caches.well_known.value(), CachedValue::Cached(value) if !value.has_expired());
     }
@@ -4775,7 +4797,8 @@ pub(crate) mod tests {
         // Call the method again to trigger a cache refresh background task.
         client.rtc_transports().await.unwrap();
 
-        // We wait for the task to finish, the endpoint should have been called again.
+        // We wait for the task to finish, the endpoint should have been called
+        // again.
         sleep(Duration::from_secs(1)).await;
         assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
     }
@@ -4789,10 +4812,10 @@ pub(crate) mod tests {
 
         let server = MatrixMockServer::new().await;
 
-        // The homeserver doesn't implement the endpoint: it responds with a 404 and an
-        // `M_UNRECOGNIZED` error (as a homeserver does for an unrecognized endpoint).
-        // We expect it to be hit only once, despite several calls, thanks to the
-        // negative caching.
+        // The homeserver doesn't implement the endpoint: it responds with a 404
+        // and an `M_UNRECOGNIZED` error (as a homeserver does for an
+        // unrecognized endpoint). We expect it to be hit only once,
+        // despite several calls, thanks to the negative caching.
         Mock::given(method("GET"))
             .and(path_regex(r"^/_matrix/client/unstable/org.matrix.msc4143/rtc/transports"))
             .respond_with(ResponseTemplate::new(404).set_body_json(json!({
@@ -4809,7 +4832,8 @@ pub(crate) mod tests {
         // First call hits the network and gets a 404, which is cached as `None`
         // (unsupported), distinct from `Some(vec![])` (supported but empty).
         assert_eq!(client.rtc_transports().await.unwrap(), None);
-        // Subsequent call hits the in-memory cache, without re-hitting the endpoint.
+        // Subsequent call hits the in-memory cache, without re-hitting the
+        // endpoint.
         assert_eq!(client.rtc_transports().await.unwrap(), None);
         assert_matches!(client.inner.caches.rtc_transports.value(), CachedValue::Cached(value) if !value.has_expired());
     }
@@ -4855,8 +4879,8 @@ pub(crate) mod tests {
 
         let _transports_mock = mock_rtc_transports_endpoint(&server, true).await;
 
-        // The homeserver implements the discovery endpoint, so the well-known must not
-        // be queried at all.
+        // The homeserver implements the discovery endpoint, so the well-known
+        // must not be queried at all.
         let _well_known_mock = server
             .mock_well_known()
             .ok()
@@ -4888,8 +4912,8 @@ pub(crate) mod tests {
 
         let client = server.client_builder().build().await;
 
-        // The homeserver doesn't implement the discovery endpoint, so the well-known
-        // foci are used instead.
+        // The homeserver doesn't implement the discovery endpoint, so the
+        // well-known foci are used instead.
         assert_eq!(client.discover_rtc_transports().await.unwrap(), Some(rtc_foci));
     }
 
@@ -4914,8 +4938,9 @@ pub(crate) mod tests {
             .build()
             .await;
 
-        // The homeserver doesn't implement the discovery endpoint, and falling back to
-        // the well-known isn't allowed, so nothing could be discovered.
+        // The homeserver doesn't implement the discovery endpoint, and falling
+        // back to the well-known isn't allowed, so nothing could be
+        // discovered.
         assert_eq!(client.discover_rtc_transports().await.unwrap(), None);
         // The other well-known consumers are disabled too.
         assert!(client.well_known_rtc_transports().await.unwrap().is_empty());
@@ -4936,8 +4961,9 @@ pub(crate) mod tests {
         let client = server.client_builder().build().await;
         client.disable_well_known_lookup(true);
 
-        // The homeserver doesn't implement the discovery endpoint, and falling back to
-        // the well-known isn't allowed, so nothing could be discovered.
+        // The homeserver doesn't implement the discovery endpoint, and falling
+        // back to the well-known isn't allowed, so nothing could be
+        // discovered.
         assert_eq!(client.discover_rtc_transports().await.unwrap(), None);
         // The other well-known consumers are disabled too.
         assert!(client.well_known_rtc_transports().await.unwrap().is_empty());
@@ -4996,7 +5022,8 @@ pub(crate) mod tests {
 
         drop(well_known_mock);
 
-        // Now, reset the cache, and observe the endpoints being called again once.
+        // Now, reset the cache, and observe the endpoints being called again
+        // once.
         client.reset_well_known().await.unwrap();
 
         server
@@ -5021,8 +5048,8 @@ pub(crate) mod tests {
             .build()
             .await;
 
-        // We don't define a mock server on purpose here, so that the error is really a
-        // network error.
+        // We don't define a mock server on purpose here, so that the error is
+        // really a network error.
         client.whoami().await.unwrap_err();
     }
 
@@ -5079,8 +5106,8 @@ pub(crate) mod tests {
         let client = MockClientBuilder::new(None).build().await;
 
         let room_id = room_id!("!room:example.org");
-        // Room is not present so the client won't be able to find it. The call will
-        // timeout.
+        // Room is not present so the client won't be able to find it. The call
+        // will timeout.
         timeout(Duration::from_secs(1), client.await_room_remote_echo(room_id)).await.unwrap_err();
     }
 
@@ -5397,8 +5424,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_load_or_fetch_max_upload_size_with_auth_matrix_version() {
-        // The default Matrix version we use is 1.11 or higher, so authenticated media
-        // is supported.
+        // The default Matrix version we use is 1.11 or higher, so authenticated
+        // media is supported.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
 
@@ -5412,8 +5439,9 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_load_or_fetch_max_upload_size_with_auth_stable_feature() {
-        // The server must advertise support for the stable feature for authenticated
-        // media support, so we mock the `GET /versions` response.
+        // The server must advertise support for the stable feature for
+        // authenticated media support, so we mock the `GET /versions`
+        // response.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().no_server_versions().build().await;
 

--- a/crates/matrix-sdk/src/client/thread_subscriptions.rs
+++ b/crates/matrix-sdk/src/client/thread_subscriptions.rs
@@ -216,13 +216,14 @@ impl ThreadSubscriptionCatchup {
         guard: &GuardedStoreAccess,
         token: Option<ThreadSubscriptionCatchupToken>,
     ) -> Result<()> {
-        // Note: saving an empty tokens list will mark the thread subscriptions list as
-        // not outdated.
+        // Note: saving an empty tokens list will mark the thread subscriptions
+        // list as not outdated.
         let mut tokens = guard.load_catchup_tokens().await?.unwrap_or_default();
 
         if let Some(token) = token {
-            // Gappy syncs on a busy account can cause the same catchup token to be sent
-            // repeatedly. We dedupe the tokens here to prevent duplicate catchup requests.
+            // Gappy syncs on a busy account can cause the same catchup token to
+            // be sent repeatedly. We dedupe the tokens here to
+            // prevent duplicate catchup requests.
             if tokens.contains(&token) {
                 trace!(?token, "Skipping duplicate catchup token");
             } else {
@@ -299,7 +300,8 @@ impl ThreadSubscriptionCatchup {
 
             match client.send(req).await {
                 Ok(resp) => {
-                    // Precompute the updates so we don't hold the guard for too long.
+                    // Precompute the updates so we don't hold the guard for too
+                    // long.
                     let updates = build_subscription_updates(&resp.subscribed, &resp.unsubscribed);
 
                     let guard = this
@@ -322,8 +324,8 @@ impl ThreadSubscriptionCatchup {
                         }
                     }
 
-                    // Refresh the tokens, as the list might have changed while we sent the
-                    // request.
+                    // Refresh the tokens, as the list might have changed while
+                    // we sent the request.
                     let mut tokens = match guard.load_catchup_tokens().await {
                         Ok(tokens) => tokens.unwrap_or_default(),
                         Err(err) => {
@@ -338,12 +340,14 @@ impl ThreadSubscriptionCatchup {
                     };
 
                     if let Some(next_batch) = resp.end {
-                        // If the response contained a next batch token, reuse the same catchup
-                        // token entry, so the `to` value remains the same.
+                        // If the response contained a next batch token, reuse
+                        // the same catchup token entry,
+                        // so the `to` value remains the same.
                         tokens[index] =
                             ThreadSubscriptionCatchupToken { from: next_batch, to: last.to };
                     } else {
-                        // No next batch, we can remove this token from the list.
+                        // No next batch, we can remove this token from the
+                        // list.
                         tokens.remove(index);
                     }
 

--- a/crates/matrix-sdk/src/deduplicating_handler.rs
+++ b/crates/matrix-sdk/src/deduplicating_handler.rs
@@ -86,26 +86,28 @@ impl<Key: Clone + Ord + std::hash::Hash> DeduplicatingHandler<Key> {
                 }
 
                 QueryState::Failure => {
-                    // The query completed with an error, but we don't know what it is; report
-                    // there was an error.
+                    // The query completed with an error, but we don't know what
+                    // it is; report there was an error.
                     Err(Error::ConcurrentRequestFailed)
                 }
 
                 QueryState::Cancelled => {
-                    // If we could take a hold onto the mutex without it being in the success or
-                    // failure state, then the query hasn't completed (e.g. it could have been
+                    // If we could take a hold onto the mutex without it being
+                    // in the success or failure state, then
+                    // the query hasn't completed (e.g. it could have been
                     // cancelled). Repeat it.
                     //
-                    // Note: there might be other waiters for the deduplicated result; they will
-                    // still be waiting for the mutex above, since the mutex is obtained for at
+                    // Note: there might be other waiters for the deduplicated
+                    // result; they will still be waiting
+                    // for the mutex above, since the mutex is obtained for at
                     // most one holder at the same time.
                     self.run_code(key, code, &mut request_guard).await
                 }
             };
         }
 
-        // Let's assume the cancelled state, if we succeed or fail we'll modify the
-        // result.
+        // Let's assume the cancelled state, if we succeed or fail we'll modify
+        // the result.
         let request_mutex = Arc::new(Mutex::new(QueryState::Cancelled));
 
         map.insert(key.clone(), request_mutex.clone());
@@ -228,8 +230,8 @@ mod tests {
         assert!(second.is_err());
         assert_eq!(*num_calls.lock().await, 1);
 
-        // Then we can still do subsequent requests that may succeed (or fail), for the
-        // same key.
+        // Then we can still do subsequent requests that may succeed (or fail),
+        // for the same key.
         let inner = || {
             let num_calls_cloned = num_calls.clone();
             async move {
@@ -286,8 +288,8 @@ mod tests {
             async move { handler.run(0, query).await }
         });
 
-        // At this point, only the "before" count has been incremented, and only once
-        // (per the deduplication contract).
+        // At this point, only the "before" count has been incremented, and only
+        // once (per the deduplication contract).
         yield_now().await;
 
         assert_eq!(*num_before.lock().await, 1);

--- a/crates/matrix-sdk/src/encryption/backups/futures.rs
+++ b/crates/matrix-sdk/src/encryption/backups/futures.rs
@@ -115,9 +115,10 @@ impl<'a> IntoFuture for WaitForSteadyState<'a> {
 
                 let mut ret = Ok(());
 
-                // TODO: Do we want to be smart here and remember the count when we started
-                // waiting and prevent the total from increasing, in case new room
-                // keys arrive after we started waiting.
+                // TODO: Do we want to be smart here and remember the count when
+                // we started waiting and prevent the total from
+                // increasing, in case new room keys arrive
+                // after we started waiting.
                 while let Some(state) = progress_stream.next().await {
                     trace!(?state, "Update state while waiting for the backup steady state");
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -109,23 +109,25 @@ impl Backups {
             // Create a new backup recovery key.
             let decryption_key = BackupDecryptionKey::new();
 
-            // Get the info about the new backup key, this needs to be uploaded to the
-            // homeserver[1].
+            // Get the info about the new backup key, this needs to be uploaded
+            // to the homeserver[1].
             //
-            // We need to sign the `RoomKeyBackupInfo` so other clients which might want
-            // to start using the backup without having access to the
-            // `BackupDecryptionKey` can do so, as per [spec]:
+            // We need to sign the `RoomKeyBackupInfo` so other clients which
+            // might want to start using the backup without having
+            // access to the `BackupDecryptionKey` can do so, as per
+            // [spec]:
             //
-            // Clients must only store keys in backups after they have ensured that the
-            // `auth_data` has not been tampered with. This can be done either by:
+            // Clients must only store keys in backups after they have ensured
+            // that the `auth_data` has not been tampered with. This
+            // can be done either by:
             //
-            //  * checking that it is signed by the user's master cross-signing key or by a
-            //    verified device belonging to the same user, or
-            //  * by deriving the public key from a private key that it obtained from a
-            //    trusted source. Trusted sources for the private key include the user
-            //    entering the key, retrieving the key stored in secret storage, or
-            //    obtaining the key via secret sharing from a verified device belonging to
-            //    the same user.
+            //  * checking that it is signed by the user's master cross-signing
+            //    key or by a verified device belonging to the same user, or
+            //  * by deriving the public key from a private key that it obtained
+            //    from a trusted source. Trusted sources for the private key
+            //    include the user entering the key, retrieving the key stored
+            //    in secret storage, or obtaining the key via secret sharing
+            //    from a verified device belonging to the same user.
             //
             //
             // [1]: https://spec.matrix.org/v1.8/client-server-api/#post_matrixclientv3room_keysversion
@@ -141,13 +143,15 @@ impl Backups {
             let response = self.client.send(request).await?;
             let version = response.version;
 
-            // Reset any state we might have had before the new backup was created.
-            // TODO: This should remove the old stored key and version.
+            // Reset any state we might have had before the new backup was
+            // created. TODO: This should remove the old stored key
+            // and version.
             olm_machine.backup_machine().disable_backup().await?;
 
             let backup_key = decryption_key.megolm_v1_public_key();
 
-            // Save the newly created keys and the version we received from the server.
+            // Save the newly created keys and the version we received from the
+            // server.
             olm_machine
                 .backup_machine()
                 .save_decryption_key(Some(decryption_key), Some(version.to_owned()))
@@ -172,8 +176,9 @@ impl Backups {
                 }
 
                 // We can ignore errors here because the only way this function
-                // fails is if the secret is not found.  But we saved the decryption
-                // key above, so this will never happen.
+                // fails is if the secret is not found.  But we saved the
+                // decryption key above, so this will never
+                // happen.
                 let _ = olm_machine.push_secret_to_verified_devices(SecretName::RecoveryKey).await;
             }
 
@@ -215,7 +220,8 @@ impl Backups {
 
         self.set_state(BackupState::Disabling);
 
-        // Create a future so we can catch errors and go back to the `Unknown` state.
+        // Create a future so we can catch errors and go back to the `Unknown`
+        // state.
         let future = async {
             let olm_machine = self.client.olm_machine().await;
             let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
@@ -278,7 +284,8 @@ impl Backups {
 
         self.set_state(BackupState::Disabling);
 
-        // Create a future so we can catch errors and go back to the `Unknown` state.
+        // Create a future so we can catch errors and go back to the `Unknown`
+        // state.
         let future = async {
             while let Some(response) = self.get_current_version().await? {
                 self.delete_backup_from_server(response.version).await?;
@@ -431,8 +438,8 @@ impl Backups {
             return Ok(cached_value);
         }
 
-        // Otherwise, delegate to fetch_exists_on_server. (It will update the cached
-        // value for us.)
+        // Otherwise, delegate to fetch_exists_on_server. (It will update the
+        // cached value for us.)
         self.fetch_exists_on_server().await
     }
 
@@ -479,7 +486,8 @@ impl Backups {
                 get_backup_keys_for_room::v3::Request::new(version.clone(), room_id.to_owned());
             let response = self.client.send(request).await?;
 
-            // Transform response to standard format (map of room ID -> room key).
+            // Transform response to standard format (map of room ID -> room
+            // key).
             let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
                 room_id.to_owned(),
                 RoomKeyBackup::new(response.sessions),
@@ -517,7 +525,8 @@ impl Backups {
                 );
                 let response = self.client.send(request).await?;
 
-                // Transform response to standard format (map of room ID -> room key).
+                // Transform response to standard format (map of room ID -> room
+                // key).
                 let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
                     room_id.to_owned(),
                     RoomKeyBackup::new(BTreeMap::from([(
@@ -674,9 +683,9 @@ impl Backups {
             }
         };
 
-        // If the request succeeded, the backup is gone. If it failed, we are not really
-        // sure what the backup state is. Either way, clear the cache so we check next
-        // time we need to know.
+        // If the request succeeded, the backup is gone. If it failed, we are
+        // not really sure what the backup state is. Either way, clear
+        // the cache so we check next time we need to know.
         self.client.inner.e2ee.backup_state.clear_backup_exists_on_server();
 
         ret
@@ -729,7 +738,8 @@ impl Backups {
                                 "A new backup version was found on the server, disabling backups."
                             );
 
-                            // TODO: If we're verified and there are other devices besides us,
+                            // TODO: If we're verified and there are other
+                            // devices besides us,
                             // request the new backup key over `m.secret.send`.
 
                             self.handle_deleted_backup_version(olm_machine).await?;
@@ -807,8 +817,9 @@ impl Backups {
     ) -> Result<bool, EnableBackupError> {
         let _guard = self.client.locks().backup_modify_lock.lock().await;
 
-        // Create a future here which allows us to catch any failure that might happen
-        // so we can later on fall back to the correct `BackupState`.
+        // Create a future here which allows us to catch any failure that might
+        // happen so we can later on fall back to the correct
+        // `BackupState`.
         let future = async {
             self.set_state(BackupState::Enabling);
 
@@ -839,8 +850,9 @@ impl Backups {
             if stored_keys.backup_version.as_ref() == Some(&current_version.version)
                 && self.are_enabled().await
             {
-                // If we already have a backup enabled which is using the currently active
-                // backup version, do nothing but tell the caller using the return value that
+                // If we already have a backup enabled which is using the
+                // currently active backup version, do nothing
+                // but tell the caller using the return value that
                 // backups are enabled.
                 Ok(true)
             } else if decryption_key.backup_key_matches(&backup_info) {
@@ -849,8 +861,9 @@ impl Backups {
                      key and enabling backups."
                 );
 
-                // We're enabling a new backup, reset the `backed_up` flags on the room keys and
-                // remove any key/version we might have.
+                // We're enabling a new backup, reset the `backed_up` flags on
+                // the room keys and remove any key/version we
+                // might have.
                 backup_machine.disable_backup().await?;
 
                 let backup_key = decryption_key.megolm_v1_public_key();
@@ -865,12 +878,14 @@ impl Backups {
                     .await?;
                 backup_machine.enable_backup_v1(backup_key).await?;
 
-                // If the user has set up the client to download any room keys, do so now. This
-                // is not really useful in a real scenario since the API to
-                // download room keys is not paginated.
+                // If the user has set up the client to download any room keys,
+                // do so now. This is not really useful in a
+                // real scenario since the API to download room
+                // keys is not paginated.
                 //
-                // You need to download all room keys at once, parse a potentially huge JSON
-                // response and decrypt all the room keys found in the backup.
+                // You need to download all room keys at once, parse a
+                // potentially huge JSON response and decrypt
+                // all the room keys found in the backup.
                 //
                 // This doesn't work for any sizeable account.
                 if self.client.inner.e2ee.encryption_settings.backup_download_strategy
@@ -978,11 +993,12 @@ impl Backups {
         let olm_machine = self.client.olm_machine().await;
         let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
 
-        // Let us first check if we have a stored backup recovery key and a backup
-        // version.
+        // Let us first check if we have a stored backup recovery key and a
+        // backup version.
         if !self.resume_backup_from_stored_backup_key(olm_machine).await? {
-            // We didn't manage to enable backups from a stored backup recovery key, let us
-            // check our secret inbox. Perhaps we can find a valid key there.
+            // We didn't manage to enable backups from a stored backup recovery
+            // key, let us check our secret inbox. Perhaps we can
+            // find a valid key there.
             self.maybe_resume_from_secret_inbox(olm_machine).await?;
         }
 
@@ -995,10 +1011,10 @@ impl Backups {
     pub(crate) async fn secret_send_event_handler(_: ToDeviceSecretSendEvent, client: Client) {
         let olm_machine = client.olm_machine().await;
 
-        // TODO: Because of our crude multi-process support, which reloads the whole
-        // [`OlmMachine`] the `secrets_stream` might stop giving you updates. Once
-        // that's fixed, stop listening to individual secret send events and
-        // listen to the secrets stream.
+        // TODO: Because of our crude multi-process support, which reloads the
+        // whole [`OlmMachine`] the `secrets_stream` might stop giving
+        // you updates. Once that's fixed, stop listening to individual
+        // secret send events and listen to the secrets stream.
         if let Some(olm_machine) = olm_machine.as_ref() {
             if let Err(e) =
                 client.encryption().backups().maybe_resume_from_secret_inbox(olm_machine).await
@@ -1222,8 +1238,8 @@ mod test {
             .mount()
             .await;
 
-        // Given there is a backup decryption key waiting in the secrets inbox, which is
-        // consistent with the public key
+        // Given there is a backup decryption key waiting in the secrets inbox,
+        // which is consistent with the public key
         queue_backup_decryption_key_secret(client, &backup_decryption_key.to_base64()).await;
 
         // When we resume backups
@@ -1259,8 +1275,8 @@ mod test {
             .mount()
             .await;
 
-        // Given there is a backup decryption key waiting in the secrets inbox, but it
-        // doesn't match the public backup key
+        // Given there is a backup decryption key waiting in the secrets inbox,
+        // but it doesn't match the public backup key
         queue_backup_decryption_key_secret(client, &backup_decryption_key.to_base64()).await;
 
         // When we attempt to resume backups
@@ -1269,8 +1285,8 @@ mod test {
         // Then no error is returned ...
         assert_matches!(res, Ok(_));
 
-        // ... even though the backup setup failed because the decryption keys were
-        // inconsistent
+        // ... even though the backup setup failed because the decryption keys
+        // were inconsistent
         assert_eq!(backups.state(), BackupState::Unknown);
     }
 
@@ -1280,7 +1296,8 @@ mod test {
         let client = server.client_builder().build().await;
         let backups = client.encryption().backups();
 
-        // Given an invalid backup decryption key is waiting in the secrets inbox
+        // Given an invalid backup decryption key is waiting in the secrets
+        // inbox
         queue_backup_decryption_key_secret(client, "not valid base64").await;
 
         // When we attempt to resume backups

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -89,8 +89,8 @@ where
             let mut buf = Vec::new();
             encryptor.read_to_end(&mut buf)?;
 
-            // Override the reasonable upload timeout value, based on the size of the
-            // encrypted payload.
+            // Override the reasonable upload timeout value, based on the size
+            // of the encrypted payload.
             let request_config =
                 request_config.map(|config| config.timeout(Media::reasonable_upload_timeout(&buf)));
 

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -272,7 +272,8 @@ impl UserIdentity {
                 let content = i.verification_request_content(methods.clone());
 
                 let room = if let Some(room) = self.client.get_dm_room(i.user_id()) {
-                    // Make sure that the user, to be verified, is still in the room
+                    // Make sure that the user, to be verified, is still in the
+                    // room
                     if !room
                         .members(RoomMemberships::ACTIVE)
                         .await?

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -384,7 +384,8 @@ impl CrossSigningResetHandle {
 
                     match e.as_uiaa_response() {
                         Some(uiaa_info) => {
-                            // Return the error except if we are at the `m.oauth` stage where we
+                            // Return the error except if we are at the
+                            // `m.oauth` stage where we
                             // want to keep polling.
                             if !matches!(self.auth_type, CrossSigningResetAuthType::OAuth(_))
                                 && uiaa_info.auth_error.is_some()
@@ -484,9 +485,9 @@ impl FromStr for DuplicateOneTimeKeyErrorMessage {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        // First we split the string into two parts, the part containing the old key and
-        // the part containing the new key. The parts are conveniently separated
-        // by a `;` character.
+        // First we split the string into two parts, the part containing the old
+        // key and the part containing the new key. The parts are
+        // conveniently separated by a `;` character.
         let mut split = s.split_terminator(';');
 
         let old_key = split
@@ -496,8 +497,8 @@ impl FromStr for DuplicateOneTimeKeyErrorMessage {
             .next()
             .ok_or(serde_json::Error::custom("New key is missing in the error message"))?;
 
-        // Now we remove the lengthy prefix from the part containing the old key, we
-        // should be left with just the JSON of the signed key.
+        // Now we remove the lengthy prefix from the part containing the old
+        // key, we should be left with just the JSON of the signed key.
         let old_key_index = old_key
             .find("Old key:")
             .ok_or(serde_json::Error::custom("Old key is missing the prefix"))?;
@@ -507,15 +508,16 @@ impl FromStr for DuplicateOneTimeKeyErrorMessage {
             .strip_prefix("Old key:")
             .ok_or(serde_json::Error::custom("Old key is missing the prefix"))?;
 
-        // The part containing the new key is much simpler, we just remove a static
-        // prefix.
+        // The part containing the new key is much simpler, we just remove a
+        // static prefix.
         let new_key = new_key
             .trim()
             .strip_prefix("new key:")
             .ok_or(serde_json::Error::custom("New key is missing the prefix"))?;
 
-        // The JSON containing the new key is for some reason quoted using single
-        // quotes, so let's replace them with normal double quotes.
+        // The JSON containing the new key is for some reason quoted using
+        // single quotes, so let's replace them with normal double
+        // quotes.
         let new_key = new_key.replace("'", "\"");
 
         // Let's deserialize now.
@@ -770,9 +772,12 @@ impl Client {
                         Some(e) if e.status_code == 400 => {
                             if let ErrorBody::Standard(StandardErrorBody { message, .. }) = &e.body
                             {
-                                // This is one of the nastiest errors we can have. The server
-                                // telling us that we already have a one-time key uploaded means
-                                // that we forgot about some of our one-time keys. This will lead to
+                                // This is one of the nastiest errors we can
+                                // have. The server
+                                // telling us that we already have a one-time
+                                // key uploaded means
+                                // that we forgot about some of our one-time
+                                // keys. This will lead to
                                 // UTDs.
                                 {
                                     let already_reported = self
@@ -955,13 +960,13 @@ impl Encryption {
     ) -> Result<(), BundleImportError> {
         self.import_secrets_bundle_impl(bundle).await?;
 
-        // Upload the device keys, this will ensure that other devices see us as a fully
-        // verified device as soon as this method returns.
+        // Upload the device keys, this will ensure that other devices see us as
+        // a fully verified device as soon as this method returns.
         self.ensure_device_keys_upload().await?;
         self.wait_for_e2ee_initialization_tasks().await;
 
-        // If our initialization tasks completed before we imported the secrets bundle,
-        // backups might not have been enabled.
+        // If our initialization tasks completed before we imported the secrets
+        // bundle, backups might not have been enabled.
         //
         // In this case attempt to enable them again.
         if !self.backups().are_enabled().await {
@@ -1855,8 +1860,9 @@ impl Encryption {
 
         // Gently try to initialize the crypto store generation counter.
         //
-        // If we don't get the lock immediately, then it is already acquired by another
-        // process, and we'll get to reload next time we acquire the lock.
+        // If we don't get the lock immediately, then it is already acquired by
+        // another process, and we'll get to reload next time we acquire
+        // the lock.
         {
             let lock_result = lock.try_lock_once().await?;
 
@@ -1904,9 +1910,10 @@ impl Encryption {
             }
             Ok(generation_number)
         } else {
-            // XXX: not sure this is reachable. Seems like the OlmMachine should always have
-            // been initialised by the time we get here. Ideally we'd panic, or return an
-            // error, but for now I'm just adding some logging to check if it
+            // XXX: not sure this is reachable. Seems like the OlmMachine should
+            // always have been initialised by the time we get here.
+            // Ideally we'd panic, or return an error, but for now
+            // I'm just adding some logging to check if it
             // happens, and returning the magic number 0.
             warn!("Encryption::on_lock_newly_acquired: called before OlmMachine initialised");
             Ok(0)
@@ -1999,9 +2006,10 @@ impl Encryption {
     ///   allow for the initial upload of cross-signing keys without
     ///   authentication, rendering this parameter obsolete.
     pub(crate) async fn spawn_initialization_task(&self, auth_data: Option<AuthData>) {
-        // It's fine to be async here as we're only getting the lock protecting the
-        // `OlmMachine`. Since the lock shouldn't be that contested right after logging
-        // in we won't delay the login or restoration of the Client.
+        // It's fine to be async here as we're only getting the lock protecting
+        // the `OlmMachine`. Since the lock shouldn't be that contested
+        // right after logging in we won't delay the login or
+        // restoration of the Client.
         let bundle_receiver_task = if self.client.inner.enable_share_history_on_invite {
             Some(BundleReceiverTask::new(&self.client).await)
         } else {
@@ -2014,8 +2022,8 @@ impl Encryption {
 
         tasks.setup_e2ee = Some(spawn(
             async move {
-                // Update the current state first, so we don't have to wait for the result of
-                // network requests
+                // Update the current state first, so we don't have to wait for
+                // the result of network requests
                 this.update_verification_state().await;
 
                 if this.settings().auto_enable_cross_signing
@@ -2190,8 +2198,9 @@ impl Encryption {
         let users = recipient_devices.iter().map(|device| device.user_id());
 
         // Will claim one-time-key for users that needs it
-        // TODO: For later optimisation: This will establish missing olm sessions with
-        // all this users devices, but we just want for some devices.
+        // TODO: For later optimisation: This will establish missing olm
+        // sessions with all this users devices, but we just want for
+        // some devices.
         self.client.claim_one_time_keys(users).await?;
 
         let olm = self.client.olm_machine().await;
@@ -2228,7 +2237,8 @@ impl Encryption {
                 .send_inner(ruma_request, Some(RequestConfig::short_retry()), Default::default())
                 .await;
 
-            // If the sending failed we need to collect the failures to report them
+            // If the sending failed we need to collect the failures to report
+            // them
             if send_result.is_err() {
                 // Mark the sending as failed
                 for (user_id, device_map) in request.messages {
@@ -2370,7 +2380,8 @@ mod tests {
             .unwrap();
         client2.matrix_auth().restore_session(session, RoomLoadSettings::default()).await.unwrap();
 
-        // When the lock isn't enabled, any attempt at locking won't return a guard.
+        // When the lock isn't enabled, any attempt at locking won't return a
+        // guard.
         let guard = client1.encryption().try_lock_store_once().await.unwrap();
         assert!(guard.is_none());
 
@@ -2381,11 +2392,13 @@ mod tests {
         let acquired1 = client1.encryption().spin_lock_store(None).await.unwrap();
         assert!(acquired1.is_some());
 
-        // Keep the olm machine, so we can see if it's changed later, by comparing Arcs.
+        // Keep the olm machine, so we can see if it's changed later, by
+        // comparing Arcs.
         let initial_olm_machine =
             client1.olm_machine().await.clone().expect("must have an olm machine");
 
-        // Also enable backup to check that new machine has the same backup keys.
+        // Also enable backup to check that new machine has the same backup
+        // keys.
         let decryption_key = matrix_sdk_base::crypto::store::types::BackupDecryptionKey::new();
         let backup_key = decryption_key.megolm_v1_public_key();
         backup_key.set_version("1".to_owned());
@@ -2531,8 +2544,8 @@ mod tests {
         // We can get its initial value, and it's Unknown
         assert_next_matches_with_timeout!(verification_state, VerificationState::Unknown);
 
-        // We set up a mocked request to check this endpoint is not called before
-        // reading the new state
+        // We set up a mocked request to check this endpoint is not called
+        // before reading the new state
         let keys_requested = Arc::new(AtomicBool::new(false));
         let inner_bool = keys_requested.clone();
 
@@ -2550,7 +2563,8 @@ mod tests {
         // When the session is initialised and the encryption tasks spawn
         set_client_session(&client).await;
 
-        // Then we can get an updated value without waiting for any network requests
+        // Then we can get an updated value without waiting for any network
+        // requests
         assert!(keys_requested.load(Ordering::SeqCst).not());
         assert_next_matches_with_timeout!(verification_state, VerificationState::Unverified);
     }

--- a/crates/matrix-sdk/src/encryption/recovery/mod.rs
+++ b/crates/matrix-sdk/src/encryption/recovery/mod.rs
@@ -304,9 +304,9 @@ impl Recovery {
 
         // Why oh why, can't we delete account data events?
         //
-        // Alright, let's attempt to "delete" the content of our current default key,
-        // for this we first need to check if there is a default key, then
-        // deserialize the content and find out the key ID.
+        // Alright, let's attempt to "delete" the content of our current default
+        // key, for this we first need to check if there is a default
+        // key, then deserialize the content and find out the key ID.
         //
         // Then we finally set the event to an empty JSON content.
         if let Ok(Some(default_event)) =
@@ -357,9 +357,9 @@ impl Recovery {
     /// ```
     #[instrument(skip_all)]
     pub fn reset_key(&self) -> Reset<'_> {
-        // TODO: Should this only be possible if we're in the RecoveryState::Enabled
-        // state? Otherwise we'll create a new secret store but won't be able to
-        // upload all the secrets.
+        // TODO: Should this only be possible if we're in the
+        // RecoveryState::Enabled state? Otherwise we'll create a new
+        // secret store but won't be able to upload all the secrets.
         Reset::new(self)
     }
 
@@ -445,7 +445,8 @@ impl Recovery {
         let cross_signing_reset_handle = self.client.encryption().reset_cross_signing().await?;
 
         if let Some(handle) = cross_signing_reset_handle {
-            // Authentication required, backups will be re-enabled after the reset
+            // Authentication required, backups will be re-enabled after the
+            // reset
             Ok(Some(IdentityResetHandle {
                 client: self.client.clone(),
                 cross_signing_reset_handle: handle,
@@ -577,8 +578,8 @@ impl Recovery {
 
     /// Did we correctly set up cross-signing and backups?
     async fn all_known_secrets_available(&self) -> Result<bool> {
-        // Cross-signing state is fine if we have all the private cross-signing keys, as
-        // indicated in the status.
+        // Cross-signing state is fine if we have all the private cross-signing
+        // keys, as indicated in the status.
         let cross_signing_complete = self
             .client
             .encryption()
@@ -589,8 +590,8 @@ impl Recovery {
             return Ok(false);
         }
 
-        // The backup state is fine if we have backups enabled locally, or if backups
-        // have been marked as disabled.
+        // The backup state is fine if we have backups enabled locally, or if
+        // backups have been marked as disabled.
         if self.client.encryption().backups().are_enabled().await {
             Ok(true)
         } else {
@@ -599,9 +600,9 @@ impl Recovery {
     }
 
     async fn should_auto_enable_backups(&self) -> Result<bool> {
-        // If we didn't already enable backups, we don't see a backup version on the
-        // server, and finally if backups have not been marked to be explicitly
-        // disabled, then we can automatically enable them.
+        // If we didn't already enable backups, we don't see a backup version on
+        // the server, and finally if backups have not been marked to be
+        // explicitly disabled, then we can automatically enable them.
         Ok(self.client.inner.e2ee.encryption_settings.auto_enable_backups
             && !self.client.encryption().backups().are_enabled().await
             && !self.client.encryption().backups().fetch_exists_on_server().await?
@@ -671,8 +672,8 @@ impl Recovery {
     async fn mark_backup_as_enabled(&self) -> Result<()> {
         self.client.account().set_account_data(KeyBackupContent { enabled: true }).await?;
 
-        // Unstable prefix: will be removed when sufficient time has passed for clients
-        // to use the stable prefix.
+        // Unstable prefix: will be removed when sufficient time has passed for
+        // clients to use the stable prefix.
         self.client.account().set_account_data(BackupDisabledContent { disabled: false }).await?;
 
         Ok(())
@@ -733,7 +734,8 @@ impl Recovery {
                 if let Some(client) = weak.get() {
                     match update {
                         Ok(update) => {
-                            // The recovery state only cares about these two states, the
+                            // The recovery state only cares about these two
+                            // states, the
                             // intermediate states that tell us that
                             // we're creating a backup are not interesting.
                             if matches!(update, BackupState::Unknown | BackupState::Enabled) {
@@ -745,7 +747,8 @@ impl Recovery {
                             }
                         }
                         Err(_) => {
-                            // We missed some updates, let's update our state in case something
+                            // We missed some updates, let's update our state in
+                            // case something
                             // changed.
                             client.encryption().recovery().update_recovery_state_no_fail().await;
                         }
@@ -762,9 +765,10 @@ impl Recovery {
         if let Some(user_id) = self.client.user_id()
             && response.master_keys.contains_key(user_id)
         {
-            // TODO: This is unnecessarily expensive, we could let the crypto crate notify
-            // us that our private keys got erased... But, the OlmMachine
-            // gets recreated and... You know the drill by now...
+            // TODO: This is unnecessarily expensive, we could let the crypto
+            // crate notify us that our private keys got erased...
+            // But, the OlmMachine gets recreated and... You know
+            // the drill by now...
             self.update_recovery_state_no_fail().await;
         }
     }

--- a/crates/matrix-sdk/src/encryption/secret_storage/futures.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/futures.rs
@@ -52,8 +52,8 @@ impl<'a> IntoFuture for CreateStore<'a> {
         Box::pin(async move {
             // Prevent multiple simultaneous calls to this method.
             //
-            // See the documentation for the lock in the `store_secret` method for more
-            // info.
+            // See the documentation for the lock in the `store_secret` method
+            // for more info.
             let client_copy = secret_storage.client.to_owned();
             let _guard = client_copy.locks().open_secret_store_lock.lock().await;
 

--- a/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/secret_store.rs
@@ -162,11 +162,12 @@ impl SecretStore {
                 .deserialize_as_unchecked::<SecretEventContent>()
                 .map_err(|e| SecretStorageError::into_import_error(secret_name.clone(), e))?;
 
-            // The `SecretEventContent` contains a map from the secret storage key ID to the
-            // ciphertext. Let's try to find a secret which was encrypted using our
-            // [`SecretStorageKey`].
+            // The `SecretEventContent` contains a map from the secret storage
+            // key ID to the ciphertext. Let's try to find a secret
+            // which was encrypted using our [`SecretStorageKey`].
             if let Some(secret_content) = secret_content.encrypted.remove(self.key.key_id()) {
-                // We found a secret we should be able to decrypt, let's try to do so.
+                // We found a secret we should be able to decrypt, let's try to
+                // do so.
                 let decrypted = self
                     .key
                     .decrypt(
@@ -184,8 +185,9 @@ impl SecretStore {
 
                 Ok(Some(secret))
             } else {
-                // We did not find a secret which was encrypted using our [`SecretStorageKey`],
-                // no need to try to decrypt.
+                // We did not find a secret which was encrypted using our
+                // [`SecretStorageKey`], no need to try to
+                // decrypt.
                 Ok(None)
             }
         } else {
@@ -231,22 +233,22 @@ impl SecretStore {
     /// # anyhow::Ok(()) };
     /// ```
     pub async fn put_secret(&self, secret_name: impl Into<SecretName>, secret: &str) -> Result<()> {
-        // This function does a read/update/store of an account data event stored on the
-        // homeserver. We first fetch the existing account data event, the event
-        // contains a map which gets updated by this method, finally we upload the
-        // modified event.
+        // This function does a read/update/store of an account data event
+        // stored on the homeserver. We first fetch the existing account
+        // data event, the event contains a map which gets updated by
+        // this method, finally we upload the modified event.
         //
-        // To prevent multiple calls to this method trying to update a secret at the
-        // same time, and thus trampling on each other we introduce a lock which
-        // acts as a semaphore.
+        // To prevent multiple calls to this method trying to update a secret at
+        // the same time, and thus trampling on each other we introduce
+        // a lock which acts as a semaphore.
         //
-        // Technically there's a low chance of this happening since we're not storing
-        // many secrets and the bigger problem is that another client might be
-        // doing this as well and the server doesn't have a mechanism to protect against
-        // this.
+        // Technically there's a low chance of this happening since we're not
+        // storing many secrets and the bigger problem is that another
+        // client might be doing this as well and the server doesn't
+        // have a mechanism to protect against this.
         //
-        // We could make this lock be per `secret_name` but this is not a performance
-        // critical method.
+        // We could make this lock be per `secret_name` but this is not a
+        // performance critical method.
         let _guard = self.client.locks().store_secret_lock.lock().await;
 
         let secret_name = secret_name.into();
@@ -273,8 +275,8 @@ impl SecretStore {
             .insert(self.key.key_id().to_owned(), Raw::new(&encrypted_secret)?.cast());
         let secret_content = Raw::from_json(to_raw_value(&secret_content)?);
 
-        // Upload the modified account data event, now that the new secret has been
-        // inserted.
+        // Upload the modified account data event, now that the new secret has
+        // been inserted.
         self.client.account().set_account_data_raw(event_type, secret_content).await?;
 
         Ok(())
@@ -415,12 +417,13 @@ impl SecretStore {
 
         info!(cross_signing_keys = ?export, "Received the cross signing keys from the server");
 
-        // We need to ensure that we have the public parts of the cross-signing keys,
-        // those are represented as the `OwnUserIdentity` struct. The public
-        // parts from the server are compared to the public parts re-derived from the
-        // private parts. We will only import the private parts of the cross-signing
-        // keys if they match to the public parts, otherwise we would risk
-        // importing some stale cross-signing keys leftover in the secret store.
+        // We need to ensure that we have the public parts of the cross-signing
+        // keys, those are represented as the `OwnUserIdentity` struct.
+        // The public parts from the server are compared to the public
+        // parts re-derived from the private parts. We will only import
+        // the private parts of the cross-signing keys if they match to
+        // the public parts, otherwise we would risk importing some
+        // stale cross-signing keys leftover in the secret store.
         let (request_id, request) = olm_machine.query_keys_for_users([olm_machine.user_id()]);
         self.client.keys_query(&request_id, request.device_keys).await?;
 
@@ -437,14 +440,16 @@ impl SecretStore {
         if status.has_self_signing {
             info!("Successfully imported the self-signing key, attempting to sign our own device");
 
-            // Now that we successfully imported them, the self-signing key can be used to
-            // verify our own device so other devices and user identities trust
-            // it if the trust our user identity.
+            // Now that we successfully imported them, the self-signing key can
+            // be used to verify our own device so other devices and
+            // user identities trust it if the trust our user
+            // identity.
             if let Some(own_device) = self.client.encryption().get_own_device().await? {
                 own_device.verify().await?;
 
-                // Another /keys/query request to ensure that the signatures we uploaded using
-                // `own_device.verify()` are attached to the `Device` we have in storage.
+                // Another /keys/query request to ensure that the signatures we
+                // uploaded using `own_device.verify()` are
+                // attached to the `Device` we have in storage.
                 let (request_id, request) =
                     olm_machine.query_keys_for_users([olm_machine.user_id()]);
                 self.client.keys_query(&request_id, request.device_keys).await?;

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -226,8 +226,8 @@ impl BackupDownloadTask {
                 break;
             }
 
-            // Check that we don't already have a task to process this event, and fire one
-            // off else if not.
+            // Check that we don't already have a task to process this event,
+            // and fire one off else if not.
             let event_id = &room_key_download_request.event_id;
             if !state_guard.active_tasks.contains_key(event_id) {
                 let event_id = event_id.to_owned();
@@ -250,27 +250,29 @@ impl BackupDownloadTask {
         #[cfg(not(test))]
         crate::sleep::sleep(Duration::from_millis(Self::DOWNLOAD_DELAY_MILLIS)).await;
 
-        // Now take the lock, and check that we still want to do a download. If we do,
-        // keep hold of a strong reference to the `Client`.
+        // Now take the lock, and check that we still want to do a download. If
+        // we do, keep hold of a strong reference to the `Client`.
         let client = {
             let mut state = state.lock().await;
 
             let Some(client) = state.client.get() else {
-                // The client was dropped while we were sleeping. We should just bail out;
-                // the main BackupDownloadTask loop will bail out too.
+                // The client was dropped while we were sleeping. We should just
+                // bail out; the main BackupDownloadTask loop
+                // will bail out too.
                 return;
             };
 
             // Check that we still want to do a download.
             if !state.should_download(&client, &download_request).await {
-                // We decided against doing a download. Mark the job done for this event before
-                // dropping the lock.
+                // We decided against doing a download. Mark the job done for
+                // this event before dropping the lock.
                 state.active_tasks.remove(&download_request.event_id);
                 return;
             }
 
-            // Before we drop the lock, indicate to other tasks that may be considering this
-            // room key, that we're going to go ahead and do a download.
+            // Before we drop the lock, indicate to other tasks that may be
+            // considering this room key, that we're going to go
+            // ahead and do a download.
             state.downloaded_room_keys.insert(download_request.to_room_key_info());
 
             client
@@ -290,19 +292,23 @@ impl BackupDownloadTask {
 
             match result {
                 Ok(true) => {
-                    // We successfully downloaded the room key. We can clear any record of previous
-                    // backoffs from the failures cache, because we won't be needing them again.
+                    // We successfully downloaded the room key. We can clear any
+                    // record of previous backoffs from the
+                    // failures cache, because we won't be needing them again.
                     state.failures_cache.remove(std::iter::once(&room_key_info))
                 }
                 Ok(false) => {
-                    // We did not find a valid backup decryption key or backup version, we did not
-                    // even attempt to download the room key.
+                    // We did not find a valid backup decryption key or backup
+                    // version, we did not even attempt to
+                    // download the room key.
                     state.downloaded_room_keys.remove(std::iter::once(&room_key_info));
                 }
                 Err(_) => {
-                    // We were unable to download the room key. Update the failure cache so that we
-                    // back off from more requests, and also remove the entry from the list of
-                    // room keys that we are downloading.
+                    // We were unable to download the room key. Update the
+                    // failure cache so that we
+                    // back off from more requests, and also remove the entry
+                    // from the list of room keys that we
+                    // are downloading.
                     state.downloaded_room_keys.remove(std::iter::once(&room_key_info));
                     state.failures_cache.insert(room_key_info);
                 }
@@ -373,7 +379,8 @@ impl BackupDownloadTaskListenerState {
             return false;
         };
 
-        // If backups aren't enabled, there's no point in trying to download a room key.
+        // If backups aren't enabled, there's no point in trying to download a
+        // room key.
         if !client.encryption().backups().are_enabled().await {
             debug!(
                 ?download_request,
@@ -384,9 +391,9 @@ impl BackupDownloadTaskListenerState {
         }
 
         // Check if the keys for this message have arrived in the meantime.
-        // If we get a StoreError doing the lookup, we assume the keys haven't arrived
-        // (though if the store is returning errors, probably something else is
-        // going to go wrong very soon).
+        // If we get a StoreError doing the lookup, we assume the keys haven't
+        // arrived (though if the store is returning errors, probably
+        // something else is going to go wrong very soon).
         if machine
             .is_room_key_available(
                 #[cfg(not(feature = "experimental-encrypted-state-events"))]
@@ -405,8 +412,8 @@ impl BackupDownloadTaskListenerState {
             return false;
         }
 
-        // Check if we already downloaded this room key, or another task is in the
-        // process of doing so.
+        // Check if we already downloaded this room key, or another task is in
+        // the process of doing so.
         let room_key_info = download_request.to_room_key_info();
         if self.downloaded_room_keys.contains(&room_key_info) {
             debug!(
@@ -448,14 +455,16 @@ impl BundleReceiverTask {
     async fn listen_task(client: WeakClient, stream: impl Stream<Item = RoomKeyBundleInfo>) {
         pin_mut!(stream);
 
-        // TODO: Listening to this stream is not enough for iOS due to the NSE killing
-        // our OlmMachine and thus also this stream. We need to add an event handler
-        // that will listen for the bundle event. To be able to add an event handler,
-        // we'll have to implement the bundle event in Ruma.
+        // TODO: Listening to this stream is not enough for iOS due to the NSE
+        // killing our OlmMachine and thus also this stream. We need to
+        // add an event handler that will listen for the bundle event.
+        // To be able to add an event handler, we'll have to implement
+        // the bundle event in Ruma.
         while let Some(bundle_info) = stream.next().await {
             let Some(client) = client.get() else {
-                // The client was dropped while we were waiting on the stream. Let's end the
-                // loop, since this means that the application has shut down.
+                // The client was dropped while we were waiting on the stream.
+                // Let's end the loop, since this means that the
+                // application has shut down.
                 break;
             };
 
@@ -483,10 +492,11 @@ impl BundleReceiverTask {
 
         let olm_machine = client.olm_machine().await;
         let Some(olm_machine) = olm_machine.as_ref() else {
-            // The Olm machine was not initialized by the time this task is ready
-            // to perform its work. This is likely a bug, as this worker is only
-            // expected to be spawned once the client is fully ready and the
-            // Olm machine is available.
+            // The Olm machine was not initialized by the time this task is
+            // ready to perform its work. This is likely a bug, as
+            // this worker is only expected to be spawned once the
+            // client is fully ready and the Olm machine is
+            // available.
             tracing::warn!("Skipping startup bundle checks because the Olm machine is unavailable");
             return;
         };
@@ -511,9 +521,10 @@ impl BundleReceiverTask {
             invalid.len(),
         );
 
-        // Iterate over the details that are valid for processing. For each valid
-        // details, check if we have the corresponding key bundle data in the
-        // store. If the data exists, attempt to re-import the bundle.
+        // Iterate over the details that are valid for processing. For each
+        // valid details, check if we have the corresponding key bundle
+        // data in the store. If the data exists, attempt to re-import
+        // the bundle.
         for RoomPendingKeyBundleDetails { room_id, inviter, .. } in valid {
             let Some(room) = client.get_room(room_id) else {
                 // Skip processing if the room is not cached in the state store.
@@ -525,8 +536,9 @@ impl BundleReceiverTask {
                 {
                     Ok(Some(bundle)) => bundle,
                     Ok(None) => {
-                        // If the bundle data is not available, skip processing. The listener task
-                        // will handle this case when the bundle arrives.
+                        // If the bundle data is not available, skip processing.
+                        // The listener task will handle
+                        // this case when the bundle arrives.
                         tracing::trace!(?room_id, "No bundle available, skipping...");
                         continue;
                     }
@@ -541,8 +553,9 @@ impl BundleReceiverTask {
             Self::handle_bundle(&room, &(&bundle).into()).await;
         }
 
-        // For each invalid details, clear the pending key bundle information from the
-        // respective room to avoid re-checking it in the future.
+        // For each invalid details, clear the pending key bundle information
+        // from the respective room to avoid re-checking it in the
+        // future.
         for RoomPendingKeyBundleDetails { room_id, .. } in &invalid {
             tracing::trace!(?room_id, "Clearing pending flag for room");
             if let Err(e) = olm_machine.store().clear_room_pending_key_bundle(room_id).await {
@@ -602,8 +615,8 @@ mod test {
     use super::*;
     use crate::test_utils::logged_in_client;
 
-    // Test that, if backups are not enabled, we don't incorrectly mark a room key
-    // as downloaded.
+    // Test that, if backups are not enabled, we don't incorrectly mark a room
+    // key as downloaded.
     #[async_test]
     async fn test_disabled_backup_does_not_mark_room_key_as_downloaded() {
         let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -228,14 +228,15 @@ impl RetryKind {
     /// if we received an error from a reverse proxy while the Matrix
     /// homeserver is down.
     fn from_status_code(status_code: StatusCode) -> Self {
-        // If the status code is 429, this is requesting a retry in HTTP, without the
-        // custom `errcode`. Treat that as a retriable request with no specified
-        // retry_after delay.
+        // If the status code is 429, this is requesting a retry in HTTP,
+        // without the custom `errcode`. Treat that as a retriable
+        // request with no specified retry_after delay.
         //
-        // All 5xx errors are considered transient, including non-standard ones like
-        // 520 ("web server returned an unknown error", from Cloudflare or another
-        // reverse proxy): they reflect the state of the server at the time of the
-        // request, and the request may well succeed when retried later.
+        // All 5xx errors are considered transient, including non-standard ones
+        // like 520 ("web server returned an unknown error", from
+        // Cloudflare or another reverse proxy): they reflect the state
+        // of the server at the time of the request, and the request may
+        // well succeed when retried later.
         if status_code == StatusCode::TOO_MANY_REQUESTS || status_code.is_server_error() {
             RetryKind::Transient { retry_after: None }
         } else {

--- a/crates/matrix-sdk/src/event_cache/back_pagination_queue.rs
+++ b/crates/matrix-sdk/src/event_cache/back_pagination_queue.rs
@@ -222,8 +222,8 @@ impl BackPaginationQueue {
         let (sender, receiver) = mpsc::unbounded_channel();
 
         // The scheduler holds a sender of its own, to be handed to the runs it
-        // spawns, so the channel never closes on its own: the task runs until the
-        // queue is dropped, which aborts it.
+        // spawns, so the channel never closes on its own: the task runs until
+        // the queue is dropped, which aborts it.
         let task = task_monitor
             .spawn_infinite_task(
                 "event_cache::back_pagination_queue",
@@ -359,17 +359,17 @@ async fn scheduler(
     trace!("Spawning the back-pagination queue executor");
 
     let mut pending_requests: BinaryHeap<PendingRequest> = BinaryHeap::new();
-    // The tasks of the currently running requests, keyed by room: also the set of
-    // rooms that can't take another run right now. Dropping the scheduler aborts
-    // all of them.
+    // The tasks of the currently running requests, keyed by room: also the set
+    // of rooms that can't take another run right now. Dropping the
+    // scheduler aborts all of them.
     let mut active_requests: HashMap<OwnedRoomId, AbortOnDrop<()>> = HashMap::new();
     let mut next_seq: u64 = 0;
 
     // Completion senders for every request the scheduler knows about (queued or
-    // running), keyed by room and priority. A duplicate request coalesces onto the
-    // existing run by adding its completion sender here rather than starting a
-    // second run. When the run finishes every waiter for the key receives the same
-    // result.
+    // running), keyed by room and priority. A duplicate request coalesces onto
+    // the existing run by adding its completion sender here rather than
+    // starting a second run. When the run finishes every waiter for the key
+    // receives the same result.
     let mut waiters: HashMap<RequestCoalescingKey, Vec<oneshot::Sender<BackPaginationRunResult>>> =
         HashMap::new();
 
@@ -378,8 +378,9 @@ async fn scheduler(
     let mut events = Vec::with_capacity(max_concurrent);
 
     loop {
-        // Schedule as many pending requests as the concurrency budget allows, never
-        // starting a second run for a room that's already running one.
+        // Schedule as many pending requests as the concurrency budget allows,
+        // never starting a second run for a room that's already running
+        // one.
         schedule(
             &event_cache,
             &mut pending_requests,
@@ -388,8 +389,8 @@ async fn scheduler(
             &sender,
         );
 
-        // Unreachable while this task holds `sender`, but guards against a hot loop
-        // if that ever stops being true.
+        // Unreachable while this task holds `sender`, but guards against a hot
+        // loop if that ever stops being true.
         if receiver.recv_many(&mut events, max_concurrent).await == 0 {
             info!("Back-pagination queue channel closed, exiting");
             break;
@@ -419,7 +420,8 @@ async fn scheduler(
 
                 SchedulerEvent::Finished(key, result) => {
                     active_requests.remove(&key.0);
-                    // Fan the single run's result out to every coalesced waiter.
+                    // Fan the single run's result out to every coalesced
+                    // waiter.
                     if let Some(senders) = waiters.remove(&key) {
                         for waiter in senders {
                             let _ = waiter.send(result);
@@ -480,8 +482,9 @@ fn schedule(
         let sender = sender.clone();
         let task = spawn(async move {
             let result = run_request(&event_cache, request.request, &request.token).await;
-            // The scheduler owns the completion senders (for coalescing), so hand it the
-            // result to fan out to every waiter for this key.
+            // The scheduler owns the completion senders (for coalescing), so
+            // hand it the result to fan out to every waiter for
+            // this key.
             let _ = sender.send(SchedulerEvent::Finished(key, result));
         });
 
@@ -569,8 +572,9 @@ async fn run_request(
             }
         };
 
-        // Reaching the start of the timeline can still come with a last batch of
-        // events, so let the stop condition see it before ending the run.
+        // Reaching the start of the timeline can still come with a last batch
+        // of events, so let the stop condition see it before ending the
+        // run.
         if (request.stop)(&outcome).is_break() {
             break BackPaginationStopReason::StopConditionMet;
         }
@@ -714,8 +718,8 @@ mod tests {
         assert!(first_token.is_cancelled());
         assert!(second_token.is_cancelled());
 
-        // Once they're all gone the key is stale, so the next caller gets a fresh
-        // token rather than an already-cancelled one.
+        // Once they're all gone the key is stale, so the next caller gets a
+        // fresh token rather than an already-cancelled one.
         let (third_token, _third_guard) = cancellation_for(&cancellations, key);
         assert!(!third_token.is_cancelled());
 

--- a/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/aggregator.rs
@@ -76,7 +76,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
                 | RelationType::Replacement
                 | RelationType::Reference
                 | _ => {
-                    // First, look for the related event in `timeline` backwards.
+                    // First, look for the related event in `timeline`
+                    // backwards.
                     if let Some(thread_root) = match timeline.events[..nth]
                         .iter()
                         .rev()
@@ -108,8 +109,9 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
 
             // No explicit relation, okay, but it can still be related to a thread!
             None => {
-                // We previously found events that are part of a thread, but we didn't see the
-                // thread root yet. And guess what? This might be this event!
+                // We previously found events that are part of a thread, but we
+                // didn't see the thread root yet. And guess
+                // what? This might be this event!
                 if let Some(event_id) = event.event_id()
                     && existing_threads.contains_key(event_id)
                 {
@@ -159,8 +161,8 @@ pub async fn aggregate_timeline_for_threads<'sync, 'state>(
         }
     }
 
-    // We must also look in the `ephemeral` events. Maybe the `timeline` is empty,
-    // but some ephemeral events target specific threads.
+    // We must also look in the `ephemeral` events. Maybe the `timeline` is
+    // empty, but some ephemeral events target specific threads.
     for ephemeral in ephemerals {
         match ephemeral.deserialize() {
             Ok(AnySyncEphemeralRoomEvent::Receipt(SyncReceiptEvent { content, .. })) => {

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -144,13 +144,13 @@ impl EventFocusedCacheState {
 
         let result = self.reload_impl().await?;
 
-        // Empty the updates_as_vector_diffs(), since it's impossible for an observer to
-        // have subscribed to this cache yet, since this code is part of the constructor
-        // flow.
+        // Empty the updates_as_vector_diffs(), since it's impossible for an
+        // observer to have subscribed to this cache yet, since this
+        // code is part of the constructor flow.
         //
-        // If we didn't empty those, such initial updates would be duplicated, since the
-        // subscriber would get the full initial list of events as diffs and as a set of
-        // initial events.
+        // If we didn't empty those, such initial updates would be duplicated,
+        // since the subscriber would get the full initial list of
+        // events as diffs and as a set of initial events.
         let _ = self.chunk.updates_as_vector_diffs();
 
         Ok(result)
@@ -198,8 +198,8 @@ impl EventFocusedCacheState {
                 let mut thread_root =
                     focused_event.and_then(|event| extract_thread_root(event.raw()));
 
-                // If there's no thread root, consider that the focused event itself is the
-                // thread root.
+                // If there's no thread root, consider that the focused event
+                // itself is the thread root.
                 if thread_root.is_none() {
                     thread_root = Some(self.focused_event_id.clone());
                 }
@@ -226,9 +226,9 @@ impl EventFocusedCacheState {
         if let Some(root_id) = thread_root {
             trace!(thread_root = %root_id, "focused event is part of a thread, setting up thread pagination");
 
-            // Check if the thread root is included in the response. Start from the
-            // beginning, since it's more likely to be around there, in that
-            // case.
+            // Check if the thread root is included in the response. Start from
+            // the beginning, since it's more likely to be around
+            // there, in that case.
             let includes_root =
                 result.events.iter().any(|event| event.event_id() == Some(&root_id));
 
@@ -353,7 +353,8 @@ impl EventFocusedCacheState {
 
         // Find the gap at the front (backward pagination token).
         let Some((gap_id, gap)) = self.first_chunk_as_gap() else {
-            // No gap at front means we've already hit the start of the timeline.
+            // No gap at front means we've already hit the start of the
+            // timeline.
             trace!("no front gap found, already at timeline start");
             return Ok(PaginationResult { events: Vec::new(), hit_end_of_timeline: true });
         };
@@ -371,8 +372,8 @@ impl EventFocusedCacheState {
             }
         };
 
-        // Events are in the reverse order, per the API contracts defined in the two
-        // fetch methods.
+        // Events are in the reverse order, per the API contracts defined in the
+        // two fetch methods.
         events.reverse();
 
         let hit_end = new_token.is_none();
@@ -668,10 +669,11 @@ impl EventFocusedCache {
     ) -> Result<()> {
         let mut state = self.inner.write().await?;
 
-        // `Redecryptor` tried to resolve the events partly based on in-store events.
-        // Because this cache doesn't persist anything in the store, `Redecryptor` is
-        // unable to resolve some events present here. To address that, let's try to
-        // resolve events here with the current `EventLinkedChunk`.
+        // `Redecryptor` tried to resolve the events partly based on in-store
+        // events. Because this cache doesn't persist anything in the
+        // store, `Redecryptor` is unable to resolve some events present
+        // here. To address that, let's try to resolve events here with
+        // the current `EventLinkedChunk`.
         let new_resolved_events = resolved_events.try_resolve_events(&state.chunk);
 
         if state.chunk.replace_utds(&new_resolved_events) {

--- a/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_linked_chunk.rs
@@ -111,17 +111,18 @@ impl EventLinkedChunk {
         gap_identifier: ChunkIdentifier,
         events: Vec<Event>,
     ) -> Result<Option<Position>, Error> {
-        // As an optimization, we'll remove the chunk if it's a gap that would be
-        // replaced with no events.
+        // As an optimization, we'll remove the chunk if it's a gap that would
+        // be replaced with no events.
         //
-        // However, our linked chunk requires that it includes at least one chunk in the
-        // in-memory representation. We could tweak this invariant, but in the
-        // meanwhile, don't remove the gap chunk if it's the only one we know
-        // about.
+        // However, our linked chunk requires that it includes at least one
+        // chunk in the in-memory representation. We could tweak this
+        // invariant, but in the meanwhile, don't remove the gap chunk
+        // if it's the only one we know about.
         let has_only_one_chunk = {
             let mut it = self.chunks.chunks();
 
-            // If there's no chunks at all, then we won't be able to find the gap chunk.
+            // If there's no chunks at all, then we won't be able to find the
+            // gap chunk.
             let _ =
                 it.next().ok_or(Error::InvalidChunkIdentifier { identifier: gap_identifier })?;
 
@@ -130,8 +131,8 @@ impl EventLinkedChunk {
         };
 
         let next_pos = if events.is_empty() && !has_only_one_chunk {
-            // There are no new events, so there's no need to create a new empty items
-            // chunk; instead, remove the gap.
+            // There are no new events, so there's no need to create a new empty
+            // items chunk; instead, remove the gap.
             self.chunks.remove_empty_chunk_at(gap_identifier)?
         } else {
             // Replace the gap by new events.
@@ -223,8 +224,8 @@ impl EventLinkedChunk {
         // Sanity check.
         assert_eq!(i, 0);
 
-        // That's the offset in the full linked chunk. Will be 0 if the linked chunk is
-        // entirely loaded, may be non-zero otherwise.
+        // That's the offset in the full linked chunk. Will be 0 if the linked
+        // chunk is entirely loaded, may be non-zero otherwise.
         let offset =
             self.event_order(first_event_pos).expect("first event's ordering must be known");
 
@@ -346,14 +347,14 @@ impl EventLinkedChunk {
             // There is a prior gap, let's replace it with the new events!
             trace!("replacing previous gap with the back-paginated events");
 
-            // Replace the gap with the events we just deduplicated. This might get rid of
-            // the underlying gap, if the conditions are favorable to
-            // us.
+            // Replace the gap with the events we just deduplicated. This might
+            // get rid of the underlying gap, if the conditions are
+            // favorable to us.
             self.replace_gap_at(gap_id, events.to_vec())
                 .expect("gap_identifier is a valid chunk id we read previously")
         } else if let Some(pos) = first_event_pos {
-            // No prior gap, but we had some events: assume we need to prepend events
-            // before those.
+            // No prior gap, but we had some events: assume we need to prepend
+            // events before those.
             trace!("inserted events before the first known event");
 
             self.chunks
@@ -367,15 +368,16 @@ impl EventLinkedChunk {
 
             self.chunks.push_items_back(events.to_vec());
 
-            // A new gap may be inserted before the new events, if there are any.
+            // A new gap may be inserted before the new events, if there are
+            // any.
             self.events().next().map(|(item_pos, _)| item_pos)
         };
 
         // And insert the new gap if needs be.
         //
-        // We only do this when at least one new, non-duplicated event, has been added
-        // to the chunk. Otherwise it means we've back-paginated all the
-        // known events.
+        // We only do this when at least one new, non-duplicated event, has been
+        // added to the chunk. Otherwise it means we've back-paginated
+        // all the known events.
         let has_new_gap = new_gap.is_some();
         if let Some(new_gap) = new_gap {
             if let Some(new_pos) = insert_new_gap_pos {
@@ -387,10 +389,10 @@ impl EventLinkedChunk {
             }
         }
 
-        // There could be an inconsistency between the network (which thinks we hit the
-        // start of the timeline) and the disk (which has the initial empty
-        // chunks), so tweak the `reached_start` value so that it reflects the
-        // disk state in priority instead.
+        // There could be an inconsistency between the network (which thinks we
+        // hit the start of the timeline) and the disk (which has the
+        // initial empty chunks), so tweak the `reached_start` value so
+        // that it reflects the disk state in priority instead.
 
         let has_gaps = self.chunks().any(|chunk| chunk.is_gap());
 
@@ -536,14 +538,15 @@ impl EventLinkedChunk {
     /// reality anymore. This provides a facility to help applying such
     /// updates.
     fn inhibit_updates_to_ordering_tracker<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
-        // Start by flushing previous pending updates to the chunk ordering, if any.
+        // Start by flushing previous pending updates to the chunk ordering, if
+        // any.
         self.order_tracker.flush_updates(false);
 
         // Call the function.
         let r = f(self);
 
-        // Now, flush other pending updates which have been caused by the function, and
-        // ignore them.
+        // Now, flush other pending updates which have been caused by the
+        // function, and ignore them.
         self.order_tracker.flush_updates(true);
 
         r
@@ -562,13 +565,14 @@ impl EventLinkedChunk {
         chunk_identifier_generator: ChunkIdentifierGenerator,
         full_linked_chunk_metadata: Option<Vec<ChunkMetadata>>,
     ) -> Result<(), LazyLoaderError> {
-        // Since `replace_with` is used only to unload some chunks, we don't want it to
-        // affect the chunk ordering.
+        // Since `replace_with` is used only to unload some chunks, we don't
+        // want it to affect the chunk ordering.
         self.inhibit_updates_to_ordering_tracker(move |this| {
             lazy_loader::replace_with(&mut this.chunks, last_chunk, chunk_identifier_generator)?;
 
-            // Don't propagate those updates to the store; this is only for the in-memory
-            // representation that we're doing this. Let's drain those store updates.
+            // Don't propagate those updates to the store; this is only for the
+            // in-memory representation that we're doing this. Let's
+            // drain those store updates.
             let _ = this.store_updates().take();
 
             this.order_tracker = this
@@ -586,8 +590,9 @@ impl EventLinkedChunk {
         &mut self,
         raw_new_first_chunk: RawChunk<Event, Gap>,
     ) -> Result<(), LazyLoaderError> {
-        // This is only used when reinserting a chunk that was in persisted storage, so
-        // we don't need to touch the chunk ordering for this.
+        // This is only used when reinserting a chunk that was in persisted
+        // storage, so we don't need to touch the chunk ordering for
+        // this.
         self.inhibit_updates_to_ordering_tracker(move |this| {
             lazy_loader::insert_new_first_chunk(&mut this.chunks, raw_new_first_chunk)
         })
@@ -956,8 +961,8 @@ mod tests {
             );
         }
 
-        // Let's imagine the `LinkedChunk` has been reset: no last chunk anymore, no
-        // metadata, nothing.
+        // Let's imagine the `LinkedChunk` has been reset: no last chunk
+        // anymore, no metadata, nothing.
         linked_chunk
             .shrink_to_last_reloaded_chunk(None, ChunkIdentifierGenerator::new_from_scratch(), None)
             .unwrap();

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -148,8 +148,8 @@ impl Caches {
             update_sender,
         );
 
-        // If at least one event has been loaded, it means there is a timeline. Let's
-        // emit a generic update.
+        // If at least one event has been loaded, it means there is a timeline.
+        // Let's emit a generic update.
         if timeline_is_not_empty {
             let _ = generic_update_sender
                 .send(room::RoomEventCacheGenericUpdate { room_id: room_id.to_owned() });
@@ -291,9 +291,9 @@ impl Caches {
     pub(super) async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
         let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
-        // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
-        // avoid cloning useless data or to clone as few data as possible. That's a fun
-        // game.
+        // This method will compute a `JoinedRoomUpdate` for each cache. The
+        // game is to avoid cloning useless data or to clone as few data
+        // as possible. That's a fun game.
         let JoinedRoomUpdate {
             // Read receipts are computed by the Event Cache, see [`read_receipts`], we
             // don't need the server value.
@@ -329,8 +329,9 @@ impl Caches {
         // Threads.
         {
             let timeline_for_threads = {
-                // To aggregate the timelines for threads, we need to lookup in the room cache
-                // and the thread caches. We acquire a read lock over all the caches, and select
+                // To aggregate the timelines for threads, we need to lookup in
+                // the room cache and the thread caches. We
+                // acquire a read lock over all the caches, and select
                 // the room cache and thread cache' states.
                 let all_states_lock = states::CacheStateLock::new(
                     states::selectors::AllStatesSelector::new(room.room_id().to_owned()),
@@ -355,7 +356,8 @@ impl Caches {
                     ..Default::default()
                 };
 
-                // Update the thread summary if and only if there are new events.
+                // Update the thread summary if and only if there are new
+                // events.
                 let update_thread_summary = updates.timeline.events.is_empty().not();
 
                 let thread = self.thread(thread_id).await?;
@@ -386,8 +388,9 @@ impl Caches {
 
         // Event-focused.
         {
-            // An event-focused cache isn't listening to live update. Consequently, it is
-            // not interested by this kind of update.
+            // An event-focused cache isn't listening to live update.
+            // Consequently, it is not interested by this kind of
+            // update.
             let _ = event_focused;
         }
 
@@ -398,9 +401,9 @@ impl Caches {
     pub(super) async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
         let Self { room, threads: _, pinned_events, event_focused, internals } = &self;
 
-        // This method will compute a `JoinedRoomUpdate` for each cache. The game is to
-        // avoid cloning useless data or to clone as few data as possible. That's a fun
-        // game.
+        // This method will compute a `JoinedRoomUpdate` for each cache. The
+        // game is to avoid cloning useless data or to clone as few data
+        // as possible. That's a fun game.
         let LeftRoomUpdate {
             // State-events are not stored in the Event Cache.
             state: _,
@@ -428,8 +431,9 @@ impl Caches {
         // Threads.
         {
             let timeline_for_threads = {
-                // To aggregate the timelines for threads, we need to lookup in the room cache
-                // and the thread caches. We acquire a read lock over all the caches, and select
+                // To aggregate the timelines for threads, we need to lookup in
+                // the room cache and the thread caches. We
+                // acquire a read lock over all the caches, and select
                 // the room cache and thread cache' states.
                 let all_caches_states_lock = states::CacheStateLock::new(
                     states::selectors::AllStatesSelector::new(room.room_id().to_owned()),
@@ -471,8 +475,9 @@ impl Caches {
 
         // Event-focused.
         {
-            // An event-focused cache isn't listening to live update. Consequently, it is
-            // not interested by this kind of update.
+            // An event-focused cache isn't listening to live update.
+            // Consequently, it is not interested by this kind of
+            // update.
             let _ = event_focused;
         }
 
@@ -517,16 +522,16 @@ impl Caches {
         event_type: Option<&str>,
         session_id: Option<&str>,
     ) -> Result<impl Iterator<Item = Event>> {
-        // All caches store their events in the store except one. Let's start by looking
-        // inside the store.
+        // All caches store their events in the store except one. Let's start by
+        // looking inside the store.
         let mut events = {
             let state = self.internals.state.read().await?;
 
             state.store.get_room_events(self.room.room_id(), event_type, session_id).await?
         };
 
-        // The only cache to not store its events is the event-focused cache. Its events
-        // only live in memory.
+        // The only cache to not store its events is the event-focused cache.
+        // Its events only live in memory.
         {
             let event_focused = self.event_focused.read().await;
 

--- a/crates/matrix-sdk/src/event_cache/caches/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pagination.rs
@@ -106,9 +106,9 @@ where
     /// Returns `Ok(None)` if the pagination token used during a network
     /// pagination has disappeared from the in-memory linked chunk after
     /// handling the response.
-    // Implementation note: return a future instead of making the function async, so
-    // as to not cause issues because the `cache` field is borrowed across await
-    // points.
+    // Implementation note: return a future instead of making the function
+    // async, so as to not cause issues because the `cache` field is
+    // borrowed across await points.
     fn run_backwards_impl(
         &self,
         batch_size: u16,
@@ -136,8 +136,8 @@ where
             }
 
             SharedPaginationStatus::Paginating { shared_task: shared } => {
-                // There was already a back-pagination request in progress; wait for it to
-                // finish and return its result.
+                // There was already a back-pagination request in progress; wait
+                // for it to finish and return its result.
                 let shared = shared.clone();
                 drop(status_guard);
                 return Either::Right(shared.fut.clone());
@@ -154,8 +154,8 @@ where
         let fut: Pin<Box<dyn SharedPaginationFuture>> = Box::pin(async move {
             match this.paginate_backwards_impl(batch_size).await? {
                 Some(outcome) => {
-                    // Back-pagination's over and successful, don't reset the status to the previous
-                    // value.
+                    // Back-pagination's over and successful, don't reset the
+                    // status to the previous value.
                     reset_status_on_drop_guard.disarm();
 
                     // Notify subscribers that pagination ended.
@@ -208,9 +208,10 @@ where
         &self,
         batch_size: u16,
     ) -> Result<Option<BackPaginationOutcome>> {
-        // A linked chunk might not be entirely loaded (if it's been lazy-loaded). Try
-        // to load from disk/storage first, then from network if disk/storage indicated
-        // there's no previous events chunk to load.
+        // A linked chunk might not be entirely loaded (if it's been
+        // lazy-loaded). Try to load from disk/storage first, then from
+        // network if disk/storage indicated there's no previous events
+        // chunk to load.
 
         loop {
             match self.cache.load_more_events_backwards().await? {
@@ -219,13 +220,14 @@ where
                     waited_for_initial_prev_token,
                 } => {
                     if prev_token.is_none() && !waited_for_initial_prev_token {
-                        // We didn't reload a pagination token, and we haven't waited for one; wait
+                        // We didn't reload a pagination token, and we haven't
+                        // waited for one; wait
                         // and start over.
 
                         const DEFAULT_WAIT_FOR_TOKEN_DURATION: Duration = Duration::from_secs(3);
 
-                        // Otherwise, wait for a notification that we received a previous-batch
-                        // token.
+                        // Otherwise, wait for a notification that we received a
+                        // previous-batch token.
                         trace!("waiting for a pagination token…");
 
                         let _ = timeout(
@@ -240,16 +242,21 @@ where
 
                         // Retry!
                         //
-                        // Note: the next call to `load_more_events_backwards` should not return
-                        // `WaitForInitialPrevToken` because we've just marked we've waited for the
-                        // initial `prev_token`, so this is not an infinite loop.
+                        // Note: the next call to `load_more_events_backwards`
+                        // should not return
+                        // `WaitForInitialPrevToken` because we've just marked
+                        // we've waited for the
+                        // initial `prev_token`, so this is not an infinite
+                        // loop.
                         //
-                        // Note 2: not a recursive call, because recursive and async have a bad time
+                        // Note 2: not a recursive call, because recursive and
+                        // async have a bad time
                         // together.
                         continue;
                     }
 
-                    // We have a gap, so resolve it with a network back-pagination.
+                    // We have a gap, so resolve it with a network
+                    // back-pagination.
                     return self.paginate_backwards_with_network(batch_size, prev_token).await;
                 }
 

--- a/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/pinned_events/mod.rs
@@ -105,7 +105,8 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
     ) -> Result<Vec<VectorDiff<Event>>> {
         match preprocessing {
             ReloadPreprocessing::ForgetAll => {
-                // Clear the `LinkedChunk` and broadcast the updates to the store.
+                // Clear the `LinkedChunk` and broadcast the updates to the
+                // store.
                 self.state.chunk.reset();
                 self.propagate_changes().await?;
             }
@@ -113,8 +114,8 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
             ReloadPreprocessing::None => {}
         }
 
-        // The task will notice there is a desynchronisation and will reload from
-        // network.
+        // The task will notice there is a desynchronisation and will reload
+        // from network.
         self.reload_from_storage().await?;
 
         Ok(self.state.chunk.updates_as_vector_diffs())
@@ -136,15 +137,16 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
         .await?;
 
         if all_duplicates {
-            // If all events are duplicates, we don't need to do anything; ignore
-            // the new events.
+            // If all events are duplicates, we don't need to do anything;
+            // ignore the new events.
             return Ok(());
         }
 
         // Remove the old duplicated events.
         //
-        // We don't have to worry about the removals can change the position of the
-        // existing events, because we are pushing all _new_ `events` at the back.
+        // We don't have to worry about the removals can change the position of
+        // the existing events, because we are pushing all _new_
+        // `events` at the back.
         self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids).await?;
 
         // We've found new relations; append them to the linked chunk.
@@ -245,9 +247,11 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
             &self.room_version_rules.redaction,
         ) {
             // It's safe to cast `redacted_event` here:
-            // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
-            //   when calling .raw(), so it's still one under the hood.
-            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
+            // - either the event was an `AnyTimelineEvent` cast to
+            //   `AnySyncTimelineEvent` when calling .raw(), so it's still one
+            //   under the hood.
+            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this
+            //   case.
             target_event.replace_raw(redacted_event.cast_unchecked());
 
             self.replace_event_at(location, target_event.clone()).await?;
@@ -281,8 +285,8 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
                     .chunk
                     .replace_event_at(position, new_event)
                     .expect("should have been a valid position of an item");
-                // We just changed the in-memory representation; synchronize this with
-                // the store.
+                // We just changed the in-memory representation; synchronize
+                // this with the store.
                 self.propagate_changes().await?;
             }
             EventLocation::Store => {
@@ -322,8 +326,8 @@ impl<'a> StateLockWriteGuard<'a, PinnedEventsCacheState> {
         let (last_chunk, chunk_id_gen) = self.store.load_last_chunk(linked_chunk_id).await?;
 
         let Some(last_chunk) = last_chunk else {
-            // No pinned events stored, make sure the in-memory linked chunk is sync'd (i.e.
-            // empty), and return.
+            // No pinned events stored, make sure the in-memory linked chunk is
+            // sync'd (i.e. empty), and return.
             if self.state.chunk.events().next().is_some() {
                 self.state.chunk.reset();
                 self.notify_subscribers(EventsOrigin::Sync);
@@ -516,8 +520,8 @@ impl PinnedEventsCache {
     ) -> Result<()> {
         let mut state = self.inner.state.write().await?;
 
-        // Drain the updates to the store, events have already been updated before
-        // calling this method.
+        // Drain the updates to the store, events have already been updated
+        // before calling this method.
         let _ = state.state.chunk.store_updates().take();
 
         if state.state.chunk.replace_utds(resolved_events) {
@@ -572,8 +576,8 @@ impl PinnedEventsCache {
                 }
             };
 
-            // Replace the whole linked chunk with those new events, and propagate updates
-            // to the observers.
+            // Replace the whole linked chunk with those new events, and
+            // propagate updates to the observers.
             match inner.state.write().await {
                 Ok(mut guard) => {
                     guard.replace_all_events(events).await.unwrap_or_else(|err| {
@@ -595,7 +599,8 @@ impl PinnedEventsCache {
                     warn!("error when reloading pinned events from storage, at start: {err}");
                 });
 
-                // Compare the initial list of pinned events to the one in the linked chunk.
+                // Compare the initial list of pinned events to the one in the
+                // linked chunk.
                 let actual_pinned_events = room.pinned_event_ids().unwrap_or_default();
                 let reloaded_set =
                     guard.state.current_event_ids().into_iter().collect::<BTreeSet<_>>();
@@ -730,15 +735,16 @@ impl PinnedEventsCache {
         }
 
         if loaded_events.is_empty() {
-            // If the list of loaded events is empty, we ran into an error to load *all* the
-            // pinned events, which needs to be reported to the caller.
+            // If the list of loaded events is empty, we ran into an error to
+            // load *all* the pinned events, which needs to be
+            // reported to the caller.
             return Err(EventCacheError::UnableToLoadPinnedEvents);
         }
 
-        // Since we have all the events and their related events, we can't nicely sort
-        // them, since we've lost all ordering information from using /event or
-        // /relations. Resort to sorting using chronological ordering (oldest ->
-        // newest).
+        // Since we have all the events and their related events, we can't
+        // nicely sort them, since we've lost all ordering information
+        // from using /event or /relations. Resort to sorting using
+        // chronological ordering (oldest -> newest).
         loaded_events.sort_by(compare_pinned_items);
 
         Ok(Some(loaded_events))

--- a/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/read_receipts.rs
@@ -245,9 +245,10 @@ impl ReadReceiptsExt for ReadReceipts {
         let mut counting_receipts = false;
 
         for event in events {
-            // Sliding sync sometimes sends the same event multiple times, so it can be at
-            // the beginning and end of a batch, for instance. In that case, just reset
-            // every time we see the event matching the receipt.
+            // Sliding sync sometimes sends the same event multiple times, so it
+            // can be at the beginning and end of a batch, for
+            // instance. In that case, just reset every time we see
+            // the event matching the receipt.
             if event.event_id() == Some(receipt_event_id) {
                 // Bingo! Switch over to the counting state, after resetting the
                 // previous counts.
@@ -320,7 +321,8 @@ impl<'cache> EventFilter for RoomReadReceiptEventFilter<'cache> {
 
     fn filter(&self, event: &TimelineEvent) -> bool {
         // This type is built from a `RoomEventCacheState`. The room event cache
-        // contains all events, including in-thread events. We need to filter them!
+        // contains all events, including in-thread events. We need to filter
+        // them!
         (self.with_threading_support && extract_thread_root(event.raw()).is_some()).not()
     }
 
@@ -333,8 +335,8 @@ impl<'cache> EventFilter for RoomReadReceiptEventFilter<'cache> {
         user_id: &UserId,
         receipt_type: ReceiptType,
     ) -> Option<(OwnedEventId, Receipt)> {
-        // We want to prioritize an `Unthreaded` receipt over a `Main`-threaded one, for
-        // better compatibility with thread-unaware clients.
+        // We want to prioritize an `Unthreaded` receipt over a `Main`-threaded
+        // one, for better compatibility with thread-unaware clients.
         for receipt_thread in [ReceiptThread::Unthreaded, ReceiptThread::Main] {
             let receipt_event = self
                 .state_store
@@ -384,9 +386,9 @@ impl<'cache> EventFilter for ThreadReadReceiptEventFilter<'cache> {
     }
 
     fn filter(&self, _event: &TimelineEvent) -> bool {
-        // This type is built from a `ThreadEventCacheState`. The thread event cache
-        // contains all in-thread events for this particular thread. No need to filter
-        // them.
+        // This type is built from a `ThreadEventCacheState`. The thread event
+        // cache contains all in-thread events for this particular
+        // thread. No need to filter them.
         true
     }
 
@@ -441,8 +443,8 @@ fn select_best_receipt<T>(
 where
     T: EventFilter,
 {
-    // If we had a new receipt event, add the main/unthreaded receipts it contains
-    // to the pending receipts list. We'll try to chase them later.
+    // If we had a new receipt event, add the main/unthreaded receipts it
+    // contains to the pending receipts list. We'll try to chase them later.
     if let Some(receipt_event) = new_receipt_event {
         for (event_id, receipts) in &receipt_event.0 {
             for ty in ALL_RECEIPT_TYPES {
@@ -459,14 +461,14 @@ where
     }
 
     // This loop folds two actions at once:
-    // - try to find the most recent receipt, by looking at the events in reverse
-    //   order (i.e. from the most recent to the least recent),
-    // - try to match stashed receipts against known events in the linked chunk, so
-    //   as to shrink the stash of pending receipts.
+    // - try to find the most recent receipt, by looking at the events in
+    //   reverse order (i.e. from the most recent to the least recent),
+    // - try to match stashed receipts against known events in the linked chunk,
+    //   so as to shrink the stash of pending receipts.
     //
-    // We can early exit out of this loop, as soon as there's no more work to do,
-    // i.e., we've found a better receipt, *and* there's no more pending receipt
-    // to try to match against events in the linked chunk.
+    // We can early exit out of this loop, as soon as there's no more work to
+    // do, i.e., we've found a better receipt, *and* there's no more pending
+    // receipt to try to match against events in the linked chunk.
 
     let mut receipt = None;
 
@@ -474,9 +476,11 @@ where
         event_filter.filter(event).then_some((event, event.event_id()?))
     }) {
         if receipt.is_none() {
-            // Try to see if the latest active receipt is still the most recent receipt.
+            // Try to see if the latest active receipt is still the most recent
+            // receipt.
             if latest_active == Some(event_id) {
-                // The latest active receipt is still the most recent receipt, so keep it.
+                // The latest active receipt is still the most recent receipt,
+                // so keep it.
                 trace!(active = %event_id, "the latest active receipt is still the most recent; stopping search");
                 receipt = Some(event_id.to_owned());
             }
@@ -488,17 +492,17 @@ where
             }
         }
 
-        // Early exit condition (see the comment above): we've already found a most
-        // recent receipt, and there's no other pending receipts to match against known
-        // events.
+        // Early exit condition (see the comment above): we've already found a
+        // most recent receipt, and there's no other pending receipts to
+        // match against known events.
         if receipt.is_some() && pending_receipts.is_empty() {
             trace!("exiting loop; found a better receipt, and no more pending receipt to match");
             break;
         }
 
-        // Try to match pending receipts to events known in the linked chunk. If we
-        // haven't found any receipt yet, the first matched pending receipt is a better
-        // one!
+        // Try to match pending receipts to events known in the linked chunk. If
+        // we haven't found any receipt yet, the first matched pending
+        // receipt is a better one!
         pending_receipts.retain(|pending| {
             if *pending == event_id {
                 if receipt.is_none() {
@@ -508,11 +512,13 @@ where
                     trace!(%event_id, "discarding a pending receipt that wasn't selected");
                 }
 
-                // Don't keep the pending receipt in the pending list: we've already identified
-                // a better, more recent receipt at this point (found == Some).
+                // Don't keep the pending receipt in the pending list: we've
+                // already identified a better, more recent
+                // receipt at this point (found == Some).
                 false
             } else {
-                // Keep the receipt, in case the associated event shows up later.
+                // Keep the receipt, in case the associated event shows up
+                // later.
                 true
             }
         });
@@ -543,8 +549,9 @@ async fn try_find_stored_receipts<T>(
             if read_receipts.latest_active.is_none() {
                 read_receipts.latest_active = Some(LatestReadReceipt { event_id });
             } else {
-                // This loop has already flagged a read receipt as the new `latest_active`.
-                // Extra read receipts can go to the pending receipts list, as they're lower
+                // This loop has already flagged a read receipt as the new
+                // `latest_active`. Extra read receipts can go
+                // to the pending receipts list, as they're lower
                 // priority, by the implementation notes above.
                 read_receipts.pending.push(event_id);
             }
@@ -570,8 +577,8 @@ pub(crate) async fn compute_unread_counts<T>(
 {
     debug!(?read_receipts, "Starting");
 
-    // If we don't have a latest active receipt for this timeline, try to reload one
-    // from the state store into the `ReadReceipts`.
+    // If we don't have a latest active receipt for this timeline, try to reload
+    // one from the state store into the `ReadReceipts`.
     if read_receipts.latest_active.is_none() {
         try_find_stored_receipts(user_id, event_filter, read_receipts).await;
     }
@@ -586,17 +593,17 @@ pub(crate) async fn compute_unread_counts<T>(
     );
 
     if let Some(event_id) = better_receipt {
-        // We've found the id of an event to which the receipt attaches. The associated
-        // event may either come from the new batch of events associated to
-        // this sync, or it may live in the past timeline events we know
-        // about.
+        // We've found the id of an event to which the receipt attaches. The
+        // associated event may either come from the new batch of events
+        // associated to this sync, or it may live in the past timeline
+        // events we know about.
 
         // First, save the event id as the latest one that has a read receipt.
         trace!(%event_id, "Saving a new active read receipt");
         read_receipts.latest_active = Some(LatestReadReceipt { event_id: event_id.clone() });
 
-        // The event for the receipt is in the linked chunk, so we'll find it and can
-        // count safely from here.
+        // The event for the receipt is in the linked chunk, so we'll find it
+        // and can count safely from here.
         read_receipts.find_and_process_events(
             &event_id,
             user_id,
@@ -609,9 +616,10 @@ pub(crate) async fn compute_unread_counts<T>(
         return;
     }
 
-    // Request a pagination: we haven't found a better receipt, but we haven't even
-    // found the latest active receipt! Hand it the receipt event ids we're chasing
-    // so the backfill can stop as soon as one of them is loaded.
+    // Request a pagination: we haven't found a better receipt, but we haven't
+    // even found the latest active receipt! Hand it the receipt event ids
+    // we're chasing so the backfill can stop as soon as one of them is
+    // loaded.
     if let Some(back_pagination_queue) = back_pagination_queue {
         let targets: HashSet<OwnedEventId> = read_receipts
             .pending
@@ -622,9 +630,9 @@ pub(crate) async fn compute_unread_counts<T>(
         paginate_for_read_receipt(back_pagination_queue, event_filter.room_id(), targets);
     }
 
-    // If we haven't returned at this point, it means we don't have any new "active"
-    // read receipt. So either there was a previous one further in the past, or
-    // none.
+    // If we haven't returned at this point, it means we don't have any new
+    // "active" read receipt. So either there was a previous one further in
+    // the past, or none.
     //
     // In that case, the number of unreads is *at most* the number of processed
     // events. Reset the number of unreads, and recount them all.
@@ -768,7 +776,8 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
-        // An edit to a message from somebody else doesn't mark the room as unread.
+        // An edit to a message from somebody else doesn't mark the room as
+        // unread.
         let ev = EventFactory::new()
             .text_msg("* edited message")
             .edit(
@@ -787,7 +796,8 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
-        // A redact of a message from somebody else doesn't mark the room as unread.
+        // A redact of a message from somebody else doesn't mark the room as
+        // unread.
         let ev = EventFactory::new()
             .redaction(event_id!("$151957878228ssqrj:localhost"))
             .sender(other_user_id)
@@ -802,7 +812,8 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let other_user_id = user_id!("@bob:example.org");
 
-        // A reaction from somebody else to a message doesn't mark the room as unread.
+        // A reaction from somebody else to a message doesn't mark the room as
+        // unread.
         let ev = EventFactory::new()
             .reaction(event_id!("$15275047031IXQRj:localhost"), "👍")
             .sender(other_user_id)
@@ -843,7 +854,8 @@ mod tests {
 
         let user_id = user_id!("@alice:example.org");
 
-        // An interesting event from oneself doesn't count as a new unread message.
+        // An interesting event from oneself doesn't count as a new unread
+        // message.
         let event = make_event(user_id, Vec::new());
         let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id);
@@ -851,7 +863,8 @@ mod tests {
         assert_eq!(receipts.num_mentions, 0);
         assert_eq!(receipts.num_notifications, 0);
 
-        // An interesting event from someone else does count as a new unread message.
+        // An interesting event from someone else does count as a new unread
+        // message.
         let event = make_event(user_id!("@bob:example.org"), Vec::new());
         let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id);
@@ -887,8 +900,8 @@ mod tests {
         assert_eq!(receipts.num_mentions, 1);
         assert_eq!(receipts.num_notifications, 1);
 
-        // Technically this `push_actions` set would be a bug somewhere else, but let's
-        // make sure to resist against it.
+        // Technically this `push_actions` set would be a bug somewhere else,
+        // but let's make sure to resist against it.
         let event = make_event(user_id!("@bob:example.org"), vec![Action::Notify, Action::Notify]);
         let mut receipts = ReadReceipts::default();
         receipts.process_event(&event, user_id);
@@ -902,16 +915,16 @@ mod tests {
         let ev0 = event_id!("$0");
         let user_id = user_id!("@alice:example.org");
 
-        // When provided with no events, we report not finding the event to which the
-        // receipt relates.
+        // When provided with no events, we report not finding the event to
+        // which the receipt relates.
         let mut receipts = ReadReceipts::default();
         assert!(receipts.find_and_process_events(ev0, user_id, [].iter()).not());
         assert_eq!(receipts.num_unread, 0);
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
 
-        // When provided with one event, that's not the receipt event, we don't count
-        // it.
+        // When provided with one event, that's not the receipt event, we don't
+        // count it.
         fn make_event(event_id: &EventId) -> TimelineEvent {
             EventFactory::new()
                 .text_msg("A")
@@ -935,9 +948,9 @@ mod tests {
         assert_eq!(receipts.num_notifications, 13);
         assert_eq!(receipts.num_mentions, 37);
 
-        // When provided with one event that's the receipt target, we find it, reset the
-        // count, and since there's nothing else, we stop there and end up with
-        // zero counts.
+        // When provided with one event that's the receipt target, we find it,
+        // reset the count, and since there's nothing else, we stop
+        // there and end up with zero counts.
         let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
@@ -949,8 +962,8 @@ mod tests {
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
 
-        // When provided with multiple events and not the receipt event, we do not count
-        // anything..
+        // When provided with multiple events and not the receipt event, we do
+        // not count anything..
         let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
@@ -975,8 +988,8 @@ mod tests {
         assert_eq!(receipts.num_notifications, 13);
         assert_eq!(receipts.num_mentions, 37);
 
-        // When provided with multiple events including one that's the receipt event, we
-        // find it and count from it.
+        // When provided with multiple events including one that's the receipt
+        // event, we find it and count from it.
         let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
@@ -1000,7 +1013,8 @@ mod tests {
         assert_eq!(receipts.num_notifications, 0);
         assert_eq!(receipts.num_mentions, 0);
 
-        // Even if duplicates are present in the new events list, the count is correct.
+        // Even if duplicates are present in the new events list, the count is
+        // correct.
         let mut receipts = ReadReceipts {
             num_unread: 42,
             num_notifications: 13,
@@ -1096,7 +1110,8 @@ mod tests {
         let room_id = room_id!("!roomid:example.org");
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
-        // Create a non-empty linked chunk, with no messages sent by the current user.
+        // Create a non-empty linked chunk, with no messages sent by the current
+        // user.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1140,8 +1155,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
         let own_user_id = user_id!("@not_alice:example.org");
 
-        // Create a non-empty linked chunk, with one message sent by the current user,
-        // which will act as an implicit read receipt.
+        // Create a non-empty linked chunk, with one message sent by the current
+        // user, which will act as an implicit read receipt.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1182,7 +1197,8 @@ mod tests {
         let room_id = room_id!("!roomid:example.org");
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
-        // Create a non-empty linked chunk, with no messages sent by the current user.
+        // Create a non-empty linked chunk, with no messages sent by the current
+        // user.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1226,7 +1242,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
         let own_user_id = user_id!("@not_alice:example.org");
 
-        // Create a non-empty linked chunk, with no messages sent by the current user.
+        // Create a non-empty linked chunk, with no messages sent by the current
+        // user.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1254,7 +1271,8 @@ mod tests {
             state_store: &state_store,
         };
 
-        // Then there's a new best receipt, which is the explicit one from the event
+        // Then there's a new best receipt, which is the explicit one from the
+        // event
         let receipt = select_best_receipt(
             own_user_id,
             &linked_chunk,
@@ -1274,7 +1292,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
         let own_user_id = user_id!("@not_alice:example.org");
 
-        // Create a non-empty linked chunk, with no messages sent by the current user.
+        // Create a non-empty linked chunk, with no messages sent by the current
+        // user.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1324,7 +1343,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
         let own_user_id = user_id!("@not_alice:example.org");
 
-        // Create a non-empty linked chunk, with no messages sent by the current user.
+        // Create a non-empty linked chunk, with no messages sent by the current
+        // user.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1349,7 +1369,8 @@ mod tests {
             state_store: &state_store,
         };
 
-        // Then there's a new best receipt, which is the matched pending receipt.
+        // Then there's a new best receipt, which is the matched pending
+        // receipt.
         let receipt = select_best_receipt(
             own_user_id,
             &linked_chunk,
@@ -1369,8 +1390,8 @@ mod tests {
         let f = EventFactory::new().room(room_id).sender(*ALICE);
         let own_user_id = user_id!("@not_alice:example.org");
 
-        // Create a non-empty linked chunk, with one message sent by the current user,
-        // which will act as an implicit read receipt.
+        // Create a non-empty linked chunk, with one message sent by the current
+        // user, which will act as an implicit read receipt.
         let mut linked_chunk = EventLinkedChunk::new();
         linked_chunk.push_events(vec![
             f.text_msg("Event 1").event_id(event_id!("$1")).into_event(),
@@ -1403,8 +1424,8 @@ mod tests {
             state_store: &state_store,
         };
 
-        // Then there's a new best receipt, which is the most advanced in the linked
-        // chunk: $4.
+        // Then there's a new best receipt, which is the most advanced in the
+        // linked chunk: $4.
         let receipt = select_best_receipt(
             own_user_id,
             &linked_chunk,
@@ -1415,8 +1436,8 @@ mod tests {
         );
         assert_eq!(receipt.unwrap(), event_id!("$4"));
 
-        // Receipt 6 is still pending, and there's a new pending receipt for 7 too. ($2
-        // has been cleaned because it has been seen).
+        // Receipt 6 is still pending, and there's a new pending receipt for 7
+        // too. ($2 has been cleaned because it has been seen).
         assert_eq!(pending_receipts.len(), 2);
         assert!(pending_receipts.iter().any(|ev| ev == event_id!("$6")));
         assert!(pending_receipts.iter().any(|ev| ev == event_id!("$7")));

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -356,7 +356,8 @@ impl RoomEventCacheInner {
 
                     handled_read_marker = true;
 
-                    // Propagate to observers. (We ignore the error if there aren't any.)
+                    // Propagate to observers. (We ignore the error if there
+                    // aren't any.)
                     self.update_sender.send(
                         RoomEventCacheUpdate::MoveReadMarkerTo { event_id: ev.content.event_id },
                         None,
@@ -402,8 +403,9 @@ impl RoomEventCacheInner {
         let state = self.state.write().await?;
 
         // Insert the event if the room is not empty, otherwise it can break the
-        // pagination logic when detecting the start of the timeline because no gap can
-        // be inserted properly: it is impossible to compute a `prev_batch` token here.
+        // pagination logic when detecting the start of the timeline because no
+        // gap can be inserted properly: it is impossible to compute a
+        // `prev_batch` token here.
         if state.room_linked_chunk().events().next().is_some() {
             return self
                 .handle_timeline_inner(
@@ -449,8 +451,8 @@ impl RoomEventCacheInner {
             self.pagination_batch_token_notifier.notify_one();
         }
 
-        // The order matters here: first send the timeline event diffs, then only the
-        // related events (read receipts, etc.).
+        // The order matters here: first send the timeline event diffs, then
+        // only the related events (read receipts, etc.).
         if !timeline_event_diffs.is_empty() {
             self.update_sender.send(
                 RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs {
@@ -615,7 +617,8 @@ mod tests {
             // Save the related event.
             state.save_events([related_event]).await.unwrap();
 
-            // Save the associated related event, which redacts the related event.
+            // Save the associated related event, which redacts the related
+            // event.
             state.save_events([associated_related_event]).await.unwrap();
         }
 
@@ -629,7 +632,8 @@ mod tests {
         let cached_event_id = event.event_id().unwrap();
         assert_eq!(cached_event_id, original_id);
 
-        // There's only the edit event (an edit event can't have its own edit event).
+        // There's only the edit event (an edit event can't have its own edit
+        // event).
         assert_eq!(related_events.len(), 1);
 
         let related_event_id = related_events[0].event_id().unwrap();
@@ -686,7 +690,8 @@ mod tests {
             // Save the related event.
             state.save_events([related_event]).await.unwrap();
 
-            // Save the associated related event, which redacts the related event.
+            // Save the associated related event, which redacts the related
+            // event.
             state.save_events([associated_related_event]).await.unwrap();
         }
 
@@ -733,7 +738,8 @@ mod tests {
             // Save the original event.
             state.save_events([original_event]).await.unwrap();
 
-            // Save an unrelated event to check it's not in the related events list.
+            // Save an unrelated event to check it's not in the related events
+            // list.
             let unrelated_id = event_id!("$2");
             state
                 .save_events([event_factory
@@ -1057,7 +1063,8 @@ mod timed_tests {
 
         // But only part of events are loaded from the store
         {
-            // The room must contain only one event because only one chunk has been loaded.
+            // The room must contain only one event because only one chunk has
+            // been loaded.
             assert_eq!(items.len(), 1);
             assert_eq!(items[0].event_id().unwrap(), event_id2);
 
@@ -1195,7 +1202,8 @@ mod timed_tests {
         // Don't forget to subscribe and like.
         event_cache.subscribe().unwrap();
 
-        // Let's check whether the generic updates are received for the initialisation.
+        // Let's check whether the generic updates are received for the
+        // initialisation.
         let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
 
         client.base_client().get_or_create_room(room_id, RoomState::Joined);
@@ -1215,13 +1223,14 @@ mod timed_tests {
 
         let (items, mut stream) = room_event_cache.subscribe().await.unwrap();
 
-        // The initial items contain one event because only the last chunk is loaded by
-        // default.
+        // The initial items contain one event because only the last chunk is
+        // loaded by default.
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].event_id().unwrap(), event_id2);
         assert!(stream.is_empty());
 
-        // The event cache knows only all events though, even if they aren't loaded.
+        // The event cache knows only all events though, even if they aren't
+        // loaded.
         assert!(room_event_cache.find_event(event_id1).await.unwrap().is_some());
         assert!(room_event_cache.find_event(event_id2).await.unwrap().is_some());
 
@@ -1256,14 +1265,15 @@ mod timed_tests {
             .await
             .unwrap();
 
-        // Just checking the generic update is correct. There is a duplicate event, so
-        // no generic changes whatsoever!
+        // Just checking the generic update is correct. There is a duplicate
+        // event, so no generic changes whatsoever!
         assert!(generic_stream.recv().now_or_never().is_none());
 
-        // The stream doesn't report these changes *yet*. Use the items vector given
-        // when subscribing, to check that the items correspond to their new
-        // positions. The duplicated item is removed (so it's not the first
-        // element anymore), and it's added to the back of the list.
+        // The stream doesn't report these changes *yet*. Use the items vector
+        // given when subscribing, to check that the items correspond to
+        // their new positions. The duplicated item is removed (so it's
+        // not the first element anymore), and it's added to the back of
+        // the list.
         let items = room_event_cache.events().await.unwrap();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].event_id().unwrap(), event_id1);
@@ -1328,12 +1338,12 @@ mod timed_tests {
 
         let items = room_event_cache.events().await.unwrap();
 
-        // Because the persisted content was invalid, the room store is reset: there are
-        // no events in the cache.
+        // Because the persisted content was invalid, the room store is reset:
+        // there are no events in the cache.
         assert!(items.is_empty());
 
-        // Storage doesn't contain anything. It would also be valid that it contains a
-        // single initial empty items chunk.
+        // Storage doesn't contain anything. It would also be valid that it
+        // contains a single initial empty items chunk.
         let raw_chunks =
             event_cache_store.load_all_chunks(LinkedChunkId::Room(room_id)).await.unwrap();
         assert!(raw_chunks.is_empty());
@@ -1355,8 +1365,8 @@ mod timed_tests {
 
         let f = EventFactory::new().room(room_id).sender(*ALICE);
 
-        // Propagate an update including a limited timeline with one message and a
-        // prev-batch token.
+        // Propagate an update including a limited timeline with one message and
+        // a prev-batch token.
         room_event_cache
             .handle_joined_room_update(JoinedRoomUpdate {
                 timeline: Timeline {
@@ -1391,8 +1401,8 @@ mod timed_tests {
                 }
             }
 
-            // The limited sync unloads the chunk, so it will appear as if there are only
-            // the events.
+            // The limited sync unloads the chunk, so it will appear as if there
+            // are only the events.
             assert_eq!(num_gaps, 0);
             assert_eq!(num_events, 1);
         }
@@ -1421,8 +1431,8 @@ mod timed_tests {
             assert_eq!(num_events, 1);
         }
 
-        // Now, propagate an update for another message, but the timeline isn't limited
-        // this time.
+        // Now, propagate an update for another message, but the timeline isn't
+        // limited this time.
         room_event_cache
             .handle_joined_room_update(JoinedRoomUpdate {
                 timeline: Timeline {
@@ -1480,7 +1490,8 @@ mod timed_tests {
         let ev1 = f.text_msg("hello world").sender(*ALICE).event_id(evid1).into_event();
         let ev2 = f.text_msg("howdy").sender(*BOB).event_id(evid2).into_event();
 
-        // Fill the event cache store with an initial linked chunk with 2 events chunks.
+        // Fill the event cache store with an initial linked chunk with 2 events
+        // chunks.
         {
             client
                 .event_cache_store()
@@ -1587,8 +1598,8 @@ mod timed_tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_id(), Some(evid2));
 
-        // But if we back-paginate, we don't need access to network to find out about
-        // the previous event.
+        // But if we back-paginate, we don't need access to network to find out
+        // about the previous event.
         let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
         assert_eq!(outcome.events.len(), 1);
         assert_eq!(outcome.events[0].event_id(), Some(evid1));
@@ -1611,7 +1622,8 @@ mod timed_tests {
         let ev2 = f.text_msg("howdy").sender(*BOB).event_id(evid2).into_event();
         let ev3 = f.text_msg("yo").event_id(evid3).into_event();
 
-        // Fill the event cache store with an initial linked chunk with 2 events chunks.
+        // Fill the event cache store with an initial linked chunk with 2 events
+        // chunks.
         {
             client
                 .event_cache_store()
@@ -1654,8 +1666,8 @@ mod timed_tests {
         let room = client.get_room(room_id).unwrap();
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
 
-        // Initially, the linked chunk only contains the last chunk, so only ev3 is
-        // loaded.
+        // Initially, the linked chunk only contains the last chunk, so only ev3
+        // is loaded.
         {
             let state = room_event_cache.inner.state.read().await.unwrap();
             let room_linked_chunk = state.room_linked_chunk();
@@ -1687,8 +1699,8 @@ mod timed_tests {
         let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
         assert!(outcome.reached_start);
 
-        // All events are now loaded, so their order is precisely their enumerated index
-        // in a linear iteration.
+        // All events are now loaded, so their order is precisely their
+        // enumerated index in a linear iteration.
         {
             let state = room_event_cache.inner.state.read().await.unwrap();
             let room_linked_chunk = state.room_linked_chunk();
@@ -1743,8 +1755,8 @@ mod timed_tests {
                 Some(1)
             );
 
-            // ev3 doesn't have an order with its previous position, since it's been
-            // deduplicated.
+            // ev3 doesn't have an order with its previous position, since it's
+            // been deduplicated.
             assert_eq!(
                 room_linked_chunk.event_order(Position::new(ChunkIdentifier::new(1), 0)),
                 None
@@ -1766,7 +1778,8 @@ mod timed_tests {
         let ev1 = f.text_msg("hello world").sender(*ALICE).event_id(evid1).into_event();
         let ev2 = f.text_msg("howdy").sender(*BOB).event_id(evid2).into_event();
 
-        // Fill the event cache store with an initial linked chunk with 2 events chunks.
+        // Fill the event cache store with an initial linked chunk with 2 events
+        // chunks.
         {
             client
                 .event_cache_store()
@@ -1823,8 +1836,8 @@ mod timed_tests {
         assert_eq!(outcome.events[0].event_id(), Some(evid1));
         assert!(outcome.reached_start);
 
-        // We also get an update about the loading from the store. Ignore it, for this
-        // test's sake.
+        // We also get an update about the loading from the store. Ignore it,
+        // for this test's sake.
         assert_let_timeout!(
             Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
                 stream1.recv()
@@ -1843,8 +1856,8 @@ mod timed_tests {
         assert!(generic_stream.is_empty());
 
         // Have another subscriber.
-        // Since it's not the first one, and the previous one loaded some more events,
-        // the second subscribers sees them all.
+        // Since it's not the first one, and the previous one loaded some more
+        // events, the second subscribers sees them all.
         let (events2, stream2) = room_event_cache.subscribe().await.unwrap();
         assert_eq!(events2.len(), 2);
         assert_eq!(events2[0].event_id(), Some(evid1));
@@ -1907,8 +1920,8 @@ mod timed_tests {
         let event_3 =
             event_factory.text_msg("eh!").sender(user_id).event_id(event_id_3).into_event();
 
-        // Fill the event cache store with an initial linked chunk of 2 chunks, and 4
-        // events.
+        // Fill the event cache store with an initial linked chunk of 2 chunks,
+        // and 4 events.
         {
             client
                 .event_cache_store()
@@ -1963,8 +1976,8 @@ mod timed_tests {
             }
         );
 
-        // Look for an event from `ALICE`: it must be `event_2`, right before `event_1`
-        // because events are looked for in reverse order.
+        // Look for an event from `ALICE`: it must be `event_2`, right before
+        // `event_1` because events are looked for in reverse order.
         assert_matches!(
             room_event_cache
                 .rfind_map_event_in_memory_by(|event| {
@@ -2087,8 +2100,9 @@ mod timed_tests {
 
         // Okay. We are ready for the test!
         //
-        // First off, let's check `room_event_cache_p0` has access to the first event
-        // loaded in-memory, then do a pagination, and see more events.
+        // First off, let's check `room_event_cache_p0` has access to the first
+        // event loaded in-memory, then do a pagination, and see more
+        // events.
         let mut updates_stream_p0 = {
             let room_event_cache = &room_event_cache_p0;
 
@@ -2171,9 +2185,9 @@ mod timed_tests {
 
         // Do this a couple times, for the fun.
         for _ in 0..3 {
-            // Third, because `room_event_cache_p1` has locked the store, the lock
-            // is dirty for `room_event_cache_p0`, so it will shrink to its last
-            // chunk!
+            // Third, because `room_event_cache_p1` has locked the store, the
+            // lock is dirty for `room_event_cache_p0`, so it will
+            // shrink to its last chunk!
             {
                 let room_event_cache = &room_event_cache_p0;
                 let updates_stream = &mut updates_stream_p0;
@@ -2181,8 +2195,9 @@ mod timed_tests {
                 // `ev_id_1` must be loaded in memory, just like before.
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
 
-                // However, `ev_id_0` must NOT be loaded in memory. It WAS loaded, but the
-                // state has been reloaded to its last chunk.
+                // However, `ev_id_0` must NOT be loaded in memory. It WAS
+                // loaded, but the state has been reloaded to
+                // its last chunk.
                 assert!(event_loaded(room_event_cache, ev_id_0).await.not());
 
                 // The reload can be observed via the updates too.
@@ -2222,9 +2237,9 @@ mod timed_tests {
                 );
             }
 
-            // Fourth, because `room_event_cache_p0` has locked the store again, the lock
-            // is dirty for `room_event_cache_p1` too!, so it will shrink to its last
-            // chunk!
+            // Fourth, because `room_event_cache_p0` has locked the store again,
+            // the lock is dirty for `room_event_cache_p1` too!, so
+            // it will shrink to its last chunk!
             {
                 let room_event_cache = &room_event_cache_p1;
                 let updates_stream = &mut updates_stream_p1;
@@ -2232,8 +2247,9 @@ mod timed_tests {
                 // `ev_id_1` must be loaded in memory, just like before.
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
 
-                // However, `ev_id_0` must NOT be loaded in memory. It WAS loaded, but the
-                // state has shrunk to its last chunk.
+                // However, `ev_id_0` must NOT be loaded in memory. It WAS
+                // loaded, but the state has shrunk to its last
+                // chunk.
                 assert!(event_loaded(room_event_cache, ev_id_0).await.not());
 
                 // The reload can be observed via the updates too.
@@ -2283,8 +2299,8 @@ mod timed_tests {
 
                 let guard = room_event_cache.inner.state.read().await.unwrap();
 
-                // Guard is kept alive, to ensure we can have multiple read guards alive with a
-                // shared access.
+                // Guard is kept alive, to ensure we can have multiple read
+                // guards alive with a shared access.
                 // See `RoomEventCacheStateLock::read` to learn more.
 
                 // The lock is no longer marked as dirty, it's been cleaned.
@@ -2309,11 +2325,12 @@ mod timed_tests {
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
                 assert!(event_loaded(room_event_cache, ev_id_0).await.not());
 
-                // Ensure `guard` is alive up to this point (in case this test is refactored, I
-                // want to make this super explicit).
+                // Ensure `guard` is alive up to this point (in case this test
+                // is refactored, I want to make this super
+                // explicit).
                 //
-                // We drop need to drop it before the pagination because the pagination needs to
-                // obtain a write lock.
+                // We drop need to drop it before the pagination because the
+                // pagination needs to obtain a write lock.
                 drop(guard);
 
                 room_event_cache.pagination().run_backwards_once(1).await.unwrap();
@@ -2340,8 +2357,8 @@ mod timed_tests {
 
                 let guard = room_event_cache.inner.state.read().await.unwrap();
 
-                // Guard is kept alive, to ensure we can have multiple read guards alive with a
-                // shared access.
+                // Guard is kept alive, to ensure we can have multiple read
+                // guards alive with a shared access.
 
                 // The lock is no longer marked as dirty, it's been cleaned.
                 assert!(guard.is_dirty().not());
@@ -2365,11 +2382,12 @@ mod timed_tests {
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
                 assert!(event_loaded(room_event_cache, ev_id_0).await.not());
 
-                // Ensure `guard` is alive up to this point (in case this test is refactored, I
-                // want to make this super explicit).
+                // Ensure `guard` is alive up to this point (in case this test
+                // is refactored, I want to make this super
+                // explicit).
                 //
-                // We drop need to drop it before the pagination because the pagination needs to
-                // obtain a write lock.
+                // We drop need to drop it before the pagination because the
+                // pagination needs to obtain a write lock.
                 drop(guard);
 
                 room_event_cache.pagination().run_backwards_once(1).await.unwrap();
@@ -2418,8 +2436,8 @@ mod timed_tests {
                     }
                 );
 
-                // Guard isn't kept alive, otherwise `event_loaded` couldn't run because it
-                // needs to obtain a read lock.
+                // Guard isn't kept alive, otherwise `event_loaded` couldn't run
+                // because it needs to obtain a read lock.
                 drop(guard);
 
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
@@ -2468,8 +2486,8 @@ mod timed_tests {
                     }
                 );
 
-                // Guard isn't kept alive, otherwise `event_loaded` couldn't run because it
-                // needs to obtain a read lock.
+                // Guard isn't kept alive, otherwise `event_loaded` couldn't run
+                // because it needs to obtain a read lock.
                 drop(guard);
 
                 assert!(event_loaded(room_event_cache, ev_id_1).await);
@@ -2554,8 +2572,9 @@ mod timed_tests {
         }
 
         // Create the `RoomEventCache` for `room_id_1`. During its creation, the
-        // cross-process lock over the store MUST be dirty, which makes no difference as
-        // a clean one: the state is just loaded, not reloaded.
+        // cross-process lock over the store MUST be dirty, which makes no
+        // difference as a clean one: the state is just loaded, not
+        // reloaded.
         let (room_event_cache_1_p0, _) =
             client_p0.get_room(room_id_1).unwrap().event_cache().await.unwrap();
 

--- a/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/pagination.rs
@@ -162,8 +162,8 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
     async fn load_more_events_backwards(&self) -> Result<LoadMoreEventsBackwardsOutcome> {
         let mut state = self.state.write().await?;
 
-        // If any in-memory chunk is a gap, don't load more events, and let the caller
-        // resolve the gap.
+        // If any in-memory chunk is a gap, don't load more events, and let the
+        // caller resolve the gap.
         if let Some(prev_token) = state.room_linked_chunk().rgap().map(|gap| gap.token) {
             return Ok(LoadMoreEventsBackwardsOutcome::Gap {
                 prev_token: Some(prev_token),
@@ -186,13 +186,15 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
             }
 
             Ok(None) => {
-                // If we never received events for this room, this means we've never received a
-                // sync for that room, because every room must have *at least* a room creation
+                // If we never received events for this room, this means we've
+                // never received a sync for that room, because
+                // every room must have *at least* a room creation
                 // event. Otherwise, we have reached the start of the timeline.
 
                 if state.room_linked_chunk().events().next().is_some() {
-                    // If there's at least one event, this means we've reached the start of the
-                    // timeline, since the chunk is fully loaded.
+                    // If there's at least one event, this means we've reached
+                    // the start of the timeline, since the
+                    // chunk is fully loaded.
                     trace!("chunk is fully loaded and non-empty: reached_start=true");
                     return Ok(LoadMoreEventsBackwardsOutcome::StartOfTimeline);
                 }
@@ -220,11 +222,11 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
 
         let chunk_content = new_first_chunk.content.clone();
 
-        // We've reached the start on disk, if and only if, there was no chunk prior to
-        // the one we just loaded.
+        // We've reached the start on disk, if and only if, there was no chunk
+        // prior to the one we just loaded.
         //
-        // This value is correct, if and only if, it is used for a chunk content of kind
-        // `Items`.
+        // This value is correct, if and only if, it is used for a chunk content
+        // of kind `Items`.
         let reached_start = new_first_chunk.previous.is_none();
 
         if let Err(err) = state.room_linked_chunk_mut().insert_new_chunk_as_first(new_first_chunk) {
@@ -243,8 +245,8 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
             return Err(err.into());
         }
 
-        // ⚠️ Let's not propagate the updates to the store! We already have these data
-        // in the store! Let's drain them.
+        // ⚠️ Let's not propagate the updates to the store! We already have
+        // these data in the store! Let's drain them.
         let _ = state.room_linked_chunk_mut().store_updates().take();
 
         // However, we want to get updates as `VectorDiff`s.
@@ -335,8 +337,8 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
     ) -> Result<Option<BackPaginationOutcome>> {
         let mut state = self.state.write().await?;
 
-        // Check that the previous token still exists; otherwise it's a sign that the
-        // room's timeline has been cleared.
+        // Check that the previous token still exists; otherwise it's a sign
+        // that the room's timeline has been cleared.
         let prev_gap_id = if let Some(token) = prev_token {
             // Find the corresponding gap in the in-memory linked chunk.
             let gap_chunk_id = state.room_linked_chunk().chunk_identifier(|chunk| {
@@ -344,10 +346,12 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
                 });
 
             if gap_chunk_id.is_none() {
-                // We got a previous-batch token from the linked chunk *before* running the
-                // request, but it is missing *after* completing the request.
+                // We got a previous-batch token from the linked chunk *before*
+                // running the request, but it is missing
+                // *after* completing the request.
                 //
-                // It may be a sign the linked chunk has been reset, but it's fine!
+                // It may be a sign the linked chunk has been reset, but it's
+                // fine!
                 return Ok(None);
             }
 
@@ -375,13 +379,14 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
         //
         // Consider the following scenario:
         // - sync returns [D, E, F]
-        // - then sync returns [] with a previous batch token PB1, so the internal
-        //   linked chunk state is [D, E, F, PB1].
+        // - then sync returns [] with a previous batch token PB1, so the
+        //   internal linked chunk state is [D, E, F, PB1].
         // - back-paginating with PB1 may return [A, B, C, D, E, F].
         //
-        // Only inserting the new events when replacing PB1 would result in a timeline
-        // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
-        // all the events, in case this happens (see also #4746).
+        // Only inserting the new events when replacing PB1 would result in a
+        // timeline ordering of [D, E, F, A, B, C], which is incorrect.
+        // So we do have to remove all the events, in case this happens
+        // (see also #4746).
 
         if !all_duplicates {
             // Let's forget all the previous events.
@@ -391,13 +396,13 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
         } else {
             // All new events are duplicated, they can all be ignored.
             events.clear();
-            // The gap can be ditched too, as it won't be useful to backpaginate any
-            // further.
+            // The gap can be ditched too, as it won't be useful to backpaginate
+            // any further.
             new_token = None;
         }
 
-        // `/messages` has been called with `dir=b` (backwards), so the events are in
-        // the inverted order; reorder them.
+        // `/messages` has been called with `dir=b` (backwards), so the events
+        // are in the inverted order; reorder them.
         let topo_ordered_events = events.iter().rev().cloned().collect::<Vec<_>>();
 
         let new_gap = new_token.as_ref().map(|prev_token| Gap { token: prev_token.clone() });
@@ -414,9 +419,9 @@ impl PaginatedCache for Arc<RoomEventCacheInner> {
         // ephemeral events not included in /messages responses, so we can
         // safely set the receipt event to None here.
         //
-        // Note: read receipts may be updated anyhow in the post-processing step, as the
-        // back-pagination may have revealed the event pointed to by the latest read
-        // receipt.
+        // Note: read receipts may be updated anyhow in the post-processing
+        // step, as the back-pagination may have revealed the event
+        // pointed to by the latest read receipt.
         let receipt_event = None;
 
         // Post-process newly inserted events.

--- a/crates/matrix-sdk/src/event_cache/caches/room/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/state.rs
@@ -134,10 +134,12 @@ impl RoomEventCacheState {
     ) -> Result<Self, EventCacheError> {
         let linked_chunk_id = LinkedChunkId::Room(&room_id);
 
-        // Load the full linked chunk's metadata, so as to feed the order tracker.
+        // Load the full linked chunk's metadata, so as to feed the order
+        // tracker.
         //
-        // If loading the full linked chunk failed, we'll clear the event cache, as it
-        // indicates that at some point, there's some malformed data.
+        // If loading the full linked chunk failed, we'll clear the event cache,
+        // as it indicates that at some point, there's some malformed
+        // data.
         let full_linked_chunk_metadata =
             match load_linked_chunk_metadata(&store_guard, linked_chunk_id).await {
                 Ok(metas) => metas,
@@ -296,12 +298,14 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
     ) -> Result<Vec<VectorDiff<Event>>, EventCacheError> {
         match preprocessing {
             ReloadPreprocessing::ForgetAll => {
-                // Clear the `LinkedChunk` and broadcast the updates to the store.
+                // Clear the `LinkedChunk` and broadcast the updates to the
+                // store.
                 self.room_linked_chunk_mut().reset();
                 self.propagate_changes().await?;
 
-                // Reset the pagination state too: pretend we never waited for the initial
-                // prev-batch token, and indicate that we're not at the start of the timeline,
+                // Reset the pagination state too: pretend we never waited for
+                // the initial prev-batch token, and indicate
+                // that we're not at the start of the timeline,
                 // since we don't know about that anymore.
                 *self.waited_for_initial_prev_token_mut() = false;
 
@@ -353,7 +357,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
                 Ok(pair) => pair,
 
                 Err(err) => {
-                    // If loading the last chunk failed, clear the entire linked chunk.
+                    // If loading the last chunk failed, clear the entire linked
+                    // chunk.
                     error!("error when reloading a linked chunk from memory: {err}");
 
                     // Clear storage for this room.
@@ -368,8 +373,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
 
         debug!("unloading the linked chunk, and resetting it to its last chunk");
 
-        // Remove all the chunks from the linked chunks, except for the last one, and
-        // updates the chunk identifier generator.
+        // Remove all the chunks from the linked chunks, except for the last
+        // one, and updates the chunk identifier generator.
         if let Err(err) = self.state.room_linked_chunk.shrink_to_last_reloaded_chunk(
             last_chunk,
             chunk_identifier_generator,
@@ -380,9 +385,10 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             self.state.room_linked_chunk.reset();
             self.propagate_changes().await?;
 
-            // Reset the pagination state too: pretend we never waited for the initial
-            // prev-batch token, and indicate that we're not at the start of the
-            // timeline, since we don't know about that anymore.
+            // Reset the pagination state too: pretend we never waited for the
+            // initial prev-batch token, and indicate that we're not
+            // at the start of the timeline, since we don't know
+            // about that anymore.
             self.state.waited_for_initial_prev_token = false;
 
             // Note: this may cancel an ongoing pagination.
@@ -393,8 +399,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             return Ok(());
         }
 
-        // Let pagination observers know that we may have not reached the start of the
-        // timeline. This may cancel an ongoing pagination.
+        // Let pagination observers know that we may have not reached the start
+        // of the timeline. This may cancel an ongoing pagination.
         self.state
             .pagination_status
             .set(SharedPaginationStatus::Idle { hit_timeline_start: false });
@@ -413,12 +419,13 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         trace!(number_of_subscribers, "received request to auto-shrink");
 
         if number_of_subscribers == 0 {
-            // There is no more subscribers listening to this cache, we can shrink the state
-            // to its last chunk to save memory.
+            // There is no more subscribers listening to this cache, we can
+            // shrink the state to its last chunk to save memory.
             //
-            // In theory, between the condition (`… == 0`) and this instruction, a new
-            // subscriber could be created, creating a race, except that this method takes a
-            // `&mut`, ensuring an exclusive access to the state, ensuring no other
+            // In theory, between the condition (`… == 0`) and this instruction,
+            // a new subscriber could be created, creating a race,
+            // except that this method takes a `&mut`, ensuring an
+            // exclusive access to the state, ensuring no other
             // subscribers can be created.
             self.shrink_to_last_reloaded_chunk().await?;
 
@@ -535,18 +542,19 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         )
         .await?;
 
-        // If the timeline isn't limited, and we already knew about some past events,
-        // then this definitely knows what the timeline head is (either we know
-        // about all the events persisted in storage, or we have a gap
-        // somewhere). In this case, we can ditch the previous-batch
-        // token, which is an optimization to avoid unnecessary future back-pagination
-        // requests.
+        // If the timeline isn't limited, and we already knew about some past
+        // events, then this definitely knows what the timeline head is
+        // (either we know about all the events persisted in storage, or
+        // we have a gap somewhere). In this case, we can ditch the
+        // previous-batch token, which is an optimization to avoid
+        // unnecessary future back-pagination requests.
         //
-        // We can also ditch it if we knew about all the events that came from sync,
-        // namely, they were all deduplicated. In this case, using the
-        // previous-batch token would only result in fetching other events we
-        // knew about. This is slightly incorrect in the presence of
-        // network splits, but this has shown to be Good Enough™.
+        // We can also ditch it if we knew about all the events that came from
+        // sync, namely, they were all deduplicated. In this case, using
+        // the previous-batch token would only result in fetching other
+        // events we knew about. This is slightly incorrect in the
+        // presence of network splits, but this has shown to be Good
+        // Enough™.
         if !timeline.limited && self.state.room_linked_chunk.events().next().is_some()
             || all_duplicates
         {
@@ -554,11 +562,11 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         }
 
         if all_duplicates {
-            // No new events and no gap (per the previous check), thus no need to change the
-            // room state. We're done!
+            // No new events and no gap (per the previous check), thus no need
+            // to change the room state. We're done!
             //
-            // We might have a new read receipt, though! If that's the case, handle it for
-            // unread counts tracking.
+            // We might have a new read receipt, though! If that's the case,
+            // handle it for unread counts tracking.
             //
             // Post-process the ephemeral events.
             self.post_process_upserted_events(empty(), extract_read_receipt(ephemeral_events))
@@ -569,16 +577,18 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
 
         let has_new_gap = prev_batch_token.is_some();
 
-        // If we've never waited for an initial previous-batch token, and we've now
-        // inserted a gap, no need to wait for a previous-batch token later.
+        // If we've never waited for an initial previous-batch token, and we've
+        // now inserted a gap, no need to wait for a previous-batch
+        // token later.
         if !self.state.waited_for_initial_prev_token && has_new_gap {
             self.state.waited_for_initial_prev_token = true;
         }
 
         // Remove the old duplicated events.
         //
-        // We don't have to worry the removals can change the position of the existing
-        // events, because we are pushing all _new_ `events` at the back.
+        // We don't have to worry the removals can change the position of the
+        // existing events, because we are pushing all _new_ `events` at
+        // the back.
         self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids).await?;
 
         self.state.room_linked_chunk.push_live_events(
@@ -594,9 +604,10 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             .await?;
 
         if timeline.limited && has_new_gap {
-            // If there was a previous batch token for a limited timeline, unload the chunks
-            // so it only contains the last one; otherwise, there might be a
-            // valid gap in between, and observers may not render it (yet).
+            // If there was a previous batch token for a limited timeline,
+            // unload the chunks so it only contains the last one;
+            // otherwise, there might be a valid gap in between, and
+            // observers may not render it (yet).
             //
             // We must do this *after* persisting these events to storage.
             self.shrink_to_last_reloaded_chunk().await?;
@@ -662,9 +673,10 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         .await;
 
         if prev_read_receipts != read_receipts {
-            // The read receipt has changed! Do a little dance to update the `RoomInfo` in
-            // the state store, and then in the room itself, so that observers
-            // can be notified of the change.
+            // The read receipt has changed! Do a little dance to update the
+            // `RoomInfo` in the state store, and then in the room
+            // itself, so that observers can be notified of the
+            // change.
             let result = room
                 .update_and_save_room_info(|mut room_info| {
                     room_info.set_read_receipts(read_receipts);
@@ -717,8 +729,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
                     .room_linked_chunk
                     .replace_event_at(position, event)
                     .expect("should have been a valid position of an item");
-                // We just changed the in-memory representation; synchronize this with
-                // the store.
+                // We just changed the in-memory representation; synchronize
+                // this with the store.
                 self.propagate_changes().await?;
             }
             EventLocation::Store => {
@@ -762,9 +774,11 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
             &self.room_version_rules.redaction,
         ) {
             // It's safe to cast `redacted_event` here:
-            // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
-            //   when calling .raw(), so it's still one under the hood.
-            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
+            // - either the event was an `AnyTimelineEvent` cast to
+            //   `AnySyncTimelineEvent` when calling .raw(), so it's still one
+            //   under the hood.
+            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this
+            //   case.
             target_event.replace_raw(redacted_event.cast_unchecked());
 
             self.replace_event_at(location, target_event.clone()).await?;
@@ -783,8 +797,8 @@ impl<'a> StateLockWriteGuard<'a, RoomEventCacheState> {
         resolved_events: &[MaybeResolvedEvent],
     ) -> Result<Option<Vec<VectorDiff<Event>>>, EventCacheError> {
         Ok(if self.room_linked_chunk_mut().replace_utds(resolved_events) {
-            // Drain the updates to the store, events have already been updated with
-            // `save_events`!
+            // Drain the updates to the store, events have already been updated
+            // with `save_events`!
             let _ = self.room_linked_chunk_mut().store_updates().take();
 
             self.post_process_upserted_events(

--- a/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/subscriber.rs
@@ -128,12 +128,13 @@ impl<T> Drop for Subscriber<T> {
         trace!("dropping a room event cache subscriber; count: {number_of_subscribers}");
 
         if number_of_subscribers == 1 {
-            // We were the last instance of the subscriber; let the auto-shrinker know by
-            // notifying it.
+            // We were the last instance of the subscriber; let the
+            // auto-shrinker know by notifying it.
 
-            // Try to send without waiting for channel capacity, and restart in a loop if it
-            // failed (until a maximum number of attempts is reached, or the send was
-            // successful). The channel shouldn't be super busy in general, so this should
+            // Try to send without waiting for channel capacity, and restart in
+            // a loop if it failed (until a maximum number of
+            // attempts is reached, or the send was successful). The
+            // channel shouldn't be super busy in general, so this should
             // resolve quickly enough.
 
             let mut message = self
@@ -146,8 +147,9 @@ impl<T> Drop for Subscriber<T> {
                 num_attempts += 1;
 
                 if num_attempts > 1024 {
-                    // If we've tried too many times, just give up with a warning; after all, this
-                    // is only an optimization.
+                    // If we've tried too many times, just give up with a
+                    // warning; after all, this is only an
+                    // optimization.
                     warn!(
                         "couldn't send notification to the auto-shrink channel \
                          after 1024 attempts; giving up"
@@ -332,13 +334,13 @@ mod tests {
             &subscribers_handle,
         );
 
-        // Drop the last subscriber. Side-effect should… take effect, but (!) the
-        // channel is full, so it's going to retry many times and will fail, resulting
-        // in no side-effect.
+        // Drop the last subscriber. Side-effect should… take effect, but (!)
+        // the channel is full, so it's going to retry many times and
+        // will fail, resulting in no side-effect.
         drop(subscriber);
 
-        // We receive the noisy message: **not** the message from the subscriber under
-        // testing.
+        // We receive the noisy message: **not** the message from the subscriber
+        // under testing.
         assert_matches!(
             auto_shrink_receiver.try_recv().unwrap(),
             AutoShrinkMessage::Room { room_id: expected_room_id } => {
@@ -346,7 +348,8 @@ mod tests {
             }
         );
 
-        // Then, we receive nothing, i.e. `subscriber` dropped without any side-effect.
+        // Then, we receive nothing, i.e. `subscriber` dropped without any
+        // side-effect.
         assert!(auto_shrink_receiver.is_empty());
     }
 
@@ -368,9 +371,9 @@ mod tests {
         // Close the `auto_shrink` channel.
         drop(auto_shrink_receiver);
 
-        // Drop the last subscriber. Side-effect should… take effect, but (!) the
-        // channel is closed, so it's going to stop immediately, resulting in no
-        // side-effect.
+        // Drop the last subscriber. Side-effect should… take effect, but (!)
+        // the channel is closed, so it's going to stop immediately,
+        // resulting in no side-effect.
         drop(subscriber);
 
         // Sadly, nothing to assert because we are now blind, but at least the

--- a/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/mod.rs
@@ -140,8 +140,8 @@ impl ThreadEventCache {
             }),
         };
 
-        // If at least one event has been loaded, it means there is a timeline. Let's
-        // emit a generic update.
+        // If at least one event has been loaded, it means there is a timeline.
+        // Let's emit a generic update.
         if timeline_is_not_empty {
             let _ = generic_update_sender
                 .send(RoomEventCacheGenericUpdate { room_id: room_id.to_owned() });
@@ -337,8 +337,8 @@ impl ThreadEventCache {
         let mut state = self.inner.state.write().await?;
         let timeline_event_diffs = state.replace_in_memory_utds(resolved_events)?;
 
-        // Drain the updates to the store, events have already been updated before
-        // calling this method.
+        // Drain the updates to the store, events have already been updated
+        // before calling this method.
         let _ = state.thread_linked_chunk_mut().store_updates().take();
 
         state
@@ -687,8 +687,8 @@ mod timed_tests {
 
         // But only part of events are loaded from the store.
         {
-            // The thread must contain only one event because only one chunk has been
-            // loaded.
+            // The thread must contain only one event because only one chunk has
+            // been loaded.
             assert_eq!(thread_events.len(), 1);
             assert_eq!(thread_events[0].event_id().unwrap(), thread_event_id_1);
 
@@ -749,8 +749,8 @@ mod timed_tests {
         );
         assert!(generic_stream.is_empty());
 
-        // Events individually are forgotten by the event cache, after clearing the
-        // threads.
+        // Events individually are forgotten by the event cache, after clearing
+        // the threads.
         assert!(thread_event_cache.find_event(thread_event_id_0).await.unwrap().is_none());
         assert!(thread_event_cache.find_event(thread_event_id_1).await.unwrap().is_none());
 
@@ -790,9 +790,9 @@ mod timed_tests {
             .in_thread(thread_root, thread_event_id_1)
             .into_event();
 
-        // Prefill the store with some data. The room usually has all events duplicated
-        // from the threads. It's important to make the test pass when checking the
-        // generic update.
+        // Prefill the store with some data. The room usually has all events
+        // duplicated from the threads. It's important to make the test
+        // pass when checking the generic update.
         let updates = vec![
             // An empty items chunk.
             Update::NewItemsChunk { previous: None, new: ChunkIdentifier::new(0), next: None },
@@ -851,14 +851,15 @@ mod timed_tests {
 
         client.base_client().get_or_create_room(room_id, RoomState::Joined);
 
-        // Let's check whether the generic updates are received for the initialisation.
+        // Let's check whether the generic updates are received for the
+        // initialisation.
         let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
         let (thread_event_cache, _drop_handles) =
             event_cache.thread(room_id, thread_root).await.unwrap();
         let (thread_events, mut thread_stream) = thread_event_cache.subscribe().await.unwrap();
 
-        // The room **and** the thread have been loaded. Two generic updates must have
-        // been triggered.
+        // The room **and** the thread have been loaded. Two generic updates
+        // must have been triggered.
         for _ in 0..2 {
             assert_matches!(
                 generic_stream.recv().await,
@@ -869,14 +870,14 @@ mod timed_tests {
         }
         assert!(generic_stream.is_empty());
 
-        // The initial events contain one event because only the last chunk is loaded by
-        // default.
+        // The initial events contain one event because only the last chunk is
+        // loaded by default.
         assert_eq!(thread_events.len(), 1);
         assert_eq!(thread_events[0].event_id().unwrap(), thread_event_id_1);
         assert!(thread_stream.is_empty());
 
-        // The thread knows all events in the storage though, even if they aren't
-        // loaded.
+        // The thread knows all events in the storage though, even if they
+        // aren't loaded.
         assert!(thread_event_cache.find_event(thread_event_id_0).await.unwrap().is_some());
         assert!(thread_event_cache.find_event(thread_event_id_1).await.unwrap().is_some());
 
@@ -911,14 +912,15 @@ mod timed_tests {
             .await
             .unwrap();
 
-        // Just checking the generic update is correct. There is a duplicate event, so
-        // no generic changes whatsoever!
+        // Just checking the generic update is correct. There is a duplicate
+        // event, so no generic changes whatsoever!
         assert!(generic_stream.recv().now_or_never().is_none());
 
-        // The stream doesn't report these changes *yet*. Use the events vector given
-        // when subscribing, to check that the events correspond to their new
-        // positions. The duplicated item is removed (so it's not the first
-        // element anymore), and it's added to the back of the list.
+        // The stream doesn't report these changes *yet*. Use the events vector
+        // given when subscribing, to check that the events correspond
+        // to their new positions. The duplicated item is removed (so
+        // it's not the first element anymore), and it's added to the
+        // back of the list.
         let (thread_events, _) = thread_event_cache.subscribe().await.unwrap();
         assert_eq!(thread_events.len(), 2);
         assert_eq!(thread_events[0].event_id(), Some(thread_event_id_0));
@@ -990,8 +992,8 @@ mod timed_tests {
         // there are no events in the cache.
         assert!(thread_events.is_empty());
 
-        // Storage doesn't contain anything. It would also be valid that it contains a
-        // single initial empty items chunk.
+        // Storage doesn't contain anything. It would also be valid that it
+        // contains a single initial empty items chunk.
         let raw_chunks = event_cache_store
             .load_all_chunks(LinkedChunkId::Thread(room_id, thread_root))
             .await
@@ -1105,8 +1107,9 @@ mod timed_tests {
 
         // Okay. We are ready for the test!
         //
-        // First off, let's check `thread_event_cache_p0` has access to the first event
-        // loaded in-memory, then do a pagination, and see more events.
+        // First off, let's check `thread_event_cache_p0` has access to the
+        // first event loaded in-memory, then do a pagination, and see
+        // more events.
         let mut updates_stream_p0 = {
             let thread_event_cache = &thread_event_cache_p0;
 
@@ -1171,15 +1174,16 @@ mod timed_tests {
 
         // Do this a couple times, for the fun.
         for _ in 0..3 {
-            // Third, because `thread_event_cache_p1` has locked the store, the lock
-            // is dirty for `thread_event_cache_p0`, so it will shrink to its last
-            // chunk for the thread!
+            // Third, because `thread_event_cache_p1` has locked the store, the
+            // lock is dirty for `thread_event_cache_p0`, so it will
+            // shrink to its last chunk for the thread!
             {
                 let thread_event_cache = &thread_event_cache_p0;
                 let updates_stream = &mut updates_stream_p0;
 
-                // `thread_event_id_1` must be loaded in memory, just like before.
-                // However, `thread_event_id_0` must NOT be loaded in memory. It WAS loaded, but
+                // `thread_event_id_1` must be loaded in memory, just like
+                // before. However, `thread_event_id_0` must NOT
+                // be loaded in memory. It WAS loaded, but
                 // the state has been reloaded to its last chunk.
                 let (initial_updates, _) = thread_event_cache.subscribe().await.unwrap();
 
@@ -1221,15 +1225,17 @@ mod timed_tests {
                 );
             }
 
-            // Fourth, because `thread_event_cache_p0` has locked the store again, the lock
-            // is dirty for `thread_event_cache_p1` too!, so it will shrink to its last
-            // chunk for the thread!
+            // Fourth, because `thread_event_cache_p0` has locked the store
+            // again, the lock is dirty for `thread_event_cache_p1`
+            // too!, so it will shrink to its last chunk for the
+            // thread!
             {
                 let thread_event_cache = &thread_event_cache_p1;
                 let updates_stream = &mut updates_stream_p1;
 
-                // `thread_event_id_1` must be loaded in memory, just like before.
-                // However, `thread_event_id_0` must NOT be loaded in memory. It WAS loaded, but
+                // `thread_event_id_1` must be loaded in memory, just like
+                // before. However, `thread_event_id_0` must NOT
+                // be loaded in memory. It WAS loaded, but
                 // the state has shrunk to its last chunk.
                 let (initial_updates, _) = thread_event_cache.subscribe().await.unwrap();
 
@@ -1292,7 +1298,8 @@ mod timed_tests {
         let event_1 =
             f.text_msg("world").event_id(event_id_1).in_thread(thread_id, event_id_1).into_event();
 
-        // Fill the event cache store with an initial linked chunk with 2 events chunks.
+        // Fill the event cache store with an initial linked chunk with 2 events
+        // chunks.
         {
             client
                 .event_cache_store()
@@ -1351,8 +1358,8 @@ mod timed_tests {
         assert_eq!(outcome.events[1].event_id(), Some(thread_id));
         assert!(outcome.reached_start);
 
-        // We also get an update about the loading from the store. Ignore it, for this
-        // test's sake.
+        // We also get an update about the loading from the store. Ignore it,
+        // for this test's sake.
         assert_let_timeout!(Ok(TimelineVectorDiffs { diffs, .. }) = stream1.recv());
         assert_eq!(diffs.len(), 2);
         assert_matches!(&diffs[0], VectorDiff::Insert { index: 0, value } => {
@@ -1371,8 +1378,8 @@ mod timed_tests {
         assert!(generic_stream.is_empty());
 
         // Have another subscriber.
-        // Since it's not the first one, and the previous one loaded some more events,
-        // the second subscribers sees them all.
+        // Since it's not the first one, and the previous one loaded some more
+        // events, the second subscribers sees them all.
         let (events2, stream2) = thread_event_cache.subscribe().await.unwrap();
         assert_eq!(events2.len(), 3);
         assert_eq!(events2[0].event_id(), Some(thread_id));

--- a/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/pagination.rs
@@ -101,8 +101,8 @@ impl PaginatedCache for ThreadEventCacheWrapper {
     async fn load_more_events_backwards(&self) -> Result<LoadMoreEventsBackwardsOutcome> {
         let mut state = self.cache.state.write().await?;
 
-        // If any in-memory chunk is a gap, don't load more events, and let the caller
-        // resolve the gap.
+        // If any in-memory chunk is a gap, don't load more events, and let the
+        // caller resolve the gap.
         if let Some(prev_token) = state.thread_linked_chunk().rgap().map(|gap| gap.token) {
             trace!(%prev_token, "thread chunk has at least a gap");
 
@@ -114,8 +114,9 @@ impl PaginatedCache for ThreadEventCacheWrapper {
 
         let prev_first_chunk = state.thread_linked_chunk().first_chunk();
 
-        // If we are here, it means all gaps have been resolved (see the `if` block
-        // above). So the first chunk is not a gap, we can load its previous chunk.
+        // If we are here, it means all gaps have been resolved (see the `if`
+        // block above). So the first chunk is not a gap, we can load
+        // its previous chunk.
         let linked_chunk_id = LinkedChunkId::Thread(&state.room_id, &state.thread_id);
         let new_first_chunk = match state
             .store
@@ -130,8 +131,9 @@ impl PaginatedCache for ThreadEventCacheWrapper {
             Ok(None) => {
                 // No previous chunk in the store.
                 //
-                // If the first in-memory event is the thread root, it's all good, we have
-                // effectively reached the start of the thread.
+                // If the first in-memory event is the thread root, it's all
+                // good, we have effectively reached the start
+                // of the thread.
                 if let Some((_pos, first_event)) = state.thread_linked_chunk().events().next()
                     && self.cache.thread_id
                         == first_event.event_id().expect("Stored events all have an ID")
@@ -164,11 +166,11 @@ impl PaginatedCache for ThreadEventCacheWrapper {
 
         let chunk_content = new_first_chunk.content.clone();
 
-        // We've reached the start on disk, if and only if, there was no chunk prior to
-        // the one we just loaded.
+        // We've reached the start on disk, if and only if, there was no chunk
+        // prior to the one we just loaded.
         //
-        // This value is correct, if and only if, it is used for a chunk content of kind
-        // `Items`.
+        // This value is correct, if and only if, it is used for a chunk content
+        // of kind `Items`.
         let reached_start = new_first_chunk.previous.is_none();
 
         if let Err(err) = state.thread_linked_chunk_mut().insert_new_chunk_as_first(new_first_chunk)
@@ -188,8 +190,8 @@ impl PaginatedCache for ThreadEventCacheWrapper {
             return Err(err.into());
         }
 
-        // ⚠️ Let's not propagate the updates to the store! We already have these data
-        // in the store! Let's drain them.
+        // ⚠️ Let's not propagate the updates to the store! We already have
+        // these data in the store! Let's drain them.
         let _ = state.thread_linked_chunk_mut().store_updates().take();
 
         // However, we want to get updates as `VectorDiff`s.
@@ -286,11 +288,13 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         };
 
         // The thread root event is **NOT** part of the `/relations` response.
-        // However, we want the thread root event to be part of the thread itself. It's
-        // easier in a lot of situations. Let's load it if necessary.
+        // However, we want the thread root event to be part of the thread
+        // itself. It's easier in a lot of situations. Let's load it if
+        // necessary.
         //
-        // It is necessary to load the thread root event when `new_token` is `None`,
-        // i.e. when we've reached the start of the thread usually.
+        // It is necessary to load the thread root event when `new_token` is
+        // `None`, i.e. when we've reached the start of the thread
+        // usually.
         //
         // We must do this dance before acquiring the state lock because
         // `Room::load_or_fetch_event` is hitting the state lock too.
@@ -304,8 +308,8 @@ impl PaginatedCache for ThreadEventCacheWrapper {
 
         let mut state = self.cache.state.write().await?;
 
-        // Check that the previous token still exists; otherwise it's a sign that the
-        // thread's timeline has been cleared.
+        // Check that the previous token still exists; otherwise it's a sign
+        // that the thread's timeline has been cleared.
         let prev_gap_id = if let Some(token) = prev_token {
             // Find the corresponding gap in the in-memory linked chunk.
             let gap_chunk_id = state.thread_linked_chunk().chunk_identifier(|chunk| {
@@ -313,10 +317,12 @@ impl PaginatedCache for ThreadEventCacheWrapper {
                 });
 
             if gap_chunk_id.is_none() {
-                // We got a previous-batch token from the linked chunk *before* running the
-                // request, but it is missing *after* completing the request.
+                // We got a previous-batch token from the linked chunk *before*
+                // running the request, but it is missing
+                // *after* completing the request.
                 //
-                // It may be a sign the linked chunk has been reset, but it's fine!
+                // It may be a sign the linked chunk has been reset, but it's
+                // fine!
                 return Ok(None);
             }
 
@@ -344,13 +350,14 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         //
         // Consider the following scenario:
         // - sync returns [D, E, F]
-        // - then sync returns [] with a previous batch token PB1, so the internal
-        //   linked chunk state is [D, E, F, PB1].
+        // - then sync returns [] with a previous batch token PB1, so the
+        //   internal linked chunk state is [D, E, F, PB1].
         // - back-paginating with PB1 may return [A, B, C, D, E, F].
         //
-        // Only inserting the new events when replacing PB1 would result in a timeline
-        // ordering of [D, E, F, A, B, C], which is incorrect. So we do have to remove
-        // all the events, in case this happens (see also #4746).
+        // Only inserting the new events when replacing PB1 would result in a
+        // timeline ordering of [D, E, F, A, B, C], which is incorrect.
+        // So we do have to remove all the events, in case this happens
+        // (see also #4746).
 
         if !all_duplicates {
             // Let's forget all the previous events.
@@ -360,13 +367,13 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         } else {
             // All new events are duplicated, they can all be ignored.
             events.clear();
-            // The gap can be ditched too, as it won't be useful to backpaginate any
-            // further.
+            // The gap can be ditched too, as it won't be useful to backpaginate
+            // any further.
             new_token = None;
         }
 
-        // `/relations` has been called with `dir=b` (backwards), so the events are in
-        // the inverted order; reorder them.
+        // `/relations` has been called with `dir=b` (backwards), so the events
+        // are in the inverted order; reorder them.
         let topo_ordered_events = events.iter().rev().cloned().collect::<Vec<_>>();
 
         let new_gap = new_token.map(|prev_token| Gap { token: prev_token });
@@ -383,9 +390,9 @@ impl PaginatedCache for ThreadEventCacheWrapper {
         // ephemeral events not included in /relations responses, so we can
         // safely set the receipt event to None here.
         //
-        // Note: read receipts may be updated anyhow in the post-processing step, as the
-        // back-pagination may have revealed the event pointed to by the latest read
-        // receipt.
+        // Note: read receipts may be updated anyhow in the post-processing
+        // step, as the back-pagination may have revealed the event
+        // pointed to by the latest read receipt.
         let receipt_event = None;
 
         // Post-process newly inserted events.

--- a/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/thread/state.rs
@@ -132,14 +132,16 @@ impl ThreadEventCacheState {
 
         // Load the thread info.
         //
-        // It will register the thread in the list of threads. It does nothing regarding
-        // events or linked chunks.
+        // It will register the thread in the list of threads. It does nothing
+        // regarding events or linked chunks.
         let thread_info = store_guard.load_thread_info(&room_id, &thread_id).await?;
 
-        // Load the full linked chunk's metadata, so as to feed the order tracker.
+        // Load the full linked chunk's metadata, so as to feed the order
+        // tracker.
         //
-        // If loading the full linked chunk failed, we'll clear the event cache, as it
-        // indicates that at some point, there's some malformed data.
+        // If loading the full linked chunk failed, we'll clear the event cache,
+        // as it indicates that at some point, there's some malformed
+        // data.
         let full_linked_chunk_metadata =
             match load_linked_chunk_metadata(&store_guard, linked_chunk_id).await {
                 Ok(metas) => metas,
@@ -230,7 +232,8 @@ impl ThreadEventCacheState {
                 Ok(pair) => pair,
 
                 Err(err) => {
-                    // If loading the last chunk failed, clear the entire linked chunk.
+                    // If loading the last chunk failed, clear the entire linked
+                    // chunk.
                     error!("error when reloading a linked chunk from memory: {err}");
 
                     // Clear storage for this thread.
@@ -243,8 +246,8 @@ impl ThreadEventCacheState {
 
         debug!("unloading the linked chunk, and resetting it to its last chunk");
 
-        // Remove all the chunks from the linked chunks, except for the last one, and
-        // updates the chunk identifier generator.
+        // Remove all the chunks from the linked chunks, except for the last
+        // one, and updates the chunk identifier generator.
         if let Err(err) = self.thread_linked_chunk.shrink_to_last_reloaded_chunk(
             last_chunk,
             chunk_identifier_generator,
@@ -255,9 +258,10 @@ impl ThreadEventCacheState {
             self.thread_linked_chunk.reset();
             self.propagate_changes(store).await?;
 
-            // Reset the pagination state too: pretend we never waited for the initial
-            // prev-batch token, and indicate that we're not at the start of the
-            // timeline, since we don't know about that anymore.
+            // Reset the pagination state too: pretend we never waited for the
+            // initial prev-batch token, and indicate that we're not
+            // at the start of the timeline, since we don't know
+            // about that anymore.
             self.waited_for_initial_prev_token = false;
 
             return Ok(());
@@ -302,8 +306,9 @@ impl<'a> StateLockReadGuard<'a, ThreadEventCacheState> {
         let latest_event_id = {
             // Find the last non-edit, non-redaction, non-redacted event.
             //
-            // TODO(@hywan): This is inefficient. We are bending the `LatestEvent` API here.
-            // Ultimately, we want to delegate the computation of `ThreadSummary` to
+            // TODO(@hywan): This is inefficient. We are bending the
+            // `LatestEvent` API here. Ultimately, we want to
+            // delegate the computation of `ThreadSummary` to
             // `LatestEvent` instead of committing crimes like these ones.
             let mut latest_event_id = self
                 .thread_linked_chunk()
@@ -319,10 +324,12 @@ impl<'a> StateLockReadGuard<'a, ThreadEventCacheState> {
                 })
                 .and_then(|(_position, event)| event.event_id().map(ToOwned::to_owned));
 
-            // If there's an edit to the latest event in the thread, use the latest edit
-            // event ID as the latest event ID for the thread summary.
+            // If there's an edit to the latest event in the thread, use the
+            // latest edit event ID as the latest event ID for the
+            // thread summary.
             //
-            // TODO(@hywan): This is one of the inefficiency I am talking about above.
+            // TODO(@hywan): This is one of the inefficiency I am talking about
+            // above.
             if let Some(event_id) = &latest_event_id
                 && let Some((original_event, edits)) = self
                     .find_event_with_relations(event_id, Some(vec![RelationType::Replacement]))
@@ -355,10 +362,10 @@ impl<'a> StateLockReadGuard<'a, ThreadEventCacheState> {
 
         // Read the latest number of thread replies from the store.
         //
-        // Implementation note: since this is based on the `m.relates_to` field, and
-        // that field can only be present on room messages, we don't have to
-        // worry about filtering out aggregation events (like reactions/edits/etc.).
-        // Pretty neat, huh?
+        // Implementation note: since this is based on the `m.relates_to` field,
+        // and that field can only be present on room messages, we don't
+        // have to worry about filtering out aggregation events (like
+        // reactions/edits/etc.). Pretty neat, huh?
         let num_replies = {
             let thread_replies = self
                 .store
@@ -434,13 +441,15 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
     ) -> Result<Vec<VectorDiff<Event>>> {
         match preprocessing {
             ReloadPreprocessing::ForgetAll => {
-                // Clear the `LinkedChunk` and broadcast the updates to the store.
+                // Clear the `LinkedChunk` and broadcast the updates to the
+                // store.
 
                 self.thread_linked_chunk_mut().reset();
                 self.state.propagate_changes(&self.store).await?;
 
-                // Reset the pagination state too: pretend we never waited for the initial
-                // prev-batch token, and indicate that we're not at the start of the timeline,
+                // Reset the pagination state too: pretend we never waited for
+                // the initial prev-batch token, and indicate
+                // that we're not at the start of the timeline,
                 // since we don't know about that anymore.
                 *self.waited_for_initial_prev_token_mut() = false;
             }
@@ -476,11 +485,11 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         .await?;
 
         if all_duplicates {
-            // If all events are duplicates, we don't need to do anything; ignore
-            // the new events.
+            // If all events are duplicates, we don't need to do anything;
+            // ignore the new events.
             //
-            // We might have a new read receipt, though! If that's the case, handle it for
-            // unread counts tracking.
+            // We might have a new read receipt, though! If that's the case,
+            // handle it for unread counts tracking.
             //
             // Post-process the ephemeral events.
             self.post_process_upserted_events(empty(), extract_read_receipt(&ephemeral_events))
@@ -491,16 +500,18 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
 
         let has_new_gap = prev_batch_token.is_some();
 
-        // If we've never waited for an initial previous-batch token, and we've now
-        // inserted a gap, no need to wait for a previous-batch token later.
+        // If we've never waited for an initial previous-batch token, and we've
+        // now inserted a gap, no need to wait for a previous-batch
+        // token later.
         if !self.state.waited_for_initial_prev_token && has_new_gap {
             self.state.waited_for_initial_prev_token = true;
         }
 
         // Remove the old duplicated events.
         //
-        // We don't have to worry about the removals can change the position of the
-        // existing events, because we are pushing all _new_ `events` at the back.
+        // We don't have to worry about the removals can change the position of
+        // the existing events, because we are pushing all _new_
+        // `events` at the back.
         self.remove_events(in_memory_duplicated_event_ids, in_store_duplicated_event_ids).await?;
 
         self.state.thread_linked_chunk.push_live_events(
@@ -516,9 +527,10 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             .await?;
 
         if timeline.limited && has_new_gap {
-            // If there was a previous batch token for a limited timeline, unload the chunks
-            // so it only contains the last one; otherwise, there might be a
-            // valid gap in between, and observers may not render it (yet).
+            // If there was a previous batch token for a limited timeline,
+            // unload the chunks so it only contains the last one;
+            // otherwise, there might be a valid gap in between, and
+            // observers may not render it (yet).
             //
             // We must do this *after* persisting these events to storage.
             self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
@@ -581,8 +593,8 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         .await;
 
         if prev_read_receipts != &read_receipts {
-            // The read receipt has changed! Do a little dance to update the `ThreadInfo` in
-            // the store.
+            // The read receipt has changed! Do a little dance to update the
+            // `ThreadInfo` in the store.
             self.state.thread_info.read_receipts = read_receipts;
 
             let room_id = &self.state.room_id;
@@ -630,9 +642,11 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
             &self.room_version_rules.redaction,
         ) {
             // It's safe to cast `redacted_event` here:
-            // - either the event was an `AnyTimelineEvent` cast to `AnySyncTimelineEvent`
-            //   when calling .raw(), so it's still one under the hood.
-            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this case.
+            // - either the event was an `AnyTimelineEvent` cast to
+            //   `AnySyncTimelineEvent` when calling .raw(), so it's still one
+            //   under the hood.
+            // - or it wasn't, and it's a plain `AnySyncTimelineEvent` in this
+            //   case.
             target_event.replace_raw(redacted_event.cast_unchecked());
 
             self.replace_event_at(location, target_event.clone()).await?;
@@ -666,8 +680,8 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
                     .thread_linked_chunk
                     .replace_event_at(position, new_event)
                     .expect("should have been a valid position of an item");
-                // We just changed the in-memory representation; synchronize this with
-                // the store.
+                // We just changed the in-memory representation; synchronize
+                // this with the store.
                 self.state.propagate_changes(&self.store).await?;
             }
             EventLocation::Store => {
@@ -751,12 +765,13 @@ impl<'a> StateLockWriteGuard<'a, ThreadEventCacheState> {
         trace!(number_of_subscribers, "received request to auto-shrink");
 
         if number_of_subscribers == 0 {
-            // There is no more subscribers listening to this cache, we can shrink the state
-            // to its last chunk to save memory.
+            // There is no more subscribers listening to this cache, we can
+            // shrink the state to its last chunk to save memory.
             //
-            // In theory, between the condition (`… == 0`) and this instruction, a new
-            // subscriber could be created, creating a race, except that this method takes a
-            // `&mut`, ensuring an exclusive access to the state, ensuring no other
+            // In theory, between the condition (`… == 0`) and this instruction,
+            // a new subscriber could be created, creating a race,
+            // except that this method takes a `&mut`, ensuring an
+            // exclusive access to the state, ensuring no other
             // subscribers can be created.
             self.state.shrink_to_last_reloaded_chunk(&self.store).await?;
 

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -38,15 +38,15 @@ pub async fn filter_duplicate_events(
     linked_chunk: &EventLinkedChunk,
     mut new_events: Vec<Event>,
 ) -> Result<DeduplicationOutcome, EventCacheError> {
-    // Remove all events with no ID, or that are duplicated among the new events,
-    // i.e. `new_events` contains duplicated events in itself (e.g. `[$e0, $e1,
-    // $e0]`, here `$e0` is duplicated).
+    // Remove all events with no ID, or that are duplicated among the new
+    // events, i.e. `new_events` contains duplicated events in itself (e.g.
+    // `[$e0, $e1, $e0]`, here `$e0` is duplicated).
     {
         let mut event_ids = BTreeSet::new();
 
         new_events.retain(|event| {
-            // Only keep events with IDs, and those for which `insert` returns `true`
-            // (meaning they were not in the set).
+            // Only keep events with IDs, and those for which `insert` returns
+            // `true` (meaning they were not in the set).
             event.event_id().is_some_and(|event_id| event_ids.insert(event_id.to_owned()))
         });
     }
@@ -59,8 +59,8 @@ pub async fn filter_duplicate_events(
         )
         .await?;
 
-    // Separate duplicated events in two collections: ones that are in-memory, ones
-    // that are in the store.
+    // Separate duplicated events in two collections: ones that are in-memory,
+    // ones that are in the store.
     let (in_memory_duplicated_event_ids, in_store_duplicated_event_ids) = {
         // Collect all in-memory chunk identifiers.
         let in_memory_chunk_identifiers =
@@ -192,8 +192,8 @@ mod tests {
         let event_id_4 = owned_event_id!("$ev4");
 
         // `event_0` and `event_1` are in the store.
-        // `event_2` and `event_3` is in the store, but also in memory: it's loaded in
-        // memory from the store.
+        // `event_2` and `event_3` is in the store, but also in memory: it's
+        // loaded in memory from the store.
         // `event_4` is nowhere, it's new.
         let event_0 = timeline_event(&event_id_0);
         let event_1 = timeline_event(&event_id_1);
@@ -242,9 +242,9 @@ mod tests {
         let event_cache_store_guard = event_cache_store.as_clean().unwrap();
 
         {
-            // When presenting with only duplicate events, some of them in the in-memory
-            // chunk, all of them in the store, we should return all of them as
-            // duplicates.
+            // When presenting with only duplicate events, some of them in the
+            // in-memory chunk, all of them in the store, we should
+            // return all of them as duplicates.
 
             let mut linked_chunk = EventLinkedChunk::new();
             linked_chunk.push_events([event_1.clone(), event_2.clone(), event_3.clone()]);
@@ -298,8 +298,8 @@ mod tests {
             (event_id_3, Position::new(ChunkIdentifier::new(0), 1))
         );
 
-        // From these 4 events, 2 are duplicated and live in the store only, they have
-        // not been loaded in memory.
+        // From these 4 events, 2 are duplicated and live in the store only,
+        // they have not been loaded in memory.
         //
         // Note that events are sorted by their descending position.
         assert_eq!(outcome.in_store_duplicated_event_ids.len(), 2);

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -628,8 +628,8 @@ impl EventCacheInner {
 
     /// Clear a single room's data.
     async fn forget_room(&self, room_id: &RoomId) -> Result<()> {
-        // The constraints are very similar to what we do in `clear_all_rooms`. See this
-        // information to understand them.
+        // The constraints are very similar to what we do in `clear_all_rooms`.
+        // See this information to understand them.
 
         let mut caches_for_all_rooms = self.by_room.write().await;
         self.state.clear_and_reload(&caches_for_all_rooms, Some(room_id)).await?;
@@ -680,10 +680,10 @@ impl EventCacheInner {
     /// Handles a single set of room updates at once.
     #[instrument(skip(self, updates))]
     async fn handle_room_updates(&self, updates: RoomUpdates) -> Result<()> {
-        // NOTE: We tried to make this concurrent at some point, but it turned out to be
-        // a performance regression, even for large sync updates. Lacking time
-        // to investigate, this code remains sequential for now. See also
-        // https://github.com/matrix-org/matrix-rust-sdk/pull/5426.
+        // NOTE: We tried to make this concurrent at some point, but it turned
+        // out to be a performance regression, even for large sync
+        // updates. Lacking time to investigate, this code remains
+        // sequential for now. See also https://github.com/matrix-org/matrix-rust-sdk/pull/5426.
 
         // Left rooms.
         for (room_id, left_room_update) in updates.left {
@@ -715,8 +715,9 @@ impl EventCacheInner {
 
         // Invited rooms.
         //
-        // We don't handle `updates.invite` because they contain stripped-state events,
-        // which is not handled by the Event Cache for the moment.
+        // We don't handle `updates.invite` because they contain stripped-state
+        // events, which is not handled by the Event Cache for the
+        // moment.
 
         Ok(())
     }
@@ -726,20 +727,22 @@ impl EventCacheInner {
         &self,
         room_id: &RoomId,
     ) -> Result<OwnedRwLockReadGuard<CachesByRoom, Caches>> {
-        // Fast path: the entry exists; let's acquire a read lock, it's cheaper than a
-        // write lock.
+        // Fast path: the entry exists; let's acquire a read lock, it's cheaper
+        // than a write lock.
         match OwnedRwLockReadGuard::try_map(self.by_room.clone().read_owned().await, |by_room| {
             by_room.get(room_id)
         }) {
             Ok(caches) => Ok(caches),
 
             Err(by_room_guard) => {
-                // Slow-path: the entry doesn't exist; let's acquire a write lock.
+                // Slow-path: the entry doesn't exist; let's acquire a write
+                // lock.
                 drop(by_room_guard);
                 let by_room_guard = self.by_room.clone().write_owned().await;
 
-                // In the meanwhile, some other caller might have obtained write access and done
-                // the same, so check for existence again.
+                // In the meanwhile, some other caller might have obtained write
+                // access and done the same, so check for
+                // existence again.
                 let mut by_room_guard =
                     match OwnedRwLockWriteGuard::try_downgrade_map(by_room_guard, |by_room| {
                         by_room.get(room_id)
@@ -815,13 +818,13 @@ mod tests {
 
         let event_cache = client.event_cache();
 
-        // If I create a room event subscriber for a room before subscribing the event
-        // cache,
+        // If I create a room event subscriber for a room before subscribing the
+        // event cache,
         let room_id = room_id!("!omelette:fromage.fr");
         let result = event_cache.room(room_id).await;
 
-        // Then it fails, because one must explicitly call `.subscribe()` on the event
-        // cache.
+        // Then it fails, because one must explicitly call `.subscribe()` on the
+        // event cache.
         assert_matches!(result, Err(EventCacheError::NotSubscribedYet));
     }
 
@@ -881,8 +884,8 @@ mod tests {
         let found2 = room_event_cache.find_event(eid2).await.unwrap().unwrap();
         assert_event_matches_msg(&found2, "you");
 
-        // Retrieving the event with id3 from the room which doesn't contain it will
-        // fail…
+        // Retrieving the event with id3 from the room which doesn't contain it
+        // will fail…
         assert!(room_event_cache.find_event(eid3).await.unwrap().is_none());
     }
 

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -50,7 +50,8 @@ pub(super) async fn load_linked_chunk_metadata(
         return Ok(None);
     }
 
-    // Transform the vector into a hashmap, for quick lookup of the predecessors.
+    // Transform the vector into a hashmap, for quick lookup of the
+    // predecessors.
     let chunk_map: HashMap<_, _> = all_chunks.iter().map(|meta| (meta.identifier, meta)).collect();
 
     // Find a last chunk.
@@ -113,7 +114,8 @@ pub(super) async fn load_linked_chunk_metadata(
             });
         };
 
-        // If the previous chunk isn't connected to the next, then the link is invalid.
+        // If the previous chunk isn't connected to the next, then the link is
+        // invalid.
         if pred_meta.next != Some(current.identifier) {
             return Err(EventCacheError::InvalidLinkedChunkMetadata {
                 details: format!(
@@ -130,8 +132,8 @@ pub(super) async fn load_linked_chunk_metadata(
 
     // At this point, `current` is the identifier of the first chunk.
     //
-    // Reorder the resulting vector, by going through the chain of `next` links, and
-    // swapping items into their final position.
+    // Reorder the resulting vector, by going through the chain of `next` links,
+    // and swapping items into their final position.
     //
     // Invariant in this loop: all items in [0..i[ are in their final, correct
     // position.
@@ -172,16 +174,17 @@ pub(super) async fn send_updates_to_store(
 
     // Strip relations from updates which insert or replace items.
     //
-    // The reason we're doing this, is that consumers of the event cache might look
-    // into bundled relations, and assume they're up to date. If we were to keep
-    // the relations in the events, when storing them, then it could be that
-    // they become outdated (as soon as a new relation comes over sync), so we'd
-    // need to update the bundled relations in this case, which would
-    // have a non-negligible cost, as we'd need to look up related events for each
-    // forwarded to a listener.
+    // The reason we're doing this, is that consumers of the event cache might
+    // look into bundled relations, and assume they're up to date. If we
+    // were to keep the relations in the events, when storing them, then it
+    // could be that they become outdated (as soon as a new relation comes
+    // over sync), so we'd need to update the bundled relations in this
+    // case, which would have a non-negligible cost, as we'd need to look up
+    // related events for each forwarded to a listener.
     //
-    // As a result, we choose to strip bundled relations from events when we forward
-    // them to the store, and consumers have to explicitly ask for relations.
+    // As a result, we choose to strip bundled relations from events when we
+    // forward them to the store, and consumers have to explicitly ask for
+    // relations.
     for update in updates.iter_mut() {
         match update {
             Update::PushItems { items, .. } => strip_relations_from_events(items),
@@ -198,11 +201,11 @@ pub(super) async fn send_updates_to_store(
         }
     }
 
-    // Spawn a task to make sure that all the changes are effectively forwarded to
-    // the store, even if the call to this method gets aborted.
+    // Spawn a task to make sure that all the changes are effectively forwarded
+    // to the store, even if the call to this method gets aborted.
     //
-    // The store cross-process locking involves an actual mutex, which ensures that
-    // storing updates happens in the expected order.
+    // The store cross-process locking involves an actual mutex, which ensures
+    // that storing updates happens in the expected order.
 
     let store = store.clone();
     let cloned_updates = updates.clone();
@@ -278,8 +281,8 @@ pub async fn find_event(
     event_linked_chunk: &EventLinkedChunk,
     store: &EventCacheStoreLockGuard,
 ) -> Result<Option<(EventLocation, Event)>> {
-    // There are supposedly fewer events loaded in memory than in the store. Let's
-    // start by looking up in the `EventLinkedChunk`.
+    // There are supposedly fewer events loaded in memory than in the store.
+    // Let's start by looking up in the `EventLinkedChunk`.
     for (position, event) in event_linked_chunk.revents() {
         if event.event_id() == Some(event_id) {
             return Ok(Some((EventLocation::Memory(position), event.clone())));
@@ -381,7 +384,8 @@ pub async fn find_event_relations(
 
     // Sort the results by their positions in the linked chunk, if available.
     //
-    // If an event doesn't have a known position, it goes to the start of the array.
+    // If an event doesn't have a known position, it goes to the start of the
+    // array.
     related.sort_by(|(_, lhs), (_, rhs)| {
         use std::cmp::Ordering;
 
@@ -393,9 +397,10 @@ pub async fn find_event_relations(
                 let lhs = event_linked_chunk.event_order(*lhs);
                 let rhs = event_linked_chunk.event_order(*rhs);
 
-                // The events should have a definite position, but in the case they don't,
-                // still consider that not having a position means you'll end at the start
-                // of the array.
+                // The events should have a definite position, but in the case
+                // they don't, still consider that not having a
+                // position means you'll end at the start of the
+                // array.
                 match (lhs, rhs) {
                     (None, None) => Ordering::Equal,
                     (None, Some(_)) => Ordering::Less,

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -186,15 +186,18 @@ impl MaybeResolvedEvent {
     pub fn try_resolve_event(self, mut unresolved_event: TimelineEvent) -> Self {
         match self {
             Self::NotYet(resolved_utd) => {
-                // There is a race between the multiple sources of updates. It's possible
-                // that two sources trigger a decryption for the same event (for example,
-                // the room key stream and the event cache updates). It is then likely that
-                // the event has been already resolved. This race is fine, but we should
-                // avoid to replace an event that has already been resolved as it is a
-                // non-negligible operation.
+                // There is a race between the multiple sources of updates. It's
+                // possible that two sources trigger a
+                // decryption for the same event (for example,
+                // the room key stream and the event cache updates). It is then
+                // likely that the event has been already
+                // resolved. This race is fine, but we should
+                // avoid to replace an event that has already been resolved as
+                // it is a non-negligible operation.
                 //
-                // Note that a simple check like “event's kind is `UnableToDecrypt`” is not
-                // enough. The event can already be decrypted but its encryption info can
+                // Note that a simple check like “event's kind is
+                // `UnableToDecrypt`” is not enough. The event
+                // can already be decrypted but its encryption info can
                 // change. So we must ensure they are also different.
                 if matches!(unresolved_event.kind, TimelineEventKind::UnableToDecrypt { .. })
                     || unresolved_event.encryption_info()
@@ -242,8 +245,9 @@ impl TryResolveEvents for [MaybeResolvedEvent] {
         for (nth, resolved_event) in self.iter().enumerate() {
             match resolved_event {
                 MaybeResolvedEvent::NotYet(resolved_utd) => {
-                    // Event has not been resolved. Let's try to locate the corresponding event with
-                    // the provided `EventLinkedChunk` and try to resolve it.
+                    // Event has not been resolved. Let's try to locate the
+                    // corresponding event with the provided
+                    // `EventLinkedChunk` and try to resolve it.
 
                     if let Some((_location, event)) =
                         event_linked_chunk.find_event(&resolved_utd.event_id)
@@ -252,10 +256,13 @@ impl TryResolveEvents for [MaybeResolvedEvent] {
                             .try_resolve_event(event);
 
                         if matches!(new_resolved_event, MaybeResolvedEvent::Resolved(_)) {
-                            // Use `slice::get_unchecked_mut` to avoid a bounds check.
+                            // Use `slice::get_unchecked_mut` to avoid a bounds
+                            // check.
                             //
-                            // SAFETY: `self` and `new_resolved_events` have the same size and
-                            // represent the same data. Thus, the index `nth` exists in
+                            // SAFETY: `self` and `new_resolved_events` have the
+                            // same size and
+                            // represent the same data. Thus, the index `nth`
+                            // exists in
                             // `new_resolved_events`.
                             unsafe {
                                 *new_resolved_events.to_mut().get_unchecked_mut(nth) =
@@ -337,11 +344,12 @@ fn filter_timeline_event_to_utd(
 ) -> Option<(OwnedEventId, Raw<AnySyncTimelineEvent>)> {
     let event_id = event.event_id().map(ToOwned::to_owned);
 
-    // Only pick out events that are UTDs, get just the Raw event as this is what
-    // the OlmMachine needs.
+    // Only pick out events that are UTDs, get just the Raw event as this is
+    // what the OlmMachine needs.
     let event = as_variant!(event.kind, TimelineEventKind::UnableToDecrypt { event, .. } => event);
-    // Zip the event ID and event together so we don't have to pick out the event ID
-    // again. We need the event ID to replace the event in the cache.
+    // Zip the event ID and event together so we don't have to pick out the
+    // event ID again. We need the event ID to replace the event in the
+    // cache.
     event_id.zip(event)
 }
 
@@ -356,8 +364,9 @@ fn filter_timeline_event_to_decrypted(
     let event_id = event.event_id().map(ToOwned::to_owned);
 
     let event = as_variant!(event.kind, TimelineEventKind::Decrypted(event) => event);
-    // Zip the event ID and event together so we don't have to pick out the event ID
-    // again. We need the event ID to replace the event in the cache.
+    // Zip the event ID and event together so we don't have to pick out the
+    // event ID again. We need the event ID to replace the event in the
+    // cache.
     event_id.zip(event)
 }
 
@@ -467,18 +476,20 @@ impl EventCache {
 
         // # Room cache, thread caches, and pinned-event cache
         //
-        // For each resolved UTD, find the corresponding event (either in-store or
-        // in-memory of the room cache), build the resolved event, and replace it in the
-        // store. We use the room cache for that because it contains all events (there
-        // is an exception with the event-focused cache, see below).
+        // For each resolved UTD, find the corresponding event (either in-store
+        // or in-memory of the room cache), build the resolved event,
+        // and replace it in the store. We use the room cache for that
+        // because it contains all events (there is an exception with
+        // the event-focused cache, see below).
         //
         // # Event-focused cache
         //
         // Events received by the sync or pagination are not forwarded to the
-        // event-focused cache: it handles its own set of events. All of them live
-        // in-memory, there are not put in the store by any cache. So this cache will
-        // miss all UTD resolutions. To address that, the event-focused cache
-        // resolves UTD on its own, without the general logic described above.
+        // event-focused cache: it handles its own set of events. All of them
+        // live in-memory, there are not put in the store by any cache.
+        // So this cache will miss all UTD resolutions. To address that,
+        // the event-focused cache resolves UTD on its own, without the
+        // general logic described above.
         {
             let room_cache = &all_caches.room;
             let mut state = room_cache.state().write().await?;
@@ -491,17 +502,20 @@ impl EventCache {
                     let maybe_resolved_event =
                         MaybeResolvedEvent::NotYet(resolved_utd).try_resolve_event(event);
 
-                    // It is an in-memory event, let's keep it apart to replace in-memory UTDs.
+                    // It is an in-memory event, let's keep it apart to replace
+                    // in-memory UTDs.
                     if matches!(location, EventLocation::Memory(_)) {
                         maybe_resolved_in_memory_events.push(maybe_resolved_event.clone());
                     }
 
-                    // Even is known, let's keep it for later, even if unresolved.
+                    // Even is known, let's keep it for later, even if
+                    // unresolved.
                     maybe_resolved_events.push(maybe_resolved_event);
                 } else {
-                    // Event is unknown by the room cache, the thread caches, nor the pinned-events
-                    // cache. However, it might be known by an event-focused cache! So let's keep it
-                    // for later.
+                    // Event is unknown by the room cache, the thread caches,
+                    // nor the pinned-events cache. However,
+                    // it might be known by an event-focused cache! So let's
+                    // keep it for later.
                     maybe_resolved_events.push(MaybeResolvedEvent::NotYet(resolved_utd));
                 }
             }
@@ -541,7 +555,8 @@ impl EventCache {
             // chunk contains which event ID, to avoid doing the linear searches
             // here.
 
-            // Replaces UTDs in each thread, and maybe update the thread summary.
+            // Replaces UTDs in each thread, and maybe update the thread
+            // summary.
             for (thread_id, thread_cache) in try_join_all(
                 all_caches.threads.read().await.iter().map(|(thread_id, thread_cache)| async {
                     Result::<_, EventCacheError>::Ok(
@@ -573,10 +588,11 @@ impl EventCache {
 
         // Resolve in-memory UTDs on the event-focused caches.
         {
-            // TODO: This ain't great for performance; there shouldn't be that many
-            // event-focused caches alive at the same time, but they could
-            // accumulate over time. Consider keeping track of which linked chunk
-            // contains which event ID, to avoid doing the linear searches here.
+            // TODO: This ain't great for performance; there shouldn't be that
+            // many event-focused caches alive at the same time, but
+            // they could accumulate over time. Consider keeping
+            // track of which linked chunk contains which event ID,
+            // to avoid doing the linear searches here.
             try_join_all(all_caches.event_focused.read().await.values().map(
                 |event_focused_cache| {
                     event_focused_cache.replace_in_memory_utds(&maybe_resolved_events)
@@ -706,8 +722,9 @@ impl EventCache {
         let mut decrypted_events = Vec::with_capacity(events.len());
 
         for (event_id, event) in events {
-            // If we managed to decrypt the event, and we should have to since we received
-            // the room key for this specific event, then replace the event.
+            // If we managed to decrypt the event, and we should have to since
+            // we received the room key for this specific event,
+            // then replace the event.
             if let Some((decrypted_event, actions)) = self
                 .decrypt_event(
                     room_id,
@@ -728,8 +745,8 @@ impl EventCache {
             trace!(?event_ids, "Successfully redecrypted events");
         }
 
-        // Replace the events and notify listeners that UTDs have been replaced with
-        // decrypted events.
+        // Replace the events and notify listeners that UTDs have been replaced
+        // with decrypted events.
         self.on_resolved_utds(room_id, decrypted_events).await?;
 
         Ok(())
@@ -749,7 +766,8 @@ impl EventCache {
                 let new_encryption_info =
                     room.get_encryption_info(session_id, &event.encryption_info.sender).await;
 
-                // Only create a replacement if the encryption info actually changed.
+                // Only create a replacement if the encryption info actually
+                // changed.
                 if let Some(new_encryption_info) = new_encryption_info
                     && event.encryption_info != new_encryption_info
                 {
@@ -1204,9 +1222,9 @@ impl Redecryptor {
         events_stream: BroadcastStream<RoomEventCacheLinkedChunkUpdate>,
         backup_state_stream: impl Stream<Item = Result<BackupState, BroadcastStreamRecvError>>,
     ) {
-        // We pin the decryption request stream here since that one doesn't need to be
-        // recreated and we don't want to miss messages coming from the stream
-        // while recreating it unnecessarily.
+        // We pin the decryption request stream here since that one doesn't need
+        // to be recreated and we don't want to miss messages coming
+        // from the stream while recreating it unnecessarily.
         pin_mut!(decryption_request_stream);
         pin_mut!(events_stream);
         pin_mut!(backup_state_stream);
@@ -1221,8 +1239,9 @@ impl Redecryptor {
         {
             info!("Regenerating the re-decryption streams");
 
-            // Report that the stream got recreated so listeners know about it, at the same
-            // time retry to decrypt anything we have cached in memory.
+            // Report that the stream got recreated so listeners know about it,
+            // at the same time retry to decrypt anything we have
+            // cached in memory.
             if send_report_and_retry_memory_events(&cache, RedecryptorReport::Lagging)
                 .await
                 .is_err()
@@ -1350,11 +1369,11 @@ mod tests {
             linked_chunk_id: LinkedChunkId<'_>,
             updates: Vec<Update<Event, Gap>>,
         ) -> Result<(), Self::Error> {
-            // This is the key behaviour of this store - we wait to set this value until
-            // someone calls `stop_delaying`.
+            // This is the key behaviour of this store - we wait to set this
+            // value until someone calls `stop_delaying`.
             //
-            // We use `sleep` here for simplicity. The cool way would be to use a custom
-            // waker or something like that.
+            // We use `sleep` here for simplicity. The cool way would be to use
+            // a custom waker or something like that.
             while self.delaying.load(Ordering::SeqCst) {
                 sleep(Duration::from_millis(10)).await;
             }
@@ -1582,9 +1601,9 @@ mod tests {
             .get_room(room_id)
             .expect("Alice should have access to the room now that we synced");
 
-        // Alice will send a single event to the room, but this will trigger a to-device
-        // message containing the room key to be sent as well. We capture both the event
-        // and the to-device message.
+        // Alice will send a single event to the room, but this will trigger a
+        // to-device message containing the room key to be sent as well.
+        // We capture both the event and the to-device message.
 
         let event_type = "m.room.message";
         let content = json!({"body": "It's a secret to everybody", "msgtype": "m.text"});
@@ -1637,8 +1656,8 @@ mod tests {
         let (_, mut subscriber) = room_cache.subscribe().await.unwrap();
         let mut generic_stream = event_cache.subscribe_to_room_generic_updates();
 
-        // We regenerate the Olm machine to check if the room key stream is recreated to
-        // correctly.
+        // We regenerate the Olm machine to check if the room key stream is
+        // recreated to correctly.
         bob.inner
             .base_client
             .regenerate_olm(None)
@@ -1660,8 +1679,8 @@ mod tests {
                 subscriber.recv()
         );
 
-        // There should be a single new event, and it should be a UTD as we did not
-        // receive the room key yet.
+        // There should be a single new event, and it should be a UTD as we did
+        // not receive the room key yet.
         assert_eq!(diffs.len(), 1);
         assert_matches!(&diffs[0], VectorDiff::Append { values });
         assert_eq!(values.len(), 1);
@@ -1745,8 +1764,8 @@ mod tests {
                 subscriber.recv()
         );
 
-        // There should be a single new event, and it should be a UTD as we did not
-        // receive the room key yet.
+        // There should be a single new event, and it should be a UTD as we did
+        // not receive the room key yet.
         assert_eq!(diffs.len(), 1);
         assert_matches!(&diffs[0], VectorDiff::Append { values });
         assert_eq!(values.len(), 1);
@@ -1817,8 +1836,8 @@ mod tests {
             refresh_info_session_ids: BTreeSet::from([session_id]),
         });
 
-        // Bob should again receive a new update from the cache, this time updating the
-        // encryption info.
+        // Bob should again receive a new update from the cache, this time
+        // updating the encryption info.
         assert_let_timeout!(
             Duration::from_secs(1),
             Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
@@ -1900,8 +1919,8 @@ mod tests {
                 subscriber.recv()
         );
 
-        // There should be a single new event, and it should be a UTD as we did not
-        // receive the room key yet.
+        // There should be a single new event, and it should be a UTD as we did
+        // not receive the room key yet.
         assert_eq!(diffs.len(), 1);
         assert_matches!(&diffs[0], VectorDiff::Append { values });
         assert_eq!(values.len(), 1);

--- a/crates/matrix-sdk/src/event_cache/states/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/states/mod.rs
@@ -107,47 +107,54 @@ impl StateLock {
 
         // Only one call at a time to `read` is allowed.
         //
-        // Why? Because in case the cross-process lock over the store is dirty, we need
-        // to upgrade the read lock over the state to a write lock.
+        // Why? Because in case the cross-process lock over the store is dirty,
+        // we need to upgrade the read lock over the state to a write
+        // lock.
         //
         // ## Upgradable read lock
         //
-        // One may argue that this upgrades can be done with an _upgradable read lock_
-        // [^1] [^2]. We don't want to use this solution: an upgradable read lock is
-        // basically a mutex because we are losing the shared access property, i.e.
-        // having multiple read locks at the same time. This is an important property to
-        // hold for performance concerns.
+        // One may argue that this upgrades can be done with an _upgradable read
+        // lock_ [^1] [^2]. We don't want to use this solution: an
+        // upgradable read lock is basically a mutex because we are
+        // losing the shared access property, i.e. having multiple read
+        // locks at the same time. This is an important property to hold
+        // for performance concerns.
         //
         // ## Downgradable write lock
         //
-        // One may also argue we could first obtain a write lock over the state from the
-        // beginning, thus removing the need to upgrade the read lock to a write lock.
-        // The write lock is then downgraded to a read lock once the dirty is cleaned
-        // up. It can potentially create a deadlock in the following situation:
+        // One may also argue we could first obtain a write lock over the state
+        // from the beginning, thus removing the need to upgrade the
+        // read lock to a write lock. The write lock is then downgraded
+        // to a read lock once the dirty is cleaned up. It can
+        // potentially create a deadlock in the following situation:
         //
-        // - `read` is called once, it takes a write lock, then downgrades it to a read
-        //   lock: the guard is kept alive somewhere,
-        // - `read` is called again, and waits to obtain the write lock, which is
-        //   impossible as long as the guard from the previous call is not dropped.
+        // - `read` is called once, it takes a write lock, then downgrades it to
+        //   a read lock: the guard is kept alive somewhere,
+        // - `read` is called again, and waits to obtain the write lock, which
+        //   is impossible as long as the guard from the previous call is not
+        //   dropped.
         //
         // ## “Atomic” read and write
         //
-        // One may finally argue to first obtain a read lock over the state, then drop
-        // it if the cross-process lock over the store is dirty, and immediately obtain
-        // a write lock (which can later be downgraded to a read lock). The problem is
-        // that this write lock is async: anything can happen between the drop and the
-        // new lock acquisition, and it's not possible to pause the runtime in the
-        // meantime.
+        // One may finally argue to first obtain a read lock over the state,
+        // then drop it if the cross-process lock over the store is
+        // dirty, and immediately obtain a write lock (which can later
+        // be downgraded to a read lock). The problem is that this write
+        // lock is async: anything can happen between the drop and the
+        // new lock acquisition, and it's not possible to pause the runtime in
+        // the meantime.
         //
         // ## Semaphore with 1 permit, aka a Mutex
         //
-        // The chosen idea is to allow only one execution at a time of this method: it
-        // becomes a critical section. That way we are free to “upgrade” the read lock
-        // by dropping it and obtaining a new write lock. All callers to this method are
-        // waiting, so nothing can happen in the meantime.
+        // The chosen idea is to allow only one execution at a time of this
+        // method: it becomes a critical section. That way we are free
+        // to “upgrade” the read lock by dropping it and obtaining a new
+        // write lock. All callers to this method are waiting, so
+        // nothing can happen in the meantime.
         //
-        // Note that it doesn't conflict with the `write` method because this latter
-        // immediately obtains a write lock, which avoids any conflict with this method.
+        // Note that it doesn't conflict with the `write` method because this
+        // latter immediately obtains a write lock, which avoids any
+        // conflict with this method.
         //
         // [^1]: https://docs.rs/lock_api/0.4.14/lock_api/struct.RwLock.html#method.upgradable_read
         // [^2]: https://docs.rs/async-lock/3.4.1/async_lock/struct.RwLock.html#method.upgradable_read
@@ -167,8 +174,9 @@ impl StateLock {
                 }
             }
             EventCacheStoreLockState::Dirty(store_guard) => {
-                // Drop the read lock, and take a write lock to modify the state.
-                // This is safe because only one reader at a time (see
+                // Drop the read lock, and take a write lock to modify the
+                // state. This is safe because only one reader
+                // at a time (see
                 // `Self::state_lock_upgrade_mutex`) is allowed.
                 drop(state_guard);
 
@@ -186,7 +194,8 @@ impl StateLock {
 
                 trace!("Lock acquired (from dirty)");
 
-                // Downgrade the write guard to a read guard, and map it into a cache state.
+                // Downgrade the write guard to a read guard, and map it into a
+                // cache state.
                 guard.downgrade()
             }
         })

--- a/crates/matrix-sdk/src/event_cache/tasks.rs
+++ b/crates/matrix-sdk/src/event_cache/tasks.rs
@@ -72,8 +72,8 @@ pub(super) async fn room_updates_task(
             }
 
             Err(RecvError::Lagged(num_skipped)) => {
-                // Forget everything we know; we could have missed events, and we have
-                // no way to reconcile at the moment!
+                // Forget everything we know; we could have missed events, and
+                // we have no way to reconcile at the moment!
                 // TODO: implement Smart Matching™,
                 warn!(num_skipped, "Lagged behind room updates, clearing all rooms");
                 if let Err(err) = inner.clear_all_rooms().await {
@@ -353,8 +353,9 @@ async fn handle_thread_subscriber_send_queue_update(
             if let Some(thread_root) = extract_thread_root_from_content(new_content.into_raw().0) {
                 events_being_sent.insert(transaction_id, thread_root);
             } else {
-                // It could be that the event isn't part of a thread anymore; handle that by
-                // removing the pending transaction id.
+                // It could be that the event isn't part of a thread anymore;
+                // handle that by removing the pending
+                // transaction id.
                 events_being_sent.remove(&transaction_id);
             }
             return true;
@@ -364,7 +365,8 @@ async fn handle_thread_subscriber_send_queue_update(
             if let Some(thread_root) = events_being_sent.remove(&transaction_id) {
                 (thread_root, event_id)
             } else {
-                // We don't know about the event that has been sent, so ignore it.
+                // We don't know about the event that has been sent, so ignore
+                // it.
                 trace!(%transaction_id, "received a sent event that we didn't know about, ignoring");
                 return true;
             }
@@ -378,7 +380,8 @@ async fn handle_thread_subscriber_send_queue_update(
         }
     };
 
-    // And if we've found such a mention, subscribe to the thread up to this event.
+    // And if we've found such a mention, subscribe to the thread up to this
+    // event.
     trace!(thread = %thread_root, up_to = %subscribe_up_to, "found a new thread to subscribe to");
 
     if let Err(err) = room.subscribe_thread_if_needed(&thread_root, Some(subscribe_up_to)).await {
@@ -427,13 +430,13 @@ async fn handle_thread_subscriber_linked_chunk_update(
         return true;
     }
 
-    // This `PushContext` is going to be used to compute whether an in-thread event
-    // would trigger a mention.
+    // This `PushContext` is going to be used to compute whether an in-thread
+    // event would trigger a mention.
     //
     // Of course, we're not interested in an in-thread event causing a mention,
     // because it's part of a thread we've subscribed to. So the
-    // `PushContext` must not include the check for thread subscriptions (otherwise
-    // it would be impossible to subscribe to new threads).
+    // `PushContext` must not include the check for thread subscriptions
+    // (otherwise it would be impossible to subscribe to new threads).
 
     let with_thread_subscriptions = false;
 
@@ -453,8 +456,8 @@ async fn handle_thread_subscriber_linked_chunk_update(
     let mut subscribe_up_to = None;
 
     // Find if there's an event that would trigger a mention for the current
-    // user, iterating from the end of the new events towards the oldest, so we can
-    // find the most recent event to subscribe to.
+    // user, iterating from the end of the new events towards the oldest, so we
+    // can find the most recent event to subscribe to.
     for ev in new_events.rev() {
         if push_context.for_event(ev.raw()).await.into_iter().any(|action| action.should_notify()) {
             let Some(event_id) = ev.event_id() else {

--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -75,8 +75,9 @@ impl EventHandlerMaps {
         ev_type: &str,
         room_id: Option<&'a RoomId>,
     ) -> impl Iterator<Item = (EventHandlerHandle, &'a EventHandlerFn)> + 'a {
-        // Use get_key_value instead of just get to be able to access the event_type
-        // from the BTreeMap key as &'static str, required for EventHandlerHandle.
+        // Use get_key_value instead of just get to be able to access the
+        // event_type from the BTreeMap key as &'static str, required
+        // for EventHandlerHandle.
         let kind_kv = self.by_kind.get_key_value(&ev_kind).map(|(_, handlers)| (None, handlers));
         let kind_type_kv = self
             .by_kind_type

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -470,7 +470,8 @@ impl Client {
             )
             .await;
 
-            // Event handlers specifically for redacted OR unredacted timeline events
+            // Event handlers specifically for redacted OR unredacted timeline
+            // events
             self.call_event_handlers(
                 room,
                 raw_event,
@@ -537,8 +538,9 @@ impl Client {
         if !futures.is_empty() {
             debug!(amount = futures.len(), "Calling event handlers");
 
-            // Run the event handler futures with the `self.event_handlers.handlers`
-            // lock no longer being held.
+            // Run the event handler futures with the
+            // `self.event_handlers.handlers` lock no longer being
+            // held.
             while let Some(()) = futures.next().await {}
         }
     }
@@ -687,20 +689,23 @@ where
         let mut this = self.project();
 
         let Some(_) = this.event_handler_guard.upgrade() else {
-            // The `EventHandlerHandle` has been dropped via `EventHandlerDropGuard`. It
+            // The `EventHandlerHandle` has been dropped via
+            // `EventHandlerDropGuard`. It
             // means the `ObservableEventHandler` has been dropped. It's time to
             // close this stream.
             return Poll::Ready(None);
         };
 
-        // First off, the subscriber is of type `Subscriber<Option<T>>` because the
-        // `SharedObservable` starts with a `None` value to indicate it has no yet
-        // received any update. We want the `Stream` to return `T`, not `Option<T>`. We
-        // then filter out all `None` value.
+        // First off, the subscriber is of type `Subscriber<Option<T>>` because
+        // the `SharedObservable` starts with a `None` value to indicate
+        // it has no yet received any update. We want the `Stream` to
+        // return `T`, not `Option<T>`. We then filter out all `None`
+        // value.
         //
-        // Second, when a `None` value is met, we want to poll again (hence the `loop`).
-        // At best, there is a new value to return. At worst, the subscriber will return
-        // `Poll::Pending` and will register the wakers accordingly.
+        // Second, when a `None` value is met, we want to poll again (hence the
+        // `loop`). At best, there is a new value to return. At worst,
+        // the subscriber will return `Poll::Pending` and will register
+        // the wakers accordingly.
 
         loop {
             match this.subscriber.as_mut().poll_next(context) {
@@ -1286,9 +1291,9 @@ mod tests {
 
     #[async_test]
     async fn test_observe_room_events_with_type_prefix() -> crate::Result<()> {
-        // To create an event handler for a room account data event type with prefix, we
-        // need to create a custom event type, none exist in the Matrix specification
-        // yet.
+        // To create an event handler for a room account data event type with
+        // prefix, we need to create a custom event type, none exist in
+        // the Matrix specification yet.
         #[derive(Debug, Clone, EventContent, Serialize)]
         #[ruma_event(type = "fake.event.*", kind = RoomAccountData)]
         struct AccountDataWithPrefixEventContent {

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -169,8 +169,8 @@ impl HttpClient {
 
             let mut uri_parts = request.uri().clone().into_parts();
 
-            // Erase the query parameters for the sake of secrecy (in case a token is
-            // present).
+            // Erase the query parameters for the sake of secrecy (in case a
+            // token is present).
             if let Some(path_and_query) = &mut uri_parts.path_and_query {
                 *path_and_query =
                     path_and_query.path().try_into().expect("path is valid PathAndQuery");
@@ -191,8 +191,9 @@ impl HttpClient {
                 );
             }
         }
-        // these macros expand to a lot of code, also want to skip monomorphization
-        // for them even though they might look super simple
+        // these macros expand to a lot of code, also want to skip
+        // monomorphization for them even though they might look super
+        // simple
         fn log_got_response() {
             debug!("Got response");
         }
@@ -214,8 +215,9 @@ impl HttpClient {
             // will be automatically dropped at the end of this function
             let _handle = self.concurrent_request_semaphore.acquire().await;
 
-            // There's a bunch of state in send_request, factor out a pinned inner
-            // future to reduce the size of futures that await this function.
+            // There's a bunch of state in send_request, factor out a pinned
+            // inner future to reduce the size of futures that await
+            // this function.
             match Box::pin(self.send_request::<R>(request, config, send_progress)).await {
                 Ok(response) => {
                     log_got_response();
@@ -321,9 +323,9 @@ impl SupportedPathBuilder for path_builder::VersionHistory {
         client: &crate::Client,
         skip_auth: bool,
     ) -> HttpResult<Cow<'static, SupportedVersions>> {
-        // We always enable "failsafe" mode for the GET /versions requests in this
-        // function. It disables trying to refresh the access token for those requests,
-        // to avoid possible deadlocks.
+        // We always enable "failsafe" mode for the GET /versions requests in
+        // this function. It disables trying to refresh the access token
+        // for those requests, to avoid possible deadlocks.
 
         if !client.auth_ctx().has_valid_access_token() {
             // Try to get the value in the cache.
@@ -331,8 +333,9 @@ impl SupportedPathBuilder for path_builder::VersionHistory {
                 return Ok(Cow::Owned(versions));
             }
 
-            // The request will skip auth so we might not get all the supported features, so
-            // just fetch the supported versions and don't cache them.
+            // The request will skip auth so we might not get all the supported
+            // features, so just fetch the supported versions and
+            // don't cache them.
             let response = client.fetch_server_versions_inner(true, None).await?;
 
             Ok(Cow::Owned(response.as_supported_versions()))
@@ -342,8 +345,9 @@ impl SupportedPathBuilder for path_builder::VersionHistory {
             let versions = if let Ok(Some(versions)) = cached_versions {
                 versions
             } else {
-                // If we're skipping auth we might not get all the supported features, so just
-                // fetch the versions and don't cache them.
+                // If we're skipping auth we might not get all the supported
+                // features, so just fetch the versions and
+                // don't cache them.
                 let request_config = RequestConfig::default().retry_limit(5).skip_auth();
                 let response =
                     client.fetch_server_versions_inner(true, Some(request_config)).await?;

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -51,8 +51,8 @@ impl HttpClient {
         // some functions split out so they only get compiled once,
         // not monomorphized per request type
         fn make_backoff(config: &RequestConfig) -> ExponentialBuilder {
-            // These values were picked because we used to use the `backoff` crate, those
-            // were defined here: https://docs.rs/backoff/0.4.0/backoff/default/index.html
+            // These values were picked because we used to use the `backoff`
+            // crate, those were defined here: https://docs.rs/backoff/0.4.0/backoff/default/index.html
             let mut backoff = ExponentialBuilder::new()
                 .with_min_delay(Duration::from_millis(500))
                 .with_max_delay(Duration::from_secs(60))
@@ -65,8 +65,9 @@ impl HttpClient {
             }
 
             if let Some(max_times) = config.retry_limit {
-                // Backon behaves a bit differently to our own handcrafted max retry logic.
-                // We were counting from one while `backon` counts from zero.
+                // Backon behaves a bit differently to our own handcrafted max
+                // retry logic. We were counting from one while
+                // `backon` counts from zero.
                 backoff = backoff.with_max_times(max_times.saturating_sub(1))
             }
 
@@ -94,13 +95,14 @@ impl HttpClient {
                 .record("response_size", response_size.display().si_short().to_string())
                 .record("request_duration", tracing::field::debug(request_duration));
 
-            // Record interesting headers. If you add more headers, ensure they're not
-            // confidential.
+            // Record interesting headers. If you add more headers, ensure
+            // they're not confidential.
             for (header_name, header_value) in response.headers() {
                 let header_name = header_name.as_str().to_lowercase();
 
-                // Header added in case of OAuth 2.0 authentication failure, so we can correlate
-                // failures with a Sentry event emitted by the OAuth 2.0 authentication server.
+                // Header added in case of OAuth 2.0 authentication failure, so
+                // we can correlate failures with a Sentry event
+                // emitted by the OAuth 2.0 authentication server.
                 if header_name == "x-sentry-event-id" {
                     tracing::Span::current()
                         .record("sentry_event_id", header_value.to_str().unwrap_or("<???>"));
@@ -116,12 +118,15 @@ impl HttpClient {
         ) -> Option<Duration> {
             match err.retry_kind() {
                 RetryKind::Transient { retry_after } => {
-                    // This bit is somewhat tricky but it's necessary so we respect the
-                    // `max_times` limit from `backon`.
+                    // This bit is somewhat tricky but it's necessary so we
+                    // respect the `max_times` limit from
+                    // `backon`.
                     //
-                    // The exponential backoff in `backon` is implemented as an iterator that
-                    // returns `None` when we hit the `max_times` limit; if it returned `None`,
-                    // that means we ran out of attempts. So it's necessary to only override
+                    // The exponential backoff in `backon` is implemented as an
+                    // iterator that returns `None` when we
+                    // hit the `max_times` limit; if it returned `None`,
+                    // that means we ran out of attempts. So it's necessary to
+                    // only override
                     // the `backon_suggested_timeout` if it's `Some`.
                     if backon_suggested_timeout.is_some() {
                         retry_after.or(backon_suggested_timeout)
@@ -131,9 +136,11 @@ impl HttpClient {
                 }
                 RetryKind::Permanent => None,
                 RetryKind::NetworkFailure => {
-                    // If we ran into a network failure, only retry if there's some retry limit
-                    // associated to this request's configuration; otherwise, we would end up
-                    // running an infinite loop of network requests in offline mode.
+                    // If we ran into a network failure, only retry if there's
+                    // some retry limit associated to this
+                    // request's configuration; otherwise, we would end up
+                    // running an infinite loop of network requests in offline
+                    // mode.
                     if has_retry_limit { backon_suggested_timeout } else { None }
                 }
             }

--- a/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/builder.rs
@@ -51,13 +51,15 @@ impl Builder {
         own_user_id: &UserId,
         power_levels: Option<&RoomPowerLevels>,
     ) -> Option<LatestEventValue> {
-        // If we are computing a value from the Event Cache, it's because we have
-        // received an update from the Event Cache. This update falls in two categories:
-        // either an event has been added or updated, or the room has been emptied (via
+        // If we are computing a value from the Event Cache, it's because we
+        // have received an update from the Event Cache. This update
+        // falls in two categories: either an event has been added or
+        // updated, or the room has been emptied (via
         // `EventCache::clear_all_rooms` for example).
         //
-        // We consider the room has been emptied by default. If we are able to scan at
-        // least one in-memory event, we consider the room has not been emptied.
+        // We consider the room has been emptied by default. If we are able to
+        // scan at least one in-memory event, we consider the room has
+        // not been emptied.
         let mut room_has_been_emptied = true;
         let mut current_value_must_be_erased = false;
 
@@ -203,8 +205,10 @@ impl Builder {
                                     content: serialized_event_content.clone(),
                                 };
 
-                                // If a local previous `LatestEventValue` exists and has been marked
-                                // as “cannot be sent”, it means the new `LatestEventValue` must
+                                // If a local previous `LatestEventValue` exists
+                                // and has been marked
+                                // as “cannot be sent”, it means the new
+                                // `LatestEventValue` must
                                 // also be marked as “cannot be sent”.
                                 let value =
                                     if let Some((_, LatestEventValue::LocalCannotBeSent(_))) =
@@ -253,9 +257,11 @@ impl Builder {
                 {
                     buffer_of_values_for_local_events.remove(position);
 
-                    // We have cancelled a local value. If there is no more local values, and if
-                    // there is no candidate for the Event Cache, we must generate some value, here
-                    // `LatestEventValue::None`, to erase any existing value.
+                    // We have cancelled a local value. If there is no more
+                    // local values, and if there is no
+                    // candidate for the Event Cache, we must generate some
+                    // value, here `LatestEventValue::None`,
+                    // to erase any existing value.
                     Some(LatestEventValue::None)
                 } else {
                     None
@@ -286,12 +292,14 @@ impl Builder {
                 {
                     let (_, value) = buffer_of_values_for_local_events.remove(position);
 
-                    // The sent event is the last of the buffer. Let's compute a proper “detached”
-                    // one if and only if the sent one was the last local one: not from the buffer,
+                    // The sent event is the last of the buffer. Let's compute a
+                    // proper “detached” one if and only if
+                    // the sent one was the last local one: not from the buffer,
                     // not from the Event Cache!.
                     if buffer_of_values_for_local_events.last().is_none() {
-                        // Try to resolve to a remote value from the event cache first. The remote
-                        // echo might already have been processed before we get here.
+                        // Try to resolve to a remote value from the event cache
+                        // first. The remote echo might
+                        // already have been processed before we get here.
                         if let Ok(Some(_)) = room_event_cache.find_event(event_id).await
                             && let Some(latest_event_value) = Self::new_remote(
                                 room_event_cache,
@@ -380,12 +388,14 @@ impl Builder {
             // was recoverable.
             RoomSendQueueUpdate::SendError { transaction_id, is_recoverable, .. } => {
                 if *is_recoverable {
-                    // If the room send queue error is recoverable, the send queue may retry to send
-                    // it in a short while, so the event should still be considered
+                    // If the room send queue error is recoverable, the send
+                    // queue may retry to send it in a short
+                    // while, so the event should still be considered
                     // sending. Leave it to that, at this point.
                     buffer_of_values_for_local_events.mark_is_sending_from(transaction_id);
                 } else {
-                    // If the error isn't recoverable, mark as a true "cannot be sent".
+                    // If the error isn't recoverable, mark as a true "cannot be
+                    // sent".
                     buffer_of_values_for_local_events.mark_cannot_be_sent_from(transaction_id);
                 }
 
@@ -721,8 +731,9 @@ fn filter_any_message_like_event_content(
             // Not all relations are accepted. Let's filter them.
             match relates_to {
                 Some(Relation::Replacement(Replacement { event_id, .. })) => {
-                    // Edits are suitable as latest events if and only if the targeted event is also
-                    // suitable. Let's remember this edit, and the associated
+                    // Edits are suitable as latest events if and only if the
+                    // targeted event is also suitable. Let'
+                    // s remember this edit, and the associated
                     // targeted event ID.
                     filter_continue_with_edit(event_id)
                 }
@@ -746,8 +757,8 @@ fn filter_any_message_like_event_content(
         }) => {
             // A redaction is not suitable.
             //
-            // However, this redaction targets the current `LatestEventValue`! It means the
-            // current value must be erased.
+            // However, this redaction targets the current `LatestEventValue`!
+            // It means the current value must be erased.
             if redacts.as_ref() == current_value_event_id {
                 filter_continue_with_erasing()
             } else {
@@ -784,8 +795,8 @@ fn filter_any_sync_state_event(
                         None => false,
                     };
 
-                    // The current user can act on the knock changes, so they should be
-                    // displayed
+                    // The current user can act on the knock changes, so they
+                    // should be displayed
                     if can_accept_or_decline_knocks {
                         return filter_break();
                     }
@@ -798,13 +809,14 @@ fn filter_any_sync_state_event(
                 | MembershipChange::Invited
                 | MembershipChange::InvitationAccepted
                 | MembershipChange::KnockAccepted => {
-                    // This member _is_ the current user, not someone else! This is a valid state
-                    // event:
+                    // This member _is_ the current user, not someone else! This
+                    // is a valid state event:
                     //
-                    // - the user is joining a room (for the first time or again): we want a
-                    //   `LatestEventValue` to get a first value!
-                    // - the user is being invited: we want a `LatestEventValue` to represent the
-                    //   invitation!
+                    // - the user is joining a room (for the first time or
+                    //   again): we want a `LatestEventValue` to get a first
+                    //   value!
+                    // - the user is being invited: we want a `LatestEventValue`
+                    //   to represent the invitation!
                     if member.state_key.deref() == own_user_id {
                         filter_break()
                     } else {
@@ -902,8 +914,8 @@ mod filter_tests {
         let event_id = event_id!("$ev0");
         let event = event_factory.redaction(event_id).into_event();
 
-        // `current_value_event_id` is `None`, it cannot be used to decide whether the
-        // current value must be erased.
+        // `current_value_event_id` is `None`, it cannot be used to decide
+        // whether the current value must be erased.
         {
             let current_value_event_id = None;
 
@@ -916,8 +928,8 @@ mod filter_tests {
             );
         }
 
-        // `current_value_event_id` is `Some(_)`, but the redaction event doesn't target
-        // this event ID.
+        // `current_value_event_id` is `Some(_)`, but the redaction event
+        // doesn't target this event ID.
         {
             let current_value_event_id = Some(owned_event_id!("$ev1"));
 
@@ -930,8 +942,9 @@ mod filter_tests {
             );
         }
 
-        // `current_value_event_id` is `Some(_)`, and the redaction event does target
-        // this event ID: great, the current value must be erased!
+        // `current_value_event_id` is `Some(_)`, and the redaction event does
+        // target this event ID: great, the current value must be
+        // erased!
         {
             let current_value_event_id = Some(event_id.to_owned());
 
@@ -1138,9 +1151,9 @@ mod filter_tests {
             );
         }
 
-        // Cannot accept. Can decline. But with an other user ID with at least the same
-        // levels, i.e. the current user cannot kick another user with the same
-        // or higher levels.
+        // Cannot accept. Can decline. But with an other user ID with at least
+        // the same levels, i.e. the current user cannot kick another
+        // user with the same or higher levels.
         {
             room_power_levels.users.insert(user_id.to_owned(), 5.into());
             room_power_levels.users.insert(other_user_id.to_owned(), 5.into());
@@ -2086,8 +2099,8 @@ mod builder_tests {
         // Initial state.
         let current_value = LatestEventValue::Remote(remote_room_message(event_id, "hello"));
 
-        // Compute a new remote value: with no candidate, but it's a `m.room.redaction`
-        // that erases `current_value`!
+        // Compute a new remote value: with no candidate, but it's a
+        // `m.room.redaction` that erases `current_value`!
         //
         // No candidate is found, so it SHOULD BE a `None`, but since we found a
         // `m.room.redaction` targeting our `current_value`, it MUST BE a
@@ -2146,8 +2159,8 @@ mod builder_tests {
         // Initial state.
         let current_value = LatestEventValue::Remote(remote_room_message(event_id, "hello"));
 
-        // Compute a new remote value: with a candidate, and a `m.room.redaction`
-        // that erases `current_value`!
+        // Compute a new remote value: with a candidate, and a
+        // `m.room.redaction` that erases `current_value`!
         //
         // A candidate is found, so it MUST BE a
         // `Some(LatestEventValue::Remote(_))`, whatever the `current_value`
@@ -2735,7 +2748,8 @@ mod builder_tests {
             )
         };
 
-        // Receiving another `NewLocalEvent`, ensuring it's pushed back in the buffer.
+        // Receiving another `NewLocalEvent`, ensuring it's pushed back in the
+        // buffer.
         {
             let transaction_id = OwnedTransactionId::from("txnid1");
             let content = new_local_echo_content(&room_send_queue, &transaction_id, "B");
@@ -2780,8 +2794,8 @@ mod builder_tests {
         };
 
         // Receiving a `SendError` targeting the first event. The
-        // `LatestEventValue` must change to indicate it “cannot be sent”, because the
-        // error is unrecoverable.
+        // `LatestEventValue` must change to indicate it “cannot be sent”,
+        // because the error is unrecoverable.
         let previous_value = {
             let update = RoomSendQueueUpdate::SendError {
                 transaction_id: transaction_id_0.clone(),
@@ -2789,8 +2803,8 @@ mod builder_tests {
                 is_recoverable: false,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's marked as “cannot be sent”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "A"
@@ -2802,9 +2816,9 @@ mod builder_tests {
             value
         };
 
-        // Receiving another `NewLocalEvent`, ensuring it's pushed back in the buffer,
-        // and as a `LocalCannotBeSent` because the previous value is itself
-        // `LocalCannotBeSent`.
+        // Receiving another `NewLocalEvent`, ensuring it's pushed back in the
+        // buffer, and as a `LocalCannotBeSent` because the previous
+        // value is itself `LocalCannotBeSent`.
         {
             let transaction_id = OwnedTransactionId::from("txnid1");
             let content = new_local_echo_content(&room_send_queue, &transaction_id, "B");
@@ -2849,8 +2863,8 @@ mod builder_tests {
             (transaction_id, value)
         };
 
-        // Receiving one `NewLocalEvent` with content of kind react! This time, it is
-        // ignored.
+        // Receiving one `NewLocalEvent` with content of kind react! This time,
+        // it is ignored.
         {
             let transaction_id = OwnedTransactionId::from("txnid1");
             let content = LocalEchoContent::React {
@@ -2925,8 +2939,8 @@ mod builder_tests {
                 transaction_id: transaction_id_1.clone(),
             };
 
-            // The `LatestEventValue` hasn't changed, it still matches the latest local
-            // event.
+            // The `LatestEventValue` hasn't changed, it still matches the
+            // latest local event.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "C"
@@ -2937,15 +2951,16 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `CancelledLocalEvent` targeting the second (so the last) event.
-        // The `LatestEventValue` must point to the first local event.
+        // Receiving a `CancelledLocalEvent` targeting the second (so the last)
+        // event. The `LatestEventValue` must point to the first local
+        // event.
         let previous_value = {
             let update = RoomSendQueueUpdate::CancelledLocalEvent {
                 transaction_id: transaction_id_2.clone(),
             };
 
-            // The `LatestEventValue` has changed, it matches the previous (so the first)
-            // local event.
+            // The `LatestEventValue` has changed, it matches the previous (so
+            // the first) local event.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "A"
@@ -2956,10 +2971,10 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `CancelledLocalEvent` targeting the first (so the last) event.
-        // The `LatestEventValue` cannot be computed from the send queue and will
-        // fallback to the event cache. The event cache is empty in this case, so we get
-        // nothing.
+        // Receiving a `CancelledLocalEvent` targeting the first (so the last)
+        // event. The `LatestEventValue` cannot be computed from the
+        // send queue and will fallback to the event cache. The event
+        // cache is empty in this case, so we get nothing.
         {
             let update =
                 RoomSendQueueUpdate::CancelledLocalEvent { transaction_id: transaction_id_0 };
@@ -3015,16 +3030,16 @@ mod builder_tests {
             value.unwrap()
         };
 
-        // Receiving a `SentEvent` targeting the first event. The `LatestEventValue`
-        // must not change.
+        // Receiving a `SentEvent` targeting the first event. The
+        // `LatestEventValue` must not change.
         let previous_value = {
             let update = RoomSendQueueUpdate::SentEvent {
                 transaction_id: transaction_id_0.clone(),
                 event_id: owned_event_id!("$ev0"),
             };
 
-            // The `LatestEventValue` hasn't changed, it still matches the latest local
-            // event.
+            // The `LatestEventValue` hasn't changed, it still matches the
+            // latest local event.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3035,9 +3050,9 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `SentEvent` targeting the first event. The `LatestEventValue`
-        // hasn't changed, this is still this event, but the status has changed to
-        // `LocalHasBeenSent`.
+        // Receiving a `SentEvent` targeting the first event. The
+        // `LatestEventValue` hasn't changed, this is still this event,
+        // but the status has changed to `LocalHasBeenSent`.
         {
             let expected_event_id = event_id!("$ev1");
             let update = RoomSendQueueUpdate::SentEvent {
@@ -3108,8 +3123,8 @@ mod builder_tests {
                 new_content,
             };
 
-            // The `LatestEventValue` hasn't changed, it still matches the latest local
-            // event.
+            // The `LatestEventValue` hasn't changed, it still matches the
+            // latest local event.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3120,8 +3135,8 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `ReplacedLocalEvent` targeting the second (so the last) event.
-        // The `LatestEventValue` is changing.
+        // Receiving a `ReplacedLocalEvent` targeting the second (so the last)
+        // event. The `LatestEventValue` is changing.
         {
             let transaction_id = &transaction_id_1;
             let LocalEchoContent::Event { serialized_event: new_content, .. } =
@@ -3135,8 +3150,8 @@ mod builder_tests {
                 new_content,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but with its new content.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but with its new content.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B."
@@ -3174,9 +3189,10 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `ReplacedLocalEvent` targeting the first event. Sadly, the new
-        // event cannot be mapped to a `LatestEventValue`! The first event is removed
-        // from the buffer, and the `LatestEventValue` becomes `None` because there is
+        // Receiving a `ReplacedLocalEvent` targeting the first event. Sadly,
+        // the new event cannot be mapped to a `LatestEventValue`! The
+        // first event is removed from the buffer, and the
+        // `LatestEventValue` becomes `None` because there is
         // no other alternative.
         {
             let new_content = SerializableEventContent::new(&AnyMessageLikeEventContent::Reaction(
@@ -3252,8 +3268,8 @@ mod builder_tests {
                 new_content,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but with its new content.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but with its new content.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value.clone(), user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3276,8 +3292,8 @@ mod builder_tests {
                 new_content,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but with its new content.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but with its new content.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "C"
@@ -3321,8 +3337,8 @@ mod builder_tests {
         };
 
         // Receiving a `SendError` targeting the first event. The
-        // `LatestEventValue` must change to indicate it “cannot be sent”, because the
-        // error is unrecoverable.
+        // `LatestEventValue` must change to indicate it “cannot be sent”,
+        // because the error is unrecoverable.
         let previous_value = {
             let update = RoomSendQueueUpdate::SendError {
                 transaction_id: transaction_id_0.clone(),
@@ -3330,8 +3346,8 @@ mod builder_tests {
                 is_recoverable: false,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's marked as “cannot be sent”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "B"
@@ -3344,17 +3360,17 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `SentEvent` targeting the first event. The `LatestEventValue`
-        // must change: since an event has been sent, the following events are now
-        // “is sending”.
+        // Receiving a `SentEvent` targeting the first event. The
+        // `LatestEventValue` must change: since an event has been sent,
+        // the following events are now “is sending”.
         {
             let update = RoomSendQueueUpdate::SentEvent {
                 transaction_id: transaction_id_0.clone(),
                 event_id: owned_event_id!("$ev0"),
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's “is sending”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3399,8 +3415,9 @@ mod builder_tests {
         };
 
         // Receiving a `SendError` targeting the first event. The
-        // `LatestEventValue` doesn't change, because the sending error is recoverable
-        // (and thus will be retried soon, or as soon as network comes back).
+        // `LatestEventValue` doesn't change, because the sending error is
+        // recoverable (and thus will be retried soon, or as soon as
+        // network comes back).
         let previous_value = {
             let update = RoomSendQueueUpdate::SendError {
                 transaction_id: transaction_id_0.clone(),
@@ -3408,8 +3425,8 @@ mod builder_tests {
                 is_recoverable: true,
             };
 
-            // The `LatestEventValue` still matches the latest local event and should still
-            // be marked as a local being sent.
+            // The `LatestEventValue` still matches the latest local event and
+            // should still be marked as a local being sent.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3422,17 +3439,17 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `SentEvent` targeting the first event. The `LatestEventValue`
-        // must change: since an event has been sent, the following events are now
-        // “is sending”.
+        // Receiving a `SentEvent` targeting the first event. The
+        // `LatestEventValue` must change: since an event has been sent,
+        // the following events are now “is sending”.
         {
             let update = RoomSendQueueUpdate::SentEvent {
                 transaction_id: transaction_id_0.clone(),
                 event_id: owned_event_id!("$ev0"),
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's “is sending”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3477,8 +3494,8 @@ mod builder_tests {
         };
 
         // Receiving a `SendError` targeting the first event. The
-        // `LatestEventValue` must change to indicate it “cannot be sent”, because the
-        // error is unrecoverable.
+        // `LatestEventValue` must change to indicate it “cannot be sent”,
+        // because the error is unrecoverable.
         let previous_value = {
             let update = RoomSendQueueUpdate::SendError {
                 transaction_id: transaction_id_0.clone(),
@@ -3486,8 +3503,8 @@ mod builder_tests {
                 is_recoverable: false,
             };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's marked as “cannot be sent”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's marked as “cannot be sent”.
             let value = assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalCannotBeSent => with body = "B"
@@ -3500,14 +3517,15 @@ mod builder_tests {
             value
         };
 
-        // Receiving a `RetryEvent` targeting the first event. The `LatestEventValue`
-        // must change: this local event and its following must be “is sending”.
+        // Receiving a `RetryEvent` targeting the first event. The
+        // `LatestEventValue` must change: this local event and its
+        // following must be “is sending”.
         {
             let update =
                 RoomSendQueueUpdate::RetryEvent { transaction_id: transaction_id_0.clone() };
 
-            // The `LatestEventValue` has changed, it still matches the latest local
-            // event but it's “is sending”.
+            // The `LatestEventValue` has changed, it still matches the latest
+            // local event but it's “is sending”.
             assert_local_value_matches_room_message_with_body!(
                 Builder::new_local(&update, &mut buffer, &room_event_cache, previous_value, user_id, None).await,
                 LatestEventValue::LocalIsSending => with body = "B"
@@ -3725,9 +3743,10 @@ mod builder_tests {
         };
         assert_eq!(buffer.buffer.len(), 1);
 
-        // Step 2: The SentEvent update arrives. The buffer is now empty but the remote
-        // echo has already been processed and the event was added to the cache. The
-        // builder should resolve to LatestEventValue::Remote.
+        // Step 2: The SentEvent update arrives. The buffer is now empty but the
+        // remote echo has already been processed and the event was
+        // added to the cache. The builder should resolve to
+        // LatestEventValue::Remote.
         assert_remote_value_matches_room_message_with_body!(
             Builder::new_local(
                 &RoomSendQueueUpdate::SentEvent {

--- a/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/latest_event/mod.rs
@@ -107,9 +107,10 @@ impl LatestEvent {
         power_levels: Option<&RoomPowerLevels>,
     ) -> NeedMoreEvents {
         if self.buffer_of_values_for_local_events.is_empty().not() {
-            // At least one `LatestEventValue` exists for local events (i.e. coming from the
-            // send queue). In this case, we don't overwrite the current value with a newly
-            // computed one from the event cache.
+            // At least one `LatestEventValue` exists for local events (i.e.
+            // coming from the send queue). In this case, we don't
+            // overwrite the current value with a newly computed one
+            // from the event cache.
             return NeedMoreEvents::No;
         }
 
@@ -164,23 +165,32 @@ impl LatestEvent {
         room: Room,
         reasons: RoomInfoNotableUpdateReasons,
     ) {
-        // If the `RoomInfo` has been updated due to a change of the own membership.
+        // If the `RoomInfo` has been updated due to a change of the own
+        // membership.
         if reasons.contains(RoomInfoNotableUpdateReasons::MEMBERSHIP) {
             let new_value = match room.state() {
                 // If the room' state is `Invited`, it means the current user has been recently
                 // invited to this room.
                 RoomState::Invited => {
-                    // Short: Let's not update a `RemoteInvite` to another `RemoteInvite`.
+                    // Short: Let's not update a `RemoteInvite` to another
+                    // `RemoteInvite`.
                     //
-                    // Long: An invite room is only constituted of stripped-state events. These
-                    // events do not have an `origin_server_ts` field. It means we cannot compute
-                    // the timestamp of the `LatestEventValue`. To workaround this, we set the
-                    // timestamp to `now()`. See `Builder::new_remote_for_invite` to learn more.
-                    // If an invite room receives a new event, its `LatestEventValue`'s timestamp
-                    // will be updated to `now()`, which will make the room bumps to the top of the
-                    // room list for example. This is not an acceptable behaviour because it can be
-                    // an “attack vector”, i.e. a way to annoy people with spammy invites. That's
-                    // why, once a `RemoteInvite` has been computed, we do not refresh it.
+                    // Long: An invite room is only constituted of
+                    // stripped-state events. These
+                    // events do not have an `origin_server_ts` field. It means
+                    // we cannot compute the timestamp of
+                    // the `LatestEventValue`. To workaround this, we set the
+                    // timestamp to `now()`. See
+                    // `Builder::new_remote_for_invite` to learn more.
+                    // If an invite room receives a new event, its
+                    // `LatestEventValue`'s timestamp
+                    // will be updated to `now()`, which will make the room
+                    // bumps to the top of the room list for
+                    // example. This is not an acceptable behaviour because it
+                    // can be an “attack vector”, i.e. a way
+                    // to annoy people with spammy invites. That's
+                    // why, once a `RemoteInvite` has been computed, we do not
+                    // refresh it.
                     if matches!(
                         self.current_value.read().await.deref(),
                         LatestEventValue::RemoteInvite { .. }
@@ -216,16 +226,17 @@ impl LatestEvent {
     /// been found, we want to latest event value to be `None`, so that it is
     /// erased correctly.
     async fn update(&mut self, new_value: LatestEventValue) {
-        // Ideally, we would set `new_value` if and only if it is different from the
-        // previous value. However, `LatestEventValue` cannot implement `PartialEq` at
-        // the time of writing (2025-12-12). So we are only updating if:
+        // Ideally, we would set `new_value` if and only if it is different from
+        // the previous value. However, `LatestEventValue` cannot
+        // implement `PartialEq` at the time of writing (2025-12-12). So
+        // we are only updating if:
         //
         // - if `LatestEventValue` and the previous value aren't `None`,
         // - if the event IDs are different.
         //
-        // We must be careful when comparing the event IDs: `None` and `Local*` have no
-        // event ID, we can't compare them at this point. Hence the `match` statement to
-        // have a fine-grained decision.
+        // We must be careful when comparing the event IDs: `None` and `Local*`
+        // have no event ID, we can't compare them at this point. Hence
+        // the `match` statement to have a fine-grained decision.
         {
             let mut guard = self.current_value.write().await;
             let previous_value = guard.deref();
@@ -257,7 +268,8 @@ impl LatestEvent {
             if do_update {
                 ObservableWriteGuard::set(&mut guard, new_value.clone());
 
-                // Release the write guard over the current value before hitting the store.
+                // Release the write guard over the current value before hitting
+                // the store.
                 drop(guard);
 
                 self.store(new_value).await;
@@ -559,8 +571,9 @@ mod tests_latest_event {
         latest_event.update(LatestEventValue::LocalIsSending(local_room_message("foo"))).await;
         assert_next_matches!(stream, LatestEventValue::LocalIsSending(_));
 
-        // An invite computed from stripped state events has no event ID either, but
-        // both values are obviously different: this must not be ignored.
+        // An invite computed from stripped state events has no event ID either,
+        // but both values are obviously different: this must not be
+        // ignored.
         latest_event
             .update(LatestEventValue::RemoteInvite {
                 event_id: None,
@@ -665,7 +678,8 @@ mod tests_latest_event {
 
         let mut latest_event = LatestEvent::new(&weak_room, None);
 
-        // First, let's create a `LatestEventValue` from the event cache. It must work.
+        // First, let's create a `LatestEventValue` from the event cache. It
+        // must work.
         {
             latest_event.update_with_event_cache(&room_event_cache, user_id, None).await;
 
@@ -704,8 +718,8 @@ mod tests_latest_event {
             );
         }
 
-        // Fourth, let's a `LatestEventValue` from the send queue. It must stay the
-        // same, but now the local event is sent.
+        // Fourth, let's a `LatestEventValue` from the send queue. It must stay
+        // the same, but now the local event is sent.
         {
             let update = RoomSendQueueUpdate::SentEvent {
                 transaction_id,
@@ -720,8 +734,8 @@ mod tests_latest_event {
             );
         }
 
-        // Finally, let's create a `LatestEventValue` from the event cache. _Now_ it's
-        // possible, because there is no more local events.
+        // Finally, let's create a `LatestEventValue` from the event cache.
+        // _Now_ it's possible, because there is no more local events.
         {
             latest_event.update_with_event_cache(&room_event_cache, user_id, None).await;
 
@@ -905,8 +919,8 @@ mod tests_latest_event {
             }
         }
 
-        // Reload the client with the same store config, and see the `LatestEventValue`
-        // is inside the `RoomInfo`.
+        // Reload the client with the same store config, and see the
+        // `LatestEventValue` is inside the `RoomInfo`.
         {
             let client = server
                 .client_builder()

--- a/crates/matrix-sdk/src/latest_events/mod.rs
+++ b/crates/matrix-sdk/src/latest_events/mod.rs
@@ -110,8 +110,8 @@ impl LatestEvents {
         let registered_rooms =
             Arc::new(RegisteredRooms::new(weak_client, &event_cache, &latest_event_queue_sender));
 
-        // The task listening to the event cache, the send queue, and the room infos
-        // updates.
+        // The task listening to the event cache, the send queue, and the room
+        // infos updates.
         let listen_task_handle = spawn(listen_to_updates_task(
             registered_rooms.clone(),
             event_cache,
@@ -288,11 +288,12 @@ impl RegisteredRooms {
             // Insert the new `RoomLatestEvents`.
             rooms.insert(room_id.to_owned(), room_latest_events);
 
-            // If the `LatestEventValue` restored by `RoomLatestEvents` is of kind `None`,
-            // let's try to re-compute it without waiting on the Event Cache (so the sync
-            // usually) or the Send Queue. Maybe the system has migrated to a new version
-            // and the `LatestEventValue` has been erased, while it is still possible to
-            // compute a correct value.
+            // If the `LatestEventValue` restored by `RoomLatestEvents` is of
+            // kind `None`, let's try to re-compute it without
+            // waiting on the Event Cache (so the sync usually) or
+            // the Send Queue. Maybe the system has migrated to a new version
+            // and the `LatestEventValue` has been erased, while it is still
+            // possible to compute a correct value.
             if is_latest_event_value_none {
                 let _ = latest_event_queue_sender
                     .send(LatestEventQueueUpdate::EventCache { room_id: room_id.to_owned() });
@@ -308,7 +309,8 @@ impl RegisteredRooms {
             Some(thread_id) => {
                 let mut rooms = self.rooms.write().await;
 
-                // The `RoomLatestEvents` doesn't exist. Let's create and insert it.
+                // The `RoomLatestEvents` doesn't exist. Let's create and insert
+                // it.
                 if rooms.contains_key(room_id).not() {
                     create_and_insert_room_latest_events(
                         room_id,
@@ -322,8 +324,9 @@ impl RegisteredRooms {
                 if let Some(room_latest_event) = rooms.get(room_id) {
                     let mut room_latest_event = room_latest_event.write().await;
 
-                    // In `RoomLatestEvents`, the `LatestEvent` for this thread doesn't exist. Let's
-                    // create and insert it.
+                    // In `RoomLatestEvents`, the `LatestEvent` for this thread
+                    // doesn't exist. Let's create and
+                    // insert it.
                     if room_latest_event.has_thread(thread_id).not() {
                         room_latest_event.create_and_insert_latest_event_for_thread(thread_id);
                     }
@@ -599,7 +602,8 @@ async fn compute_latest_events(
             let room_latest_events = room_latest_events.write().await;
 
             // Release the lock on `registered_rooms`.
-            // It is possible because `room_latest_events` is an owned lock guard.
+            // It is possible because `room_latest_events` is an owned lock
+            // guard.
             drop(rooms);
 
             ControlFlow::Break(room_latest_events)
@@ -893,7 +897,8 @@ mod tests {
             assert!(latest_event_queue_receiver.is_empty());
         }
 
-        // New event cache update, but this time, the `LatestEvents` is listening to it.
+        // New event cache update, but this time, the `LatestEvents` is
+        // listening to it.
         {
             registered_rooms.write().await.insert(
                 room_id.clone(),
@@ -969,7 +974,8 @@ mod tests {
             assert!(latest_event_queue_receiver.is_empty());
         }
 
-        // New send queue update, but this time, the `LatestEvents` is listening to it.
+        // New send queue update, but this time, the `LatestEvents` is listening
+        // to it.
         {
             registered_rooms.write().await.insert(
                 room_id.clone(),
@@ -1048,7 +1054,8 @@ mod tests {
             assert!(latest_event_queue_receiver.is_empty());
         }
 
-        // New room info update, but this time, the `LatestEvents` is listening to it.
+        // New room info update, but this time, the `LatestEvents` is listening
+        // to it.
         {
             registered_rooms.write().await.insert(
                 room_id.clone(),
@@ -1103,8 +1110,8 @@ mod tests {
             .await
             .insert(room_id.clone(), With::inner(RoomLatestEvents::new(weak_room, event_cache)));
 
-        // - `RoomInfoNotableUpdateReasons::LATEST_EVENT` is forbidden, otherwise it
-        //   could create loops.
+        // - `RoomInfoNotableUpdateReasons::LATEST_EVENT` is forbidden,
+        //   otherwise it could create loops.
         // - Other reasons are ignored, except
         //   `RoomInfoNotableUpdateReasons::MEMBERSHIP`.
         for reason in {
@@ -1283,9 +1290,10 @@ mod tests {
             )
             .await;
 
-        // The event cache has received its update from the sync. It has emitted a
-        // generic update, which has been received by `LatestEvents` tasks, up to the
-        // `compute_latest_events` which has updated the latest event value.
+        // The event cache has received its update from the sync. It has emitted
+        // a generic update, which has been received by `LatestEvents`
+        // tasks, up to the `compute_latest_events` which has updated
+        // the latest event value.
         assert_matches!(
             latest_event_stream.next().await,
             Some(LatestEventValue::Remote(RemoteLatestEventValue { kind: TimelineEventKind::PlainText { event }, .. })) => {
@@ -1387,7 +1395,8 @@ mod tests {
         let room_1 = client.base_client().get_or_create_room(&room_id_1, RoomState::Joined);
 
         // Set up the rooms.
-        // `room_0` always has a `LatestEventValue::None` as its the default value.
+        // `room_0` always has a `LatestEventValue::None` as its the default
+        // value.
         let mut room_info_1 = room_0.clone_info();
         room_info_1.set_latest_event(LatestEventValue::LocalIsSending(local_room_message("foo")));
         room_1.update_room_info(|_| (room_info_1, Default::default())).await;
@@ -1472,8 +1481,9 @@ mod tests {
                 )
                 .await;
 
-            // The room has received its update from the sync. It has emitted a room info
-            // update, which has been received by `LatestEvents` tasks, up to the
+            // The room has received its update from the sync. It has emitted a
+            // room info update, which has been received by
+            // `LatestEvents` tasks, up to the
             // `compute_latest_events` which has updated the latest event value.
             assert_matches!(
                 latest_event_stream.next().await,
@@ -1503,10 +1513,12 @@ mod tests {
                 )
                 .await;
 
-            // The room has received its update from the sync. It has emitted a room info
-            // update, which has been received by `LatestEvents` tasks, up to the
-            // `compute_latest_events` which has NOT updated the latest event value because
-            // a previous `RemoteInvite` was already computed.
+            // The room has received its update from the sync. It has emitted a
+            // room info update, which has been received by
+            // `LatestEvents` tasks, up to the
+            // `compute_latest_events` which has NOT updated the latest event
+            // value because a previous `RemoteInvite` was already
+            // computed.
             assert!(timeout(Duration::from_secs(1), latest_event_stream.next()).await.is_err());
 
             assert_pending!(latest_event_stream);
@@ -1528,8 +1540,9 @@ mod tests {
                 )
                 .await;
 
-            // The event cache has received its update from the sync. It has emitted a
-            // generic update, which has been received by `LatestEvents` tasks, up to the
+            // The event cache has received its update from the sync. It has
+            // emitted a generic update, which has been received by
+            // `LatestEvents` tasks, up to the
             // `compute_latest_events` which has updated the latest event value.
             assert_matches!(
                 latest_event_stream.next().await,

--- a/crates/matrix-sdk/src/latest_events/room_latest_events.rs
+++ b/crates/matrix-sdk/src/latest_events/room_latest_events.rs
@@ -151,11 +151,11 @@ impl RoomLatestEventsWriteGuard {
     /// Update the latest events for the room and its threads, based on the
     /// event cache data.
     pub async fn update_with_event_cache(&mut self) {
-        // Get the power levels of the user for the current room if the `WeakRoom` is
-        // still valid.
+        // Get the power levels of the user for the current room if the
+        // `WeakRoom` is still valid.
         //
-        // Get it once for all the updates of all the latest events for this room (be
-        // the room and its threads).
+        // Get it once for all the updates of all the latest events for this
+        // room (be the room and its threads).
         let Some(room) = self.inner.weak_room.get() else {
             // No room? Let's stop the update.
             error!(room = ?self.inner.weak_room, "Room is unknown");
@@ -173,8 +173,9 @@ impl RoomLatestEventsWriteGuard {
         let room_event_cache = match inner
             .room_event_cache
             .get_or_try_init(|| async {
-                // It's fine to drop the `EventCacheDropHandles` here as the caller
-                // (`LatestEventState`) owns a clone of the `EventCache`.
+                // It's fine to drop the `EventCacheDropHandles` here as the
+                // caller (`LatestEventState`) owns a clone of
+                // the `EventCache`.
                 let (room_event_cache, _drop_handles) =
                     inner.event_cache.room(room.room_id()).await?;
 
@@ -210,11 +211,11 @@ impl RoomLatestEventsWriteGuard {
     /// Update the latest events for the room and its threads, based on the
     /// send queue update.
     pub async fn update_with_send_queue(&mut self, send_queue_update: &RoomSendQueueUpdate) {
-        // Get the power levels of the user for the current room if the `WeakRoom` is
-        // still valid.
+        // Get the power levels of the user for the current room if the
+        // `WeakRoom` is still valid.
         //
-        // Get it once for all the updates of all the latest events for this room (be
-        // the room and its threads).
+        // Get it once for all the updates of all the latest events for this
+        // room (be the room and its threads).
         let Some(room) = self.inner.weak_room.get() else {
             // No room? Let's stop the update.
             return;
@@ -230,8 +231,9 @@ impl RoomLatestEventsWriteGuard {
         let room_event_cache = match inner
             .room_event_cache
             .get_or_try_init(|| async {
-                // It's fine to drop the `EventCacheDropHandles` here as the caller
-                // (`LatestEventState`) owns a clone of the `EventCache`.
+                // It's fine to drop the `EventCacheDropHandles` here as the
+                // caller (`LatestEventState`) owns a clone of
+                // the `EventCache`.
                 let (room_event_cache, _drop_handles) =
                     inner.event_cache.room(room.room_id()).await?;
 
@@ -305,9 +307,10 @@ impl RoomLatestEventsWriteGuard {
         let power_levels = power_levels.cloned();
 
         // This filters each batch to spot a candidate and `Builder::new_remote`
-        // filters the same events again when it computes the value afterwards. That
-        // second pass can't be skipped though as an event's edits are newer than it
-        // and a stop condition only ever sees the batch it just loaded.
+        // filters the same events again when it computes the value afterwards.
+        // That second pass can't be skipped though as an event's edits
+        // are newer than it and a stop condition only ever sees the
+        // batch it just loaded.
         let stop = move |outcome: &BackPaginationOutcome| {
             let found = outcome.events.iter().any(|event| {
                 filter_timeline_event(event, None, &own_user_id, power_levels.as_ref()).is_break()
@@ -369,9 +372,10 @@ mod tests {
 
         client.base_client().get_or_create_room(room_id, RoomState::Joined);
 
-        // A linked chunk with a single gap: no events in memory (so no candidate),
-        // but a token to paginate from. Set up directly so no sync (and thus no
-        // competing read-receipt pagination) races the backfill.
+        // A linked chunk with a single gap: no events in memory (so no
+        // candidate), but a token to paginate from. Set up directly so
+        // no sync (and thus no competing read-receipt pagination) races
+        // the backfill.
         client
             .event_cache_store()
             .lock()
@@ -418,8 +422,8 @@ mod tests {
 
         room_latest_events.write().await.update_with_event_cache().await;
 
-        // The backfill runs in the background; wait for the events it loads, then
-        // recompute as the update it emits would.
+        // The backfill runs in the background; wait for the events it loads,
+        // then recompute as the update it emits would.
         assert_let_timeout!(Ok(_) = updates.recv());
 
         room_latest_events.write().await.update_with_event_cache().await;

--- a/crates/matrix-sdk/src/live_locations_observer.rs
+++ b/crates/matrix-sdk/src/live_locations_observer.rs
@@ -214,8 +214,8 @@ impl LiveLocationsObserver {
         let beacon_info_event_id = &event.content.relates_to.event_id;
         let mut shares = shares.lock();
         if let Some(idx) = shares.iter().position(|s| s.beacon_id == *beacon_info_event_id) {
-            // Check if beacon info is still live, if not, remove the share and ignore the
-            // beacon event.
+            // Check if beacon info is still live, if not, remove the share and
+            // ignore the beacon event.
             let mut share = shares[idx].clone();
             if !share.beacon_info.is_live() {
                 shares.remove(idx);

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -288,8 +288,8 @@ impl Media {
         content_type: &Mime,
         data: Vec<u8>,
     ) -> Result<()> {
-        // Do a best-effort at reporting an expired MXC URI here; otherwise the server
-        // may complain about it later.
+        // Do a best-effort at reporting an expired MXC URI here; otherwise the
+        // server may complain about it later.
         if let Some(expire_date) = uri.expire_date
             && MilliSecondsSinceUnixEpoch::now() >= expire_date
         {
@@ -433,8 +433,8 @@ impl Media {
         request: &MediaRequestParameters,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
-        // This is a local media. Force to read the media's content from the store: it
-        // cannot exist somewhere else!
+        // This is a local media. Force to read the media's content from the
+        // store: it cannot exist somewhere else!
         if Self::is_local_uri(&request.source) {
             if let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
@@ -447,8 +447,8 @@ impl Media {
             }
         }
 
-        // Read from the cache: if it doesn't exist, the execution continues by reading
-        // the media from the network.
+        // Read from the cache: if it doesn't exist, the execution continues by
+        // reading the media from the network.
         if use_cache
             && let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
@@ -836,8 +836,9 @@ impl MediaFetcher for DefaultMediaFetcher {
                             file.as_ref().clone().into(),
                         )?;
 
-                        // Encrypted size should be the same as the decrypted size,
-                        // rounded up to a cipher block.
+                        // Encrypted size should be the same as the decrypted
+                        // size, rounded up to a cipher
+                        // block.
                         let mut decrypted = Vec::with_capacity(content_len);
 
                         reader.read_to_end(&mut decrypted)?;

--- a/crates/matrix-sdk/src/message_search.rs
+++ b/crates/matrix-sdk/src/message_search.rs
@@ -152,8 +152,8 @@ impl Room {
     ) -> impl Stream<Item = Result<Vec<(f32, OwnedEventId)>, IndexError>> + use<> {
         let room = self.clone();
 
-        // TODO: use the client/server API search endpoint for public rooms, as those
-        // may require lots of time for indexing all events.
+        // TODO: use the client/server API search endpoint for public rooms, as
+        // those may require lots of time for indexing all events.
         try_stream! {
             let mut offset = 0;
             loop {
@@ -459,8 +459,8 @@ mod tests {
             let results: Vec<(OwnedRoomId, f32, OwnedEventId)> =
                 client.search_messages("world".to_owned()).build().try_concat().await.unwrap();
             assert_eq!(results.len(), 2);
-            // Search results order is not guaranteed, so we check that both expected
-            // results are present.
+            // Search results order is not guaranteed, so we check that both
+            // expected results are present.
             assert!(results.iter().any(|(room_id, _, event_id)| {
                 room_id == room_id1 && event_id == result_event_id1
             }));
@@ -478,8 +478,8 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(results.len(), 2);
-            // Search results order is not guaranteed, so we check that both expected
-            // results are present.
+            // Search results order is not guaranteed, so we check that both
+            // expected results are present.
             assert!(results.iter().any(|(room_id, event)| {
                 room_id == room_id1 && event.event_id() == Some(result_event_id1)
             }));
@@ -502,13 +502,15 @@ mod tests {
 
         let f = EventFactory::new().sender(user_id!("@user_id:localhost"));
 
-        // Both rooms get two documents of identical length (padded with filler so
-        // document-length normalization and the per-corpus IDF of "world" match across
-        // rooms). The score then depends only on how many times "world" appears.
+        // Both rooms get two documents of identical length (padded with filler
+        // so document-length normalization and the per-corpus IDF of
+        // "world" match across rooms). The score then depends only on
+        // how many times "world" appears.
         //
-        // Term frequencies are 4, 3, 2, 1, split so the rooms alternate by rank:
-        // room1 holds the 4x and 2x events, room2 the 3x and 1x events. A correct
-        // cross-room sort therefore interleaves the rooms: r1, r2, r1, r2.
+        // Term frequencies are 4, 3, 2, 1, split so the rooms alternate by
+        // rank: room1 holds the 4x and 2x events, room2 the 3x and 1x
+        // events. A correct cross-room sort therefore interleaves the
+        // rooms: r1, r2, r1, r2.
         let r1_rank1 = event_id!("$r1_rank1:localhost"); // room1, "world" x4
         let r2_rank2 = event_id!("$r2_rank2:localhost"); // room2, "world" x3
         let r1_rank3 = event_id!("$r1_rank3:localhost"); // room1, "world" x2

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -218,8 +218,9 @@ impl NotificationSettings {
         if let Err(error) =
             self.set_underride_push_rule_actions(poll_start_rule_id, actions.clone()).await
         {
-            // The poll start event rules are currently unstable so they might not be found
-            // on every homeserver. Let's ignore this error for the moment.
+            // The poll start event rules are currently unstable so they might
+            // not be found on every homeserver. Let's ignore this
+            // error for the moment.
             if let NotificationSettingsError::RuleNotFound(rule_id) = &error {
                 debug!("Unable to update poll start push rule: rule `{rule_id}` not found");
             } else {
@@ -338,8 +339,8 @@ impl NotificationSettings {
             .filter(|(kind, rule_id)| kind != &new_rule_kind || rule_id != new_rule_id)
             .collect();
 
-        // Build the command list to delete all other custom rules, with the exception
-        // of the newly inserted rule.
+        // Build the command list to delete all other custom rules, with the
+        // exception of the newly inserted rule.
         let mut rule_commands = RuleCommands::new(rules.ruleset);
         rule_commands.insert_rule(new_rule_kind.clone(), room_id, notify)?;
         for (kind, rule_id) in custom_rules {
@@ -407,8 +408,8 @@ impl NotificationSettings {
                 self.delete_user_defined_room_rules(room_id).await
             }
         } else {
-            // This is the default mode, create a custom rule to unmute this room by setting
-            // the mode to `AllMessages`
+            // This is the default mode, create a custom rule to unmute this
+            // room by setting the mode to `AllMessages`
             self.set_room_notification_mode(room_id, RoomNotificationMode::AllMessages).await
         }
     }
@@ -715,7 +716,8 @@ mod tests {
         let client = logged_in_client(Some(server.uri())).await;
         let room_id = get_test_room_id();
 
-        // Initialize with a muted `Room` rule to be in `MentionsAndKeywordsOnly`
+        // Initialize with a muted `Room` rule to be in
+        // `MentionsAndKeywordsOnly`
         let settings = from_insert_rules(&client, vec![(RuleKind::Room, &room_id, false)]);
         assert_eq!(
             settings.get_user_defined_room_notification_mode(&room_id).await.unwrap(),
@@ -763,8 +765,8 @@ mod tests {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
-        // The default mode must be `MentionsAndKeywords` if the corresponding Underride
-        // rule doesn't notify
+        // The default mode must be `MentionsAndKeywords` if the corresponding
+        // Underride rule doesn't notify
         let mut ruleset = get_server_default_ruleset();
         ruleset.set_actions(
             RuleKind::Underride,
@@ -778,8 +780,8 @@ mod tests {
             RoomNotificationMode::MentionsAndKeywordsOnly
         );
 
-        // The default mode must be `MentionsAndKeywords` if the corresponding Underride
-        // rule is disabled
+        // The default mode must be `MentionsAndKeywords` if the corresponding
+        // Underride rule is disabled
         ruleset.set_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::RoomOneToOne, false)?;
 
         let settings = NotificationSettings::new(client, ruleset);
@@ -969,10 +971,11 @@ mod tests {
         Mock::given(method("DELETE"))
             .and(path_regex(r"_matrix/client/r0/pushrules/global/room/.*"))
             .and(move |_: &wiremock::Request| {
-                // Make sure that the PUT is executed before the DELETE, so that the following
-                // sync results will give the following transitions:
-                // `AllMessages` -> `AllMessages` -> `Mute` by sending the
-                // DELETE before the PUT, we would have `AllMessages` ->
+                // Make sure that the PUT is executed before the DELETE, so that
+                // the following sync results will give the
+                // following transitions: `AllMessages` ->
+                // `AllMessages` -> `Mute` by sending the DELETE
+                // before the PUT, we would have `AllMessages` ->
                 // `Default` -> `Mute`
 
                 let put_was_called = put_was_called.load(Ordering::SeqCst);
@@ -991,11 +994,12 @@ mod tests {
 
         let room_id = get_test_room_id();
 
-        // Set the initial state to `AllMessages` by setting a `Room` rule that notifies
+        // Set the initial state to `AllMessages` by setting a `Room` rule that
+        // notifies
         let settings = from_insert_rules(&client, vec![(RuleKind::Room, &room_id, true)]);
 
-        // Set the new mode to `Mute`, this will add a new `Override` rule without
-        // action and remove the `Room` rule.
+        // Set the new mode to `Mute`, this will add a new `Override` rule
+        // without action and remove the `Room` rule.
         settings.set_room_notification_mode(&room_id, RoomNotificationMode::Mute).await?;
 
         assert_eq!(
@@ -1018,7 +1022,8 @@ mod tests {
 
         let room_id = get_test_room_id();
 
-        // Set the initial state to `AllMessages` by setting a `Room` rule that notifies
+        // Set the initial state to `AllMessages` by setting a `Room` rule that
+        // notifies
         let settings = from_insert_rules(&client, vec![(RuleKind::Room, &room_id, true)]);
 
         assert_eq!(
@@ -1050,7 +1055,8 @@ mod tests {
 
         let room_id = get_test_room_id();
 
-        // Set the initial state to `AllMessages` by setting a `Room` rule that notifies
+        // Set the initial state to `AllMessages` by setting a `Room` rule that
+        // notifies
         let settings = from_insert_rules(&client, vec![(RuleKind::Room, &room_id, true)]);
 
         assert_eq!(
@@ -1235,8 +1241,8 @@ mod tests {
             }
         );
 
-        // and the new mode returned by `get_default_room_notification_mode()` should
-        // reflect the change.
+        // and the new mode returned by `get_default_room_notification_mode()`
+        // should reflect the change.
         assert_matches!(
             settings.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::No).await,
             RoomNotificationMode::MentionsAndKeywordsOnly
@@ -1293,8 +1299,8 @@ mod tests {
             }
         );
 
-        // and the new mode returned by `get_default_room_notification_mode()` should
-        // reflect the change.
+        // and the new mode returned by `get_default_room_notification_mode()`
+        // should reflect the change.
         assert_matches!(
             settings.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::Yes).await,
             RoomNotificationMode::MentionsAndKeywordsOnly
@@ -1337,8 +1343,8 @@ mod tests {
             )
             .await?;
 
-        // The new mode returned should be `AllMessages` which means that the disabled
-        // rule (`RoomOneToOne`) has been enabled.
+        // The new mode returned should be `AllMessages` which means that the
+        // disabled rule (`RoomOneToOne`) has been enabled.
         assert_matches!(
             settings.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::Yes).await,
             RoomNotificationMode::AllMessages
@@ -1612,8 +1618,8 @@ mod tests {
             )
             .await?;
 
-        // the new mode returned by `get_default_room_notification_mode()` should
-        // reflect the change.
+        // the new mode returned by `get_default_room_notification_mode()`
+        // should reflect the change.
         assert_matches!(
             settings.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::No).await,
             RoomNotificationMode::MentionsAndKeywordsOnly

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -115,10 +115,12 @@ impl RuleCommands {
         enabled: bool,
     ) -> Result<(), NotificationSettingsError> {
         if rule_id == PredefinedOverrideRuleId::IsRoomMention.as_str() {
-            // Handle specific case for `PredefinedOverrideRuleId::IsRoomMention`
+            // Handle specific case for
+            // `PredefinedOverrideRuleId::IsRoomMention`
             self.set_room_mention_enabled(enabled)
         } else if rule_id == PredefinedOverrideRuleId::IsUserMention.as_str() {
-            // Handle specific case for `PredefinedOverrideRuleId::IsUserMention`
+            // Handle specific case for
+            // `PredefinedOverrideRuleId::IsUserMention`
             self.set_user_mention_enabled(enabled)
         } else {
             self.set_enabled_internal(kind, rule_id, enabled)
@@ -145,7 +147,8 @@ impl RuleCommands {
                 PredefinedContentRuleId::ContainsUserName.as_str(),
                 enabled,
             ) {
-                // This rule has been removed from the spec, so it's fine if it wasn't found.
+                // This rule has been removed from the spec, so it's fine if it
+                // wasn't found.
                 if !err.is_rule_not_found() {
                     return Err(err);
                 }
@@ -157,7 +160,8 @@ impl RuleCommands {
                 PredefinedOverrideRuleId::ContainsDisplayName.as_str(),
                 enabled,
             ) {
-                // This rule has been removed from the spec, so it's fine if it wasn't found.
+                // This rule has been removed from the spec, so it's fine if it
+                // wasn't found.
                 if !err.is_rule_not_found() {
                     return Err(err);
                 }
@@ -185,7 +189,8 @@ impl RuleCommands {
             PredefinedOverrideRuleId::RoomNotif.as_str(),
             enabled,
         ) {
-            // This rule has been removed from the spec, so it's fine if it wasn't found.
+            // This rule has been removed from the spec, so it's fine if it
+            // wasn't found.
             if !err.is_rule_not_found() {
                 return Err(err);
             }
@@ -332,14 +337,15 @@ mod tests {
 
         let mut rule_commands = RuleCommands::new(ruleset);
 
-        // Deletion should fail if an attempt is made to delete a rule that does not
-        // exist.
+        // Deletion should fail if an attempt is made to delete a rule that does
+        // not exist.
         assert_matches!(
             rule_commands.delete_rule(RuleKind::Room, room_id.to_string()),
             Err(RemovePushRuleError::NotFound) => {}
         );
 
-        // Deletion should fail if an attempt is made to delete a default server rule.
+        // Deletion should fail if an attempt is made to delete a default server
+        // rule.
         assert_matches!(
             rule_commands.delete_rule(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention.to_string()),
             Err(RemovePushRuleError::ServerDefault) => {}
@@ -548,7 +554,8 @@ mod tests {
         let mut ruleset = get_server_default_ruleset();
         let mut rule_commands = RuleCommands::new(ruleset.clone());
 
-        // Starting with an empty action list for `PredefinedUnderrideRuleId::Message`.
+        // Starting with an empty action list for
+        // `PredefinedUnderrideRuleId::Message`.
         ruleset
             .set_actions(RuleKind::Underride, PredefinedUnderrideRuleId::Message, vec![])
             .unwrap();

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -108,12 +108,13 @@ impl Rules {
         is_encrypted: IsEncrypted,
         is_one_to_one: IsOneToOne,
     ) -> RoomNotificationMode {
-        // get the correct default rule ID based on `is_encrypted` and `is_one_to_one`
+        // get the correct default rule ID based on `is_encrypted` and
+        // `is_one_to_one`
         let predefined_rule_id = get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one);
         let rule_id = predefined_rule_id.as_str();
 
-        // If there is an `Underride` rule that should trigger a notification, the mode
-        // is `AllMessages`
+        // If there is an `Underride` rule that should trigger a notification,
+        // the mode is `AllMessages`
         if self
             .ruleset
             .get(RuleKind::Underride, rule_id)
@@ -425,8 +426,8 @@ pub(crate) mod tests {
         let rules = Rules::new(ruleset);
         let mode = rules.get_user_defined_room_notification_mode(&room_id_a);
 
-        // The mode should be Mute as there is an Override rule that doesn't notify,
-        // with a condition matching the room_id_a
+        // The mode should be Mute as there is an Override rule that doesn't
+        // notify, with a condition matching the room_id_a
         assert_eq!(mode, Some(RoomNotificationMode::Mute));
     }
 
@@ -492,8 +493,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_is_user_mention_enabled() {
-        // If `IsUserMention` is enable, then is_user_mention_enabled() should return
-        // `true` even if the deprecated rules are disabled
+        // If `IsUserMention` is enable, then is_user_mention_enabled() should
+        // return `true` even if the deprecated rules are disabled
         let mut ruleset = server_default_ruleset_with_legacy_mentions();
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true)
@@ -517,8 +518,8 @@ pub(crate) mod tests {
                 .unwrap()
         );
 
-        // If `IsUserMention` is disabled, then is_user_mention_enabled() should return
-        // `false` even if the deprecated rules are enabled
+        // If `IsUserMention` is disabled, then is_user_mention_enabled() should
+        // return `false` even if the deprecated rules are enabled
         let mut ruleset = server_default_ruleset_with_legacy_mentions();
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, false)
@@ -553,8 +554,9 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_is_room_mention_enabled() {
-        // If `IsRoomMention` is present and enabled then is_room_mention_enabled()
-        // should return `true` even if the deprecated rule is disabled
+        // If `IsRoomMention` is present and enabled then
+        // is_room_mention_enabled() should return `true` even if the
+        // deprecated rule is disabled
         let mut ruleset = server_default_ruleset_with_legacy_mentions();
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention, true)
@@ -574,8 +576,9 @@ pub(crate) mod tests {
                 .unwrap()
         );
 
-        // If `IsRoomMention` is present and disabled then is_room_mention_enabled()
-        // should return `false` even if the deprecated rule is enabled
+        // If `IsRoomMention` is present and disabled then
+        // is_room_mention_enabled() should return `false` even if the
+        // deprecated rule is enabled
         let mut ruleset = server_default_ruleset_with_legacy_mentions();
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention, false)

--- a/crates/matrix-sdk/src/paginators/room.rs
+++ b/crates/matrix-sdk/src/paginators/room.rs
@@ -163,9 +163,10 @@ impl<PR: PaginableRoom> Paginator<PR> {
     ) -> Result<StartFromResult, PaginatorError> {
         self.check_state(PaginatorState::Initial)?;
 
-        // Note: it's possible two callers have checked the state and both figured it's
-        // initial. This check below makes sure there's at most one which can set the
-        // state to FetchingTargetEvent, preventing a race condition.
+        // Note: it's possible two callers have checked the state and both
+        // figured it's initial. This check below makes sure there's at
+        // most one which can set the state to FetchingTargetEvent,
+        // preventing a race condition.
         if self.state.set_if_not_eq(PaginatorState::FetchingTargetEvent).is_none() {
             return Err(PaginatorError::InvalidPreviousState {
                 expected: PaginatorState::Initial,
@@ -181,9 +182,9 @@ impl<PR: PaginableRoom> Paginator<PR> {
         let response =
             self.room.event_with_context(event_id, lazy_load_members, num_events).await?;
 
-        // NOTE: it's super important to not have any `await` after this point, since we
-        // don't want the task to be interrupted anymore, or the internal state
-        // may become incorrect.
+        // NOTE: it's super important to not have any `await` after this point,
+        // since we don't want the task to be interrupted anymore, or
+        // the internal state may become incorrect.
 
         let has_prev = response.prev_batch_token.is_some();
         let has_next = response.next_batch_token.is_some();
@@ -206,8 +207,8 @@ impl<PR: PaginableRoom> Paginator<PR> {
         self.state.set(PaginatorState::Idle);
 
         // Consolidate the events into a linear timeline, topologically ordered.
-        // - the events before are returned in the reverse topological order: invert
-        //   them.
+        // - the events before are returned in the reverse topological order:
+        //   invert them.
         // - insert the target event, if set.
         // - the events after are returned in the correct topological order.
 
@@ -294,9 +295,10 @@ impl<PR: PaginableRoom> Paginator<PR> {
             }
         };
 
-        // Note: it's possible two callers have checked the state and both figured it's
-        // idle. This check below makes sure there's at most one which can set the
-        // state to paginating, preventing a race condition.
+        // Note: it's possible two callers have checked the state and both
+        // figured it's idle. This check below makes sure there's at
+        // most one which can set the state to paginating, preventing a
+        // race condition.
         if self.state.set_if_not_eq(PaginatorState::Paginating).is_none() {
             return Err(PaginatorError::InvalidPreviousState {
                 expected: PaginatorState::Idle,
@@ -313,9 +315,9 @@ impl<PR: PaginableRoom> Paginator<PR> {
         // reset_state_guard.
         let response = self.room.messages(options).await?;
 
-        // NOTE: it's super important to not have any `await` after this point, since we
-        // don't want the task to be interrupted anymore, or the internal state
-        // may be incorrect.
+        // NOTE: it's super important to not have any `await` after this point,
+        // since we don't want the task to be interrupted anymore, or
+        // the internal state may be incorrect.
 
         let hit_end_of_timeline = response.end.is_none();
 
@@ -394,9 +396,9 @@ impl PaginableRoom for Room {
                 Ok(result) => result,
 
                 Err(err) => {
-                    // If the error was a 404, then the event wasn't found on the server;
-                    // special case this to make it easy to react to
-                    // such an error.
+                    // If the error was a 404, then the event wasn't found on
+                    // the server; special case this to make
+                    // it easy to react to such an error.
                     if let Some(error) = err.as_client_api_error()
                         && error.status_code == 404
                     {
@@ -498,8 +500,9 @@ mod tests {
                 .event_id(event_id)
                 .into_event();
 
-            // Properly simulate `num_events`: take either the closest num_events events
-            // before, or use all of the before events and then consume after events.
+            // Properly simulate `num_events`: take either the closest
+            // num_events events before, or use all of the before
+            // events and then consume after events.
             let mut num_events = u64::from(num_events) as usize;
 
             let prev_events = self.prev_events.lock().await;
@@ -641,8 +644,8 @@ mod tests {
         let context =
             paginator.start_from(event_id, uint!(10)).await.expect("start_from should work");
 
-        // Then I only get 10 events + the target event, even if there was more than 10
-        // events in the room.
+        // Then I only get 10 events + the target event, even if there was more
+        // than 10 events in the room.
         assert_eq!(context.events.len(), 11);
 
         for i in 0..10 {
@@ -792,8 +795,8 @@ mod tests {
         assert_event_matches_msg(&context.events[0], "initial");
         assert_eq!(context.events[0].raw().deserialize().unwrap().event_id(), event_id);
 
-        // There's a next batch, but no previous batch (i.e. we've hit the start of the
-        // timeline).
+        // There's a next batch, but no previous batch (i.e. we've hit the start
+        // of the timeline).
         assert!(!context.has_prev);
         assert!(context.has_next);
 
@@ -890,7 +893,8 @@ mod tests {
         // Mark the dummy room as ready. The query may now terminate.
         room.mark_ready();
 
-        // After fetching the initial event data, the paginator switches to `Idle`.
+        // After fetching the initial event data, the paginator switches to
+        // `Idle`.
         assert_eq!(state.next().await, Some(PaginatorState::Idle));
 
         join_handle.await.expect("joined failed").expect("/context failed");

--- a/crates/matrix-sdk/src/paginators/thread.rs
+++ b/crates/matrix-sdk/src/paginators/thread.rs
@@ -127,7 +127,8 @@ impl<P: PaginableThread> ThreadedEventsLoader<P> {
             };
         }
 
-        // Finally insert the thread root if at the end of the timeline going backwards
+        // Finally insert the thread root if at the end of the timeline going
+        // backwards
         if hit_end_of_timeline {
             let root_event = self
                 .room

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -227,8 +227,8 @@ macro_rules! set_caption {
         let filename = $event.filename().to_owned();
         // As a reminder:
         // - body and no filename set means the body is the filename
-        // - body and filename set means the body is the caption, and filename is the
-        //   filename.
+        // - body and filename set means the body is the caption, and filename is
+        //   the filename.
         if let Some(caption) = $caption {
             $event.filename = Some(filename);
             $event.body = caption;

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -204,8 +204,8 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
             #[cfg(feature = "e2e-encryption")]
             if room.latest_encryption_state().await?.is_encrypted() {
                 Span::current().record("is_room_encrypted", true);
-                // Reactions are currently famously not encrypted, skip encrypting
-                // them until they are.
+                // Reactions are currently famously not encrypted, skip
+                // encrypting them until they are.
                 if event_type == "m.reaction" {
                     trace!("Sending plaintext event because of the event type.");
                 } else {

--- a/crates/matrix-sdk/src/room/identity_status_changes.rs
+++ b/crates/matrix-sdk/src/room/identity_status_changes.rs
@@ -130,10 +130,10 @@ fn filter_for_initial_update(
     mut input: Vec<IdentityStatusChange>,
     own_user_id: &UserId,
 ) -> Vec<IdentityStatusChange> {
-    // We are never interested in changes to our own identity, and also for initial
-    // updates, we are only interested in "bad" states where we need to
-    // notify the user, so we can remove Verified states (Pinned states are
-    // already missing, because Pinned is considered the default).
+    // We are never interested in changes to our own identity, and also for
+    // initial updates, we are only interested in "bad" states where we need
+    // to notify the user, so we can remove Verified states (Pinned states
+    // are already missing, because Pinned is considered the default).
     input.retain(|change| {
         change.user_id != own_user_id && change.changed_to != IdentityState::Verified
     });
@@ -488,8 +488,8 @@ mod tests {
 
         // And we were notified about the change when the user left
         let change2 = assert_next_with_timeout!(stream);
-        // Note: the user left the room, but we see that as them "becoming pinned" i.e.
-        // "you no longer need to notify about this user".
+        // Note: the user left the room, but we see that as them "becoming
+        // pinned" i.e. "you no longer need to notify about this user".
         assert_eq!(change2[0].user_id, t.bob_user_id());
         assert_eq!(change2[0].changed_to, IdentityState::Pinned);
         assert_eq!(change2.len(), 1);
@@ -507,10 +507,11 @@ mod tests {
         let stream = t.subscribe_to_identity_status_changes().await;
         pin_mut!(stream);
 
-        // NOTE: below we pull the changes out of the subscription after each action.
-        // This makes sure that the identity changes and membership changes are properly
-        // ordered. If we pull them out later, the identity changes get shifted forward
-        // because they rely on less-complex async stuff under the hood. Calling
+        // NOTE: below we pull the changes out of the subscription after each
+        // action. This makes sure that the identity changes and
+        // membership changes are properly ordered. If we pull them out
+        // later, the identity changes get shifted forward because they
+        // rely on less-complex async stuff under the hood. Calling
         // next_change ends up winding the async machinery sufficiently that the
         // membership change and any subsequent events have fully completed.
 
@@ -588,9 +589,9 @@ mod tests {
         assert_eq!(next_change.len(), 1);
     }
 
-    // TODO: I (andyb) haven't figured out how to test room membership changes that
-    // affect our own user (they should not be shown). Specifically, I haven't
-    // figure out how to get out own user into a non-pinned state.
+    // TODO: I (andyb) haven't figured out how to test room membership changes
+    // that affect our own user (they should not be shown). Specifically, I
+    // haven't figure out how to get out own user into a non-pinned state.
 
     mod test_setup {
         use futures_core::Stream;
@@ -675,7 +676,8 @@ mod tests {
                         .await
                         .expect("Should not fail to pin");
                 } else {
-                    // There was no existing identity. Set one. It will be pinned by default.
+                    // There was no existing identity. Set one. It will be
+                    // pinned by default.
                     self.change_bob_identity(IdentityChangeDataSet::key_query_with_identity_a())
                         .await;
                 }
@@ -705,8 +707,9 @@ mod tests {
                 let requested_master_key = master_key_json(&requested);
                 let a_master_key = master_key_json(&a);
 
-                // Change/set their identity pin it, then change it again - this will definitely
-                // unpin, even if the first identity we supply is their very first, making them
+                // Change/set their identity pin it, then change it again - this
+                // will definitely unpin, even if the first
+                // identity we supply is their very first, making them
                 // initially pinned.
                 if requested_master_key == a_master_key {
                     self.change_bob_identity(b).await;
@@ -813,8 +816,9 @@ mod tests {
                     .await
                     .expect("Should be able to bootstrap cross-signing");
 
-                // Note: if you change the user_id, you will need to change lots of hard-coded
-                // stuff inside IdentityChangeDataSet
+                // Note: if you change the user_id, you will need to change lots
+                // of hard-coded stuff inside
+                // IdentityChangeDataSet
                 let bob_user_id = owned_user_id!("@bob:localhost");
 
                 let sync_response_builder = SyncResponseBuilder::default();

--- a/crates/matrix-sdk/src/room/messages.rs
+++ b/crates/matrix-sdk/src/room/messages.rs
@@ -294,10 +294,10 @@ impl RelationsOptions {
             };
         }
 
-        // This match to common out the different `Response` types into a single one. It
-        // would've been nice that Ruma used the same response type for all the
-        // responses, but it is likely doing so to guard against possible future
-        // changes.
+        // This match to common out the different `Response` types into a single
+        // one. It would've been nice that Ruma used the same response
+        // type for all the responses, but it is likely doing so to
+        // guard against possible future changes.
         let (chunk, prev_batch, next_batch, recursion_depth) = match self.include_relations {
             IncludeRelations::AllRelations => {
                 let request = fill_params!(relations::get_relating_events::v1::Request::new(
@@ -335,7 +335,8 @@ impl RelationsOptions {
 
         let push_ctx = room.push_context().await?;
         let chunk = join_all(chunk.into_iter().map(|ev| {
-            // Cast safety: an `AnyMessageLikeEvent` is a subset of an `AnyTimelineEvent`.
+            // Cast safety: an `AnyMessageLikeEvent` is a subset of an
+            // `AnyTimelineEvent`.
             room.try_decrypt_event(ev.cast(), push_ctx.as_ref())
         }))
         .await;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -417,15 +417,15 @@ impl Room {
             );
         }
 
-        // If the room was in Invited state we should also forget it when declining the
-        // invite.
+        // If the room was in Invited state we should also forget it when
+        // declining the invite.
         let should_forget = matches!(self.state(), RoomState::Invited);
 
         let request = leave_room::v3::Request::new(self.inner.room_id().to_owned());
         let response = self.client.send(request).await;
 
-        // The server can return with an error that is acceptable to ignore. Let's find
-        // which one.
+        // The server can return with an error that is acceptable to ignore.
+        // Let's find which one.
         if let Err(error) = response {
             #[allow(clippy::collapsible_match)]
             let ignore_error = if let Some(error) = error.client_api_error_kind() {
@@ -672,7 +672,8 @@ impl Room {
                     .into_iter()
                     .filter(|user_id| *user_id != own_user_id)
                     .collect();
-                // Ignore the result. It can only fail if there are no listeners.
+                // Ignore the result. It can only fail if there are no
+                // listeners.
                 let _ = sender.send(typing_user_ids);
             }
         });
@@ -759,7 +760,8 @@ impl Room {
         event: Raw<AnyTimelineEvent>,
         push_ctx: Option<&PushContext>,
     ) -> TimelineEvent {
-        // If we have either an encrypted message-like or state event, try to decrypt.
+        // If we have either an encrypted message-like or state event, try to
+        // decrypt.
         match event.deserialize_as::<AnySyncTimelineEvent>() {
             Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
                 SyncMessageLikeEvent::Original(_),
@@ -866,12 +868,13 @@ impl Room {
         request_config: Option<RequestConfig>,
     ) -> Result<(TimelineEvent, Vec<TimelineEvent>)> {
         let fetch_relations = async || {
-            // If there's only a single filter, we can use a more efficient request,
-            // specialized on the filter type.
+            // If there's only a single filter, we can use a more efficient
+            // request, specialized on the filter type.
             //
             // Otherwise, we need to get all the relations:
             // - either because no filters implies we fetch all relations,
-            // - or because there are multiple filters and we must filter out manually.
+            // - or because there are multiple filters and we must filter out
+            //   manually.
             let include_relations = if let Some(filter) = &filter
                 && filter.len() == 1
             {
@@ -892,7 +895,8 @@ impl Room {
                 match self.relations(event_id.to_owned(), opts.clone()).await {
                     Ok(relations) => {
                         if let Some(filter) = filter.as_ref() {
-                            // Manually filter out the relation types we're interested in.
+                            // Manually filter out the relation types we're
+                            // interested in.
                             events.extend(relations.chunk.into_iter().filter_map(|ev| {
                                 let (rel_type, _) = extract_relation(ev.raw())?;
                                 filter
@@ -920,16 +924,17 @@ impl Room {
             }
         };
 
-        // First, try to load the event *and* its relations from the event cache, all at
-        // once.
+        // First, try to load the event *and* its relations from the event
+        // cache, all at once.
         let event_cache = match self.event_cache().await {
             Ok((event_cache, drop_handles)) => {
                 if let Some((event, mut relations)) =
                     event_cache.find_event_with_relations(event_id, filter.clone()).await?
                 {
                     if relations.is_empty() {
-                        // The event cache doesn't have any relations for this event, try to fetch
-                        // them from the server instead.
+                        // The event cache doesn't have any relations for this
+                        // event, try to fetch them from
+                        // the server instead.
                         relations = fetch_relations().await;
                     }
 
@@ -947,8 +952,8 @@ impl Room {
             }
         };
 
-        // Fetch the event from the server. A failure here is fatal, as we must return
-        // the target event.
+        // Fetch the event from the server. A failure here is fatal, as we must
+        // return the target event.
         let event = self.event(event_id, request_config).await?;
 
         // Try to get the relations from the event cache (if we have one).
@@ -960,8 +965,8 @@ impl Room {
             return Ok((event, relations));
         }
 
-        // We couldn't find the relations in the event cache; fetch them from the
-        // server.
+        // We couldn't find the relations in the event cache; fetch them from
+        // the server.
         Ok((event, fetch_relations().await))
     }
 
@@ -1032,7 +1037,8 @@ impl Room {
                     )
                     .await?;
 
-                // That's a large `Future`. Let's `Box::pin` to reduce its size on the stack.
+                // That's a large `Future`. Let's `Box::pin` to reduce its size
+                // on the stack.
                 Box::pin(self.client.base_client().receive_all_members(
                     self.room_id(),
                     &request,
@@ -1075,8 +1081,8 @@ impl Room {
                     Err(err) => return Err(err.into()),
                 };
 
-                // Persist the event and the fact that we requested it from the server in
-                // `RoomInfo`.
+                // Persist the event and the fact that we requested it from the
+                // server in `RoomInfo`.
                 self.update_and_save_room_info(|mut room_info| {
                     room_info.mark_encryption_state_synced();
                     room_info.set_encryption_event(response);
@@ -1478,8 +1484,9 @@ impl Room {
             // Check whether the parent recognizes this room as its child
             .map(|(state_key, sender): (OwnedRoomId, OwnedUserId)| async move {
                 let Some(parent_room) = self.client.get_room(&state_key) else {
-                    // We are not in the room, cannot check if the relationship is reciprocal
-                    // TODO: try peeking into the room
+                    // We are not in the room, cannot check if the relationship
+                    // is reciprocal TODO: try peeking into
+                    // the room
                     return Ok(ParentSpace::Unverifiable(state_key));
                 };
                 // Get the m.space.child state of the parent with this room's id
@@ -1490,8 +1497,8 @@ impl Room {
                 {
                     match child_event.deserialize() {
                         Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(_))) => {
-                            // There is a valid m.space.child in the parent pointing to
-                            // this room
+                            // There is a valid m.space.child in the parent
+                            // pointing to this room
                             return Ok(ParentSpace::Reciprocal(parent_room));
                         }
                         Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {}
@@ -1509,8 +1516,8 @@ impl Room {
                     // relationship: https://spec.matrix.org/v1.8/client-server-api/#mspacechild
                 }
 
-                // No reciprocal m.space.child found, let's check if the sender has the
-                // power to set it
+                // No reciprocal m.space.child found, let's check if the sender
+                // has the power to set it
                 let Some(member) = parent_room.get_member(&sender).await? else {
                     // Sender is not even in the parent room
                     return Ok(ParentSpace::Illegitimate(parent_room));
@@ -1900,8 +1907,8 @@ impl Room {
                     .encryption()
                     .backups()
                     .maybe_download_room_key(self.room_id().to_owned(), event.clone());
-                // Cast safety: Anything that can be cast to EncryptedEvent must be a timeline
-                // event.
+                // Cast safety: Anything that can be cast to EncryptedEvent must
+                // be a timeline event.
                 Ok(TimelineEvent::from_utd(event.clone().cast_unchecked(), utd_info))
             }
         }
@@ -2021,9 +2028,10 @@ impl Room {
         let request = invite_user::v3::Request::new(self.room_id().to_owned(), recipient);
         self.client.send(request).await?;
 
-        // Force a future room members reload before sending any event to prevent UTDs
-        // that can happen when some event is sent after a room member has been invited
-        // but before the /sync request could fetch the membership change event.
+        // Force a future room members reload before sending any event to
+        // prevent UTDs that can happen when some event is sent after a
+        // room member has been invited but before the /sync request
+        // could fetch the membership change event.
         self.mark_members_missing();
 
         Ok(())
@@ -2040,9 +2048,10 @@ impl Room {
         let request = invite_user::v3::Request::new(self.room_id().to_owned(), recipient);
         self.client.send(request).await?;
 
-        // Force a future room members reload before sending any event to prevent UTDs
-        // that can happen when some event is sent after a room member has been invited
-        // but before the /sync request could fetch the membership change event.
+        // Force a future room members reload before sending any event to
+        // prevent UTDs that can happen when some event is sent after a
+        // room member has been invited but before the /sync request
+        // could fetch the membership change event.
         self.mark_members_missing();
 
         Ok(())
@@ -2161,8 +2170,8 @@ impl Room {
         thread: ReceiptThread,
         event_id: OwnedEventId,
     ) -> Result<()> {
-        // Since the receipt type and the thread aren't Hash/Ord, flatten then as a
-        // string key.
+        // Since the receipt type and the thread aren't Hash/Ord, flatten then
+        // as a string key.
         let request_key = format!("{}|{}", receipt_type, thread.as_str().unwrap_or("<unthreaded>"));
 
         self.client
@@ -2170,7 +2179,8 @@ impl Room {
             .locks
             .read_receipt_deduplicated_handler
             .run((request_key, event_id.clone()), async {
-                // We will unset the unread flag if we send an unthreaded receipt.
+                // We will unset the unread flag if we send an unthreaded
+                // receipt.
                 let is_unthreaded = thread == ReceiptThread::Unthreaded;
 
                 let mut request = create_receipt::v3::Request::new(
@@ -2239,8 +2249,8 @@ impl Room {
             }
             self.send_state_event(content).await?;
 
-            // Spin on the sync beat event, since the first sync we receive might not
-            // include the encryption event.
+            // Spin on the sync beat event, since the first sync we receive
+            // might not include the encryption event.
             //
             // TODO do we want to return an error here if we time out? This
             // could be quite useful if someone wants to enable encryption and
@@ -2248,7 +2258,8 @@ impl Room {
             let res = timeout(
                 async {
                     loop {
-                        // Listen for sync events, then check if the encryption state is known.
+                        // Listen for sync events, then check if the encryption
+                        // state is known.
                         self.client.inner.sync_beat.listen().await;
                         let _state_store_lock =
                             self.client.base_client().state_store_lock().lock().await;
@@ -2284,10 +2295,11 @@ impl Room {
                 return Ok(());
             }
 
-            // If after waiting for multiple syncs, we don't have the encryption state we
-            // expect, assume the local encryption state is incorrect; this will
-            // cause the SDK to re-request it later for confirmation, instead of
-            // assuming it's sync'd and correct (and not encrypted).
+            // If after waiting for multiple syncs, we don't have the encryption
+            // state we expect, assume the local encryption state is
+            // incorrect; this will cause the SDK to re-request it
+            // later for confirmation, instead of assuming it's
+            // sync'd and correct (and not encrypted).
             debug!("still not marked as encrypted, marking encryption state as missing");
 
             self.update_and_save_room_info_with_store_guard(&store_guard, |mut info| {
@@ -2550,8 +2562,8 @@ impl Room {
             .map(|tracked| (tracked.user_id, tracked.dirty))
             .collect();
 
-        // A member has no unknown devices iff it was tracked *and* the tracking is
-        // not considered dirty.
+        // A member has no unknown devices iff it was tracked *and* the tracking
+        // is not considered dirty.
         let members_with_unknown_devices =
             members.iter().filter(|member| tracked.get(*member).is_none_or(|dirty| *dirty));
 
@@ -2760,8 +2772,9 @@ impl Room {
         if store_in_cache {
             let media_store_lock_guard = self.client.media_store().lock().await?;
 
-            // A failure to cache shouldn't prevent the whole upload from finishing
-            // properly, so only log errors during caching.
+            // A failure to cache shouldn't prevent the whole upload from
+            // finishing properly, so only log errors during
+            // caching.
 
             debug!("caching the media");
             let request =
@@ -2874,8 +2887,9 @@ impl Room {
             content = content.add_mentions(mentions);
         }
         if let Some(reply) = reply {
-            // Since we just created the event, there is no relation attached to it. Thus,
-            // it is safe to add the reply relation without overriding anything.
+            // Since we just created the event, there is no relation attached to
+            // it. Thus, it is safe to add the reply relation
+            // without overriding anything.
             content = self.make_reply_event(content.into(), reply).await?;
         }
         Ok(content)
@@ -3642,8 +3656,9 @@ impl Room {
             Ok(power_levels) => Some(power_levels.into()),
             Err(error) => {
                 if matches!(room_info.state(), RoomState::Joined) {
-                    // It's normal to not have the power levels in a non-joined room, so don't log
-                    // the error if the room is not joined
+                    // It's normal to not have the power levels in a non-joined
+                    // room, so don't log the error if the
+                    // room is not joined
                     error!("Could not compute power levels for push conditions: {error}");
                 }
                 None
@@ -3749,19 +3764,20 @@ impl Room {
             return Err(Error::InsufficientData);
         };
 
-        let sender_member =
-            if let Some(member) = self.get_member_no_sync(member.event().sender()).await? {
-                // If the sender room member info is already available, return it
-                Some(member)
-            } else if self.are_members_synced() {
-                // The room members are synced and we couldn't find the sender info
-                None
-            } else if self.sync_members().await.is_ok() {
-                // Try getting the sender room member info again after syncing
-                self.get_member_no_sync(member.event().sender()).await?
-            } else {
-                None
-            };
+        let sender_member = if let Some(member) =
+            self.get_member_no_sync(member.event().sender()).await?
+        {
+            // If the sender room member info is already available, return it
+            Some(member)
+        } else if self.are_members_synced() {
+            // The room members are synced and we couldn't find the sender info
+            None
+        } else if self.sync_members().await.is_ok() {
+            // Try getting the sender room member info again after syncing
+            self.get_member_no_sync(member.event().sender()).await?
+        } else {
+            None
+        };
 
         Ok(RoomMemberWithSenderInfo { room_member: member, sender_info: sender_member })
     }
@@ -3788,12 +3804,14 @@ impl Room {
         let request = forget_room::v3::Request::new(room_id.to_owned());
         let _response = self.client.send(request).await?;
 
-        // If it was a DM, remove the room from the `m.direct` global account data.
+        // If it was a DM, remove the room from the `m.direct` global account
+        // data.
         if self.inner.direct_targets_length() != 0
             && let Err(e) = self.set_is_direct(false).await
         {
-            // It is not important whether we managed to remove the room, it will not have
-            // any consequences, so just log the error.
+            // It is not important whether we managed to remove the room, it
+            // will not have any consequences, so just log the
+            // error.
             warn!(?room_id, "failed to remove room from m.direct account data: {e}");
         }
 
@@ -3829,10 +3847,10 @@ impl Room {
         } else if let Ok(is_encrypted) =
             self.latest_encryption_state().await.map(|state| state.is_encrypted())
         {
-            // Otherwise, if encrypted status is available, get the default mode for this
-            // type of room.
-            // From the point of view of notification settings, a `one-to-one` room is one
-            // that involves exactly two people.
+            // Otherwise, if encrypted status is available, get the default mode
+            // for this type of room.
+            // From the point of view of notification settings, a `one-to-one`
+            // room is one that involves exactly two people.
             let is_one_to_one = IsOneToOne::from(self.active_members_count() == 2);
             let default_mode = notification_settings
                 .get_default_room_notification_mode(IsEncrypted::from(is_encrypted), is_one_to_one)
@@ -3851,8 +3869,8 @@ impl Room {
     //
     // Note for maintainers:
     //
-    // The fact the result is cached is an important property. If you change that in
-    // the future, please review all calls to this method.
+    // The fact the result is cached is an important property. If you change
+    // that in the future, please review all calls to this method.
     pub async fn user_defined_notification_mode(&self) -> Option<RoomNotificationMode> {
         if !matches!(self.state(), RoomState::Joined) {
             return None;
@@ -4156,14 +4174,15 @@ impl Room {
 
         let mut room_info_stream = self.subscribe_info();
 
-        // Spawn a task that will clean up the seen knock request ids when updated room
-        // members are received
+        // Spawn a task that will clean up the seen knock request ids when
+        // updated room members are received
         let clear_seen_ids_handle = spawn({
             let this = self.clone();
             async move {
                 let mut member_updates_stream = this.room_member_updates_sender.subscribe();
                 while member_updates_stream.recv().await.is_ok() {
-                    // If room members were updated, try to remove outdated seen knock request ids
+                    // If room members were updated, try to remove outdated seen
+                    // knock request ids
                     if let Err(err) = this.remove_outdated_seen_knock_requests_ids().await {
                         warn!("Failed to remove seen knock requests: {err}")
                     }
@@ -4320,8 +4339,8 @@ impl Room {
         };
 
         fn clamp(value: Option<Duration>, limits: &Option<LifetimeLimits>) -> Option<Duration> {
-            // No limit for this property: per MSC1763, use the room's value as-is,
-            // whether it has a value or not
+            // No limit for this property: per MSC1763, use the room's value
+            // as-is, whether it has a value or not
             let Some(limits) = limits else { return value };
             let Some(value) = value else {
                 // A value is not set, fall back to the minimum limit (which may
@@ -4352,10 +4371,10 @@ impl Room {
 
         // The two bounds are clamped independently against separate limits, so
         // they can still conflict (min_lifetime > max_lifetime). MSC1763 treats
-        // `max_lifetime` as a MUST (mandatory purge deadline) and `min_lifetime`
-        // as a SHOULD (retention floor), so we should honor the `max_lifetime`
-        // as having a greater priority and cap `min_lifetime` as such, in the
-        // event of this overlap.
+        // `max_lifetime` as a MUST (mandatory purge deadline) and
+        // `min_lifetime` as a SHOULD (retention floor), so we should
+        // honor the `max_lifetime` as having a greater priority and cap
+        // `min_lifetime` as such, in the event of this overlap.
         let min_lifetime = min_lifetime.map(|min| {
             let Some(max) = max_lifetime else { return min };
             if min > max {
@@ -4487,8 +4506,9 @@ impl Room {
 
             Err(err) => {
                 if let Some(ErrorKind::ConflictingUnsubscription) = err.client_api_error_kind() {
-                    // In this case: the server indicates that the user unsubscribed *after* the
-                    // event ID we've used in an automatic subscription; don't
+                    // In this case: the server indicates that the user
+                    // unsubscribed *after* the event ID we'
+                    // ve used in an automatic subscription; don't
                     // save the subscription state in the database, as the
                     // previous one should be more correct.
                     trace!("Thread subscription skipped: {err}");
@@ -4512,11 +4532,13 @@ impl Room {
         automatic: Option<OwnedEventId>,
     ) -> Result<()> {
         if let Some(prev_sub) = self.load_or_fetch_thread_subscription(thread_root).await? {
-            // If we have a previous subscription, we should only send the new one if it's
-            // manual and the previous one was automatic.
+            // If we have a previous subscription, we should only send the new
+            // one if it's manual and the previous one was
+            // automatic.
             if !prev_sub.automatic || automatic.is_some() {
-                // Either we had already a manual subscription, or we had an automatic one and
-                // the new one is automatic too: nothing to do!
+                // Either we had already a manual subscription, or we had an
+                // automatic one and the new one is automatic
+                // too: nothing to do!
                 return Ok(());
             }
         }
@@ -4724,12 +4746,13 @@ impl Room {
                 is_direct
             }
             DmRoomDefinition::TwoMembers => {
-                // If there is a single target and at most 2 active members, it's a DM.
-                // Try getting the calculated active service members count from the room info.
+                // If there is a single target and at most 2 active members,
+                // it's a DM. Try getting the calculated active
+                // service members count from the room info.
                 let active_service_member_count =
                     self.active_service_members_count().unwrap_or_else(|| {
-                        // Otherwise just use an approximated value based on the service members
-                        // count.
+                        // Otherwise just use an approximated value based on the
+                        // service members count.
                         self.service_members().map(|members| members.len()).unwrap_or_default()
                             as u64
                     });
@@ -5013,8 +5036,8 @@ mod tests {
         // Step 1, preshare the room keys.
         room.preshare_room_key().await.unwrap();
 
-        // Step 2, force lock invalidation by pretending another client obtained the
-        // lock.
+        // Step 2, force lock invalidation by pretending another client obtained
+        // the lock.
         {
             let client = Client::builder()
                 .homeserver_url("http://localhost:1234")
@@ -5046,8 +5069,8 @@ mod tests {
         let olm = client.olm_machine().await;
         let olm = olm.as_ref().expect("Olm machine wasn't started");
 
-        // Now pretend we're encrypting an event; the olm machine shouldn't rely on
-        // caching the outgoing session before.
+        // Now pretend we're encrypting an event; the olm machine shouldn't rely
+        // on caching the outgoing session before.
         let _encrypted_content = olm
             .encrypt_room_event_raw(room.room_id(), "test-event", &message_like_event_content!({}))
             .await
@@ -5619,7 +5642,8 @@ mod tests {
 
     #[async_test]
     async fn test_effective_retention_server_room_override() {
-        // Server per-room override should win even if room has its own state event.
+        // Server per-room override should win even if room has its own state
+        // event.
         let server = MatrixMockServer::new().await;
         let client = server.client_builder().build().await;
         let room = room_with_retention(

--- a/crates/matrix-sdk/src/room/power_levels.rs
+++ b/crates/matrix-sdk/src/room/power_levels.rs
@@ -220,8 +220,8 @@ pub fn power_level_user_changes(
         }
     }
 
-    // Any remaining users from the old power levels have had their power level set
-    // back to default.
+    // Any remaining users from the old power levels have had their power level
+    // set back to default.
     for (user_id, power_level) in prev_users {
         if power_level != content.users_default {
             changes.insert(user_id, content.users_default.into());
@@ -282,8 +282,8 @@ mod tests {
 
     #[test]
     fn test_apply_room_settings() {
-        // Given a set of power levels and some settings that only change the specific
-        // state event levels.
+        // Given a set of power levels and some settings that only change the
+        // specific state event levels.
         let mut power_levels = default_power_levels();
 
         let new_level = int!(100);
@@ -329,8 +329,8 @@ mod tests {
 
     #[test]
     fn test_apply_state_event_to_default() {
-        // Given a set of power levels and some settings that change the room name level
-        // back to the default level.
+        // Given a set of power levels and some settings that change the room
+        // name level back to the default level.
         let original_level = int!(100);
         let mut power_levels = default_power_levels();
         power_levels.events = BTreeMap::from_iter(vec![
@@ -383,8 +383,8 @@ mod tests {
 
     #[test]
     fn test_apply_beacon_settings() {
-        // Given a set of power levels and some settings that only change the beacon
-        // and beacon_info event levels.
+        // Given a set of power levels and some settings that only change the
+        // beacon and beacon_info event levels.
         let mut power_levels = default_power_levels();
 
         let new_level = int!(25);
@@ -429,8 +429,8 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_add_mod() {
-        // Given a set of power levels and a new set of power levels that adds a new
-        // moderator.
+        // Given a set of power levels and a new set of power levels that adds a
+        // new moderator.
         let prev_content = default_power_levels_event_content();
         let mut content = prev_content.clone();
         content.users.insert(OwnedUserId::try_from("@charlie:example.com").unwrap(), int!(50));
@@ -445,8 +445,8 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_remove_mod() {
-        // Given a set of power levels and a new set of power levels that removes a
-        // moderator.
+        // Given a set of power levels and a new set of power levels that
+        // removes a moderator.
         let prev_content = default_power_levels_event_content();
         let mut content = prev_content.clone();
         content.users.remove(&OwnedUserId::try_from("@bob:example.com").unwrap());
@@ -461,8 +461,8 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_change_mod() {
-        // Given a set of power levels and a new set of power levels that changes a
-        // moderator to an admin.
+        // Given a set of power levels and a new set of power levels that
+        // changes a moderator to an admin.
         let prev_content = default_power_levels_event_content();
         let mut content = prev_content.clone();
         content.users.insert(OwnedUserId::try_from("@bob:example.com").unwrap(), int!(100));
@@ -477,8 +477,9 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_new_default() {
-        // Given a set of power levels and a new set of power levels that changes the
-        // default user power level to moderator and removes the only moderator.
+        // Given a set of power levels and a new set of power levels that
+        // changes the default user power level to moderator and removes
+        // the only moderator.
         let prev_content = default_power_levels_event_content();
         let mut content = prev_content.clone();
         content.users_default = int!(50);
@@ -493,7 +494,8 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_no_change() {
-        // Given a set of power levels and a new set of power levels that's the same.
+        // Given a set of power levels and a new set of power levels that's the
+        // same.
         let prev_content = default_power_levels_event_content();
         let content = prev_content.clone();
 
@@ -506,8 +508,8 @@ mod tests {
 
     #[test]
     fn test_user_power_level_changes_other_properties() {
-        // Given a set of power levels and a new set of power levels with changes that
-        // don't include the user power levels.
+        // Given a set of power levels and a new set of power levels with
+        // changes that don't include the user power levels.
         let prev_content = default_power_levels_event_content();
         let mut content = prev_content.clone();
         content.events_default = int!(100);

--- a/crates/matrix-sdk/src/room/privacy_settings.rs
+++ b/crates/matrix-sdk/src/room/privacy_settings.rs
@@ -222,7 +222,8 @@ mod tests {
             .mount()
             .await;
 
-        // After that, we'd create a new room alias association in the room directory
+        // After that, we'd create a new room alias association in the room
+        // directory
         server.mock_room_directory_create_room_alias().ok().mock_once().mount().await;
 
         let published = room

--- a/crates/matrix-sdk/src/room/reply.rs
+++ b/crates/matrix-sdk/src/room/reply.rs
@@ -122,11 +122,12 @@ async fn make_reply_event<S: EventSource>(
 
     // [The specification](https://spec.matrix.org/v1.10/client-server-api/#user-and-room-mentions) says:
     //
-    // > Users should not add their own Matrix ID to the `m.mentions` property as
+    // > Users should not add their own Matrix ID to the `m.mentions` property
+    // > as
     // > outgoing messages cannot self-notify.
     //
-    // If the replied to event has been written by the current user, let's toggle to
-    // `AddMentions::No`.
+    // If the replied to event has been written by the current user, let's
+    // toggle to `AddMentions::No`.
     let mention_the_sender =
         if own_user_id == event.sender() { AddMentions::No } else { reply.add_mentions };
 

--- a/crates/matrix-sdk/src/room/shared_room_history.rs
+++ b/crates/matrix-sdk/src/room/shared_room_history.rs
@@ -50,9 +50,9 @@ pub(super) async fn share_room_history(room: &Room, user_id: OwnedUserId) -> Res
         return Ok(());
     }
 
-    // 0.b. We should only share room history if the *current* visibility allows it.
-    //      Note: the specification states we should assume `shared` if no event
-    //      exists, see https://spec.matrix.org/v1.17/client-server-api/#server-behaviour-7.
+    // 0.b. We should only share room history if the *current* visibility allows
+    // it.      Note: the specification states we should assume `shared` if
+    // no event      exists, see https://spec.matrix.org/v1.17/client-server-api/#server-behaviour-7.
     if matches!(
         room.history_visibility_or_default(),
         HistoryVisibility::Joined | HistoryVisibility::Invited
@@ -146,8 +146,8 @@ pub(super) async fn share_room_history(room: &Room, user_id: OwnedUserId) -> Res
 ///
 /// Returns `true` if the key bundle should be accepted, otherwise `false`.
 pub(crate) async fn should_accept_key_bundle(room: &Room, bundle_info: &RoomKeyBundleInfo) -> bool {
-    // If we don't have any invite acceptance details, then this client wasn't the
-    // one that accepted the invite.
+    // If we don't have any invite acceptance details, then this client wasn't
+    // the one that accepted the invite.
     let Ok(Some(details)) =
         room.client.base_client().get_pending_key_bundle_details_for_room(room.room_id()).await
     else {
@@ -188,8 +188,8 @@ pub(crate) async fn should_accept_key_bundle(room: &Room, bundle_info: &RoomKeyB
 pub(crate) fn should_process_room_pending_key_bundle_details(
     details: &RoomPendingKeyBundleDetails,
 ) -> bool {
-    // We accept historic room key bundles up to one day after we have accepted an
-    // invite.
+    // We accept historic room key bundles up to one day after we have accepted
+    // an invite.
     const DAY: Duration = Duration::from_secs(24 * 60 * 60);
 
     details
@@ -236,11 +236,11 @@ pub(crate) async fn maybe_accept_key_bundle(room: &Room, inviter: &UserId) -> Re
 
     tracing::Span::current().record("bundle_sender", bundle_info.sender_user.as_str());
 
-    // Ensure that we get a fresh list of devices for the inviter, in case we need
-    // to recalculate the `SenderData`.
-    // XXX: is this necessary, given (with exclude-insecure-devices), we should have
-    // checked that the inviter device was cross-signed when we received the
-    // to-device message?
+    // Ensure that we get a fresh list of devices for the inviter, in case we
+    // need to recalculate the `SenderData`.
+    // XXX: is this necessary, given (with exclude-insecure-devices), we should
+    // have checked that the inviter device was cross-signed when we
+    // received the to-device message?
     let (req_id, request) =
         olm_machine.query_keys_for_users(iter::once(bundle_info.sender_user.as_ref()));
 
@@ -261,17 +261,17 @@ pub(crate) async fn maybe_accept_key_bundle(room: &Room, inviter: &UserId) -> Re
     {
         Ok(bundle_content) => bundle_content,
         Err(err) => {
-            // If we encountered an HTTP client error, we should check the status code to
-            // see if we have been sent a bogus link.
+            // If we encountered an HTTP client error, we should check the
+            // status code to see if we have been sent a bogus link.
             let Some(err) = err.client_api_error_kind() else {
-                // Some other error occurred, which we may be able to recover from at the next
-                // client startup.
+                // Some other error occurred, which we may be able to recover
+                // from at the next client startup.
                 return Ok(());
             };
 
             if ErrorKind::NotFound == *err {
-                // Clear the pending flag since checking these details again at startup are
-                // guaranteed to fail.
+                // Clear the pending flag since checking these details again at
+                // startup are guaranteed to fail.
                 olm_machine.store().clear_room_pending_key_bundle(room.room_id()).await?;
             }
 
@@ -301,9 +301,9 @@ pub(crate) async fn maybe_accept_key_bundle(room: &Room, inviter: &UserId) -> Re
     // olm_machine.store().clear_received_room_key_bundle_data(room.room_id(),
     // user_id).await?;
 
-    // If we have reached this point, the bundle was either successfully imported,
-    // or was malformed and failed to deserialise. In either case, we can clear
-    // the room pending state.
+    // If we have reached this point, the bundle was either successfully
+    // imported, or was malformed and failed to deserialise. In either case,
+    // we can clear the room pending state.
     olm_machine.store().clear_room_pending_key_bundle(room.room_id()).await?;
 
     Ok(())

--- a/crates/matrix-sdk/src/room_directory_search.rs
+++ b/crates/matrix-sdk/src/room_directory_search.rs
@@ -245,7 +245,8 @@ mod tests {
                 return false;
             };
 
-            // The body's `since` field is set equal to the matcher's next_token.
+            // The body's `since` field is set equal to the matcher's
+            // next_token.
             if !body.get_field::<String>("since").is_ok_and(|s| s == self.next_token) {
                 return false;
             }
@@ -254,8 +255,8 @@ mod tests {
                 return false;
             }
 
-            // The body's `filter` field has `generic_search_term` equal to the matcher's
-            // next_token.
+            // The body's `filter` field has `generic_search_term` equal to the
+            // matcher's next_token.
             if !body.get_field::<Filter>("filter").is_ok_and(|s| {
                 if self.filter_term.is_none() {
                     s.is_none() || s.is_some_and(|s| s.generic_search_term.is_none())

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -168,8 +168,8 @@ impl RoomPreview {
             }
         }
 
-        // Finally, if everything else fails, try to build the room from information
-        // that the client itself might have about it.
+        // Finally, if everything else fails, try to build the room from
+        // information that the client itself might have about it.
         if let Some(room) = client.get_room(&room_id) {
             Ok(Self::from_known_room(&room).await)
         } else {
@@ -186,15 +186,17 @@ impl RoomPreview {
         room_or_alias_id: &RoomOrAliasId,
         via: Vec<OwnedServerName>,
     ) -> crate::Result<Option<Self>> {
-        // Get either the room alias or the room id without the leading identifier char
+        // Get either the room alias or the room id without the leading
+        // identifier char
         let search_term = if room_or_alias_id.is_room_alias_id() {
             Some(room_or_alias_id.as_str()[1..].to_owned())
         } else {
             None
         };
 
-        // If we have no alias, filtering using a room id is impossible, so just take
-        // the first 100 results and try to find the current room #YOLO
+        // If we have no alias, filtering using a room id is impossible, so just
+        // take the first 100 results and try to find the current room
+        // #YOLO
         let batch_size = if search_term.is_some() { 20 } else { 100 };
 
         if via.is_empty() {
@@ -248,9 +250,9 @@ impl RoomPreview {
 
         let response = client.send(request).await?;
 
-        // The server returns a `Left` room state for rooms the user has not joined. Be
-        // more precise than that, and set it to `None` if we haven't joined
-        // that room.
+        // The server returns a `Left` room state for rooms the user has not
+        // joined. Be more precise than that, and set it to `None` if we
+        // haven't joined that room.
         let cached_room = client.get_room(&room_id);
         let state = if cached_room.is_none() {
             None
@@ -411,8 +413,8 @@ mod tests {
         let server_names =
             ensure_server_names_is_not_empty(own_server_name, Vec::new(), room_or_alias_id);
 
-        // There was no own server name to check against, so no additional server name
-        // was added
+        // There was no own server name to check against, so no additional
+        // server name was added
         assert!(server_names.is_empty());
     }
 
@@ -436,8 +438,8 @@ mod tests {
         let server_names =
             ensure_server_names_is_not_empty(own_server_name, Vec::new(), room_or_alias_id);
 
-        // The room id's server name was the same as our own server name, so there's no
-        // need to add it
+        // The room id's server name was the same as our own server name, so
+        // there's no need to add it
         assert!(server_names.is_empty());
     }
 

--- a/crates/matrix-sdk/src/search_index/mod.rs
+++ b/crates/matrix-sdk/src/search_index/mod.rs
@@ -704,7 +704,8 @@ mod tests {
 
         let f = EventFactory::new().room(room_id).sender(user_id!("@user_id:localhost"));
 
-        // Indexable dummy message required because RoomIndex is initialised lazily.
+        // Indexable dummy message required because RoomIndex is initialised
+        // lazily.
         let dummy = f.text_msg("dummy").event_id(dummy_id);
 
         let original = f.text_msg("This is a message").event_id(original_id);
@@ -744,8 +745,8 @@ mod tests {
 
         assert_eq!(results.len(), 0, "Search should return 0 results, got {results:?}");
 
-        // Adding the original after some pending edits should add the latest edit
-        // instead of the original.
+        // Adding the original after some pending edits should add the latest
+        // edit instead of the original.
         server
             .sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(original))
             .await;
@@ -759,8 +760,8 @@ mod tests {
             results[0].1
         );
 
-        // Editing the original after it exists and there has been another edit should
-        // delete the previous edits and add this one
+        // Editing the original after it exists and there has been another edit
+        // should delete the previous edits and add this one
         server.sync_room(&client, JoinedRoomBuilder::new(room_id).add_timeline_event(edit3)).await;
 
         let results = room.search("message", 3, None).await.unwrap();

--- a/crates/matrix-sdk/src/send_queue/mod.rs
+++ b/crates/matrix-sdk/src/send_queue/mod.rs
@@ -232,7 +232,8 @@ impl SendQueue {
                 },
             );
 
-        // Getting the [`RoomSendQueue`] is sufficient to spawn the task if needs be.
+        // Getting the [`RoomSendQueue`] is sufficient to spawn the task if
+        // needs be.
         for room_id in room_ids {
             if let Some(room) = self.client.get_room(&room_id) {
                 let _ = self.for_room(room);
@@ -293,8 +294,8 @@ impl SendQueue {
             room.set_enabled(enabled);
         }
 
-        // Reload some extra rooms that might not have been awaken yet, but could have
-        // requests from previous sessions.
+        // Reload some extra rooms that might not have been awaken yet, but
+        // could have requests from previous sessions.
         self.respawn_tasks_for_rooms_with_unsent_requests().await;
     }
 
@@ -682,8 +683,8 @@ impl RoomSendQueue {
                 break;
             }
 
-            // Try to apply dependent requests now; those applying to previously failed
-            // attempts (local echoes) would succeed now.
+            // Try to apply dependent requests now; those applying to previously
+            // failed attempts (local echoes) would succeed now.
             let mut new_updates = Vec::new();
             if let Err(err) = queue.apply_dependent_requests(&mut new_updates).await {
                 warn!("errors when applying dependent requests: {err}");
@@ -712,7 +713,8 @@ impl RoomSendQueue {
 
                 Err(err) => {
                     warn!("error when loading next request to send: {err}");
-                    // Don't hammer a failing store; back off a bit before retrying.
+                    // Don't hammer a failing store; back off a bit before
+                    // retrying.
                     matrix_sdk_common::sleep::sleep(STORE_ERROR_BACKOFF).await;
                     continue;
                 }
@@ -743,8 +745,9 @@ impl RoomSendQueue {
                     ..
                 } = &queued_request.kind
                 {
-                    // Prepare to watch and communicate the request's progress for media uploads, if
-                    // it has been requested.
+                    // Prepare to watch and communicate the request's progress
+                    // for media uploads, if it has been
+                    // requested.
                     let (media_upload_progress_info, http_progress) =
                         if report_media_upload_progress.load(Ordering::SeqCst) {
                             let media_upload_progress_info =
@@ -794,25 +797,37 @@ impl RoomSendQueue {
                                 },
                             );
 
-                            // The event has been sent to the server and the server has received it.
-                            // Yepee! Now, we usually wait on the server to give us back the event
-                            // via the sync.
+                            // The event has been sent to the server and the
+                            // server has received it.
+                            // Yepee! Now, we usually wait on the server to give
+                            // us back the event via
+                            // the sync.
                             //
-                            // Problem: sometimes the network lags, can be down, or the server may
+                            // Problem: sometimes the network lags, can be down,
+                            // or the server may
                             // be slow; well, anything can happen.
                             //
-                            // It results in a weird situation where the user sees its event being
-                            // sent, then disappears before it's received again from the server.
+                            // It results in a weird situation where the user
+                            // sees its event being
+                            // sent, then disappears before it's received again
+                            // from the server.
                             //
-                            // To avoid this situation, we eagerly save the event in the Event
-                            // Cache. It's similar to what would happen if the event was echoed back
-                            // from the server via the sync, but we avoid any network issues. The
-                            // Event Cache is smart enough to deduplicate events based on the event
+                            // To avoid this situation, we eagerly save the
+                            // event in the Event
+                            // Cache. It's similar to what would happen if the
+                            // event was echoed back
+                            // from the server via the sync, but we avoid any
+                            // network issues. The
+                            // Event Cache is smart enough to deduplicate events
+                            // based on the event
                             // ID, so it's safe to do that.
                             //
-                            // If this little feature fails, it MUST NOT stop the Send Queue. Any
-                            // errors are logged, but the Send Queue will continue as if everything
-                            // happened successfully. This feature is not considered “crucial”.
+                            // If this little feature fails, it MUST NOT stop
+                            // the Send Queue. Any
+                            // errors are logged, but the Send Queue will
+                            // continue as if everything
+                            // happened successfully. This feature is not
+                            // considered “crucial”.
                             if let Ok((room_event_cache, _drop_handles)) = room.event_cache().await
                             {
                                 let timeline_event = match Raw::from_json_string(
@@ -857,7 +872,8 @@ impl RoomSendQueue {
                                     }
                                 };
 
-                                // In case of an error, just log the error but don't stop the Send
+                                // In case of an error, just log the error but
+                                // don't stop the Send
                                 // Queue. This feature is not crucial.
                                 if let Some(timeline_event) = timeline_event
                                     && let Err(err) = room_event_cache
@@ -878,7 +894,8 @@ impl RoomSendQueue {
                         }
 
                         SentRequestKey::Media(sent_media_info) => {
-                            // Generate some final progress information, even if incremental
+                            // Generate some final progress information, even if
+                            // incremental
                             // progress wasn't requested.
                             let index =
                                 media_upload_progress_info.as_ref().map_or(0, |info| info.index);
@@ -890,8 +907,10 @@ impl RoomSendQueue {
                                 })
                                 .unwrap_or(AbstractProgress { current: 1, total: 1 });
 
-                            // Purposefully don't use `send_update` here, because we don't want to
-                            // notify the global listeners about an upload progress update.
+                            // Purposefully don't use `send_update` here,
+                            // because we don't want to
+                            // notify the global listeners about an upload
+                            // progress update.
                             let _ = update_sender.send(RoomSendQueueUpdate::MediaUpload {
                                 related_to: related_txn_id.as_ref().unwrap_or(&txn_id).clone(),
                                 file: Some(sent_media_info.file),
@@ -911,7 +930,8 @@ impl RoomSendQueue {
                                 },
                             );
 
-                            // The redaction event has been sent to the server and the server has
+                            // The redaction event has been sent to the server
+                            // and the server has
                             // received it. It's safe to cache the event
                             // now to avoid any inconsistencies until the server
                             // sends down the remote echo via the sync.
@@ -965,7 +985,8 @@ impl RoomSendQueue {
                                     }
                                 };
 
-                                // In case of an error, just log the error but don't stop the Send
+                                // In case of an error, just log the error but
+                                // don't stop the Send
                                 // Queue. This feature is not crucial.
                                 if let Some(timeline_event) = timeline_event
                                     && let Err(err) = room_event_cache
@@ -1015,14 +1036,16 @@ impl RoomSendQueue {
                         _ => false,
                     };
 
-                    // Disable the queue for this room after any kind of error happened.
+                    // Disable the queue for this room after any kind of error
+                    // happened.
                     locally_enabled.store(false, Ordering::SeqCst);
 
                     if is_recoverable {
                         warn!(txn_id = %txn_id, error = ?err, "Recoverable error when sending request: {err}, disabling send queue");
 
-                        // In this case, we intentionally keep the request in the queue, but mark it
-                        // as not being sent anymore.
+                        // In this case, we intentionally keep the request in
+                        // the queue, but mark it as not
+                        // being sent anymore.
                         queue.mark_as_not_being_sent(&txn_id).await;
 
                         // Let observers know about a failure *after* we've
@@ -1033,9 +1056,11 @@ impl RoomSendQueue {
                     } else {
                         warn!(txn_id = %txn_id, error = ?err, "Unrecoverable error when sending request: {err}");
 
-                        // Mark the request as wedged, so it's not picked at any future point;
-                        // it will also block subsequent requests in the same room from being
-                        // sent, until it's unwedged or removed, so as to preserve ordering.
+                        // Mark the request as wedged, so it's not picked at any
+                        // future point; it will also
+                        // block subsequent requests in the same room from being
+                        // sent, until it's unwedged or removed, so as to
+                        // preserve ordering.
                         if let Err(storage_error) =
                             queue.mark_as_wedged(&txn_id, QueueWedgeError::from(&err)).await
                         {
@@ -1232,8 +1257,8 @@ impl RoomSendQueue {
     pub fn set_enabled(&self, enabled: bool) {
         self.inner.locally_enabled.store(enabled, Ordering::SeqCst);
 
-        // No need to wake a task to tell it it's been disabled, so only notify if we're
-        // re-enabling the queue.
+        // No need to wake a task to tell it it's been disabled, so only notify
+        // if we're re-enabling the queue.
         if enabled {
             self.inner.notifier.notify_one();
         }
@@ -1474,11 +1499,13 @@ impl QueueStorage {
         let queued_requests =
             guard.client()?.state_store().load_send_queue_requests(&self.room_id).await?;
 
-        // Only ever consider the head of the queue: requests must be sent in the
-        // order they were queued, so a wedged request (which failed to be sent with an
-        // unrecoverable error) blocks all the requests queued after it. Otherwise,
-        // messages would be sent out of order, until the wedged request is either
-        // manually unwedged or removed (both of which will wake up the sending task).
+        // Only ever consider the head of the queue: requests must be sent in
+        // the order they were queued, so a wedged request (which failed
+        // to be sent with an unrecoverable error) blocks all the
+        // requests queued after it. Otherwise, messages would be sent
+        // out of order, until the wedged request is either
+        // manually unwedged or removed (both of which will wake up the sending
+        // task).
         if let Some(request) = queued_requests.first().filter(|queued| !queued.is_wedged()) {
             let (cancel_upload_tx, cancel_upload_rx) =
                 if matches!(request.kind, QueuedRequestKind::MediaUpload { .. }) {
@@ -1702,7 +1729,8 @@ impl QueueStorage {
         let client = guard.client()?;
         let store = client.state_store();
 
-        // There's only a single media to be sent, so it has at most one thumbnail.
+        // There's only a single media to be sent, so it has at most one
+        // thumbnail.
         let thumbnail_file_sizes = vec![thumbnail.as_ref().map(|t| t.file_size)];
 
         let thumbnail_info = self
@@ -1799,8 +1827,8 @@ impl QueueStorage {
             {
                 let upload_thumbnail_txn = thumbnail_info.txn.clone();
 
-                // Save the thumbnail upload request as a dependent request of the last file
-                // upload.
+                // Save the thumbnail upload request as a dependent request of
+                // the last file upload.
                 store
                     .save_dependent_queued_request(
                         &self.room_id,
@@ -1823,7 +1851,8 @@ impl QueueStorage {
                 None
             };
 
-            // Save the file upload as a dependent request of the previous upload.
+            // Save the file upload as a dependent request of the previous
+            // upload.
             store
                 .save_dependent_queued_request(
                     &self.room_id,
@@ -1848,8 +1877,8 @@ impl QueueStorage {
             last_upload_file_txn = upload_file_txn.clone();
         }
 
-        // Push the request for the event itself as a dependent request of the last file
-        // upload.
+        // Push the request for the event itself as a dependent request of the
+        // last file upload.
         store
             .save_dependent_queued_request(
                 &self.room_id,
@@ -1911,7 +1940,8 @@ impl QueueStorage {
                 )
                 .await?;
 
-            // Save the file upload request as a dependent request of the thumbnail upload.
+            // Save the file upload request as a dependent request of the
+            // thumbnail upload.
             store
                 .save_dependent_queued_request(
                     &self.room_id,
@@ -1967,15 +1997,16 @@ impl QueueStorage {
 
         // If the target event has been already sent, abort immediately.
         if !requests.iter().any(|item| item.transaction_id == transaction_id) {
-            // We didn't find it as a queued request; try to find it as a dependent queued
-            // request.
+            // We didn't find it as a queued request; try to find it as a
+            // dependent queued request.
             let dependent_requests = store.load_dependent_queued_requests(&self.room_id).await?;
             if !dependent_requests
                 .into_iter()
                 .filter_map(|item| item.is_own_event().then_some(item.own_transaction_id))
                 .any(|child_txn| *child_txn == *transaction_id)
             {
-                // We didn't find it as either a request or a dependent request, abort.
+                // We didn't find it as either a request or a dependent request,
+                // abort.
                 return Ok(None);
             }
         }
@@ -2007,9 +2038,10 @@ impl QueueStorage {
 
         let queued_requests = store.load_send_queue_requests(&self.room_id).await?;
 
-        // Media upload requests aren't returned as echoes themselves (the media event,
-        // represented as a dependent request, is), so carry their send errors over to
-        // the dependent request's echo: a wedged upload wedges the media event.
+        // Media upload requests aren't returned as echoes themselves (the media
+        // event, represented as a dependent request, is), so carry
+        // their send errors over to the dependent request's echo: a
+        // wedged upload wedges the media event.
         let mut media_upload_errors: HashMap<OwnedTransactionId, QueueWedgeError> = queued_requests
             .iter()
             .filter_map(|queued| match queued.kind {
@@ -2036,8 +2068,10 @@ impl QueueStorage {
                     },
 
                     QueuedRequestKind::MediaUpload { .. } => {
-                        // Don't return uploaded medias as their own things; the accompanying
-                        // event represented as a dependent request should be sufficient.
+                        // Don't return uploaded medias as their own things; the
+                        // accompanying
+                        // event represented as a dependent request should be
+                        // sufficient.
                         return None;
                     }
 
@@ -2080,7 +2114,8 @@ impl QueueStorage {
                 }),
 
                 DependentQueuedRequestKind::UploadFileOrThumbnail { .. } => {
-                    // Don't reflect these: only the associated event is interesting to observers.
+                    // Don't reflect these: only the associated event is
+                    // interesting to observers.
                     None
                 }
 
@@ -2092,7 +2127,8 @@ impl QueueStorage {
                 } => {
                     let upload_thumbnail_txn = thumbnail_info.map(|info| info.txn);
 
-                    // If one of the uploads wedged, the media event is wedged too.
+                    // If one of the uploads wedged, the media event is wedged
+                    // too.
                     let send_error = media_upload_errors.remove(&file_upload).or_else(|| {
                         upload_thumbnail_txn
                             .as_ref()
@@ -2210,7 +2246,8 @@ impl QueueStorage {
                         .get_room(&self.room_id)
                         .ok_or(RoomSendQueueError::RoomDisappeared)?;
 
-                    // Check the event is one we know how to edit with an edit event.
+                    // Check the event is one we know how to edit with an edit
+                    // event.
 
                     // It must be deserializable…
                     let edited_content = match new_content.deserialize() {
@@ -2300,9 +2337,10 @@ impl QueueStorage {
                         .get_room(&self.room_id)
                         .ok_or(RoomSendQueueError::RoomDisappeared)?;
 
-                    // Ideally we'd use the send queue to send the redaction, but the protocol has
-                    // changed the shape of a room.redaction after v11, so keep it simple and try
-                    // once here.
+                    // Ideally we'd use the send queue to send the redaction,
+                    // but the protocol has changed the
+                    // shape of a room.redaction after v11, so keep it simple
+                    // and try once here.
 
                     if let Err(err) = room
                         .redact(
@@ -2316,8 +2354,8 @@ impl QueueStorage {
                         return Ok(false);
                     }
                 } else {
-                    // The parent event is still local (sending must have failed); redact the local
-                    // echo.
+                    // The parent event is still local (sending must have
+                    // failed); redact the local echo.
                     let removed = store
                         .remove_send_queue_request(
                             &self.room_id,
@@ -2480,7 +2518,8 @@ impl QueueStorage {
             match self.try_apply_single_dependent_request(&client, dependent, new_updates).await {
                 Ok(should_remove) => {
                     if should_remove {
-                        // The dependent request has been successfully applied, forget about it.
+                        // The dependent request has been successfully applied,
+                        // forget about it.
                         store
                             .remove_dependent_queued_request(&self.room_id, &dependent_id)
                             .await
@@ -2860,7 +2899,8 @@ impl SendHandle {
 
         for handles in &self.media_handles {
             if queue.abort_upload(&self.transaction_id, handles).await? {
-                // Wake up the queue, in case it was blocked on this request being wedged.
+                // Wake up the queue, in case it was blocked on this request
+                // being wedged.
                 self.room.inner.notifier.notify_one();
 
                 // Propagate a cancelled update.
@@ -2879,7 +2919,8 @@ impl SendHandle {
         if queue.cancel_event(&self.transaction_id, reason).await? {
             trace!("successful abort");
 
-            // Wake up the queue, in case it was blocked on this request being wedged.
+            // Wake up the queue, in case it was blocked on this request being
+            // wedged.
             self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
@@ -2992,10 +3033,10 @@ impl SendHandle {
 
         // If we have media handles, also try to unwedge them.
         //
-        // It's fine to always do it to *all* the transaction IDs at once, because only
-        // one of the three requests will be active at the same time, i.e. only
-        // one entry will be updated in the store. The other two are either
-        // done, or dependent requests.
+        // It's fine to always do it to *all* the transaction IDs at once,
+        // because only one of the three requests will be active at the
+        // same time, i.e. only one entry will be updated in the store.
+        // The other two are either done, or dependent requests.
 
         for handles in &self.media_handles {
             room.queue
@@ -3008,7 +3049,8 @@ impl SendHandle {
             }
         }
 
-        // Wake up the queue, in case the room was asleep before unwedging the request.
+        // Wake up the queue, in case the room was asleep before unwedging the
+        // request.
         room.notifier.notify_one();
 
         self.room.send_update(RoomSendQueueUpdate::RetryEvent {
@@ -3035,7 +3077,8 @@ impl SendHandle {
         {
             trace!("successfully queued react");
 
-            // Wake up the queue, in case the room was asleep before the sending.
+            // Wake up the queue, in case the room was asleep before the
+            // sending.
             self.room.inner.notifier.notify_one();
 
             // Propagate a new local event.
@@ -3095,8 +3138,8 @@ impl SendReactionHandle {
             return Ok(true);
         }
 
-        // The reaction has already been queued for sending, try to abort it using a
-        // regular abort.
+        // The reaction has already been queued for sending, try to abort it
+        // using a regular abort.
         let handle = SendHandle {
             room: self.room.clone(),
             transaction_id: self.transaction_id.clone().into(),
@@ -3143,7 +3186,8 @@ impl SendRedactionHandle {
         if queue.cancel_event(&self.transaction_id, None).await? {
             trace!("successful redaction abort");
 
-            // Wake up the queue, in case it was blocked on this request being wedged.
+            // Wake up the queue, in case it was blocked on this request being
+            // wedged.
             self.room.inner.notifier.notify_one();
 
             // Propagate a cancelled update too.
@@ -3177,8 +3221,8 @@ fn canonicalize_dependent_requests(
                     | DependentQueuedRequestKind::RedactEventWithReason { .. }
             )
         }) {
-            // The parent event has already been flagged for redaction, don't consider the
-            // other dependent events.
+            // The parent event has already been flagged for redaction, don't
+            // consider the other dependent events.
             continue;
         }
 

--- a/crates/matrix-sdk/src/send_queue/progress.rs
+++ b/crates/matrix-sdk/src/send_queue/progress.rs
@@ -110,9 +110,10 @@ impl RoomSendQueue {
         };
 
         let offsets = {
-            // If we're uploading a file, we may have already uploaded a thumbnail; get its
-            // size from the in-memory thumbnail sizes cache. This will account in the
-            // current and total size, for the overall progress of
+            // If we're uploading a file, we may have already uploaded a
+            // thumbnail; get its size from the in-memory thumbnail
+            // sizes cache. This will account in the current and
+            // total size, for the overall progress of
             // thumbnail+file.
             let already_uploaded_thumbnail_bytes = if thumbnail_source.is_some() {
                 queue
@@ -128,9 +129,10 @@ impl RoomSendQueue {
 
             let already_uploaded_thumbnail_bytes = already_uploaded_thumbnail_bytes.unwrap_or(0);
 
-            // If we're uploading a thumbnail, get the size of the file to be uploaded after
-            // it, from the database. This will account in the total progress of the
-            // file+thumbnail upload (we're currently uploading the thumbnail,
+            // If we're uploading a thumbnail, get the size of the file to be
+            // uploaded after it, from the database. This will
+            // account in the total progress of the file+thumbnail
+            // upload (we're currently uploading the thumbnail,
             // in the first step).
             let pending_file_bytes = match RoomSendQueue::get_dependent_pending_file_upload_size(
                 own_txn_id, room,
@@ -146,8 +148,8 @@ impl RoomSendQueue {
                 }
             };
 
-            // In nominal cases where the send queue is used correctly, only one of these
-            // two values will be non-zero.
+            // In nominal cases where the send queue is used correctly, only one
+            // of these two values will be non-zero.
             AbstractProgress {
                 current: already_uploaded_thumbnail_bytes,
                 total: already_uploaded_thumbnail_bytes + pending_file_bytes,
@@ -167,8 +169,8 @@ impl RoomSendQueue {
         let dependent_requests =
             client.state_store().load_dependent_queued_requests(room.room_id()).await?;
 
-        // Try to find a depending request which depends on the target one, and that's a
-        // media upload.
+        // Try to find a depending request which depends on the target one, and
+        // that's a media upload.
         let Some((cache_key, parent_is_thumbnail_upload)) =
             dependent_requests.into_iter().find_map(|r| {
                 if r.parent_transaction_id != txn_id {
@@ -217,13 +219,14 @@ impl RoomSendQueue {
         let update_sender = update_sender.clone();
         let media_upload_info = *media_upload_info;
 
-        // Watch and communicate the progress on a detached background task. Once
-        // the progress observable is dropped, next() will return None and the
-        // task will end.
+        // Watch and communicate the progress on a detached background task.
+        // Once the progress observable is dropped, next() will return
+        // None and the task will end.
         spawn(async move {
             while let Some(progress) = subscriber.next().await {
-                // Purposefully don't use `send_update` here, because we don't want to notify
-                // the global listeners about an upload progress update.
+                // Purposefully don't use `send_update` here, because we don't
+                // want to notify the global listeners about an
+                // upload progress update.
                 let _ = update_sender.send(RoomSendQueueUpdate::MediaUpload {
                     related_to: related_txn_id.clone(),
                     file: None,

--- a/crates/matrix-sdk/src/send_queue/upload.rs
+++ b/crates/matrix-sdk/src/send_queue/upload.rs
@@ -67,8 +67,8 @@ use crate::{
 /// Replace the source by the final ones in all the media types handled by
 /// [`Room::make_attachment_type()`].
 fn update_media_event_after_upload(echo: &mut RoomMessageEventContent, sent: SentMediaInfo) {
-    // Some variants look really similar below, but the `event` and `info` are all
-    // different types…
+    // Some variants look really similar below, but the `event` and `info` are
+    // all different types…
     match &mut echo.msgtype {
         MessageType::Audio(event) => {
             event.source = sent.file;
@@ -93,9 +93,10 @@ fn update_media_event_after_upload(echo: &mut RoomMessageEventContent, sent: Sen
         }
 
         _ => {
-            // All `MessageType` created by `Room::make_attachment_type` should be
-            // handled here. The only way to end up here is that a message type has
-            // been tampered with in the database.
+            // All `MessageType` created by `Room::make_attachment_type` should
+            // be handled here. The only way to end up here is that
+            // a message type has been tampered with in the
+            // database.
             error!("Invalid message type in database: {}", echo.msgtype());
             // Only crash debug builds.
             debug_assert!(false, "invalid message type in database");
@@ -111,17 +112,17 @@ fn update_gallery_event_after_upload(
     sent: HashMap<String, AccumulatedSentMediaInfo>,
 ) {
     let MessageType::Gallery(gallery) = &mut echo.msgtype else {
-        // All `GalleryItemType` created by `Room::make_gallery_item_type` should be
-        // handled here. The only way to end up here is that a item type has
-        // been tampered with in the database.
+        // All `GalleryItemType` created by `Room::make_gallery_item_type`
+        // should be handled here. The only way to end up here is that a
+        // item type has been tampered with in the database.
         error!("Invalid gallery item types in database");
         // Only crash debug builds.
         debug_assert!(false, "invalid item type in database {:?}", echo.msgtype());
         return;
     };
 
-    // Some variants look really similar below, but the `event` and `info` are all
-    // different types…
+    // Some variants look really similar below, but the `event` and `info` are
+    // all different types…
     for itemtype in gallery.itemtypes.iter_mut() {
         match itemtype {
             GalleryItemType::Audio(event) => match sent.get(&event.source.unique_key()) {
@@ -157,9 +158,10 @@ fn update_gallery_event_after_upload(
             },
 
             _ => {
-                // All `GalleryItemType` created by `Room::make_gallery_item_type` should be
-                // handled here. The only way to end up here is that a item type has
-                // been tampered with in the database.
+                // All `GalleryItemType` created by
+                // `Room::make_gallery_item_type` should be
+                // handled here. The only way to end up here is that a item type
+                // has been tampered with in the database.
                 error!("Invalid gallery item types in database");
                 // Only crash debug builds.
                 debug_assert!(false, "invalid gallery item type in database {itemtype:?}");
@@ -442,8 +444,8 @@ impl RoomSendQueue {
             let txn = TransactionId::new();
             trace!(upload_thumbnail_txn = %txn, "media has a thumbnail");
 
-            // Create the information required for filling the thumbnail section of the
-            // event.
+            // Create the information required for filling the thumbnail section
+            // of the event.
             let (data, content_type, thumbnail_info) = thumbnail.into_parts();
             let file_size = data.len();
 
@@ -552,8 +554,8 @@ impl QueueStorage {
             extra_content,
         )?;
 
-        // Indicates observers that the upload finished, by editing the local echo for
-        // the event into its final form before sending.
+        // Indicates observers that the upload finished, by editing the local
+        // echo for the event into its final form before sending.
         new_updates.push(RoomSendQueueUpdate::ReplacedLocalEvent {
             transaction_id: event_txn.clone(),
             new_content: new_content.clone(),
@@ -605,8 +607,8 @@ impl QueueStorage {
         for (item_info, sent_media) in zip(item_infos, sent_media_vec) {
             let FinishGalleryItemInfo { file_upload: file_upload_txn, thumbnail_info } = item_info;
 
-            // Store the sent media under the original cache key for later insertion into
-            // the local echo.
+            // Store the sent media under the original cache key for later
+            // insertion into the local echo.
             let from_req = Media::make_local_file_media_request(&file_upload_txn);
             sent_infos.insert(from_req.source.unique_key(), sent_media.clone());
 
@@ -624,8 +626,8 @@ impl QueueStorage {
         let new_content = SerializableEventContent::new(&local_echo.into())
             .map_err(RoomSendQueueStorageError::JsonSerialization)?;
 
-        // Indicates observers that the upload finished, by editing the local echo for
-        // the event into its final form before sending.
+        // Indicates observers that the upload finished, by editing the local
+        // echo for the event into its final form before sending.
         new_updates.push(RoomSendQueueUpdate::ReplacedLocalEvent {
             transaction_id: event_txn.clone(),
             new_content: new_content.clone(),
@@ -661,8 +663,8 @@ impl QueueStorage {
         event_txn: OwnedTransactionId,
         parent_is_thumbnail_upload: bool,
     ) -> Result<(), RoomSendQueueError> {
-        // The previous file or thumbnail has been sent, now transform the dependent
-        // file or thumbnail upload request into a ready one.
+        // The previous file or thumbnail has been sent, now transform the
+        // dependent file or thumbnail upload request into a ready one.
         let sent_media = parent_key
             .into_media()
             .ok_or(RoomSendQueueError::StorageError(RoomSendQueueStorageError::InvalidParentKey))?;
@@ -682,11 +684,12 @@ impl QueueStorage {
              or thumbnail upload request",
         );
 
-        // If the parent request was a thumbnail upload, don't add it to the list of
-        // accumulated medias yet because its dependent file upload is still
-        // pending. If the parent request was a file upload, we know that both
-        // the file and its thumbnail (if any) have finished uploading and we
-        // can add them to the accumulated sent media.
+        // If the parent request was a thumbnail upload, don't add it to the
+        // list of accumulated medias yet because its dependent file
+        // upload is still pending. If the parent request was a file
+        // upload, we know that both the file and its thumbnail (if any)
+        // have finished uploading and we can add them to the
+        // accumulated sent media.
         #[cfg(feature = "unstable-msc4274")]
         let accumulated = if parent_is_thumbnail_upload {
             sent_media.accumulated
@@ -754,11 +757,13 @@ impl QueueStorage {
         if let Some(thumbnail_txn) = &handles.upload_thumbnail_txn
             && store.remove_send_queue_request(&self.room_id, thumbnail_txn).await?
         {
-            // The thumbnail upload existed as a request: either it was pending (something
-            // else was being sent), or it was actively being sent.
+            // The thumbnail upload existed as a request: either it was pending
+            // (something else was being sent), or it was actively
+            // being sent.
             trace!("could remove thumbnail request, removing 2 dependent requests now");
 
-            // 1. Try to abort sending using the being_sent info, in case it was active.
+            // 1. Try to abort sending using the being_sent info, in case it was
+            //    active.
             if let Some(info) = guard.being_sent.as_ref()
                 && info.transaction_id == *thumbnail_txn
             {
@@ -794,11 +799,13 @@ impl QueueStorage {
 
         if !removed_dependent_upload {
             if store.remove_send_queue_request(&self.room_id, &handles.upload_file_txn).await? {
-                // The upload existed as a request: either it was pending (something else was
-                // being sent), or it was actively being sent.
+                // The upload existed as a request: either it was pending
+                // (something else was being sent), or it was
+                // actively being sent.
                 trace!("could remove file upload request, removing 1 dependent request");
 
-                // 1. Try to abort sending using the being_sent info, in case it was active.
+                // 1. Try to abort sending using the being_sent info, in case it
+                //    was active.
                 if let Some(info) = guard.being_sent.as_ref()
                     && info.transaction_id == handles.upload_file_txn
                 {
@@ -819,23 +826,27 @@ impl QueueStorage {
             } else {
                 // The upload was not in the send queue, so it's completed.
                 //
-                // It means the event sending is either still queued as a dependent request, or
-                // it's graduated into a request.
+                // It means the event sending is either still queued as a
+                // dependent request, or it's graduated into a
+                // request.
                 if !removed_dependent_event
                     && !store
                         .remove_dependent_queued_request(&self.room_id, &event_as_dependent)
                         .await?
                 {
-                    // The media event has been promoted into a request, or the promoted request
-                    // has been sent already: we couldn't abort, let the caller decide what to do.
+                    // The media event has been promoted into a request, or the
+                    // promoted request has been sent
+                    // already: we couldn't abort, let the caller decide what to
+                    // do.
                     debug!("uploads already happened => deferring to aborting an event sending");
                     return Ok(false);
                 }
             }
         }
 
-        // At this point, all the requests and dependent requests have been cleaned up.
-        // Perform the final step: empty the cache from the local items.
+        // At this point, all the requests and dependent requests have been
+        // cleaned up. Perform the final step: empty the cache from the
+        // local items.
         {
             let media_store = client.media_store().lock().await?;
             media_store
@@ -868,13 +879,15 @@ impl QueueStorage {
         // The media event can be in one of three states:
         // - still stored as a dependent request,
         // - stored as a queued request, active (aka it's being sent).
-        // - stored as a queued request, not active yet (aka it's not being sent yet),
+        // - stored as a queued request, not active yet (aka it's not being sent
+        //   yet),
         //
         // We'll handle each of these cases one by one.
 
         {
-            // If the event can be found as a dependent event, update the captions, save it
-            // back into the database, and return early.
+            // If the event can be found as a dependent event, update the
+            // captions, save it back into the database, and return
+            // early.
             let dependent_requests = store.load_dependent_queued_requests(&self.room_id).await?;
 
             if let Some(found) =
@@ -1016,9 +1029,10 @@ async fn update_media_cache_keys_after_upload(
                 "storing thumbnail as a thumbnail for the uploaded media, and a file in itself, in cache store"
             );
 
-            // Try to reload the content of the thumbnail from the media store. As it's not
-            // a strong requirement to store the thumbnail a second time, we
-            // silently log errors instead of propagating them to the caller.
+            // Try to reload the content of the thumbnail from the media store.
+            // As it's not a strong requirement to store the
+            // thumbnail a second time, we silently log errors
+            // instead of propagating them to the caller.
             match media_store
                 .get_media_content(&MediaRequestParameters {
                     source: from_request_params.source.clone(),
@@ -1027,8 +1041,9 @@ async fn update_media_cache_keys_after_upload(
                 .await
             {
                 Ok(Some(thumbnail_content)) => {
-                    // Also cache this as a thumbnail for the thumbnail, in the media store; the
-                    // ElementX apps expect that specific format for thumbnails.
+                    // Also cache this as a thumbnail for the thumbnail, in the
+                    // media store; the ElementX apps expect
+                    // that specific format for thumbnails.
                     media_store
                         .add_media_content(
                             &MediaRequestParameters {
@@ -1052,7 +1067,8 @@ async fn update_media_cache_keys_after_upload(
                 }
 
                 Err(err) => {
-                    // Silently log the error, but proceed, as storing the thumbnail as such isn't
+                    // Silently log the error, but proceed, as storing the
+                    // thumbnail as such isn't
                     // a strong requirement.
                     error!(
                         from = ?from_request_params.source,

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -58,17 +58,18 @@ pub(super) async fn store_sliding_sync_state(
         let position = _position;
         let instance_storage_key = format_storage_key_for_sliding_sync(storage_key);
 
-        // FIXME (TERRIBLE HACK): we want to save `pos` in a cross-process safe manner,
-        // with both processes sharing the same database backend; that needs to
-        // go in the crypto process store at the moment, but should be fixed
-        // later on.
+        // FIXME (TERRIBLE HACK): we want to save `pos` in a cross-process safe
+        // manner, with both processes sharing the same database
+        // backend; that needs to go in the crypto process store at the
+        // moment, but should be fixed later on.
         if let Some(olm_machine) = &*sliding_sync.inner.client.olm_machine().await {
             let pos_blob = serde_json::to_vec(&FrozenSlidingSyncPos { pos: position.pos.clone() })?;
             olm_machine.store().set_custom_value(&instance_storage_key, pos_blob).await?;
         }
     }
 
-    // Write every `SlidingSyncList` that's configured for caching into the store.
+    // Write every `SlidingSyncList` that's configured for caching into the
+    // store.
     let frozen_lists = {
         sliding_sync
             .inner
@@ -119,11 +120,12 @@ pub(super) async fn restore_sliding_sync_list(
         }
 
         Some(Err(_)) => {
-            // List has been found, but it wasn't possible to deserialize it. It's declared
-            // as obsolete. The main reason might be that the internal representation of a
-            // `SlidingSyncList` might have changed. Instead of considering this as a strong
-            // error, we remove the entry from the cache and keep the list in its initial
-            // state.
+            // List has been found, but it wasn't possible to deserialize it.
+            // It's declared as obsolete. The main reason might be
+            // that the internal representation of a
+            // `SlidingSyncList` might have changed. Instead of considering this
+            // as a strong error, we remove the entry from the cache
+            // and keep the list in its initial state.
             warn!(
                 list_name,
                 "failed to deserialize the list from the cache, it is obsolete; removing the cache entry!"
@@ -251,7 +253,8 @@ mod tests {
                 .build()
                 .await?;
 
-            // Modify both lists, so we can check expected caching behavior later.
+            // Modify both lists, so we can check expected caching behavior
+            // later.
             {
                 let lists = sliding_sync.inner.lists.write().await;
 
@@ -294,7 +297,8 @@ mod tests {
         let sliding_sync = client
             .sliding_sync(sync_id)?
             .add_cached_list(SlidingSyncList::builder("list_foo").once_built(move |list| {
-                // In the `once_built()` handler, nothing has been read from the cache yet.
+                // In the `once_built()` handler, nothing has been read from the
+                // cache yet.
                 assert_eq!(list.maximum_number_of_rooms(), None);
 
                 let mut stream = cloned_stream.write().unwrap();
@@ -371,10 +375,11 @@ mod tests {
         // After restoring, to-device token could be read.
         assert_eq!(restored_fields.pos.unwrap(), pos);
 
-        // Test the "migration" path: assume a missing to-device token in crypto store,
-        // but present in a former state store.
+        // Test the "migration" path: assume a missing to-device token in crypto
+        // store, but present in a former state store.
 
-        // For our sanity, check no to-device token has been saved in the database.
+        // For our sanity, check no to-device token has been saved in the
+        // database.
         {
             let olm_machine = client.base_client().olm_machine().await;
             let olm_machine = olm_machine.as_ref().unwrap();

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -192,7 +192,8 @@ impl SlidingSyncResponseProcessor {
             )
             .await?
         {
-            // Some new keys might have been received, so trigger a backup if needed.
+            // Some new keys might have been received, so trigger a backup if
+            // needed.
             self.client.encryption().backups().maybe_trigger_backup();
 
             to_device_events
@@ -274,8 +275,8 @@ async fn update_in_memory_caches(
 ) {
     let _timer = timer!(tracing::Level::TRACE, "update_in_memory_caches");
 
-    // If the push rules have changed, update the cached notification mode for *all*
-    // the joined rooms.
+    // If the push rules have changed, update the cached notification mode for
+    // *all* the joined rooms.
     if response.account_data.iter().any(|event| {
         event
             .get_field::<GlobalAccountDataEventType>("type")
@@ -295,8 +296,8 @@ async fn update_in_memory_caches(
             }
         }
     } else {
-        // Otherwise, precompute the cached user-defined notification mode only for the
-        // newly joined rooms.
+        // Otherwise, precompute the cached user-defined notification mode only
+        // for the newly joined rooms.
 
         // We'll compute the rules only once, lazily, if needs be.
         let mut rules = None;
@@ -312,14 +313,16 @@ async fn update_in_memory_caches(
                 continue;
             };
 
-            // Reuse the previous `Rules` instance, or compute it once and for all.
+            // Reuse the previous `Rules` instance, or compute it once and for
+            // all.
             let rules = if let Some(rules) = &mut rules {
                 rules
             } else {
                 rules.insert(client.notification_settings().await.rules().await.clone())
             };
 
-            // Define an initial value for the cached user-defined notification mode.
+            // Define an initial value for the cached user-defined notification
+            // mode.
             if let Some(mode) = rules.get_user_defined_room_notification_mode(room.room_id()) {
                 room.update_cached_user_defined_notification_mode(mode);
             }
@@ -336,8 +339,9 @@ async fn handle_receipts_extension(
 ) -> Result<()> {
     let _timer = timer!(tracing::Level::TRACE, "handle_receipts_extension");
 
-    // We need to compute read receipts for each joined room that has received an
-    // update, or from each room that has received a receipt ephemeral event.
+    // We need to compute read receipts for each joined room that has received
+    // an update, or from each room that has received a receipt ephemeral
+    // event.
     let room_ids = BTreeSet::from_iter(
         sync_response
             .rooms
@@ -438,8 +442,8 @@ mod tests {
         let client = MockClientBuilder::new(None).build().await;
         let available_versions = client.available_sliding_sync_versions().await;
 
-        // `.well-known` and `/versions` aren't available. It's impossible to find any
-        // versions.
+        // `.well-known` and `/versions` aren't available. It's impossible to
+        // find any versions.
         assert!(available_versions.is_empty());
     }
 
@@ -579,8 +583,9 @@ mod tests {
         );
 
         // Mock a sync response.
-        // Even if the room doesn't appear in the response, its notification mode will
-        // be updated immediately if a new `m.push_rules` is received.
+        // Even if the room doesn't appear in the response, its notification
+        // mode will be updated immediately if a new `m.push_rules` is
+        // received.
         {
             let server_response = assign!(http::Response::new("0".to_owned()), {
                 extensions: assign!(http::response::Extensions::default(), {
@@ -728,8 +733,8 @@ mod tests {
         );
         assert!(room_info_notable_update_stream.is_empty());
 
-        // When I send sliding sync response containing a couple of events with no read
-        // receipt.
+        // When I send sliding sync response containing a couple of events with
+        // no read receipt.
         let room_id = room_id!("!r:e.uk");
         let f = EventFactory::new().room(room_id).sender(user_id!("@u:h.uk"));
         let events = vec![
@@ -775,8 +780,8 @@ mod tests {
             }
         );
 
-        // At some point, we receive an update for the `LATEST_EVENT` too, since this is
-        // enabled by default.
+        // At some point, we receive an update for the `LATEST_EVENT` too, since
+        // this is enabled by default.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -55,7 +55,8 @@ pub struct SlidingSyncListBuilder {
 #[cfg(not(tarpaulin_include))]
 impl fmt::Debug for SlidingSyncListBuilder {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Print debug values for the builder, except `once_built` which is ignored.
+        // Print debug values for the builder, except `once_built` which is
+        // ignored.
         formatter
             .debug_struct("SlidingSyncListBuilder")
             .field("sync_mode", &self.sync_mode)
@@ -244,10 +245,10 @@ impl SlidingSyncListBuilder {
 
         // If we reloaded from the cache, update values in the list here.
         //
-        // Note about ordering: because of the contract with the observables, the
-        // initial values, if filled, have to be observable in the `once_built`
-        // callback. That's why we're doing this here *after* constructing the
-        // list, and not a few lines above.
+        // Note about ordering: because of the contract with the observables,
+        // the initial values, if filled, have to be observable in the
+        // `once_built` callback. That's why we're doing this here
+        // *after* constructing the list, and not a few lines above.
 
         if let Some(SlidingSyncListCachedData { maximum_number_of_rooms }) =
             self.reloaded_cached_data

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -75,8 +75,8 @@ impl SlidingSyncList {
     {
         self.inner.set_sync_mode(sync_mode.into());
 
-        // When the sync mode is changed, the sync loop must skip over any work in its
-        // iteration and jump to the next iteration.
+        // When the sync mode is changed, the sync loop must skip over any work
+        // in its iteration and jump to the next iteration.
         self.inner.internal_channel_send_if_possible(
             SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration,
         );
@@ -162,8 +162,9 @@ impl SlidingSyncList {
     ///   server.
     #[instrument(skip(self), fields(name = self.name()))]
     pub(super) fn update(&mut self, maximum_number_of_rooms: Option<u32>) -> Result<bool, Error> {
-        // Make sure to update the generator state first; ordering matters because
-        // `update_room_list` observes the latest ranges in the response.
+        // Make sure to update the generator state first; ordering matters
+        // because `update_room_list` observes the latest ranges in the
+        // response.
         if let Some(maximum_number_of_rooms) = maximum_number_of_rooms {
             self.inner.update_request_generator_state(maximum_number_of_rooms)?;
         }
@@ -273,7 +274,8 @@ impl SlidingSyncListInner {
     /// Update the state to the next request, and return it.
     fn next_request(&self) -> Result<http::request::List, Error> {
         let ranges = {
-            // Use a dedicated scope to ensure the lock is released before continuing.
+            // Use a dedicated scope to ensure the lock is released before
+            // continuing.
             let mut request_generator = self.request_generator.write().unwrap();
             request_generator.generate_next_ranges(self.maximum_number_of_rooms.get())?
         };

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -139,8 +139,9 @@ impl SlidingSyncListRequestGenerator {
             SlidingSyncListRequestGeneratorKind::Paging { fully_loaded: true, .. }
             | SlidingSyncListRequestGeneratorKind::Growing { fully_loaded: true, .. }
             | SlidingSyncListRequestGeneratorKind::Selective => {
-                // Nothing to do: we already have the full ranges, return the existing ranges.
-                // For the growing and paging modes, keep the current value of `requested_end`,
+                // Nothing to do: we already have the full ranges, return the
+                // existing ranges. For the growing and paging
+                // modes, keep the current value of `requested_end`,
                 // which is still valid.
                 Ok(self.ranges.clone())
             }
@@ -152,8 +153,9 @@ impl SlidingSyncListRequestGenerator {
                 requested_end,
                 ..
             } => {
-                // In paging-mode, range starts at the number of fetched rooms. Since ranges are
-                // inclusive, and since the number of fetched rooms starts at 1,
+                // In paging-mode, range starts at the number of fetched rooms.
+                // Since ranges are inclusive, and since the
+                // number of fetched rooms starts at 1,
                 // not at 0, there is no need to add 1 here.
                 let range_start = number_of_fetched_rooms;
                 let range_desired_size = batch_size;
@@ -178,8 +180,9 @@ impl SlidingSyncListRequestGenerator {
                 requested_end,
                 ..
             } => {
-                // In growing-mode, range always starts from 0. However, the end is growing by
-                // adding `batch_size` to the previous number of fetched rooms.
+                // In growing-mode, range always starts from 0. However, the end
+                // is growing by adding `batch_size` to the
+                // previous number of fetched rooms.
                 let range_start = 0;
                 let range_desired_size = number_of_fetched_rooms.saturating_add(*batch_size);
 
@@ -224,12 +227,14 @@ impl SlidingSyncListRequestGenerator {
                 })?;
 
                 // Calculate the maximum bound for the range.
-                // At this step, the server has given us a maximum number of rooms for this
-                // list. That's our `range_maximum`.
+                // At this step, the server has given us a maximum number of
+                // rooms for this list. That's our
+                // `range_maximum`.
                 let mut range_maximum = maximum_number_of_rooms;
 
-                // But maybe the user has defined a maximum number of rooms to fetch? In this
-                // case, let's take the minimum of the two.
+                // But maybe the user has defined a maximum number of rooms to
+                // fetch? In this case, let's take the minimum
+                // of the two.
                 if let Some(maximum_number_of_rooms_to_fetch) = maximum_number_of_rooms_to_fetch {
                     range_maximum = min(range_maximum, *maximum_number_of_rooms_to_fetch);
                 }
@@ -241,8 +246,9 @@ impl SlidingSyncListRequestGenerator {
 
                 // The current range hasn't reached its maximum, let's continue.
                 if range_end < range_maximum {
-                    // Update the number of fetched rooms forward. Do not forget that ranges are
-                    // inclusive, so let's add 1.
+                    // Update the number of fetched rooms forward. Do not forget
+                    // that ranges are inclusive, so let's
+                    // add 1.
                     *number_of_fetched_rooms = range_end.saturating_add(1);
 
                     // The list is still not fully loaded.
@@ -263,7 +269,8 @@ impl SlidingSyncListRequestGenerator {
                     // We update the `fully_loaded` marker.
                     *fully_loaded = true;
 
-                    // The range is covering the entire list, from 0 to its maximum.
+                    // The range is covering the entire list, from 0 to its
+                    // maximum.
                     self.ranges = vec![0..=range_maximum];
 
                     // Finally, let's update the list' state.
@@ -307,17 +314,17 @@ fn create_range(
     // The `end`, by default, is `start` + `desired_size`.
     let mut end = start + desired_size;
 
-    // But maybe the user has defined a maximum number of rooms to fetch? In this
-    // case, take the minimum of the two.
+    // But maybe the user has defined a maximum number of rooms to fetch? In
+    // this case, take the minimum of the two.
     if let Some(maximum_number_of_rooms_to_fetch) = maximum_number_of_rooms_to_fetch {
         end = min(end, maximum_number_of_rooms_to_fetch);
     }
 
-    // But there is more! The server can tell us what is the maximum number of rooms
-    // fulfilling a particular list. For example, if the server says there is 42
-    // rooms for a particular list, with a `start` of 40 and a `batch_size` of 20,
-    // the range must be capped to `[40; 42]`; the range `[40; 60]` would be invalid
-    // and could be rejected by the server.
+    // But there is more! The server can tell us what is the maximum number of
+    // rooms fulfilling a particular list. For example, if the server says
+    // there is 42 rooms for a particular list, with a `start` of 40 and a
+    // `batch_size` of 20, the range must be capped to `[40; 42]`; the range
+    // `[40; 60]` would be invalid and could be rejected by the server.
     if let Some(maximum_number_of_rooms) = maximum_number_of_rooms {
         end = min(end, maximum_number_of_rooms);
     }
@@ -325,8 +332,9 @@ fn create_range(
     // Finally, because the bounds of the range are inclusive, 1 is subtracted.
     end = end.saturating_sub(1);
 
-    // Make sure `start` is smaller than `end`. It can happen if `start` is greater
-    // than `maximum_number_of_rooms_to_fetch` or `maximum_number_of_rooms`.
+    // Make sure `start` is smaller than `end`. It can happen if `start` is
+    // greater than `maximum_number_of_rooms_to_fetch` or
+    // `maximum_number_of_rooms`.
     if start > end {
         return Err(Error::InvalidRange { start, end });
     }
@@ -353,42 +361,45 @@ mod tests {
         // From 100, we want 100 items.
         assert_matches!(create_range(100, 100, None, None), Ok(range) if range == RangeInclusive::new(100, 199));
 
-        // From 0, we want 100 items, but there is a maximum number of rooms to fetch
-        // defined at 50.
+        // From 0, we want 100 items, but there is a maximum number of rooms to
+        // fetch defined at 50.
         assert_matches!(create_range(0, 100, Some(50), None), Ok(range) if range == RangeInclusive::new(0, 49));
 
-        // From 49, we want 100 items, but there is a maximum number of rooms to fetch
-        // defined at 50. There is 1 item to load.
+        // From 49, we want 100 items, but there is a maximum number of rooms to
+        // fetch defined at 50. There is 1 item to load.
         assert_matches!(create_range(49, 100, Some(50), None), Ok(range) if range == RangeInclusive::new(49, 49));
 
-        // From 50, we want 100 items, but there is a maximum number of rooms to fetch
-        // defined at 50.
+        // From 50, we want 100 items, but there is a maximum number of rooms to
+        // fetch defined at 50.
         assert_matches!(
             create_range(50, 100, Some(50), None),
             Err(Error::InvalidRange { start: 50, end: 49 })
         );
 
-        // From 0, we want 100 items, but there is a maximum number of rooms defined at
-        // 50.
+        // From 0, we want 100 items, but there is a maximum number of rooms
+        // defined at 50.
         assert_matches!(create_range(0, 100, None, Some(50)), Ok(range) if range == RangeInclusive::new(0, 49));
 
-        // From 49, we want 100 items, but there is a maximum number of rooms defined at
+        // From 49, we want 100 items, but there is a maximum number of rooms
+        // defined at
         // 50. There is 1 item to load.
         assert_matches!(create_range(49, 100, None, Some(50)), Ok(range) if range == RangeInclusive::new(49, 49));
 
-        // From 50, we want 100 items, but there is a maximum number of rooms defined at
-        // 50.
+        // From 50, we want 100 items, but there is a maximum number of rooms
+        // defined at 50.
         assert_matches!(
             create_range(50, 100, None, Some(50)),
             Err(Error::InvalidRange { start: 50, end: 49 })
         );
 
-        // From 0, we want 100 items, but there is a maximum number of rooms to fetch
-        // defined at 75, and a maximum number of rooms defined at 50.
+        // From 0, we want 100 items, but there is a maximum number of rooms to
+        // fetch defined at 75, and a maximum number of rooms defined at
+        // 50.
         assert_matches!(create_range(0, 100, Some(75), Some(50)), Ok(range) if range == RangeInclusive::new(0, 49));
 
-        // From 0, we want 100 items, but there is a maximum number of rooms to fetch
-        // defined at 50, and a maximum number of rooms defined at 75.
+        // From 0, we want 100 items, but there is a maximum number of rooms to
+        // fetch defined at 50, and a maximum number of rooms defined at
+        // 75.
         assert_matches!(create_range(0, 100, Some(50), Some(75)), Ok(range) if range == RangeInclusive::new(0, 49));
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -199,14 +199,15 @@ impl SlidingSync {
     ) {
         let mut room_subscriptions = self.inner.room_subscriptions.write().unwrap();
 
-        // Remove the subscriptions to the rooms that are not in `room_ids` anymore.
+        // Remove the subscriptions to the rooms that are not in `room_ids`
+        // anymore.
         let number_of_subscriptions_before = room_subscriptions.len();
         room_subscriptions.retain(|room_id, _| room_ids.contains(&room_id.as_ref()));
         let a_subscription_has_been_removed =
             room_subscriptions.len() != number_of_subscriptions_before;
 
-        // Add the subscriptions to the rooms that aren't subscribed yet, and refresh
-        // the settings of the ones that already are.
+        // Add the subscriptions to the rooms that aren't subscribed yet, and
+        // refresh the settings of the ones that already are.
         let a_subscription_has_been_added_or_updated = upsert_room_subscriptions(
             &mut room_subscriptions,
             &self.inner.client,
@@ -214,8 +215,8 @@ impl SlidingSync {
             settings,
         );
 
-        // The in-flight request must be cancelled as soon as the set of subscriptions
-        // has changed.
+        // The in-flight request must be cancelled as soon as the set of
+        // subscriptions has changed.
         if cancel_in_flight_request
             && (a_subscription_has_been_added_or_updated || a_subscription_has_been_removed)
         {
@@ -324,17 +325,19 @@ impl SlidingSync {
 
         // Transform a Sliding Sync Response to a `SyncResponse`.
         //
-        // We may not need the `sync_response` in the future (once `SyncResponse` will
-        // move to Sliding Sync, i.e. to `http::Response`), but processing the
-        // `sliding_sync_response` is vital, so it must be done somewhere; for now it
+        // We may not need the `sync_response` in the future (once
+        // `SyncResponse` will move to Sliding Sync, i.e. to
+        // `http::Response`), but processing the `sliding_sync_response`
+        // is vital, so it must be done somewhere; for now it
         // happens here.
 
         let sync_response = {
             let _timer = timer!("response processor");
 
             let response_processor = {
-                // Take the lock to synchronise accesses to the state store, to avoid concurrent
-                // sliding syncs overwriting each other's room infos.
+                // Take the lock to synchronise accesses to the state store, to
+                // avoid concurrent sliding syncs overwriting
+                // each other's room infos.
                 let state_store_guard = {
                     let _timer = timer!("acquiring the `state_store_lock`");
 
@@ -346,8 +349,9 @@ impl SlidingSync {
 
                 // Process thread subscriptions if they're available.
                 //
-                // It's important to do this *before* handling the room responses, so that
-                // notifications can be properly generated based on the thread subscriptions,
+                // It's important to do this *before* handling the room
+                // responses, so that notifications can be
+                // properly generated based on the thread subscriptions,
                 // for the events in threads we've subscribed to.
                 if self.is_thread_subscriptions_enabled() {
                     response_processor
@@ -367,8 +371,8 @@ impl SlidingSync {
                         .await?
                 }
 
-                // Only handle the room's subsection of the response, if this sliding sync was
-                // configured to do so.
+                // Only handle the room's subsection of the response, if this
+                // sliding sync was configured to do so.
                 if must_process_rooms_response {
                     response_processor
                         .handle_room_response(
@@ -398,12 +402,14 @@ impl SlidingSync {
 
                 updated_rooms.extend(sliding_sync_response.rooms.keys().cloned());
 
-                // There might be other rooms that were only mentioned in the sliding sync
-                // extensions part of the response, and thus would result in rooms present in
-                // the `sync_response.joined`. Mark them as updated too.
+                // There might be other rooms that were only mentioned in the
+                // sliding sync extensions part of the response,
+                // and thus would result in rooms present in the
+                // `sync_response.joined`. Mark them as updated too.
                 //
-                // Since we've removed rooms that were in the room subsection from
-                // `sync_response.rooms.joined`, the remaining ones aren't already present in
+                // Since we've removed rooms that were in the room subsection
+                // from `sync_response.rooms.joined`, the
+                // remaining ones aren't already present in
                 // `updated_rooms` and wouldn't cause any duplicates.
                 updated_rooms.extend(sync_response.rooms.joined.keys().cloned());
 
@@ -420,8 +426,9 @@ impl SlidingSync {
                 let mut updated_lists = Vec::with_capacity(sliding_sync_response.lists.len());
                 let mut lists = self.inner.lists.write().await;
 
-                // Iterate on known lists, not on lists in the response. Rooms may have been
-                // updated that were not involved in any list update.
+                // Iterate on known lists, not on lists in the response. Rooms
+                // may have been updated that were not involved
+                // in any list update.
                 for (name, list) in lists.iter_mut() {
                     if let Some(updates) = sliding_sync_response.lists.get(name) {
                         let maximum_number_of_rooms: u32 =
@@ -481,10 +488,11 @@ impl SlidingSync {
         // Collect the `pos`.
         //
         // Wait on the `position` mutex to be available. It means no request nor
-        // response is running. The `position` mutex is released whether the response
-        // has been fully handled successfully, in this case the `pos` is updated, or
-        // the response handling has failed, in this case the `pos` hasn't been updated
-        // and the same `pos` will be used for this new request.
+        // response is running. The `position` mutex is released whether the
+        // response has been fully handled successfully, in this case
+        // the `pos` is updated, or the response handling has failed, in
+        // this case the `pos` hasn't been updated and the same `pos`
+        // will be used for this new request.
         let mut position_guard = {
             debug!("Waiting to acquire the `position` lock");
 
@@ -503,11 +511,13 @@ impl SlidingSync {
             None
         };
 
-        // Update pos: either the one restored from the database, if any and the sliding
-        // sync was configured so, or read it from the memory cache.
+        // Update pos: either the one restored from the database, if any and the
+        // sliding sync was configured so, or read it from the memory
+        // cache.
         let pos = if self.inner.share_pos {
             if let Some(fields) = &restored_fields {
-                // Override the memory one with the database one, for consistency.
+                // Override the memory one with the database one, for
+                // consistency.
                 if fields.pos != position_guard.pos {
                     info!(
                         "Pos from previous request ('{:?}') was different from \
@@ -524,14 +534,15 @@ impl SlidingSync {
             position_guard.pos.clone()
         };
 
-        // When the client sends a request with no `pos`, MSC4186 returns no device
-        // lists updates, as it only returns changes since the provided `pos`
-        // (which is `null` in this case); this is in line with sync v2.
+        // When the client sends a request with no `pos`, MSC4186 returns no
+        // device lists updates, as it only returns changes since the
+        // provided `pos` (which is `null` in this case); this is in
+        // line with sync v2.
         //
-        // Therefore, with MSC4186, the device list cache must be marked as to be
-        // re-downloaded if the `since` token is `None`, otherwise it's easy to miss
-        // device lists updates that happened between the previous request and the new
-        // “initial” request.
+        // Therefore, with MSC4186, the device list cache must be marked as to
+        // be re-downloaded if the `since` token is `None`, otherwise
+        // it's easy to miss device lists updates that happened between
+        // the previous request and the new “initial” request.
         #[cfg(feature = "e2e-encryption")]
         if pos.is_none() && self.is_e2ee_enabled() {
             info!("Marking all tracked users as dirty");
@@ -543,8 +554,8 @@ impl SlidingSync {
 
         // Configure the timeout.
         //
-        // The `timeout` query is necessary when all lists require it. Please see
-        // [`SlidingSyncList::requires_timeout`].
+        // The `timeout` query is necessary when all lists require it. Please
+        // see [`SlidingSyncList::requires_timeout`].
         let timeout = match timeout {
             PollTimeout::None => None,
             PollTimeout::Some(timeout) => Some(Duration::from_secs(timeout.into())),
@@ -602,11 +613,13 @@ impl SlidingSync {
         let requested_required_states = RequestedRequiredStates::from(&request);
         let request = self.inner.client.send(request).with_request_config(request_config);
 
-        // Send the request and get a response with end-to-end encryption support.
+        // Send the request and get a response with end-to-end encryption
+        // support.
         //
-        // Sending the `/sync` request out when end-to-end encryption is enabled means
-        // that we need to also send out any outgoing e2ee related request out
-        // coming from the `OlmMachine::outgoing_requests()` method.
+        // Sending the `/sync` request out when end-to-end encryption is enabled
+        // means that we need to also send out any outgoing e2ee related
+        // request out coming from the `OlmMachine::outgoing_requests()`
+        // method.
 
         #[cfg(feature = "e2e-encryption")]
         let response = {
@@ -616,16 +629,18 @@ impl SlidingSync {
                 // 1. Send the sliding sync request and get a response,
                 // 2. Send the E2EE requests.
                 //
-                // We don't want to use a `join` or `try_join` because we want to fail if and
-                // only if sending the sliding sync request fails. Failing to send the E2EE
+                // We don't want to use a `join` or `try_join` because we want
+                // to fail if and only if sending the sliding
+                // sync request fails. Failing to send the E2EE
                 // requests should just result in a log.
                 //
-                // We also want to give the priority to sliding sync request. E2EE requests are
-                // sent concurrently to the sliding sync request, but the priority is on waiting
+                // We also want to give the priority to sliding sync request.
+                // E2EE requests are sent concurrently to the
+                // sliding sync request, but the priority is on waiting
                 // a sliding sync response.
                 //
-                // If sending sliding sync request fails, the sending of E2EE requests must be
-                // aborted as soon as possible.
+                // If sending sliding sync request fails, the sending of E2EE
+                // requests must be aborted as soon as possible.
 
                 let client = self.inner.client.clone();
                 let e2ee_uploads = spawn(
@@ -643,8 +658,9 @@ impl SlidingSync {
                 // Wait on the sliding sync request success or failure early.
                 let response = request.await?;
 
-                // At this point, if `request` has been resolved successfully, we wait on
-                // `e2ee_uploads`. It did run concurrently, so it should not be blocking for too
+                // At this point, if `request` has been resolved successfully,
+                // we wait on `e2ee_uploads`. It did run
+                // concurrently, so it should not be blocking for too
                 // long. Otherwise —if `request` has failed— `e2ee_uploads` has
                 // been dropped, so aborted.
                 e2ee_uploads.await.map_err(|error| Error::JoinError {
@@ -658,13 +674,15 @@ impl SlidingSync {
             }
         };
 
-        // Send the request and get a response _without_ end-to-end encryption support.
+        // Send the request and get a response _without_ end-to-end encryption
+        // support.
         #[cfg(not(feature = "e2e-encryption"))]
         let response = request.await?;
 
         debug!("Received response");
 
-        // At this point, the request has been sent, and a response has been received.
+        // At this point, the request has been sent, and a response has been
+        // received.
         //
         // We must ensure the handling of the response cannot be stopped/
         // cancelled. It must be done entirely, otherwise we can have
@@ -675,14 +693,14 @@ impl SlidingSync {
         // future that cannot be cancelled by anything.
         let this = self.clone();
 
-        // Spawn a new future to ensure that the code inside this future cannot be
-        // cancelled if this method is cancelled.
+        // Spawn a new future to ensure that the code inside this future cannot
+        // be cancelled if this method is cancelled.
         let future = async move {
             debug!("Start handling response");
 
             // In case the task running this future is detached, we must
-            // ensure responses are handled one at a time. At this point we still own
-            // `position_guard`, so we're fine.
+            // ensure responses are handled one at a time. At this point we
+            // still own `position_guard`, so we're fine.
 
             // Handle the response.
             let updates = this
@@ -692,7 +710,8 @@ impl SlidingSync {
             this.cache_to_storage(&position_guard).await?;
 
             // Release the position guard lock.
-            // It means that other responses can be generated and then handled later.
+            // It means that other responses can be generated and then handled
+            // later.
             drop(position_guard);
 
             debug!("Done handling response");
@@ -725,8 +744,8 @@ impl SlidingSync {
 
     /// Should we process the room's subpart of a response?
     async fn must_process_rooms_response(&self) -> bool {
-        // We consider that we must, if there's any room subscription or there's any
-        // list.
+        // We consider that we must, if there's any room subscription or there's
+        // any list.
         !self.inner.room_subscriptions.read().unwrap().is_empty()
             || !self.inner.lists.read().await.is_empty()
     }
@@ -856,16 +875,16 @@ impl SlidingSync {
             position.pos = None;
 
             // Propagate to disk.
-            // Note: this propagates both the sliding sync state and the cached lists'
-            // state to disk.
+            // Note: this propagates both the sliding sync state and the cached
+            // lists' state to disk.
             if let Err(err) = self.cache_to_storage(&position).await {
                 warn!("Failed to invalidate cached sliding sync state: {err}");
             }
         }
 
         {
-            // Clear all room subscriptions: we don't want to resend all room subscriptions
-            // when the session will restart.
+            // Clear all room subscriptions: we don't want to resend all room
+            // subscriptions when the session will restart.
             self.inner.room_subscriptions.write().unwrap().clear();
         }
     }
@@ -1108,8 +1127,8 @@ mod tests {
         let client = logged_in_client(None).await;
         let own_user_id = client.user_id().expect("client should be logged in").to_owned();
 
-        // Given a stored global profile for the current user, received through a
-        // previous sync.
+        // Given a stored global profile for the current user, received through
+        // a previous sync.
         let mut response = http::Response::new("0".to_owned());
 
         let mut profile_changes = UserProfileChanges::new();
@@ -1249,8 +1268,8 @@ mod tests {
         let room0 = sliding_sync.inner.client.get_room(room_id_0).unwrap();
 
         // Members aren't synced.
-        // We need to make them synced, so that we can test that subscribing to a room
-        // make members not synced. That's a desired feature.
+        // We need to make them synced, so that we can test that subscribing to
+        // a room make members not synced. That's a desired feature.
         assert!(room0.are_members_synced().not());
 
         {
@@ -1279,8 +1298,8 @@ mod tests {
 
         sliding_sync.add_room_subscriptions(&[room_id_0, room_id_1], None, true);
 
-        // OK, we have subscribed to some rooms. Let's check on `room0` if members are
-        // now marked as not synced.
+        // OK, we have subscribed to some rooms. Let's check on `room0` if
+        // members are now marked as not synced.
         assert!(room0.are_members_synced().not());
 
         {
@@ -1438,8 +1457,9 @@ mod tests {
         assert_eq!(timeline_limit_of_room_0(), Some(10u32.into()));
         assert!(internal_channel.try_recv().is_err());
 
-        // Resubscribe with new settings: they must be applied, and the in-flight
-        // request must be cancelled so that they are sent right away.
+        // Resubscribe with new settings: they must be applied, and the
+        // in-flight request must be cancelled so that they are sent
+        // right away.
         sliding_sync.set_room_subscriptions(&[room_id_0], settings(42), true);
 
         assert_eq!(timeline_limit_of_room_0(), Some(42u32.into()));
@@ -1464,8 +1484,8 @@ mod tests {
 
         let mut internal_channel = sliding_sync.inner.internal_channel.subscribe();
 
-        // A first-ever subscription: nothing is removed, but a subscription is added,
-        // so the in-flight request must be cancelled.
+        // A first-ever subscription: nothing is removed, but a subscription is
+        // added, so the in-flight request must be cancelled.
         sliding_sync.set_room_subscriptions(&[room_id_0], None, true);
 
         assert_matches!(
@@ -1520,7 +1540,8 @@ mod tests {
             Ok(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
         );
 
-        // All the subscriptions are removed: the in-flight request must be cancelled.
+        // All the subscriptions are removed: the in-flight request must be
+        // cancelled.
         sliding_sync.reset_and_add_room_subscriptions(&[], None, true);
 
         assert!(sliding_sync.inner.room_subscriptions.read().unwrap().is_empty());
@@ -1581,8 +1602,8 @@ mod tests {
         let room0 = sliding_sync.inner.client.get_room(room_id_0).unwrap();
 
         // Members aren't synced.
-        // We need to make them synced, so that we can test that subscribing to a room
-        // make members not synced. That's a desired feature.
+        // We need to make them synced, so that we can test that subscribing to
+        // a room make members not synced. That's a desired feature.
         assert!(room0.are_members_synced().not());
 
         {
@@ -1611,8 +1632,8 @@ mod tests {
 
         sliding_sync.set_room_subscriptions(&[room_id_0, room_id_1], None, true);
 
-        // OK, we have subscribed to some rooms. Let's check on `room0` if members are
-        // now marked as not synced.
+        // OK, we have subscribed to some rooms. Let's check on `room0` if
+        // members are now marked as not synced.
         assert!(room0.are_members_synced().not());
 
         // Both resubscribed rooms are subscribed.
@@ -1747,7 +1768,8 @@ mod tests {
         assert!(lists.contains_key("foo"));
         assert!(lists.contains_key("bar"));
 
-        // this test also ensures that Tokio is not panicking when calling `add_list`.
+        // this test also ensures that Tokio is not panicking when calling
+        // `add_list`.
 
         Ok(())
     }
@@ -1817,9 +1839,10 @@ mod tests {
         }
     }
 
-    // With MSC4186, with the `e2ee` extension enabled, if a request has no `pos`,
-    // all the tracked users by the `OlmMachine` must be marked as dirty, i.e.
-    // `/key/query` requests must be sent. See the code to see the details.
+    // With MSC4186, with the `e2ee` extension enabled, if a request has no
+    // `pos`, all the tracked users by the `OlmMachine` must be marked as
+    // dirty, i.e. `/key/query` requests must be sent. See the code to see
+    // the details.
     //
     // This test is asserting that.
     #[async_test]
@@ -1836,8 +1859,9 @@ mod tests {
         let bob = user_id!("@bob:localhost");
         let me = user_id!("@example:localhost");
 
-        // Track and mark users are not dirty, so that we can check they are “dirty”
-        // after that. Dirty here means that a `/key/query` must be sent.
+        // Track and mark users are not dirty, so that we can check they are
+        // “dirty” after that. Dirty here means that a `/key/query` must
+        // be sent.
         {
             let olm_machine = client.olm_machine().await;
             let olm_machine = olm_machine.as_ref().unwrap();
@@ -2003,8 +2027,8 @@ mod tests {
         let sync = sliding_sync.sync();
         pin_mut!(sync);
 
-        // Sync goes well, and then the position is saved both into the internal memory
-        // and the database.
+        // Sync goes well, and then the position is saved both into the internal
+        // memory and the database.
         let next = sync.next().await;
         assert_matches!(next, Some(Ok(_update_summary)));
 
@@ -2014,13 +2038,13 @@ mod tests {
             .await?
             .expect("must have restored fields");
 
-        // While it has been saved into the database, it's not necessarily going to be
-        // used later!
+        // While it has been saved into the database, it's not necessarily going
+        // to be used later!
         assert_eq!(restored_fields.pos.as_deref(), Some("0"));
 
-        // Now, even if we mess with the position stored in the database, the sliding
-        // sync instance isn't configured to reload the stream position from the
-        // database, so it won't be changed.
+        // Now, even if we mess with the position stored in the database, the
+        // sliding sync instance isn't configured to reload the stream
+        // position from the database, so it won't be changed.
         {
             let other_sync = client.sliding_sync("forgetful-sync")?.build().await?;
 
@@ -2037,8 +2061,8 @@ mod tests {
             assert_eq!(request.pos.as_deref(), Some("0"));
         }
 
-        // Recreating a sliding sync with the same ID doesn't preload the pos, if not
-        // asked to.
+        // Recreating a sliding sync with the same ID doesn't preload the pos,
+        // if not asked to.
         {
             let sliding_sync = client.sliding_sync("forgetful-sync")?.build().await?;
             assert!(sliding_sync.inner.position.lock().await.pos.is_none());
@@ -2092,8 +2116,8 @@ mod tests {
         let sync = sliding_sync.sync();
         pin_mut!(sync);
 
-        // Sync goes well, and then the position is saved both into the internal memory
-        // and the database.
+        // Sync goes well, and then the position is saved both into the internal
+        // memory and the database.
         let next = sync.next().await;
         assert_matches!(next, Some(Ok(_update_summary)));
 
@@ -2103,8 +2127,8 @@ mod tests {
             .await?
             .expect("must have restored fields");
 
-        // While it has been saved into the database, it's not necessarily going to be
-        // used later!
+        // While it has been saved into the database, it's not necessarily going
+        // to be used later!
         assert_eq!(restored_fields.pos.as_deref(), Some("0"));
 
         // Another process modifies the stream position under our feet...
@@ -2133,8 +2157,8 @@ mod tests {
             assert_eq!(request.pos.as_deref(), Some("42"));
         }
 
-        // Invalidating the session will remove the in-memory value AND the database
-        // value.
+        // Invalidating the session will remove the in-memory value AND the
+        // database value.
         sliding_sync.expire_session().await;
 
         {
@@ -2314,8 +2338,8 @@ mod tests {
             };
         }
 
-        // Simulate a response that only changes the marked unread state of the room to
-        // true
+        // Simulate a response that only changes the marked unread state of the
+        // room to true
 
         let server_response = make_mark_unread_response("1", room_id.clone(), true, false);
 
@@ -2507,8 +2531,8 @@ mod tests {
             })
         });
 
-        // Don't process non-encryption events if the sliding sync is configured for
-        // encryption only.
+        // Don't process non-encryption events if the sliding sync is configured
+        // for encryption only.
 
         let sliding_sync = client
             .sliding_sync("test")?
@@ -2546,8 +2570,8 @@ mod tests {
         // Room events haven't.
         assert!(client.get_room(&room).is_none());
 
-        // Conversely, only process room lists events if the sliding sync was configured
-        // as so.
+        // Conversely, only process room lists events if the sliding sync was
+        // configured as so.
         let client = logged_in_client(Some(server.uri())).await;
 
         let sliding_sync = client
@@ -2654,8 +2678,8 @@ mod tests {
             .build()
             .await?;
 
-        // Spawn two requests in parallel. Before #2430, this lead to a deadlock and the
-        // test would never terminate.
+        // Spawn two requests in parallel. Before #2430, this lead to a deadlock
+        // and the test would never terminate.
         let requests = join_all([sliding_sync.sync_once(), sliding_sync.sync_once()]);
 
         for result in requests.await {
@@ -2780,8 +2804,8 @@ mod tests {
 
         let (request, _, _) = sliding_sync.generate_sync_request().await?;
 
-        // Zero list means sliding sync is fully loaded, so there is a timeout to wait
-        // on new update to pop.
+        // Zero list means sliding sync is fully loaded, so there is a timeout
+        // to wait on new update to pop.
         assert!(request.timeout.is_some());
 
         Ok(())

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -159,7 +159,8 @@ impl Client {
 
         let response = Box::pin(self.base_client().receive_sync_response(response)).await?;
 
-        // Some new keys might have been received, so trigger a backup if needed.
+        // Some new keys might have been received, so trigger a backup if
+        // needed.
         #[cfg(feature = "e2e-encryption")]
         self.encryption().backups().maybe_trigger_backup();
 

--- a/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/encryption.rs
@@ -124,16 +124,16 @@ impl MatrixMockServer {
         alice.update_tracked_users_for_testing([bob_user_id]).instrument(alice_span.clone()).await;
 
         // let bob be aware of Alice keys in order to be able to decrypt custom
-        // to-device (the device keys check are deferred for `m.room.key` so this is not
-        // needed for sending room messages for example).
+        // to-device (the device keys check are deferred for `m.room.key` so
+        // this is not needed for sending room messages for example).
         bob.update_tracked_users_for_testing([alice_user_id]).instrument(bob_span.clone()).await;
 
         // Have Alice and Bob upload their signed device keys.
         self.mock_sync().ok_and_run(alice, |_x| {}).instrument(alice_span.clone()).await;
         self.mock_sync().ok_and_run(bob, |_x| {}).instrument(bob_span).await;
 
-        // Run a sync so we do send outgoing requests, including the /keys/query for
-        // getting bob's identity.
+        // Run a sync so we do send outgoing requests, including the /keys/query
+        // for getting bob's identity.
         self.mock_sync().ok_and_run(alice, |_x| {}).instrument(alice_span).await;
     }
 
@@ -175,7 +175,8 @@ impl MatrixMockServer {
         // Have Bob track Carl, so she queries his keys later.
         bob.update_tracked_users_for_testing([carl.user_id().unwrap()]).await;
 
-        // Have Alice and Bob upload their signed device keys, and download Carl's keys.
+        // Have Alice and Bob upload their signed device keys, and download
+        // Carl's keys.
         {
             self.mock_sync().ok_and_run(alice, |_| {}).await;
             self.mock_sync().ok_and_run(bob, |_| {}).await;
@@ -590,7 +591,8 @@ fn mock_keys_upload(
             let mut keys = keys.lock().unwrap();
             let devices = keys.device.entry(new_device_keys.user_id.clone()).or_default();
 
-            // Either merge signatures if an entry is already present, or insert a new one.
+            // Either merge signatures if an entry is already present, or insert
+            // a new one.
             if let Some(device_keys) = devices.get_mut(&key_id) {
                 let mut existing = device_keys.deserialize().unwrap();
 
@@ -616,8 +618,8 @@ fn mock_keys_upload(
 
         if let Some(otks) = params.one_time_keys {
             // We need a trick to find out what userId|device this OTK is for.
-            // This is not part of the payload, a real server uses the access token(?)
-            // Let's look at the signatures to find out
+            // This is not part of the payload, a real server uses the access
+            // token(?) Let's look at the signatures to find out
             for (key_id, raw_otk) in otks {
                 let otk = raw_otk.deserialize().unwrap();
                 match otk {
@@ -750,8 +752,8 @@ fn mock_keys_signature_upload(keys: Arc<Mutex<Keys>>) -> impl Fn(&Request) -> Re
                 }
 
                 // Otherwise, try to find a field in keys.device.
-                // Either merge signatures if an entry is already present, or insert a new
-                // entry.
+                // Either merge signatures if an entry is already present, or
+                // insert a new entry.
                 let known_devices = keys.device.entry(user.clone()).or_default();
                 let device_keys = known_devices
                     .get_mut(key_id)

--- a/crates/matrix-sdk/src/test_utils/mocks/mod.rs
+++ b/crates/matrix-sdk/src/test_utils/mocks/mod.rs
@@ -1231,7 +1231,8 @@ impl MatrixMockServer {
 
     /// Create a prebuilt mock for the endpoint used to get the related events.
     pub fn mock_room_relations(&self) -> MockEndpoint<'_, RoomRelationsEndpoint> {
-        // Routing happens in the final method ok(), since it can get complicated.
+        // Routing happens in the final method ok(), since it can get
+        // complicated.
         let mock = Mock::given(method("GET"));
         self.mock_endpoint(mock, RoomRelationsEndpoint::default()).expect_default_access_token()
     }
@@ -2693,8 +2694,9 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     /// ```
     pub fn for_type(mut self, event_type: StateEventType) -> Self {
         self.endpoint.event_type = Some(event_type);
-        // Note: we may have already defined a path, but this one ought to be more
-        // specialized (unless for_key/for_type were called multiple times).
+        // Note: we may have already defined a path, but this one ought to be
+        // more specialized (unless for_key/for_type were called
+        // multiple times).
         Self { mock: self.mock.and(path_regex(Self::generate_path_regexp(&self.endpoint))), ..self }
     }
 
@@ -2818,8 +2820,9 @@ impl<'a> MockEndpoint<'a, RoomSendStateEndpoint> {
     /// ```
     pub fn for_key(mut self, state_key: String) -> Self {
         self.endpoint.state_key = Some(state_key);
-        // Note: we may have already defined a path, but this one ought to be more
-        // specialized (unless for_key/for_type were called multiple times).
+        // Note: we may have already defined a path, but this one ought to be
+        // more specialized (unless for_key/for_type were called
+        // multiple times).
         Self { mock: self.mock.and(path_regex(Self::generate_path_regexp(&self.endpoint))), ..self }
     }
 
@@ -3078,8 +3081,8 @@ impl<'a> MockEndpoint<'a, RoomEventEndpoint> {
     pub fn ok(self, event: TimelineEvent) -> MatrixMock<'a> {
         let event_path = if self.endpoint.match_event_id {
             let event_id = event.event_id().expect("an event id is required");
-            // The event id should begin with `$`, which would be taken as the end of the
-            // regex so we need to escape it
+            // The event id should begin with `$`, which would be taken as the
+            // end of the regex so we need to escape it
             event_id.as_str().replace("$", "\\$")
         } else {
             // Event is at the end, so no need to add anything.
@@ -3187,8 +3190,8 @@ impl<'a> MockEndpoint<'a, RoomEventContextEndpoint> {
     pub fn ok(self, response: RoomContextResponseTemplate) -> MatrixMock<'a> {
         let event_path = if self.endpoint.match_event_id {
             let event_id = response.event.event_id().expect("an event id is required");
-            // The event id should begin with `$`, which would be taken as the end of the
-            // regex so we need to escape it
+            // The event id should begin with `$`, which would be taken as the
+            // end of the regex so we need to escape it
             event_id.as_str().replace("$", "\\$")
         } else {
             // Event is at the end, so no need to add anything.

--- a/crates/matrix-sdk/src/utils/local_server.rs
+++ b/crates/matrix-sdk/src/utils/local_server.rs
@@ -183,8 +183,8 @@ impl LocalServerBuilder {
                     return Ok::<_, Infallible>(StatusCode::METHOD_NOT_ALLOWED.into_response());
                 }
 
-                // We only need to get the first response so we consume the transmitter the
-                // first time.
+                // We only need to get the first response so we consume the
+                // transmitter the first time.
                 if let Some(data_sender) = data_sender_mutex.lock().take() {
                     let _ =
                         data_sender.send(request.uri().query().map(|s| QueryString(s.to_owned())));

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -138,7 +138,8 @@ impl Serialize for Capabilities {
                     Filter::State(filter) => PrintStateEventFilter(filter).fmt(f),
                     Filter::ToDevice(filter) => {
                         // As per MSC 3819 https://github.com/matrix-org/matrix-spec-proposals/pull/3819
-                        // ToDevice capabilities is in the form of `m.send.to_device:<event type>`
+                        // ToDevice capabilities is in the form of
+                        // `m.send.to_device:<event type>`
                         // or `m.receive.to_device:<event type>`
                         write!(f, "{}", filter.event_type)
                     }
@@ -151,7 +152,8 @@ impl Serialize for Capabilities {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self.0 {
                     MessageLikeEventFilter::WithType(event_type) => {
-                        // TODO: escape `#` as `\#` and `\` as `\\` in event_type
+                        // TODO: escape `#` as `\#` and `\` as `\\` in
+                        // event_type
                         write!(f, "{event_type}")
                     }
                     MessageLikeEventFilter::RoomMessageWithMsgtype(msgtype) => {
@@ -286,7 +288,8 @@ impl<'de> Deserialize<'de> for Capabilities {
         }
 
         fn parse_state_event_filter(s: &str) -> StateEventFilter {
-            // TODO: Search for un-escaped `#` only, replace `\\` by `\` and `\#` by `#`
+            // TODO: Search for un-escaped `#` only, replace `\\` by `\` and
+            // `\#` by `#`
             match s.split_once('#') {
                 Some((event_type, state_key)) => {
                     StateEventFilter::WithTypeAndStateKey(event_type.into(), state_key.to_owned())

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -219,8 +219,8 @@ impl<'a> TryFrom<&'a Raw<AnyTimelineEvent>> for FilterInput<'a> {
     type Error = serde_json::Error;
 
     fn try_from(raw_event: &'a Raw<AnyTimelineEvent>) -> Result<Self, Self::Error> {
-        // FilterInput first checks if it can deserialize as a state event (state_key
-        // exists) and then as a message-like event.
+        // FilterInput first checks if it can deserialize as a state event
+        // (state_key exists) and then as a message-like event.
         raw_event.deserialize_as()
     }
 }
@@ -251,9 +251,10 @@ pub struct FilterInputToDevice<'a> {
 impl<'a> TryFrom<&'a Raw<AnyToDeviceEvent>> for FilterInput<'a> {
     type Error = serde_json::Error;
     fn try_from(raw_event: &'a Raw<AnyToDeviceEvent>) -> Result<Self, Self::Error> {
-        // deserialize_as::<FilterInput> will first try state, message-like and then
-        // to-device. The `AnyToDeviceEvent` would match message like first, so
-        // we need to explicitly deserialize as `FilterInputToDevice`.
+        // deserialize_as::<FilterInput> will first try state, message-like and
+        // then to-device. The `AnyToDeviceEvent` would match message
+        // like first, so we need to explicitly deserialize as
+        // `FilterInputToDevice`.
         raw_event.deserialize_as::<FilterInputToDevice<'a>>().map(FilterInput::ToDevice)
     }
 }
@@ -278,9 +279,11 @@ impl<'a> From<&'a SendEventRequest> for FilterInput<'a> {
                         .unwrap_or_else(|e| {
                             debug!("Failed to deserialize event content for filter: {e}");
                             // Fallback to empty content is safe.
-                            // If we do have a filter matching any content type, it will match
+                            // If we do have a filter matching any content type,
+                            // it will match
                             // independent of the body.
-                            // Any filter that does only match a specific content type will not
+                            // Any filter that does only match a specific
+                            // content type will not
                             // match the empty content.
                             Default::default()
                         })
@@ -369,7 +372,8 @@ mod tests {
         assert!(!reaction_event_filter().matches(&FilterInput::state("m.reaction", "")));
     }
 
-    // Tests against an `m.room.member` filter with `state_key = "@self:example.me"`
+    // Tests against an `m.room.member` filter with `state_key =
+    // "@self:example.me"`
     fn self_member_event_filter() -> Filter {
         Filter::State(StateEventFilter::WithTypeAndStateKey(
             StateEventType::RoomMember,

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -241,8 +241,9 @@ impl WidgetMachine {
 
                 match &mut self.pending_state_updates {
                     Some(InitialStateUpdate { postponed_updates, .. }) => {
-                        // This state update is racing with the read requests used to calculate the
-                        // initial state; postpone it
+                        // This state update is racing with the read requests
+                        // used to calculate the initial
+                        // state; postpone it
                         postponed_updates.push(state);
                         Vec::new()
                     }
@@ -629,8 +630,8 @@ impl WidgetMachine {
         raw_request: Raw<FromWidgetRequest>,
         result: Result<impl Serialize, FromWidgetErrorResponse>,
     ) -> Action {
-        // we do not want tho expose this to never allow sending arbitrary errors.
-        // Errors always need to be `FromWidgetErrorResponse`.
+        // we do not want tho expose this to never allow sending arbitrary
+        // errors. Errors always need to be `FromWidgetErrorResponse`.
         #[instrument(skip_all)]
         fn send_response_data(
             raw_request: Raw<FromWidgetRequest>,
@@ -644,8 +645,8 @@ impl WidgetMachine {
                 serde_json::to_string(&object)
             };
 
-            // SAFETY: we expect the raw request to be a valid JSON map, to which we add a
-            // new field.
+            // SAFETY: we expect the raw request to be a valid JSON map, to
+            // which we add a new field.
             let serialized = f().expect("error when attaching response to incoming request");
 
             Action::SendToWidget(serialized)
@@ -724,10 +725,10 @@ impl WidgetMachine {
         &mut self,
         events: Vec<Raw<AnyStateEvent>>,
     ) -> Option<Vec<Action>> {
-        // Pull the updates struct out of the machine temporarily so that we can match
-        // on it in one place, mutate it, and still be able to call
-        // `send_to_widget_request` later in this block (which borrows the machine
-        // mutably)
+        // Pull the updates struct out of the machine temporarily so that we can
+        // match on it in one place, mutate it, and still be able to
+        // call `send_to_widget_request` later in this block (which
+        // borrows the machine mutably)
         match self.pending_state_updates.take() {
             None => {
                 error!(
@@ -741,22 +742,26 @@ impl WidgetMachine {
                 updates.initial_state.push(events);
 
                 if updates.initial_state.len() != updates.request_count {
-                    // Not all of the initial state requests have completed yet; put the updates
-                    // struct back so we can continue accumulating the initial state.
+                    // Not all of the initial state requests have completed yet;
+                    // put the updates struct back so we can
+                    // continue accumulating the initial state.
                     self.pending_state_updates = Some(updates);
                     return None;
                 }
 
-                // The initial state is complete; combine the data and push it to the widget in
-                // a single action.
+                // The initial state is complete; combine the data and push it
+                // to the widget in a single action.
                 let initial =
                     self.send_state_update(updates.initial_state.into_iter().flatten().collect());
-                // Also flush any state updates that had been postponed until after the initial
-                // state push. We deliberately do not bundle these updates into a single action,
-                // since they might contain some repeated updates to the same room state entry
-                // which could confuse the widget if included in the same `events` array. It's
-                // easiest to let the widget process each update sequentially rather than put
-                // effort into coalescing them - this is for an edge case after all.
+                // Also flush any state updates that had been postponed until
+                // after the initial state push. We deliberately
+                // do not bundle these updates into a single action,
+                // since they might contain some repeated updates to the same
+                // room state entry which could confuse the
+                // widget if included in the same `events` array. It's
+                // easiest to let the widget process each update sequentially
+                // rather than put effort into coalescing them -
+                // this is for an edge case after all.
                 let postponed = updates
                     .postponed_updates
                     .into_iter()
@@ -801,13 +806,13 @@ impl WidgetMachine {
             .collect();
 
         if !state_filters.is_empty() {
-            // Begin accumulating the initial state to be pushed to the widget. Since this
-            // widget driver currently doesn't implement capability
-            // renegotiation, we can be sure that we aren't overwriting another
-            // in-progress update.
+            // Begin accumulating the initial state to be pushed to the widget.
+            // Since this widget driver currently doesn't implement
+            // capability renegotiation, we can be sure that we
+            // aren't overwriting another in-progress update.
             if self.pending_state_updates.is_some() {
-                // Or so we should be. Let's at least log something if we ever break that
-                // invariant.
+                // Or so we should be. Let's at least log something if we ever
+                // break that invariant.
                 error!("Another initial state update is in progress; overwriting it");
             }
             self.pending_state_updates = Some(InitialStateUpdate {
@@ -817,9 +822,9 @@ impl WidgetMachine {
             })
         }
 
-        // For each room state filter that the widget has been approved to read, fire
-        // off a request to the driver to determine the initial values of the
-        // matching room state entries
+        // For each room state filter that the widget has been approved to read,
+        // fire off a request to the driver to determine the initial
+        // values of the matching room state entries
         let initial_state_actions = state_filters.iter().flat_map(|filter| {
             self.send_matrix_driver_request(match filter {
                 StateEventFilter::WithType(event_type) => ReadStateRequest {
@@ -836,8 +841,10 @@ impl WidgetMachine {
                     machine
                         .process_read_initial_state_response(result.unwrap_or_else(|e| {
                             error!("Reading initial room state failed: {e}");
-                            // Pretend that we just got an empty response so the initial state
-                            // update won't be completely blocked on this one bit of missing data
+                            // Pretend that we just got an empty response so the
+                            // initial state
+                            // update won't be completely blocked on this one
+                            // bit of missing data
                             Vec::new()
                         }))
                         .unwrap_or_default()
@@ -883,8 +890,8 @@ impl WidgetMachine {
     fn negotiate_capabilities(&mut self) -> Vec<Action> {
         let mut actions = Vec::new();
 
-        // XXX: This branch appears to be accounting for capability **re**negotiation
-        // (MSC2974), which isn't implemented yet
+        // XXX: This branch appears to be accounting for capability
+        // **re**negotiation (MSC2974), which isn't implemented yet
         if matches!(&self.capabilities, CapabilitiesState::Negotiated(c) if !c.read.is_empty()) {
             actions.push(Action::Unsubscribe);
         }

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -265,8 +265,8 @@ impl MatrixDriver {
         let drop_guard = self.room.client().event_handler_drop_guard(handle);
 
         // The receiver will get a combination of state and message like events.
-        // These always come from the timeline (rather than the state section of the
-        // sync).
+        // These always come from the timeline (rather than the state section of
+        // the sync).
         EventReceiver { rx, _drop_guard: drop_guard }
     }
 
@@ -285,14 +285,16 @@ impl MatrixDriver {
             async move |raw: Raw<AnyToDeviceEvent>,
                         encryption_info: Option<EncryptionInfo>,
                         client: Client| {
-                // Some to-device traffic is used by the SDK for internal machinery.
-                // They should not be exposed to widgets.
+                // Some to-device traffic is used by the SDK for internal
+                // machinery. They should not be exposed to
+                // widgets.
                 if Self::should_filter_message_to_widget(&raw) {
                     return;
                 }
 
-                // Encryption can be enabled after the widget has been instantiated,
-                // we want to keep track of the latest status
+                // Encryption can be enabled after the widget has been
+                // instantiated, we want to keep track of the
+                // latest status
                 let Some(room) = client.get_room(&room_id) else {
                     warn!("Room {room_id} not found in client.");
                     return;
@@ -305,13 +307,16 @@ impl MatrixDriver {
                     // Default consider encrypted
                     .unwrap_or(true);
 
-                // Whether the to-device message reached us encrypted. `encryption_info` is
-                // `Some(..)` only when the message arrived as `m.room.encrypted` and was
-                // successfully Olm-decrypted by the SDK; clear (and UTD) messages carry `None`.
+                // Whether the to-device message reached us encrypted.
+                // `encryption_info` is `Some(..)` only when the
+                // message arrived as `m.room.encrypted` and was
+                // successfully Olm-decrypted by the SDK; clear (and UTD)
+                // messages carry `None`.
                 let encrypted = encryption_info.is_some();
 
                 if room_encrypted && !encrypted {
-                    // The room is encrypted so the to-device traffic should be too.
+                    // The room is encrypted so the to-device traffic should be
+                    // too.
                     warn!(
                         ?room_id,
                         "Received to-device event in clear for a widget in an e2e room, dropping."
@@ -319,13 +324,16 @@ impl MatrixDriver {
                     return;
                 }
 
-                // There are no per-room specific decryption settings (trust requirements), so
-                // we can just send it to the widget.
+                // There are no per-room specific decryption settings (trust
+                // requirements), so we can just send it to the
+                // widget.
 
-                // The raw to-device event contains more fields than the widget needs, so we
-                // clean it up to only type/content/sender and add the MSC3819 `encrypted`
-                // flag. It is ok to forward an encrypted to-device message even if the room is
-                // clear, so both cases go through the same path.
+                // The raw to-device event contains more fields than the widget
+                // needs, so we clean it up to only
+                // type/content/sender and add the MSC3819 `encrypted`
+                // flag. It is ok to forward an encrypted to-device message even
+                // if the room is clear, so both cases go
+                // through the same path.
                 #[derive(Deserialize, Serialize)]
                 struct CleanEventHelper<'a> {
                     #[serde(rename = "type")]
@@ -343,7 +351,8 @@ impl MatrixDriver {
 
                 let _ = serde_json::from_str::<CleanEventHelper<'_>>(raw.json().get())
                     .map(|mut clean_event_helper| {
-                        // Important, always set the `encrypted` flag based on encryption_info
+                        // Important, always set the `encrypted` flag based on
+                        // encryption_info
                         clean_event_helper.encrypted = encrypted;
                         clean_event_helper
                     })
@@ -368,8 +377,8 @@ impl MatrixDriver {
         };
 
         // Filter out all the internal crypto related traffic.
-        // The SDK has already zeroized the critical data, but let's not leak any
-        // information
+        // The SDK has already zeroized the critical data, but let's not leak
+        // any information
         let filtered = Self::is_internal_type(event_type.as_str());
 
         if filtered {
@@ -411,11 +420,12 @@ impl MatrixDriver {
             BTreeMap<DeviceIdOrAllDevices, Raw<AnyToDeviceEventContent>>,
         >,
     ) -> Result<SendToDeviceEventResponse> {
-        // TODO: block this at the negotiation stage, no reason to let widget believe
-        // they can do that
+        // TODO: block this at the negotiation stage, no reason to let widget
+        // believe they can do that
         if Self::is_internal_type(&event_type.to_string()) {
             warn!("Widget tried to send internal to-device message <{}>, ignoring", event_type);
-            // Silently return a success response, the widget will not receive the message
+            // Silently return a success response, the widget will not receive
+            // the message
             return Ok(Default::default());
         }
 
@@ -435,9 +445,9 @@ impl MatrixDriver {
             trace!("Sending to-device message in encrypted room <{}>", self.room.room_id());
 
             // The widget-api uses a [user -> device -> content] map, but the
-            // crypto-sdk API allow to encrypt a given content for multiple recipients.
-            // Lets convert the [user -> device -> content] to a [content -> user -> device
-            // map].
+            // crypto-sdk API allow to encrypt a given content for multiple
+            // recipients. Lets convert the [user -> device ->
+            // content] to a [content -> user -> device map].
             let mut content_to_recipients_map: BTreeMap<
                 &str,
                 BTreeMap<OwnedUserId, Vec<DeviceIdOrAllDevices>>,
@@ -497,8 +507,9 @@ impl MatrixDriver {
             let user_devices = client.encryption().get_user_devices(&user_id).await?;
 
             let user_devices = if recipient_device_ids.contains(&DeviceIdOrAllDevices::AllDevices) {
-                // If the user wants to send to all devices, there's nothing to filter and no
-                // need to inspect other entries in the user's device list.
+                // If the user wants to send to all devices, there's nothing to
+                // filter and no need to inspect other entries
+                // in the user's device list.
                 let devices: Vec<_> = user_devices.devices().collect();
                 // TODO: What to do if the user has no devices?
                 if devices.is_empty() {
@@ -507,7 +518,8 @@ impl MatrixDriver {
                     )
                 }
                 // TODO: What if the `recipient_device_ids` has both
-                // `AllDevices` and other devices but one of the  other devices is not found.
+                // `AllDevices` and other devices but one of the  other devices
+                // is not found.
                 if recipient_device_ids.len() > 1 {
                     warn!(
                         "The recipient_device_ids list for {user_id} contains both `AllDevices` and explicit `DeviceId` entries. Only consider `AllDevices`",
@@ -515,8 +527,9 @@ impl MatrixDriver {
                 }
                 devices
             } else {
-                // If the user wants to send to only some devices, filter out any devices that
-                // aren't part of the recipient_device_ids list.
+                // If the user wants to send to only some devices, filter out
+                // any devices that aren't part of the
+                // recipient_device_ids list.
                 let filtered_devices = user_devices
                     .devices()
                     .map(|device| (device.device_id().to_owned(), device))
@@ -532,8 +545,9 @@ impl MatrixDriver {
                     .filter_map(|d| as_variant!(d, DeviceIdOrAllDevices::DeviceId))
                     .collect();
 
-                // Let's now find any devices that are part of the recipient_device_ids list but
-                // were not found in our store.
+                // Let's now find any devices that are part of the
+                // recipient_device_ids list but were not found
+                // in our store.
                 let missing_devices: Vec<_> =
                     list_of_devices.difference(&found_device_ids).map(|d| d.to_owned()).collect();
                 if !missing_devices.is_empty() {

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -145,11 +145,12 @@ impl WidgetDriver {
         let (incoming_msg_tx, incoming_msg_rx) = unbounded_channel();
 
         // Forward all of the incoming messages from the widget.
-        // TODO: This spawns a detached task, it would be nice to have an owner for this
-        // task. One way to achieve this if `WidgetDriver::run()` returns a handle that
-        // we can drop which will clean up the task and the channels. It's not too bad,
-        // since canelling `run()` will drop the sender this task listens which finishes
-        // the task.
+        // TODO: This spawns a detached task, it would be nice to have an owner
+        // for this task. One way to achieve this if
+        // `WidgetDriver::run()` returns a handle that we can drop which
+        // will clean up the task and the channels. It's not too bad,
+        // since canelling `run()` will drop the sender this task listens which
+        // finishes the task.
         spawn({
             let incoming_msg_tx = incoming_msg_tx.clone();
             let from_widget_rx = self.from_widget_rx.clone();
@@ -161,9 +162,9 @@ impl WidgetDriver {
             }
         });
 
-        // Create the widget API machine. The widget machine will process messages it
-        // receives from the widget and convert it into actions the `MatrixDriver` will
-        // then execute on.
+        // Create the widget API machine. The widget machine will process
+        // messages it receives from the widget and convert it into
+        // actions the `MatrixDriver` will then execute on.
         let (mut widget_machine, initial_actions) = WidgetMachine::new(
             self.settings.widget_id().to_owned(),
             room.room_id().to_owned(),
@@ -176,7 +177,8 @@ impl WidgetDriver {
         let stream = UnboundedReceiverStream::new(incoming_msg_rx)
             .flat_map(|message| tokio_stream::iter(widget_machine.process(message)));
 
-        // Let's combine our set of initial actions with the stream of received actions.
+        // Let's combine our set of initial actions with the stream of received
+        // actions.
         let mut combined = tokio_stream::iter(initial_actions).chain(stream);
 
         // Let's now process all actions we receive forever.
@@ -226,9 +228,10 @@ impl WidgetDriver {
 
                     MatrixDriverRequestData::SendEvent(req) => {
                         let SendEventRequest { event_type, state_key, content, delay } = req;
-                        // The widget api action does not use the unstable prefix:
-                        // `org.matrix.msc4140.delay` so we
-                        // cannot use the `DelayParameters` here and need to convert
+                        // The widget api action does not use the unstable
+                        // prefix: `org.matrix.msc4140.
+                        // delay` so we cannot use the
+                        // `DelayParameters` here and need to convert
                         // manually.
                         let delay_event_parameter = delay.map(|d| DelayParameters::Timeout {
                             timeout: Duration::from_millis(d),
@@ -268,7 +271,8 @@ impl WidgetDriver {
                         .map(MatrixDriverResponse::RtcTransportsReceived),
                 };
 
-                // Forward the Matrix driver response to the incoming message stream.
+                // Forward the Matrix driver response to the incoming message
+                // stream.
                 incoming_msg_tx
                     .send(IncomingMessage::MatrixDriverResponse { request_id, response })
                     .map_err(|_| ())?;

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -382,12 +382,13 @@ impl WidgetSettings {
         let query =
             serde_html_form::to_string(query_params).map_err(|_| url::ParseError::Overflow)?;
 
-        // Revert the encoding for the template parameters. So we can have a unified
-        // replace logic.
+        // Revert the encoding for the template parameters. So we can have a
+        // unified replace logic.
         let query = query.replace("%24", "$");
 
-        // All the params will be set inside the fragment (to keep the traffic to the
-        // server minimal and most importantly don't send the passwords).
+        // All the params will be set inside the fragment (to keep the traffic
+        // to the server minimal and most importantly don't send the
+        // passwords).
         raw_url.set_fragment(Some(&format!("?{query}")));
 
         // for EC we always want init on content load to be true.
@@ -455,8 +456,8 @@ mod tests {
         }
     }
 
-    // Convert query strings to BTreeSet so that we can compare the urls independent
-    // of the order of the params.
+    // Convert query strings to BTreeSet so that we can compare the urls
+    // independent of the order of the params.
     type QuerySet = BTreeSet<(String, String)>;
 
     use serde_html_form::from_str;
@@ -803,12 +804,12 @@ mod tests {
 
     #[test]
     fn test_call_intent_serialization() {
-        // The call intent serialized value must match the expected enum names as
-        // defined in the Element-Call repo:
+        // The call intent serialized value must match the expected enum names
+        // as defined in the Element-Call repo:
         // https://github.com/element-hq/element-call/blob/de8fdcfa694659a29f2c7a4401dd09cfec846a96/src/UrlParams.ts#L32
-        // The enum uses serde rename `snake_case` to serialize the values, but it makes
-        // it invisible that it is important, so ensure that the values are
-        // correct.
+        // The enum uses serde rename `snake_case` to serialize the values, but
+        // it makes it invisible that it is important, so ensure that
+        // the values are correct.
         assert_eq!(serde_json::to_string(&Intent::StartCall).unwrap(), r#""start_call""#);
         assert_eq!(serde_json::to_string(&Intent::JoinExisting).unwrap(), r#""join_existing""#);
         assert_eq!(

--- a/crates/matrix-sdk/src/widget/settings/url_params.rs
+++ b/crates/matrix-sdk/src/widget/settings/url_params.rs
@@ -53,7 +53,8 @@ pub fn replace_properties(url: &mut Url, props: QueryProperties) {
         (CLIENT_ID, encode(&props.client_id).into()),
     ]
     .map(|to_replace| {
-        // It's safe to unwrap here since we know all replace strings start with `$`
+        // It's safe to unwrap here since we know all replace strings start with
+        // `$`
         (to_replace.0.get(1..).unwrap(), to_replace.1)
     });
 
@@ -67,7 +68,8 @@ pub fn replace_properties(url: &mut Url, props: QueryProperties) {
         let mut section_added = false;
         for (old, new) in &replace_map {
             section.split_once(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '_'));
-            // It's safe to unwrap here since we know all replace strings start with `$`
+            // It's safe to unwrap here since we know all replace strings start
+            // with `$`
             if section.starts_with(old) {
                 result.push_str(new);
                 if let Some(rest) = section.get(old.len()..) {

--- a/crates/matrix-sdk/tests/integration/account.rs
+++ b/crates/matrix-sdk/tests/integration/account.rs
@@ -304,7 +304,8 @@ async fn test_get_cached_avatar_url() {
     let res_avatar_url = account.get_cached_avatar_url().await.unwrap();
     assert_eq!(res_avatar_url.as_deref(), Some(avatar_url));
 
-    // Fetch it again from the homeserver, a missing value should empty the cache.
+    // Fetch it again from the homeserver, a missing value should empty the
+    // cache.
     {
         let _guard = server
             .mock_get_profile_field(user_id, ProfileFieldName::AvatarUrl)
@@ -385,8 +386,8 @@ async fn test_clear_status() {
 
     use ruma::profile::Status;
 
-    // Given an account that already has a status (locally echoed into the store for
-    // this test).
+    // Given an account that already has a status (locally echoed into the store
+    // for this test).
     let server = MatrixMockServer::new().await;
     server
         .mock_versions()
@@ -437,8 +438,8 @@ async fn test_clear_status() {
 #[cfg(feature = "unstable-msc4426")]
 #[async_test]
 async fn test_set_status_without_profile_sync() {
-    // Given an account on a server that doesn't support the profiles sliding sync
-    // extension.
+    // Given an account on a server that doesn't support the profiles sliding
+    // sync extension.
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().server_versions(vec![MatrixVersion::V1_16]).build().await;
     let user_id = client.user_id().unwrap();

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1847,9 +1847,9 @@ async fn test_logout() {
     let oauth_client = server.client_builder().logged_in_with_oauth().build().await;
     let res = oauth_client.logout().await;
 
-    // This returns an error because it requires a HTTPS server URI, or to be able
-    // to call `OAuth::insecure_rewrite_https_to_http()`, but at least we are
-    // testing the OAuth branch inside `Client::logout()`.
+    // This returns an error because it requires a HTTPS server URI, or to be
+    // able to call `OAuth::insecure_rewrite_https_to_http()`, but at least
+    // we are testing the OAuth branch inside `Client::logout()`.
     assert_matches!(res, Err(Error::OAuth(oauth_error)));
     assert_matches!(*oauth_error, OAuthError::Logout(OAuthTokenRevocationError::Url(_)));
 }
@@ -1934,8 +1934,8 @@ async fn test_server_version_without_auth() {
     // token has expired.
     server.mock_versions().expect_default_access_token().error_unknown_token(true).mount().await;
 
-    // If we do not provide an access token, all is fine as the endpoint does not
-    // require one.
+    // If we do not provide an access token, all is fine as the endpoint does
+    // not require one.
     server.mock_versions().expect_missing_access_token().ok().mount().await;
 
     let request_config = RequestConfig::new().disable_retry();

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -647,8 +647,8 @@ async fn test_incremental_upload_of_keys() -> TestResult {
 
     let backups = client.encryption().backups();
 
-    // This is the call we want to check. The newly created outbound session should
-    // be uploaded to backup.
+    // This is the call we want to check. The newly created outbound session
+    // should be uploaded to backup.
     mount_and_assert_called_once(
         &server,
         "PUT",
@@ -722,8 +722,8 @@ async fn test_incremental_upload_of_keys_sliding_sync() -> TestResult {
 
     let backups = client.encryption().backups();
 
-    // This is the call we want to check. The newly created outbound session should
-    // be uploaded to backup.
+    // This is the call we want to check. The newly created outbound session
+    // should be uploaded to backup.
     let (endpoint_called_sender, endpoint_called_receiver) = std::sync::mpsc::channel();
     Mock::given(method("PUT"))
         .and(path("_matrix/client/unstable/room_keys/keys"))
@@ -806,8 +806,8 @@ async fn test_incremental_upload_of_keys_sliding_sync() -> TestResult {
 
     // Wait for the endpoint to be called, at most for 10 seconds.
     //
-    // Don't plain use `recv_timeout()` on the main task, since this would prevent
-    // forward progress of the wiremock code.
+    // Don't plain use `recv_timeout()` on the main task, since this would
+    // prevent forward progress of the wiremock code.
     timeout(
         spawn_blocking(move || endpoint_called_receiver.recv().unwrap()),
         Duration::from_secs(10),
@@ -1467,7 +1467,8 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
 
     init_client_secret_storage_and_backup(&client, &server).await;
 
-    // Create an outbound group session which we will use to encrypt a test event.
+    // Create an outbound group session which we will use to encrypt a test
+    // event.
     let sender_identity_keys = IdentityKeys {
         ed25519: Ed25519SecretKey::new().public_key(),
         curve25519: Curve25519PublicKey::from(&Curve25519SecretKey::new()),
@@ -1479,8 +1480,8 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
         matrix_sdk_base::crypto::EncryptionSettings::default(),
     )?;
 
-    // Export the `OutboundGroupSession` to an `InboundGroupSession`, and export it
-    // to the backup. We do this now, at ratchet index 0.
+    // Export the `OutboundGroupSession` to an `InboundGroupSession`, and export
+    // it to the backup. We do this now, at ratchet index 0.
     let inbound_group_session = inbound_session_from_outbound_session(
         sender_identity_keys.ed25519,
         room_id,
@@ -1499,7 +1500,8 @@ async fn test_enable_from_secret_storage_and_download_after_utd_from_old_message
     )?;
     mock_get_event(room_id, event_id, encrypted_event_content, &server).await;
 
-    // Now, import the megolm session into the client's store, at ratchet index 1.
+    // Now, import the megolm session into the client's store, at ratchet index
+    // 1.
     {
         let inbound_group_session = inbound_session_from_outbound_session(
             sender_identity_keys.ed25519,

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -124,8 +124,8 @@ async fn test_reset_unstable_oauth() {
         .await;
 
     // And finally succeed.
-    // This works because the first mocked endpoint that matches the path is used
-    // until it is invalidated by `up_to_n_times`.
+    // This works because the first mocked endpoint that matches the path is
+    // used until it is invalidated by `up_to_n_times`.
     server
         .mock_upload_cross_signing_keys()
         .ok()
@@ -182,8 +182,8 @@ async fn test_reset_stable_oauth() {
 
     server.mock_upload_keys().ok().expect(1).named("Initial device keys upload").mount().await;
 
-    // First, return the UIAA response without expecting the UIAA auth data in the
-    // request.
+    // First, return the UIAA response without expecting the UIAA auth data in
+    // the request.
     server
         .mock_upload_cross_signing_keys()
         .uiaa_stable_oauth(session, None)
@@ -192,8 +192,8 @@ async fn test_reset_stable_oauth() {
         .mount()
         .await;
 
-    // Then return the UIAA response 5 times while expecting the UIAA auth data in
-    // the request.
+    // Then return the UIAA response 5 times while expecting the UIAA auth data
+    // in the request.
     let extra_error =
         StandardErrorBody::new(ErrorKind::Forbidden, "Stage not completed".to_owned());
     server
@@ -207,8 +207,8 @@ async fn test_reset_stable_oauth() {
         .await;
 
     // And finally succeed.
-    // This works because the first mocked endpoint that matches the path is used
-    // until it is invalidated by `up_to_n_times`.
+    // This works because the first mocked endpoint that matches the path is
+    // used until it is invalidated by `up_to_n_times`.
     server
         .mock_upload_cross_signing_keys()
         .expect_uiaa_auth_data(&expected_auth_data)

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -1023,7 +1023,8 @@ async fn test_reset_identity() {
         "After the reset we have the cross-signing available.",
     );
 
-    // After reset backups should get renabled but recovery needs setting up again
+    // After reset backups should get renabled but recovery needs setting up
+    // again
     assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
     assert_eq!(client.encryption().recovery().state(), RecoveryState::Disabled);
 

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -291,9 +291,10 @@ async fn test_set_in_secret_store() {
     let uploaded_content: Arc<Mutex<Option<SecretEventContent>>> = Mutex::new(None).into();
 
     {
-        // This mock is scoped because, at first we don't have a `foo` event in our
-        // account data. Only when we call `secret_store.set_secret()` will we
-        // have one, and a different mock will be required for the next GET request.
+        // This mock is scoped because, at first we don't have a `foo` event in
+        // our account data. Only when we call
+        // `secret_store.set_secret()` will we have one, and a different
+        // mock will be required for the next GET request.
         let _guard = Mock::given(method("GET"))
             .and(path("_matrix/client/r0/user/@example:localhost/account_data/foo"))
             .and(header("authorization", "Bearer 1234"))

--- a/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/shared_history.rs
@@ -287,8 +287,8 @@ async fn test_shared_history_crash_before_import() {
     let bob_user_id = user_id!("@bob:localhost");
     let bob_device_id = device_id!("BOBDEVICE");
 
-    // Use a common store path for Bob so we can persist invite acceptance details
-    // over the crash.
+    // Use a common store path for Bob so we can persist invite acceptance
+    // details over the crash.
     let bob_sqlite_path = tempdir().unwrap();
     let encryption_settings =
         EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
@@ -444,8 +444,8 @@ async fn test_room_key_rotation_on_gappy_sync_v3() {
     let alice_factory = EventFactory::new().room(room_id).sender(alice_id);
     let bob_factory = EventFactory::new().room(room_id).sender(bob_id);
 
-    // Alice and Bob are in a room. Since this is the first sync, Alice should load
-    // the member list.
+    // Alice and Bob are in a room. Since this is the first sync, Alice should
+    // load the member list.
     matrix_mock_server
         .mock_get_members()
         .ok(vec![alice_factory.member(alice_id).into_raw()])
@@ -485,8 +485,8 @@ async fn test_room_key_rotation_on_gappy_sync_v3() {
     // Bob leaves, but we get a gappy sync. Alice should fully reload the room
     // member list.
     //
-    // (Note: any update to the membership, even a Join, will trigger a reload of
-    // the room member list and discard the session.)
+    // (Note: any update to the membership, even a Join, will trigger a reload
+    // of the room member list and discard the session.)
     matrix_mock_server
         .mock_get_members()
         .ok(vec![alice_factory.member(alice_id).into_raw()])

--- a/crates/matrix-sdk/tests/integration/encryption/verification.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/verification.rs
@@ -35,8 +35,8 @@ async fn test_own_verification() {
     // Have Alice bootstrap cross-signing.
     bootstrap_cross_signing(&alice).await;
 
-    // The local device is considered verified by default, we need a keys query to
-    // run
+    // The local device is considered verified by default, we need a keys query
+    // to run
     let own_device = alice.encryption().get_device(&user_id, &device_id).await.unwrap().unwrap();
     assert!(own_device.is_verified());
     assert!(!own_device.is_deleted());

--- a/crates/matrix-sdk/tests/integration/event_cache/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/mod.rs
@@ -53,13 +53,13 @@ async fn test_must_explicitly_subscribe() {
 
     let room_id = room_id!("!omelette:fromage.fr");
 
-    // If I create a room event subscriber for a room before subscribing the event
-    // cache,
+    // If I create a room event subscriber for a room before subscribing the
+    // event cache,
     let room = server.sync_joined_room(&client, room_id).await;
     let result = room.event_cache().await;
 
-    // Then it fails, because one must explicitly call `.subscribe()` on the event
-    // cache.
+    // Then it fails, because one must explicitly call `.subscribe()` on the
+    // event cache.
     assert_matches!(result, Err(EventCacheError::NotSubscribedYet));
 }
 
@@ -286,11 +286,12 @@ async fn test_backpaginate_once() {
         room_event_cache.pagination().run_backwards_once(20).await.unwrap()
     };
 
-    // I'll get all the previous events, in "reverse" order (same as the response).
+    // I'll get all the previous events, in "reverse" order (same as the
+    // response).
     let BackPaginationOutcome { events, reached_start } = outcome;
 
-    // The event cache figures this is the last chunk of events in the room, because
-    // there's no prior gap this time.
+    // The event cache figures this is the last chunk of events in the room,
+    // because there's no prior gap this time.
     assert!(reached_start);
 
     assert_eq!(events.len(), 2);
@@ -607,7 +608,8 @@ async fn test_reset_while_backpaginating() {
     //
     // So events have to happen in this order:
     // - the backpagination request is sent, with a prev-batch A
-    // - the sync endpoint returns *after* the backpagination started, before the
+    // - the sync endpoint returns *after* the backpagination started, before
+    //   the
     // backpagination ends
     // - the backpagination ends, with a prev-batch token that's now stale.
     //
@@ -657,14 +659,15 @@ async fn test_reset_while_backpaginating() {
 
     let outcome = backpagination.await.expect("join failed").unwrap();
 
-    // Backpagination will automatically restart, so eventually we get the events.
+    // Backpagination will automatically restart, so eventually we get the
+    // events.
     let BackPaginationOutcome { events, .. } = outcome;
     assert!(!events.is_empty());
 
     // Assert the updates as diffs.
     {
-        // The room shrinks the linked chunk to the last event chunk, so it clears and
-        // re-adds the latest event.
+        // The room shrinks the linked chunk to the last event chunk, so it
+        // clears and re-adds the latest event.
         assert_let_timeout!(
             Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
                 room_stream.recv()
@@ -728,8 +731,8 @@ async fn test_backpaginating_without_token() {
     // We don't have a token.
     let pagination = room_event_cache.pagination();
 
-    // If we try to back-paginate with a token, it will hit the end of the timeline
-    // and give us the resulting event.
+    // If we try to back-paginate with a token, it will hit the end of the
+    // timeline and give us the resulting event.
     let BackPaginationOutcome { events, reached_start } =
         pagination.run_backwards_once(20).await.unwrap();
 
@@ -788,8 +791,8 @@ async fn test_limited_timeline_resets_pagination() {
     let mut pagination_status = pagination.status();
     assert_eq!(pagination_status.get(), PaginationStatus::Idle { hit_timeline_start: false });
 
-    // If we try to back-paginate with a token, it will hit the end of the timeline
-    // and give us the resulting event.
+    // If we try to back-paginate with a token, it will hit the end of the
+    // timeline and give us the resulting event.
     let BackPaginationOutcome { events, reached_start } =
         pagination.run_backwards_once(20).await.unwrap();
 
@@ -823,7 +826,8 @@ async fn test_limited_timeline_resets_pagination() {
         )
         .await;
 
-    // We have a limited sync, which triggers a shrink to the latest chunk: a gap.
+    // We have a limited sync, which triggers a shrink to the latest chunk: a
+    // gap.
     assert_let_timeout!(
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
             room_stream.recv()
@@ -931,10 +935,10 @@ async fn test_backpaginate_with_no_initial_events() {
 
     // The first back-pagination will return these two events.
     //
-    // Note: it's important to return the same event that came from sync: since we
-    // will back-paginate without a prev-batch token first, we'll back-paginate
-    // from the end of the timeline, which must include the event we got from
-    // sync.
+    // Note: it's important to return the same event that came from sync: since
+    // we will back-paginate without a prev-batch token first, we'll
+    // back-paginate from the end of the timeline, which must include the
+    // event we got from sync.
 
     // We need to trigger the following conditions:
     // - a back-pagination starts,
@@ -944,8 +948,9 @@ async fn test_backpaginate_with_no_initial_events() {
     // - We don't have a prev-batch token to start with, so the first
     //   back-pagination doesn't start before DEFAULT_WAIT_FOR_TOKEN_DURATION
     //   seconds.
-    // - While the back-pagination is actually running, we need a sync adding events
-    //   to happen (after DEFAULT_WAIT_FOR_TOKEN_DURATION + 500 milliseconds).
+    // - While the back-pagination is actually running, we need a sync adding
+    //   events to happen (after DEFAULT_WAIT_FOR_TOKEN_DURATION + 500
+    //   milliseconds).
     // - The back-pagination finishes after this sync (after
     //   DEFAULT_WAIT_FOR_TOKEN_DURATION + 1 seconds).
 
@@ -975,15 +980,15 @@ async fn test_backpaginate_with_no_initial_events() {
 
     let pagination = room_event_cache.pagination();
 
-    // Run pagination: since there's no token, we'll wait a bit for a sync to return
-    // one, and since there's none, we'll end up starting from the end of the
-    // timeline.
+    // Run pagination: since there's no token, we'll wait a bit for a sync to
+    // return one, and since there's none, we'll end up starting from the
+    // end of the timeline.
     let pagination_clone = pagination.clone();
 
     let first_pagination = spawn(async move { pagination_clone.run_backwards_once(20).await });
 
-    // Make sure we've waited for the initial token long enough (3 seconds, as of
-    // 2024-12-16).
+    // Make sure we've waited for the initial token long enough (3 seconds, as
+    // of 2024-12-16).
     sleep(Duration::from_millis(3000) + wait_time).await;
     server
         .sync_room(
@@ -1037,7 +1042,8 @@ async fn test_backpaginate_replace_empty_gap() {
     let (events, mut stream) = room_event_cache.subscribe().await.unwrap();
     wait_for_initial_events(events, &mut stream).await;
 
-    // The first back-pagination will return a previous-batch token, but no events.
+    // The first back-pagination will return a previous-batch token, but no
+    // events.
     server
         .mock_room_messages()
         .match_from("prev_batch")
@@ -1090,7 +1096,8 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
         f.text_msg("sup").event_id(event_id!("$3")).into_raw_sync(),
     ];
 
-    // Start with a room with a few events, limited timeline and prev-batch token.
+    // Start with a room with a few events, limited timeline and prev-batch
+    // token.
     let room = server
         .sync_room(
             &client,
@@ -1124,11 +1131,11 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
         .mount()
         .await;
 
-    // The first sync was limited, so we have unloaded the full linked chunk, and it
-    // only contains the events returned by the sync.
+    // The first sync was limited, so we have unloaded the full linked chunk,
+    // and it only contains the events returned by the sync.
     //
-    // The first back-pagination will hit the network, and let us know we've reached
-    // the end of the room.
+    // The first back-pagination will hit the network, and let us know we've
+    // reached the end of the room.
 
     let outcome = pagination.run_backwards_once(20).await.unwrap();
     assert!(outcome.reached_start);
@@ -1156,12 +1163,12 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
         assert_eq!(events.len(), 3);
     }
 
-    // If any of the following back-paginations fail with a network error, that's
-    // because we've stored a gap that's useless. All back-paginations must be
-    // loading from the store.
+    // If any of the following back-paginations fail with a network error,
+    // that's because we've stored a gap that's useless. All
+    // back-paginations must be loading from the store.
     //
-    // The sync was limited, which unloaded the linked chunk, and reloaded only the
-    // final events chunk.
+    // The sync was limited, which unloaded the linked chunk, and reloaded only
+    // the final events chunk.
 
     let outcome = pagination.run_backwards_once(20).await.unwrap();
     assert!(outcome.events.is_empty());
@@ -1190,7 +1197,8 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
 
     let f = EventFactory::new().room(room_id).sender(user_id!("@a:b.c"));
 
-    // Start with a room with a single event, limited timeline and prev-batch token.
+    // Start with a room with a single event, limited timeline and prev-batch
+    // token.
     let room = server
         .sync_room(
             &client,
@@ -1259,9 +1267,9 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
         .await;
 
     // Run pagination once: it will consume prev-batch2 first, which is the most
-    // recent token, which returns an empty batch, thus indicating the start of the
-    // room; but we still have a chunk in storage, so it appears like it's not the
-    // start *yet*.
+    // recent token, which returns an empty batch, thus indicating the start of
+    // the room; but we still have a chunk in storage, so it appears like
+    // it's not the start *yet*.
     let pagination = room_event_cache.pagination();
 
     let outcome = pagination.run_backwards_once(20).await.unwrap();
@@ -1269,8 +1277,8 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
     assert!(outcome.events.is_empty());
     assert!(stream.is_empty());
 
-    // For prev-batch, the back-pagination returns two events we already know, and a
-    // previous batch token.
+    // For prev-batch, the back-pagination returns two events we already know,
+    // and a previous batch token.
     server
         .mock_room_messages()
         .match_from("prev-batch")
@@ -1283,17 +1291,17 @@ async fn test_no_gap_stored_after_deduplicated_backpagination() {
         .mount()
         .await;
 
-    // Run pagination a second time: it will consume prev-batch, which is the least
-    // recent token.
+    // Run pagination a second time: it will consume prev-batch, which is the
+    // least recent token.
     let outcome = pagination.run_backwards_once(20).await.unwrap();
     assert!(outcome.reached_start);
     assert!(outcome.events.is_empty());
     assert!(stream.is_empty());
 
-    // If this back-pagination fails, that's because it's trying to hit network. In
-    // that case, it means we stored the gap with the prev-batch3 token, while
-    // we shouldn't have to, since it is useless; all events were deduplicated
-    // from the previous pagination.
+    // If this back-pagination fails, that's because it's trying to hit network.
+    // In that case, it means we stored the gap with the prev-batch3 token,
+    // while we shouldn't have to, since it is useless; all events were
+    // deduplicated from the previous pagination.
 
     let (events, stream) = room_event_cache.subscribe().await.unwrap();
     assert_event_matches_msg(&events[0], "hello");
@@ -1318,7 +1326,8 @@ async fn test_dont_delete_gap_that_wasnt_inserted() {
 
     let f = EventFactory::new().room(room_id).sender(user_id!("@a:b.c"));
 
-    // Start with a room with a single event, limited timeline and prev-batch token.
+    // Start with a room with a single event, limited timeline and prev-batch
+    // token.
     let room = server
         .sync_room(
             &client,
@@ -1354,8 +1363,8 @@ async fn test_dont_delete_gap_that_wasnt_inserted() {
     // This doesn't cause an update, because nothing changed.
     assert!(stream.is_empty());
 
-    // After a restart, a sync with the same sliding sync window may return the same
-    // events, but no prev-batch token this time.
+    // After a restart, a sync with the same sliding sync window may return the
+    // same events, but no prev-batch token this time.
     server
         .sync_room(
             &client,
@@ -1457,8 +1466,8 @@ async fn test_apply_redaction_when_redaction_comes_later() {
     // And done for now.
     assert!(subscriber.is_empty());
 
-    // If another client is created with the same store, then the stored event is
-    // already redacted.
+    // If another client is created with the same store, then the stored event
+    // is already redacted.
     drop(client);
 
     let client = server
@@ -1821,8 +1830,8 @@ async fn test_lazy_loading() {
         // Oh! 5 events! How classy.
         assert_eq!(outcome.events.len(), 5);
 
-        // Hello you. Well… Uoy olleh! Remember, this is a backwards pagination, so
-        // events are returned in reverse order.
+        // Hello you. Well… Uoy olleh! Remember, this is a backwards pagination,
+        // so events are returned in reverse order.
         assert_event_id!(outcome.events[0], "$ev2_4");
         assert_event_id!(outcome.events[1], "$ev2_3");
         assert_event_id!(outcome.events[2], "$ev2_2");
@@ -1866,8 +1875,8 @@ async fn test_lazy_loading() {
     // moaare!
     //
     // One more chunk will be loaded from the store. This new chunk contains a
-    // gap. Network will be reached. 4 events will be received, and inserted in the
-    // event cache store, forever 🫶.
+    // gap. Network will be reached. 4 events will be received, and inserted in
+    // the event cache store, forever 🫶.
     {
         let _network_pagination = mock_server
             .mock_room_messages()
@@ -1898,7 +1907,8 @@ async fn test_lazy_loading() {
         assert_event_id!(outcome.events[2], "$ev1_2");
         assert_event_id!(outcome.events[3], "$ev1_1");
 
-        // And there is more because we didn't reach the start of the timeline yet.
+        // And there is more because we didn't reach the start of the timeline
+        // yet.
         assert!(outcome.reached_start.not());
 
         // Let's check the stream. It should reflect what the
@@ -1991,11 +2001,11 @@ async fn test_lazy_loading() {
     // pagination, because (i) it contained an `end` token, and (ii) not all the
     // fetched events were duplicated. Let's paginate again!
     //
-    // The new network pagination will return, let's say, 2 known events. They will
-    // all be deduplicated, so zero events will be inserted. However, we do paginate
-    // until there's at least one event. The first pagination will return zero
-    // event, the gap chunk will be removed, a second pagination will then run.
-    // This time, the store will be hit.
+    // The new network pagination will return, let's say, 2 known events. They
+    // will all be deduplicated, so zero events will be inserted. However,
+    // we do paginate until there's at least one event. The first pagination
+    // will return zero event, the gap chunk will be removed, a second
+    // pagination will then run. This time, the store will be hit.
     {
         let _network_pagination = mock_server
             .mock_room_messages()
@@ -2018,10 +2028,11 @@ async fn test_lazy_loading() {
 
         let outcome = room_event_cache.pagination().run_backwards_until(1).await.unwrap();
 
-        // 🙊 … 5 events! Wait, what? Yes! The network has returned 2 known events, they
-        // have all been deduplicated, resulting in the removal of the gap chunk.
-        // We then re-ran the pagination, and this time the store is reached, and it
-        // reflects the deduplicated $ev0_5 from a previous back-pagination.
+        // 🙊 … 5 events! Wait, what? Yes! The network has returned 2 known
+        // events, they have all been deduplicated, resulting in the
+        // removal of the gap chunk. We then re-ran the pagination, and
+        // this time the store is reached, and it reflects the
+        // deduplicated $ev0_5 from a previous back-pagination.
         assert_eq!(outcome.events.len(), 5);
 
         // Hello to all of you!
@@ -2169,10 +2180,10 @@ async fn test_deduplication() {
         .await;
 
     // What should we see?
-    // - On `updates_stream`: 2 events from the loaded chunk #1 must be removed, and
-    //   6 events must be added inserted (!); indeed, 4 are removed and re-inserted
-    //   at the back, plus 2 events are newly inserted at the back, so 6 are
-    //   inserted,
+    // - On `updates_stream`: 2 events from the loaded chunk #1 must be removed,
+    //   and 6 events must be added inserted (!); indeed, 4 are removed and
+    //   re-inserted at the back, plus 2 events are newly inserted at the back,
+    //   so 6 are inserted,
     // - On the store, 2 events must be removed from chunk #0
     //
     // First off, let's check `updates_stream`.
@@ -2208,7 +2219,8 @@ async fn test_deduplication() {
     {
         let outcome = room_event_cache.pagination().run_backwards_until(1).await.unwrap();
 
-        // Alrighty, we should get 2 events since 2 of 4 should have been removed.
+        // Alrighty, we should get 2 events since 2 of 4 should have been
+        // removed.
         assert_eq!(outcome.events.len(), 2);
 
         // Hello, in reverse order because it's a backward pagination.
@@ -2297,7 +2309,8 @@ async fn test_timeline_then_empty_timeline_then_deduplication_with_storage() {
         )
         .await;
 
-    // The timeline is limited, so the linked chunk is shrunk to the latest chunk.
+    // The timeline is limited, so the linked chunk is shrunk to the latest
+    // chunk.
     assert_let_timeout!(
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents(TimelineVectorDiffs { diffs, .. })) =
             subscriber.recv()
@@ -2383,8 +2396,8 @@ async fn test_clear_all_rooms() {
     let f = EventFactory::new().room(sleeping_room_id);
     let ev0 = f.text_msg("hi").sender(*ALICE).event_id(event_id!("$ev0")).into_event();
 
-    // Feed the cache with one room with one event, before the client is created.
-    // This room will remain sleeping.
+    // Feed the cache with one room with one event, before the client is
+    // created. This room will remain sleeping.
     {
         let cid = ChunkIdentifier::new(0);
         event_cache_store
@@ -2489,8 +2502,8 @@ async fn test_sync_while_back_paginate() {
         .state_store(state_memory_store);
 
     {
-        // First, initialize the sync so the client is aware of the room, in the state
-        // store.
+        // First, initialize the sync so the client is aware of the room, in the
+        // state store.
         let client = server
             .client_builder()
             .on_builder(|builder| builder.store_config(store_config.clone()))
@@ -2499,8 +2512,8 @@ async fn test_sync_while_back_paginate() {
         server.sync_joined_room(&client, room_id).await;
     }
 
-    // Then, use a new client that will restore the state from the state store, and
-    // with an empty event cache store.
+    // Then, use a new client that will restore the state from the state store,
+    // and with an empty event cache store.
     let client = server
         .client_builder()
         .on_builder(|builder| builder.store_config(store_config))
@@ -2653,8 +2666,8 @@ async fn test_relations_ordering() {
         .edit(target_event_id, RoomMessageEventContentWithoutRelation::text_plain("hello world"))
         .event_id(edit4);
 
-    // We receive two edit events via sync, as well as a gap; this will shrink the
-    // linked chunk.
+    // We receive two edit events via sync, as well as a gap; this will shrink
+    // the linked chunk.
     server
         .sync_room(
             &client,
@@ -2682,8 +2695,8 @@ async fn test_relations_ordering() {
     let (_, relations) =
         room_event_cache.find_event_with_relations(target_event_id, None).await.unwrap().unwrap();
     assert_eq!(relations.len(), 2);
-    // And the edit events are correctly ordered according to their position in the
-    // linked chunk.
+    // And the edit events are correctly ordered according to their position in
+    // the linked chunk.
     assert_eq!(relations[0].event_id().unwrap(), edit3);
     assert_eq!(relations[1].event_id().unwrap(), edit4);
 
@@ -2703,8 +2716,8 @@ async fn test_relations_ordering() {
     assert_eq!(outcome.events.len(), 1);
 
     {
-        // Sanity check: we load the first chunk with the first event, from disk, and
-        // reach the start of the timeline.
+        // Sanity check: we load the first chunk with the first event, from
+        // disk, and reach the start of the timeline.
         let outcome = room_event_cache.pagination().run_backwards_once(1).await.unwrap();
         assert!(outcome.reached_start);
     }
@@ -2899,8 +2912,8 @@ async fn test_send_queue_does_insert_event_in_the_event_cache() {
     let room_id = room_id!("!omelette:fromage.fr");
     let f = EventFactory::new().room(room_id).sender(user_id!("@a:b.c"));
 
-    // Inject a first event via the sync so that the Event Cache is _not_ empty, and
-    // the Send Queue can insert its event inside the Event Cache.
+    // Inject a first event via the sync so that the Event Cache is _not_ empty,
+    // and the Send Queue can insert its event inside the Event Cache.
     let room = server
         .sync_room(
             &client,
@@ -3021,8 +3034,8 @@ async fn test_backpaginate_on_a_single_event_inserted_via_send_queue_from_an_emp
     let outcome = room_event_cache.pagination().run_backwards_once(20).await.unwrap();
     let BackPaginationOutcome { reached_start, .. } = outcome;
 
-    // The event cache can't know whether this is the start or not, and it shouldn't
-    // assume so.
+    // The event cache can't know whether this is the start or not, and it
+    // shouldn't assume so.
     assert!(reached_start.not());
 }
 
@@ -3074,8 +3087,8 @@ async fn test_order_tracker_is_reset_when_cross_process_is_dirty() {
     // Little dance to force `process_a` to be dirty:
     // - process A syncs 2 events,
     // - process B syncs a gap + 1 event (to ensure process A won't be able to
-    //   retrieve an event if something went wrong): it is dirty, it will reload, no
-    //   problem,
+    //   retrieve an event if something went wrong): it is dirty, it will
+    //   reload, no problem,
     // - process B syncs a gap + 1 event again: it is not dirty, no problem.
     // - process A is syncs 3 events: it is dirty, it will reload, but if the
     //   `OrderTracker` is not reset correctly, it will panic.

--- a/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/read_receipts.rs
@@ -444,7 +444,8 @@ async fn test_gappy_sync_keeps_then_next_sync_resets_unread_count() {
     let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
     assert!(room_cache_updates.is_empty());
 
-    // First sync: two messages from BOB, no read receipt → unread count becomes 2.
+    // First sync: two messages from BOB, no read receipt → unread count becomes
+    // 2.
     server
         .sync_room(
             &client,
@@ -470,8 +471,8 @@ async fn test_gappy_sync_keeps_then_next_sync_resets_unread_count() {
 
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
-    // The unread count is recomputed while "$1" and "$2" are still in the linked
-    // chunk (shrinking happens after), so it remains 2.
+    // The unread count is recomputed while "$1" and "$2" are still in the
+    // linked chunk (shrinking happens after), so it remains 2.
     assert_eq!(room.num_unread_messages(), 2);
 
     // Normal (non-gappy) sync: one new message from BOB.
@@ -511,8 +512,8 @@ async fn test_mentions_increments_unread_mentions() {
     let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
     assert!(room_cache_updates.is_empty());
 
-    // For mentions to be properly counted, we need to have a member event for the
-    // current user.
+    // For mentions to be properly counted, we need to have a member event for
+    // the current user.
     let member_event = f
         .member(client.user_id().unwrap())
         .membership(MembershipState::Join)
@@ -557,8 +558,8 @@ async fn test_compute_unread_counts_considers_active_receipt() {
     let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
     assert!(room_cache_updates.is_empty());
 
-    // Starting with a room with 1 implicit receipt, then two messages from Bob, and
-    // a receipt on Bob's first message $2,
+    // Starting with a room with 1 implicit receipt, then two messages from Bob,
+    // and a receipt on Bob's first message $2,
     server
         .sync_room(
             &client,
@@ -585,7 +586,8 @@ async fn test_compute_unread_counts_considers_active_receipt() {
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
-    // The message counts are properly updated (one new message unread after $2).
+    // The message counts are properly updated (one new message unread after
+    // $2).
     assert_eq!(room.num_unread_messages(), 1);
 
     // Provided a sync with one new message from Bob in the same room,
@@ -631,8 +633,8 @@ async fn test_select_best_receipt_considers_thread_config() {
     let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
     assert!(room_cache_updates.is_empty());
 
-    // Starting with a room that has two messages from Bob, and one threaded answer
-    // to one of Bob's messages.
+    // Starting with a room that has two messages from Bob, and one threaded
+    // answer to one of Bob's messages.
     let thread_root = event_id!("$1");
     server
         .sync_room(
@@ -651,8 +653,8 @@ async fn test_select_best_receipt_considers_thread_config() {
 
     assert_let_timeout!(Ok(_) = room_cache_updates.recv());
 
-    // The message counts include all messages from the main timeline, because the
-    // implicit receipt sent in a thread isn't taken into account.
+    // The message counts include all messages from the main timeline, because
+    // the implicit receipt sent in a thread isn't taken into account.
     assert_eq!(room.num_unread_messages(), 2);
 }
 
@@ -690,8 +692,8 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
         Ok(RoomEventCacheUpdate::UpdateTimelineEvents(..)) = room_cache_updates.recv()
     );
 
-    // Then, provided a sync with a single duplicated message sent by somebody else,
-    // but a read receipt for the existing message $2,
+    // Then, provided a sync with a single duplicated message sent by somebody
+    // else, but a read receipt for the existing message $2,
     server
         .sync_room(
             &client,
@@ -715,7 +717,8 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
         Ok(RoomEventCacheUpdate::AddEphemeralEvents { .. }) = room_cache_updates.recv()
     );
 
-    // The message counts are properly updated (zero new message unread after $2).
+    // The message counts are properly updated (zero new message unread after
+    // $2).
     assert_eq!(room.num_unread_messages(), 0);
 }
 
@@ -742,8 +745,8 @@ async fn test_compute_unread_counts_triggers_backpaginations() {
     let (_, mut room_cache_updates) = room_event_cache.subscribe().await.unwrap();
     assert!(room_cache_updates.is_empty());
 
-    // Already set up the mock for /messages, as the background pagination will hit
-    // it as soon as the sync is received.
+    // Already set up the mock for /messages, as the background pagination will
+    // hit it as soon as the sync is received.
     server
         .mock_room_messages()
         .match_from("prev_batch")
@@ -788,8 +791,8 @@ async fn test_compute_unread_counts_triggers_backpaginations() {
     // timeline, which are $3 and $4).
     assert_eq!(room.num_unread_messages(), 2);
 
-    // Then, there's a background pagination happening in the room, which will fetch
-    // the missing $1 and $2.
+    // Then, there's a background pagination happening in the room, which will
+    // fetch the missing $1 and $2.
     assert_let_timeout!(Duration::from_millis(150), Ok(_) = room_cache_updates.recv());
 
     // The message counts are properly updated (three messages after $1).
@@ -807,8 +810,9 @@ async fn test_read_receipt_from_store_used_as_latest_active() {
     let room_id = room_id!("!omelette:fromage.fr");
     let f = EventFactory::new().room(room_id).sender(*BOB);
 
-    // Important test note: the read receipt must be in the state store *before* the
-    // event cache is subscribed to, so that it's not marked as active at start.
+    // Important test note: the read receipt must be in the state store *before*
+    // the event cache is subscribed to, so that it's not marked as active
+    // at start.
     let room = server
         .sync_room(
             &client,
@@ -854,8 +858,9 @@ async fn test_all_read_receipts_from_store_used_as_latest_active() {
     let room_id = room_id!("!omelette:fromage.fr");
     let f = EventFactory::new().room(room_id).sender(*BOB);
 
-    // Important test note: the read receipt must be in the state store *before* the
-    // event cache is subscribed to, so that it's not marked as active at start.
+    // Important test note: the read receipt must be in the state store *before*
+    // the event cache is subscribed to, so that it's not marked as active
+    // at start.
     let room = server
         .sync_room(
             &client,

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/mod.rs
@@ -105,8 +105,9 @@ async fn test_thread_contains_its_root_event() {
         .mount()
         .await;
 
-    // So, technically, since the thread root will be added to the thread itself,
-    // the `/room/…/event` endpoint will be hit for the thread root event.
+    // So, technically, since the thread root will be added to the thread
+    // itself, the `/room/…/event` endpoint will be hit for the thread root
+    // event.
     server
         .mock_room_event()
         .match_event_id()
@@ -275,12 +276,12 @@ async fn test_deduplication() {
         )
         .await;
 
-    // Still no updates on the stream: the event has been deduplicated, and there
-    // were no gaps.
+    // Still no updates on the stream: the event has been deduplicated, and
+    // there were no gaps.
     assert!(thread_stream.is_empty());
 
-    // If I backpaginate in that thread, and the pagination only returns events I
-    // already knew about, the stream is still empty.
+    // If I backpaginate in that thread, and the pagination only returns events
+    // I already knew about, the stream is still empty.
     server
         .mock_room_relations()
         .match_target_event(thread_root.to_owned())
@@ -351,8 +352,8 @@ async fn thread_subscription_test_setup() -> ThreadSubscriptionTestSetup {
     assert!(initial_events.is_empty());
     assert!(subscriber.is_empty());
 
-    // Provide a dummy sync with the room's member profile of the current user, so
-    // the push context can be created.
+    // Provide a dummy sync with the room's member profile of the current user,
+    // so the push context can be created.
     let own_user_id = client.user_id().unwrap();
     let f = EventFactory::new().room(room_id).sender(*ALICE);
     let member = f.member(own_user_id).sender(own_user_id);
@@ -370,8 +371,8 @@ async fn thread_subscription_test_setup() -> ThreadSubscriptionTestSetup {
         })
         .await;
 
-    // Wait for the initial sync processing to complete; it will trigger a member
-    // update, at the very least.
+    // Wait for the initial sync processing to complete; it will trigger a
+    // member update, at the very least.
     assert_let_timeout!(Ok(RoomEventCacheUpdate::UpdateMembers { .. }) = subscriber.recv());
 
     let first_reply_event_id = event_id!("$first_reply");
@@ -412,8 +413,8 @@ async fn thread_subscription_test_setup() -> ThreadSubscriptionTestSetup {
 async fn test_auto_subscribe_thread_via_sync() {
     let mut s = thread_subscription_test_setup().await;
 
-    // (The endpoint will be called for the current thread, and with an automatic
-    // subscription up to the given event ID.)
+    // (The endpoint will be called for the current thread, and with an
+    // automatic subscription up to the given event ID.)
     s.server
         .mock_room_put_thread_subscription()
         .match_automatic_event_id(&s.mention_event_id)
@@ -426,8 +427,9 @@ async fn test_auto_subscribe_thread_via_sync() {
     let mut thread_subscriber_updates =
         s.client.event_cache().subscribe_thread_subscriber_updates();
 
-    // When I receive 3 events (1 non mention, 1 mention, then 1 non mention again),
-    // from sync, I'll get subscribed to the thread because of the second event.
+    // When I receive 3 events (1 non mention, 1 mention, then 1 non mention
+    // again), from sync, I'll get subscribed to the thread because of the
+    // second event.
     s.server
         .sync_room(&s.client, JoinedRoomBuilder::new(&s.room_id).add_timeline_bulk(s.events))
         .await;
@@ -469,8 +471,8 @@ async fn test_dont_auto_subscribe_on_already_subscribed_thread() {
             s.subscriber.recv()
     );
 
-    // Let a bit of time for the background thread subscriber task to process the
-    // update.
+    // Let a bit of time for the background thread subscriber task to process
+    // the update.
     sleep(Duration::from_millis(200)).await;
 
     // The actual check is the `expect` call above!
@@ -535,8 +537,8 @@ async fn test_auto_subscribe_on_thread_paginate() {
         .mount()
         .await;
 
-    // (The endpoint will be called for the current thread, and with an automatic
-    // subscription up to the given event ID.)
+    // (The endpoint will be called for the current thread, and with an
+    // automatic subscription up to the given event ID.)
     s.server
         .mock_room_put_thread_subscription()
         .match_automatic_event_id(&s.mention_event_id)
@@ -618,8 +620,8 @@ async fn test_auto_subscribe_on_thread_paginate_root_event() {
         .mount()
         .await;
 
-    // (The endpoint will be called for the current thread, and with an automatic
-    // subscription up to the given event ID.)
+    // (The endpoint will be called for the current thread, and with an
+    // automatic subscription up to the given event ID.)
     s.server
         .mock_room_put_thread_subscription()
         .match_automatic_event_id(thread_root_id)
@@ -639,9 +641,10 @@ async fn test_auto_subscribe_on_thread_paginate_root_event() {
 
 #[async_test]
 async fn test_redact_touches_threads() {
-    // We start with a thread with some replies, then receive redactions for those
-    // replies over sync. We observe that the thread linked chunks are correctly
-    // updated, as well as the thread summary on the thread root event.
+    // We start with a thread with some replies, then receive redactions for
+    // those replies over sync. We observe that the thread linked chunks are
+    // correctly updated, as well as the thread summary on the thread root
+    // event.
 
     let s = thread_subscription_test_setup().await;
     let f = s.factory;
@@ -704,8 +707,8 @@ async fn test_redact_touches_threads() {
 
     let thread_events = wait_for_initial_events(thread_events, &mut thread_stream).await;
 
-    // Sanity check: both events are present in the thread, and the thread summary
-    // is correct.
+    // Sanity check: both events are present in the thread, and the thread
+    // summary is correct.
     {
         assert_eq!(thread_events.len(), 3);
         assert_eq!(thread_events[0].event_id(), Some(thread_root_id.as_ref()));
@@ -876,10 +879,10 @@ async fn test_redact_touches_threads() {
 
 #[async_test]
 async fn test_edits_touches_threads() {
-    // We start with a thread with some replies, then receive an edit and an invalid
-    // edit for the replies over sync. We observe that valid edits update the
-    // thread linked chunks as well as the thread summary on the thread root
-    // event. Invalid ones don't update the state.
+    // We start with a thread with some replies, then receive an edit and an
+    // invalid edit for the replies over sync. We observe that valid edits
+    // update the thread linked chunks as well as the thread summary on the
+    // thread root event. Invalid ones don't update the state.
 
     let s = thread_subscription_test_setup().await;
     let f = s.factory;
@@ -1026,7 +1029,8 @@ async fn test_edits_touches_threads() {
                 assert_let!(VectorDiff::Set { index: 0, value: new_root } = &diffs[0]);
                 assert_eq!(new_root.event_id(), Some(thread_root_id.as_ref()));
                 let summary = new_root.thread_summary.summary().unwrap();
-                // But the `latest_reply` is still `first_edit`, not `second_edit`!
+                // But the `latest_reply` is still `first_edit`, not
+                // `second_edit`!
                 assert_eq!(summary.latest_reply.as_deref(), Some(first_edit));
                 assert_eq!(summary.num_replies, 2);
             }

--- a/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache/threads/read_receipts.rs
@@ -476,8 +476,8 @@ async fn test_mentions_increments_unread_mentions() {
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
     assert!(thread_updates.is_empty());
 
-    // For mentions to be properly counted, we need to have a member event for the
-    // current user.
+    // For mentions to be properly counted, we need to have a member event for
+    // the current user.
     let member_event = f
         .member(client.user_id().unwrap())
         .membership(MembershipState::Join)
@@ -525,8 +525,8 @@ async fn test_compute_unread_counts_considers_active_receipt() {
     let (_, mut thread_updates) = thread.subscribe().await.unwrap();
     assert!(thread_updates.is_empty());
 
-    // Starting with a room with 1 implicit receipt, then two messages from Alice,
-    // and a receipt on Alice's first message $2,
+    // Starting with a room with 1 implicit receipt, then two messages from
+    // Alice, and a receipt on Alice's first message $2,
     server
         .sync_room(
             &client,
@@ -561,7 +561,8 @@ async fn test_compute_unread_counts_considers_active_receipt() {
 
     assert_let_timeout!(Ok(_) = thread_updates.recv());
 
-    // The message counts are properly updated (one new message unread after $2).
+    // The message counts are properly updated (one new message unread after
+    // $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 1);
 
     // Provided a sync with one new message from Alice in the same room.
@@ -621,8 +622,8 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
     // We receive the thread update for the two new messages.
     assert_let_timeout!(Ok(_) = thread_updates.recv());
 
-    // Then, provided a sync with a single duplicated message sent by somebody else,
-    // but a read receipt for the existing message $2,
+    // Then, provided a sync with a single duplicated message sent by somebody
+    // else, but a read receipt for the existing message $2,
     server
         .sync_room(
             &client,
@@ -648,7 +649,8 @@ async fn test_unread_counts_updated_after_duplicate_only_sync_response() {
     // deduplicated. So. Just wait a little bit :-].
     sleep(Duration::from_millis(100)).await;
 
-    // The message counts are properly updated (zero new message unread after $2).
+    // The message counts are properly updated (zero new message unread after
+    // $2).
     assert_eq!(thread.num_unread_messages().await.unwrap(), 0);
 }
 
@@ -664,8 +666,9 @@ async fn test_read_receipt_from_store_used_as_latest_active() {
     let thread_id = event_id!("$t");
     let f = EventFactory::new().room(room_id).sender(*ALICE);
 
-    // Important test note: the read receipt must be in the state store *before* the
-    // event cache is subscribed to, so that it's not marked as active at start.
+    // Important test note: the read receipt must be in the state store *before*
+    // the event cache is subscribed to, so that it's not marked as active
+    // at start.
     server
         .sync_room(
             &client,

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -410,8 +410,8 @@ async fn test_login_with_cross_signing_bootstrapping() {
 
                     *num_calls += 1;
                 } else {
-                    // Second time, we use a login token. Pretend MSC3967 is enabled and require an
-                    // empty auth.
+                    // Second time, we use a login token. Pretend MSC3967 is
+                    // enabled and require an empty auth.
                     assert!(params.auth.is_none());
                 }
             }

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -157,8 +157,8 @@ async fn test_get_media_file_no_auth() {
 
 #[async_test]
 async fn test_get_media_file_with_auth_matrix_1_11() {
-    // The server must advertise support for v1.11 or newer for authenticated media
-    // support, so we make the request instead of assuming.
+    // The server must advertise support for v1.11 or newer for authenticated
+    // media support, so we make the request instead of assuming.
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().no_server_versions().build().await;
 
@@ -227,8 +227,9 @@ async fn test_get_media_file_with_auth_matrix_1_11() {
 
 #[async_test]
 async fn test_get_media_file_with_auth_matrix_stable_feature() {
-    // The server must advertise support for the stable feature for authenticated
-    // media support, so we make the request instead of assuming.
+    // The server must advertise support for the stable feature for
+    // authenticated media support, so we make the request instead of
+    // assuming.
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().no_server_versions().build().await;
 
@@ -430,8 +431,8 @@ async fn test_get_media_preview_empty_response_no_auth() {
 #[async_test]
 async fn test_get_media_preview_disabled_by_server() {
     // Homeservers may disable URL previews entirely, in which case the endpoint
-    // is not routed at all and answers `M_UNRECOGNIZED`. That must surface as an
-    // error rather than being mistaken for "no preview available".
+    // is not routed at all and answers `M_UNRECOGNIZED`. That must surface as
+    // an error rather than being mistaken for "no preview available".
     let server = MatrixMockServer::new().await;
     let client = server.client_builder().no_server_versions().build().await;
 

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -767,8 +767,8 @@ async fn test_oauth_handle_refresh_tokens_without_versions() {
         .mount()
         .await;
 
-    // If we do not provide an access token, all is fine as the endpoint does not
-    // require one.
+    // If we do not provide an access token, all is fine as the endpoint does
+    // not require one.
     server
         .mock_versions()
         .expect_missing_access_token()
@@ -915,8 +915,8 @@ async fn test_refresh_token_not_handled_supported_versions_not_cached() {
 
     let client = server.client_builder().no_server_versions().build().await;
 
-    // We need to use an endpoint that doesn't require authentication, so it doesn't
-    // try to refresh the token.
+    // We need to use an endpoint that doesn't require authentication, so it
+    // doesn't try to refresh the token.
     let oauth_server = server.oauth();
     oauth_server.mock_server_metadata().ok().expect(1).named("server_metadata").mount().await;
 

--- a/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/attachment/mod.rs
@@ -154,9 +154,9 @@ async fn test_room_attachment_send_wrong_info() {
 
     mock.mock_authenticated_media_config().ok_default().mount().await;
 
-    // Note: this mock is NOT called because the height and width are lost, because
-    // we're trying to send the attachment as an image, while we provide a
-    // `VideoInfo`.
+    // Note: this mock is NOT called because the height and width are lost,
+    // because we're trying to send the attachment as an image, while we
+    // provide a `VideoInfo`.
     //
     // So long for static typing.
 
@@ -278,8 +278,8 @@ async fn test_room_attachment_send_info_thumbnail() {
     // The event was sent.
     assert_eq!(response.event_id, expected_event_id);
 
-    // The media is immediately cached in the cache store, so we don't need to set
-    // up another mock endpoint for getting the media.
+    // The media is immediately cached in the cache store, so we don't need to
+    // set up another mock endpoint for getting the media.
     let reloaded = client.media().get_media_content(&media_request, true).await.unwrap();
     assert_eq!(reloaded, b"Hello world");
 
@@ -300,7 +300,8 @@ async fn test_room_attachment_send_info_thumbnail() {
         .await
         .unwrap_err();
 
-    // But it is not found when requesting it as a thumbnail with a different size.
+    // But it is not found when requesting it as a thumbnail with a different
+    // size.
     let thumbnail_request = MediaRequestParameters {
         source: MediaSource::Plain(thumbnail_mxc),
         format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(uint!(42), uint!(1337))),

--- a/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/beacon/mod.rs
@@ -178,8 +178,9 @@ async fn test_most_recent_event_in_stream() {
     // querying.
     assert_let_timeout!(Ok(_) = event_cache_updates_stream.recv());
 
-    // Create the stream after syncing all beacon events — the initial snapshot is
-    // loaded from the event cache and already reflects the latest beacon.
+    // Create the stream after syncing all beacon events — the initial snapshot
+    // is loaded from the event cache and already reflects the latest
+    // beacon.
     let live_locations_observer = room.live_locations_observer().await;
     let (mut shares, _stream) = live_locations_observer.subscribe();
 
@@ -238,7 +239,8 @@ async fn test_observe_single_live_location_share() {
     let (initial, stream) = live_locations_observer.subscribe();
     pin_mut!(stream);
 
-    // Initial snapshot contains the beacon_info from state (no last_location yet).
+    // Initial snapshot contains the beacon_info from state (no last_location
+    // yet).
     assert_eq!(initial.len(), 1);
     assert!(initial[0].last_location.is_none());
 
@@ -357,7 +359,8 @@ async fn test_location_update_for_already_tracked_user() {
     let (initial, stream) = live_locations_observer.subscribe();
     pin_mut!(stream);
 
-    // Initial snapshot contains the beacon_info from state (no last_location yet).
+    // Initial snapshot contains the beacon_info from state (no last_location
+    // yet).
     assert_eq!(initial.len(), 1);
     assert!(initial[0].last_location.is_none());
 
@@ -387,7 +390,8 @@ async fn test_location_update_for_already_tracked_user() {
     assert_eq!(last_location.location.uri, "geo:10,20;u=5");
     assert_eq!(share.beacon_info.description, Some("Alice location".to_owned()));
 
-    // Alice's second beacon — already tracked, beacon_info is reused from cache.
+    // Alice's second beacon — already tracked, beacon_info is reused from
+    // cache.
     server
         .sync_room(
             &client,
@@ -411,7 +415,8 @@ async fn test_location_update_for_already_tracked_user() {
     assert_eq!(user_id, user_id!("@alice:localhost"));
     let last_location = last_location.expect("Expected last location");
     assert_eq!(last_location.location.uri, "geo:30,40;u=10");
-    // beacon_info is preserved from the initial share — not re-fetched from state.
+    // beacon_info is preserved from the initial share — not re-fetched from
+    // state.
     assert_eq!(beacon_info.description, Some("Alice location".to_owned()));
 }
 
@@ -443,7 +448,8 @@ async fn test_beacon_info_stop_removes_user_from_stream() {
     let (initial, stream) = live_locations_observer.subscribe();
     pin_mut!(stream);
 
-    // Initial snapshot contains the beacon_info from state (no last_location yet).
+    // Initial snapshot contains the beacon_info from state (no last_location
+    // yet).
     assert_eq!(initial.len(), 1);
     assert!(initial[0].last_location.is_none());
 

--- a/crates/matrix-sdk/tests/integration/room/calls.rs
+++ b/crates/matrix-sdk/tests/integration/room/calls.rs
@@ -45,7 +45,8 @@ async fn test_subscribe_to_decline_call_events() {
                 let mut decliners_sequences = decliners_sequences.lock().unwrap();
                 decliners_sequences.push(user_id);
 
-                // When we have received 2 typing notifications, we can stop listening.
+                // When we have received 2 typing notifications, we can stop
+                // listening.
                 if decliners_sequences.len() == 2 {
                     break;
                 }
@@ -92,8 +93,8 @@ async fn test_decline_call() {
     let unknown_event_id = owned_event_id!("$00002:localhost");
     let own_notification_event_id = owned_event_id!("$00003:localhost");
 
-    // Subscribe to the event cache (to avoid having to remotely fetch the related
-    // event)
+    // Subscribe to the event cache (to avoid having to remotely fetch the
+    // related event)
     let event_cache = client.event_cache();
     event_cache.subscribe().unwrap();
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -898,8 +898,8 @@ async fn test_is_dm_using_matrix_spec() {
         .await;
 
     let room = server.sync_joined_room(&client, room_id).await;
-    // Room has direct targets, so it's considered direct and a DM using the spec
-    // definition.
+    // Room has direct targets, so it's considered direct and a DM using the
+    // spec definition.
     assert!(room.compute_is_dm().await.unwrap());
 
     // We mock the m.direct account data with no targets

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -857,7 +857,8 @@ async fn test_subscribe_to_typing_notifications() {
                 let mut typing_sequences = typing_sequences.lock().unwrap();
                 typing_sequences.push(typing_user_ids);
 
-                // When we have received 2 typing notifications, we can stop listening.
+                // When we have received 2 typing notifications, we can stop
+                // listening.
                 if typing_sequences.len() == 2 {
                     break;
                 }
@@ -865,8 +866,8 @@ async fn test_subscribe_to_typing_notifications() {
         }
     });
 
-    // Then send a typing notification with 3 users typing, including the current
-    // user.
+    // Then send a typing notification with 3 users typing, including the
+    // current user.
     let f = EventFactory::new();
     server
         .sync_room(
@@ -1233,8 +1234,8 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_membership_changed() 
     let seen = room.get_seen_knock_request_ids().await.unwrap();
     assert_eq!(seen.len(), 1);
 
-    // If we then load the members again and the previously knocking member is in
-    // another state now
+    // If we then load the members again and the previously knocking member is
+    // in another state now
     let joined_event = f.member(user_id).membership(MembershipState::Join).into_raw();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;
@@ -1278,8 +1279,8 @@ async fn test_remove_outdated_seen_knock_requests_ids_when_we_have_an_outdated_k
     let seen = room.get_seen_knock_request_ids().await.unwrap();
     assert_eq!(seen.len(), 1);
 
-    // If we then load the members again and the previously knocking member has a
-    // different event id
+    // If we then load the members again and the previously knocking member has
+    // a different event id
     let knock_event = f
         .member(user_id)
         .membership(MembershipState::Knock)
@@ -1340,8 +1341,8 @@ async fn test_subscribe_to_knock_requests_clears_seen_ids_on_member_reload() {
     assert_eq!(seen_knock.event_id, knock_event_id);
     assert!(seen_knock.is_seen);
 
-    // If we then load the members again and the previously knocking member is in
-    // another state now
+    // If we then load the members again and the previously knocking member is
+    // in another state now
     let joined_event = f.member(user_id).membership(MembershipState::Join).into_raw();
 
     server.mock_get_members().ok(vec![joined_event]).mock_once().mount().await;

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -73,7 +73,8 @@ async fn test_get_notification_mode() {
     assert_matches!(mode, Some(RoomNotificationMode::AllMessages));
 
     // Joined room without user-defined rules
-    // As this room has no user-defined rules, the encryption status will be fetched
+    // As this room has no user-defined rules, the encryption status will be
+    // fetched
     Mock::given(method("GET"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.encryption/"))
         .and(header("authorization", "Bearer 1234"))
@@ -157,8 +158,8 @@ async fn test_cached_notification_mode_is_updated_when_syncing() {
         Some(RoomNotificationMode::AllMessages)
     );
 
-    // Now if we receive a response with no custom push rules for the room, just the
-    // base ones
+    // Now if we receive a response with no custom push rules for the room, just
+    // the base ones
     let mut ruleset = Ruleset::default();
     ruleset.underride = [
         ConditionalPushRule::call(),

--- a/crates/matrix-sdk/tests/integration/room/pinned_events.rs
+++ b/crates/matrix-sdk/tests/integration/room/pinned_events.rs
@@ -37,8 +37,8 @@ impl PinningTestSetup<'_> {
 
         server.mock_room_state_encryption().plain().mount().await;
 
-        // This is necessary to get an empty list of pinned events when there are no
-        // pinned events state event in the required state.
+        // This is necessary to get an empty list of pinned events when there
+        // are no pinned events state event in the required state.
         Mock::given(method("GET"))
             .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*"))
             .and(header("authorization", "Bearer 1234"))
@@ -179,8 +179,8 @@ async fn test_pinned_events_are_loaded_from_network_then_are_reloaded_from_stora
         // Sync the room with the pinned event ID in the room state.
         //
         // This is important: the pinned events list must include our event ID,
-        // otherwise the initial reload from network will clear the storage-loaded
-        // events.
+        // otherwise the initial reload from network will clear the
+        // storage-loaded events.
         let pinned_events_state = f.room_pinned_events(vec![pinned_event_id.to_owned()]);
 
         let _room = server
@@ -194,8 +194,8 @@ async fn test_pinned_events_are_loaded_from_network_then_are_reloaded_from_stora
         let (pinned_events_cache, _drop_handles) =
             event_cache.pinned_events(room_id).await.unwrap();
 
-        // Getting the pinned events cache triggers `PinnedEventsCache::new()` which
-        // spawns a task that calls `reload_from_storage()` first.
+        // Getting the pinned events cache triggers `PinnedEventsCache::new()`
+        // which spawns a task that calls `reload_from_storage()` first.
         let (events, mut subscriber) = pinned_events_cache.subscribe().await.unwrap();
         let mut events = events.into();
 
@@ -362,8 +362,8 @@ async fn test_pinned_events_dont_include_thread_responses() {
 
     server.mock_room_event().match_event_id().ok(pinned_event.clone()).mock_once().mount().await;
 
-    // Serve a thread relation over network; it should NOT be included in the pinned
-    // event cache for that room.
+    // Serve a thread relation over network; it should NOT be included in the
+    // pinned event cache for that room.
     server
         .mock_room_relations()
         .match_subrequest(IncludeRelations::AllRelations)
@@ -412,9 +412,9 @@ async fn test_pinned_events_dont_include_thread_responses() {
         }
     }
 
-    // Verify the pinned event was loaded from the network, and that there wasn't
-    // any other event loaded (in particular, the thread response shouldn't be
-    // included in the pinned events).
+    // Verify the pinned event was loaded from the network, and that there
+    // wasn't any other event loaded (in particular, the thread response
+    // shouldn't be included in the pinned events).
     assert_eq!(events.len(), 1, "Expected pinned events to be loaded from network");
     assert_eq!(
         events[0].event_id().unwrap(),

--- a/crates/matrix-sdk/tests/integration/room/spaces.rs
+++ b/crates/matrix-sdk/tests/integration/room/spaces.rs
@@ -138,8 +138,8 @@ async fn sync_space(
     sync_token: String,
     state_events: Vec<JsonValue>,
 ) -> String {
-    // synthetize a summary for the space by using a sample summary and replacing
-    // the room id
+    // synthetize a summary for the space by using a sample summary and
+    // replacing the room id
     let mut parent_sync = test_json::DEFAULT_SYNC_SUMMARY.clone();
     let join = parent_sync["rooms"]["join"].as_object_mut().unwrap();
     let mut timeline = join.remove(DEFAULT_TEST_ROOM_ID.as_str()).unwrap();

--- a/crates/matrix-sdk/tests/integration/room/tags.rs
+++ b/crates/matrix-sdk/tests/integration/room/tags.rs
@@ -117,8 +117,8 @@ async fn test_set_favourite_on_low_priority_room() {
     assert!(room.is_favourite().not());
     assert!(room.is_low_priority());
 
-    // Server will be called to set the room as favourite, and to unset the room as
-    // low priority.
+    // Server will be called to set the room as favourite, and to unset the room
+    // as low priority.
     mock_tag_api(&server, TagName::Favorite, TagOperation::Set, 1).await;
     mock_tag_api(&server, TagName::LowPriority, TagOperation::Remove, 1).await;
 
@@ -190,8 +190,8 @@ async fn test_set_low_priority_on_favourite_room() {
     assert!(room.is_favourite());
     assert!(room.is_low_priority().not());
 
-    // Server will be called to set the room as favourite, and to unset the room as
-    // low priority.
+    // Server will be called to set the room as favourite, and to unset the room
+    // as low priority.
     mock_tag_api(&server, TagName::LowPriority, TagOperation::Set, 1).await;
     mock_tag_api(&server, TagName::Favorite, TagOperation::Remove, 1).await;
 

--- a/crates/matrix-sdk/tests/integration/room/thread.rs
+++ b/crates/matrix-sdk/tests/integration/room/thread.rs
@@ -42,8 +42,8 @@ async fn test_subscribe_thread() {
     let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap().unwrap();
     assert_eq!(subscription, ThreadSubscription { automatic: true });
 
-    // If I try to get a subscription for a thread event that's unknown, I get no
-    // `ThreadSubscription`, not an error.
+    // If I try to get a subscription for a thread event that's unknown, I get
+    // no `ThreadSubscription`, not an error.
     let subscription =
         room.fetch_thread_subscription(owned_event_id!("$another_root")).await.unwrap();
     assert!(subscription.is_none());
@@ -65,8 +65,8 @@ async fn test_subscribe_thread() {
     let subscription = room.fetch_thread_subscription(root_id.clone()).await.unwrap();
     assert_matches!(subscription, None);
 
-    // Subscribing automatically to the thread may also return a `M_SKIPPED` error
-    // that should be non-fatal.
+    // Subscribing automatically to the thread may also return a `M_SKIPPED`
+    // error that should be non-fatal.
     server
         .mock_room_put_thread_subscription()
         .match_room_id(room_id.to_owned())
@@ -91,9 +91,9 @@ async fn test_subscribe_thread_if_needed() {
     let room_id = room_id!("!test:example.org");
     let room = server.sync_joined_room(&client, room_id).await;
 
-    // If there's no prior subscription, the function `subscribe_thread_if_needed`
-    // will automatically subscribe to the thread, whether the new subscription
-    // is automatic or not.
+    // If there's no prior subscription, the function
+    // `subscribe_thread_if_needed` will automatically subscribe to the
+    // thread, whether the new subscription is automatic or not.
     for (root_id, automatic) in [
         (owned_event_id!("$root"), None),
         (owned_event_id!("$woot"), Some(owned_event_id!("$woot"))),
@@ -168,16 +168,16 @@ async fn test_subscribe_thread_if_needed() {
             .mount()
             .await;
 
-        // No-op! (The PUT endpoint hasn't been mocked, so this would result in a 404 if
-        // it were trying to hit it.)
+        // No-op! (The PUT endpoint hasn't been mocked, so this would result in
+        // a 404 if it were trying to hit it.)
         room.subscribe_thread_if_needed(&root_id, automatic).await.unwrap();
     }
 }
 
 #[async_test]
 async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
-    // This test checks that the evaluation of push rules for threads will correctly
-    // call `Room::fetch_thread_subscription` for threads.
+    // This test checks that the evaluation of push rules for threads will
+    // correctly call `Room::fetch_thread_subscription` for threads.
 
     let server = MatrixMockServer::new().await;
     let client = server
@@ -226,8 +226,8 @@ async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
         .mount()
         .await;
 
-    // Given an event in the thread I'm subscribed to, the push rule evaluation will
-    // trigger the thread subscription endpoint,
+    // Given an event in the thread I'm subscribed to, the push rule evaluation
+    // will trigger the thread subscription endpoint,
     let event =
         f.text_msg("hello to you too!").in_thread(&thread_root_id, &thread_root_id).into_raw_sync();
 
@@ -235,8 +235,8 @@ async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
     let actions = push_context.for_event(&event).await;
     assert!(actions.iter().any(|action| action.should_notify()));
 
-    // But for a thread that I haven't subscribed to (i.e. the endpoint returns 404,
-    // because it's not set up), no actions are returned.
+    // But for a thread that I haven't subscribed to (i.e. the endpoint returns
+    // 404, because it's not set up), no actions are returned.
     let another_thread_root_id = event_id!("$another_root");
     let event = f
         .text_msg("bonjour à vous également !")
@@ -249,9 +249,9 @@ async fn test_thread_push_rule_is_triggered_for_subscribed_threads() {
 
 #[async_test]
 async fn test_thread_push_rules_and_notification_modes() {
-    // This test checks that, given a combination of a global notification mode, and
-    // a room notification mode, we do get notifications for thread events according
-    // to the subscriptions.
+    // This test checks that, given a combination of a global notification mode,
+    // and a room notification mode, we do get notifications for thread
+    // events according to the subscriptions.
 
     let server = MatrixMockServer::new().await;
     let client = server
@@ -324,7 +324,8 @@ async fn test_thread_push_rules_and_notification_modes() {
 
     // If room mode = AllMessages,
     settings.set_room_notification_mode(room_id, RoomNotificationMode::AllMessages).await.unwrap();
-    // Ack the push rules change via sync, for it to be applied in the push context.
+    // Ack the push rules change via sync, for it to be applied in the push
+    // context.
     let ruleset = settings.ruleset().await;
     server
         .mock_sync()
@@ -364,7 +365,8 @@ async fn test_thread_push_rules_and_notification_modes() {
         })
         .await;
 
-    // The thread event will not trigger a notification, as the room has been muted.
+    // The thread event will not trigger a notification, as the room has been
+    // muted.
     let actions = room.push_context().await.unwrap().unwrap().traced_for_event(&event).await;
     assert!(!actions.iter().any(|action| action.should_notify()));
 
@@ -380,7 +382,8 @@ async fn test_thread_push_rules_and_notification_modes() {
 
     // If room mode = AllMessages,
     settings.set_room_notification_mode(room_id, RoomNotificationMode::AllMessages).await.unwrap();
-    // Ack the push rules change via sync, for it to be applied in the push context.
+    // Ack the push rules change via sync, for it to be applied in the push
+    // context.
     let ruleset = settings.ruleset().await;
     server
         .mock_sync()
@@ -398,7 +401,8 @@ async fn test_thread_push_rules_and_notification_modes() {
         .set_room_notification_mode(room_id, RoomNotificationMode::MentionsAndKeywordsOnly)
         .await
         .unwrap();
-    // Ack the push rules change via sync, for it to be applied in the push context.
+    // Ack the push rules change via sync, for it to be applied in the push
+    // context.
     let ruleset = settings.ruleset().await;
     server
         .mock_sync()
@@ -413,7 +417,8 @@ async fn test_thread_push_rules_and_notification_modes() {
 
     // If room mode = mute,
     settings.set_room_notification_mode(room_id, RoomNotificationMode::Mute).await.unwrap();
-    // Ack the push rules change via sync, for it to be applied in the push context.
+    // Ack the push rules change via sync, for it to be applied in the push
+    // context.
     let ruleset = settings.ruleset().await;
     server
         .mock_sync()
@@ -422,7 +427,8 @@ async fn test_thread_push_rules_and_notification_modes() {
         })
         .await;
 
-    // The thread event will not trigger a notification, as the room has been muted.
+    // The thread event will not trigger a notification, as the room has been
+    // muted.
     let actions = room.push_context().await.unwrap().unwrap().traced_for_event(&event).await;
     assert!(!actions.iter().any(|action| action.should_notify()));
 }

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -119,7 +119,8 @@ fn mock_jpeg_upload<'a>(
 ) -> MatrixMock<'a> {
     let mxc = mxc.to_owned();
     mock.mock_upload().expect_mime_type("image/jpeg").respond_with(move |_req: &Request| {
-        // Wait for the signal from the main task that we can process this query.
+        // Wait for the signal from the main task that we can process this
+        // query.
         let mock_lock = lock.clone();
         std::thread::spawn(move || {
             tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -444,7 +445,8 @@ async fn test_smoke() {
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
 
-    // When the queue is enabled and I send message in some order, it does send it.
+    // When the queue is enabled and I send message in some order, it does send
+    // it.
     let event_id = event_id!("$1");
 
     let lock = Arc::new(Mutex::new(()));
@@ -456,7 +458,8 @@ async fn test_smoke() {
 
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -510,7 +513,8 @@ async fn test_smoke_raw() {
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
 
-    // When the queue is enabled and I send message in some order, it does send it.
+    // When the queue is enabled and I send message in some order, it does send
+    // it.
     let event_id = event_id!("$1");
 
     mock.mock_room_state_encryption().plain().mount().await;
@@ -576,7 +580,8 @@ async fn test_error_then_locally_reenabling() {
     let scoped_send = mock
         .mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -849,7 +854,8 @@ async fn test_cancellation() {
     let num_request = std::sync::Mutex::new(1);
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -892,26 +898,26 @@ async fn test_cancellation() {
     // Let the background task start now.
     yield_now().await;
 
-    // While the first item is being sent, the system records the intent to abort
-    // it.
+    // While the first item is being sent, the system records the intent to
+    // abort it.
     assert!(handle1.abort().await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn1 });
     assert!(watch.is_empty());
 
-    // The second item is pending, so we can abort it, using the handle returned by
-    // `send()`.
+    // The second item is pending, so we can abort it, using the handle returned
+    // by `send()`.
     assert!(handle2.abort().await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn2 });
     assert!(watch.is_empty());
 
-    // The third item is pending, so we can abort it, using the handle received from
-    // the update.
+    // The third item is pending, so we can abort it, using the handle received
+    // from the update.
     assert!(handle3.abort().await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn3 });
     assert!(watch.is_empty());
 
-    // The fourth item is pending, so we can abort it, using an handle provided by
-    // the initial array of values.
+    // The fourth item is pending, so we can abort it, using an handle provided
+    // by the initial array of values.
     let (mut local_echoes, _) = q.subscribe().await.unwrap();
 
     // At this point, local echoes = txn1, txn4, txn5.
@@ -938,9 +944,9 @@ async fn test_cancellation() {
 
 #[async_test]
 async fn test_edit() {
-    // Simplified version of test_cancellation: we don't test for *every single way*
-    // to edit a local echo, since if the cancellation test passes, all ways
-    // would work here too similarly.
+    // Simplified version of test_cancellation: we don't test for *every single
+    // way* to edit a local echo, since if the cancellation test passes, all
+    // ways would work here too similarly.
 
     let mock = MatrixMockServer::new().await;
 
@@ -967,7 +973,8 @@ async fn test_edit() {
     let num_request = std::sync::Mutex::new(1);
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -990,8 +997,8 @@ async fn test_edit() {
         .mount()
         .await;
 
-    // The /event endpoint is used to retrieve the original event, during creation
-    // of the edit event.
+    // The /event endpoint is used to retrieve the original event, during
+    // creation of the edit event.
     mock.mock_room_event()
         .room(room_id)
         .ok(EventFactory::new()
@@ -1015,8 +1022,8 @@ async fn test_edit() {
     // Let the background task start now.
     yield_now().await;
 
-    // While the first item is being sent, the system remembers the intent to edit
-    // it, and will send it later.
+    // While the first item is being sent, the system remembers the intent to
+    // edit it, and will send it later.
     assert!(
         handle1
             .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
@@ -1025,8 +1032,8 @@ async fn test_edit() {
     );
     assert_update!((global_watch, watch) => edit { body = "it's never too late!", txn = txn1 });
 
-    // The second item is pending, so we can edit it, using the handle returned by
-    // `send()`.
+    // The second item is pending, so we can edit it, using the handle returned
+    // by `send()`.
     assert!(
         handle2
             .edit(RoomMessageEventContent::text_plain("new content, who diz").into())
@@ -1079,7 +1086,8 @@ async fn test_edit_with_poll_start() {
     let num_request = std::sync::Mutex::new(1);
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -1103,8 +1111,8 @@ async fn test_edit_with_poll_start() {
         .mount()
         .await;
 
-    // The /event endpoint is used to retrieve the original event, during creation
-    // of the edit event.
+    // The /event endpoint is used to retrieve the original event, during
+    // creation of the edit event.
     mock.mock_room_event()
         .ok(EventFactory::new()
             .poll_start("poll_start", "question", vec!["Answer A"])
@@ -1215,7 +1223,8 @@ async fn test_edit_while_being_sent_and_fails() {
 
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -1240,8 +1249,8 @@ async fn test_edit_while_being_sent_and_fails() {
     // Let the background task start now.
     yield_now().await;
 
-    // While the first item is being sent, the system remembers the intent to edit
-    // it, and will send it later.
+    // While the first item is being sent, the system remembers the intent to
+    // edit it, and will send it later.
     assert!(
         handle
             .edit(RoomMessageEventContent::text_plain("it's never too late!").into())
@@ -1258,8 +1267,8 @@ async fn test_edit_while_being_sent_and_fails() {
 
     assert!(watch.is_empty());
 
-    // Looking back at the local echoes will indicate a local echo for `it's never
-    // too late`.
+    // Looking back at the local echoes will indicate a local echo for `it's
+    // never too late`.
     let (local_echoes, _) = q.subscribe().await.unwrap();
     assert_eq!(local_echoes.len(), 1);
     assert_eq!(local_echoes[0].transaction_id, txn1);
@@ -1373,7 +1382,8 @@ async fn test_abort_after_disable() {
     let report = errors.recv().await.unwrap();
     assert_eq!(report.room_id, room.room_id());
 
-    // The room updates will report the error, then the cancelled event, eventually.
+    // The room updates will report the error, then the cancelled event,
+    // eventually.
     assert_update!((global_watch, watch) => error { recoverable=true, });
 
     // The room queue has been disabled, but not the client wide one.
@@ -1464,7 +1474,8 @@ async fn test_abort_while_being_sent_and_fails() {
 
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -1489,8 +1500,8 @@ async fn test_abort_while_being_sent_and_fails() {
     // Let the background task start now.
     yield_now().await;
 
-    // While the item is being sent, the system remembers the intent to redact it
-    // later.
+    // While the item is being sent, the system remembers the intent to redact
+    // it later.
     assert!(handle.abort().await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn1 });
 
@@ -1502,8 +1513,8 @@ async fn test_abort_while_being_sent_and_fails() {
 
     assert!(watch.is_empty());
 
-    // Looking back at the local echoes will indicate a local echo for `it's never
-    // too late`.
+    // Looking back at the local echoes will indicate a local echo for `it's
+    // never too late`.
     let (local_echoes, _) = q.subscribe().await.unwrap();
     assert!(local_echoes.is_empty());
 }
@@ -1548,8 +1559,8 @@ async fn test_abort_with_reason_while_being_sent_then_sent() {
     // Let the background task pick the request up.
     sleep(Duration::from_millis(250)).await;
 
-    // While the item is being sent, the system remembers the intent to redact it
-    // later, along with the reason.
+    // While the item is being sent, the system remembers the intent to redact
+    // it later, along with the reason.
     assert!(handle.abort_with_reason(Some("changed my mind".to_owned())).await.unwrap());
     assert_update!((global_watch, watch) => cancelled { txn = txn });
 
@@ -1601,9 +1612,10 @@ async fn test_unrecoverable_errors() {
 
     mock.mock_room_state_encryption().plain().mount().await;
 
-    // Respond to the first /send with an unrecoverable error. The success mock for
-    // the second message is only mounted after the wedged message gets cancelled,
-    // so a request sneaking past the wedge fails loudly regardless of timing.
+    // Respond to the first /send with an unrecoverable error. The success mock
+    // for the second message is only mounted after the wedged message gets
+    // cancelled, so a request sneaking past the wedge fails loudly
+    // regardless of timing.
     mock.mock_room_send().error_too_large().mock_once().mount().await;
 
     // Queue two messages.
@@ -1624,17 +1636,17 @@ async fn test_unrecoverable_errors() {
     assert_eq!(report.room_id, room.room_id());
     assert!(!report.is_recoverable);
 
-    // The room updates will report the error for the first message as unrecoverable
-    // too.
+    // The room updates will report the error for the first message as
+    // unrecoverable too.
     assert_update!((global_watch, watch) => error { recoverable=false, txn=txn1 });
 
     // The permanent error disables the room send queue.
     assert!(!room.send_queue().is_enabled());
     room.send_queue().set_enabled(true);
 
-    // The second message is NOT sent: the wedged first message blocks the queue, so
-    // messages aren't sent out of order. Its success mock is only mounted below, so
-    // a request sneaking past the wedge fails loudly.
+    // The second message is NOT sent: the wedged first message blocks the
+    // queue, so messages aren't sent out of order. Its success mock is only
+    // mounted below, so a request sneaking past the wedge fails loudly.
     //
     // Cancelling the wedged message unblocks the queue.
     mock.mock_room_send().ok(event_id!("$42")).mock_once().mount().await;
@@ -1697,8 +1709,8 @@ async fn test_unwedge_unrecoverable_errors() {
     assert_eq!(report.room_id, room.room_id());
     assert!(!report.is_recoverable);
 
-    // The room updates will report the error for the first message as unrecoverable
-    // too.
+    // The room updates will report the error for the first message as
+    // unrecoverable too.
     assert_update!((global_watch, watch) => error { recoverable=false, txn=txn1 });
 
     // The queue is disabled, because it ran into an error.
@@ -1722,10 +1734,10 @@ async fn test_unwedge_unrecoverable_errors() {
 
 #[async_test]
 async fn test_no_network_access_error_is_recoverable() {
-    // This is subtle, but for the `drop(server)` below to be effectful, it needs to
-    // not be a pooled wiremock server (the default), which will keep the dropped
-    // server in a static. Using the line below will create a "bare" server,
-    // which is effectively dropped upon `drop()`.
+    // This is subtle, but for the `drop(server)` below to be effectful, it
+    // needs to not be a pooled wiremock server (the default), which will
+    // keep the dropped server in a static. Using the line below will create
+    // a "bare" server, which is effectively dropped upon `drop()`.
     let server = wiremock::MockServer::builder().start().await;
     let mock = MatrixMockServer::from_server(server);
     let client = mock.client_builder().build().await;
@@ -1734,8 +1746,8 @@ async fn test_no_network_access_error_is_recoverable() {
     let room_id = room_id!("!a:b.c");
     let room = mock.sync_joined_room(&client, room_id).await;
 
-    // Dropping the server: any subsequent attempt to connect mimics an unreachable
-    // server, which might be caused by missing network.
+    // Dropping the server: any subsequent attempt to connect mimics an
+    // unreachable server, which might be caused by missing network.
     drop(mock);
 
     let mut errors = client.send_queue().subscribe_errors();
@@ -1767,8 +1779,8 @@ async fn test_no_network_access_error_is_recoverable() {
     assert_eq!(report.room_id, room.room_id());
     assert!(report.is_recoverable);
 
-    // The room updates will report the error for the first message as recoverable
-    // too.
+    // The room updates will report the error for the first message as
+    // recoverable too.
     assert_update!((global_watch, watch) => error { recoverable=true, txn=txn1});
 
     // The room queue is disabled, because the error was recoverable.
@@ -1883,7 +1895,8 @@ async fn test_reactions() {
 
     mock.mock_room_send()
         .respond_with(move |_req: &Request| {
-            // Wait for the signal from the main thread that we can process this query.
+            // Wait for the signal from the main thread that we can process this
+            // query.
             let mock_lock = mock_lock.clone();
             let event_id = std::thread::spawn(move || {
                 tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -1904,8 +1917,8 @@ async fn test_reactions() {
         .mount()
         .await;
 
-    // Sending of the second emoji has started; abort it, it will result in a redact
-    // request.
+    // Sending of the second emoji has started; abort it, it will result in a
+    // redact request.
     mock.mock_room_redact().ok(event_id!("$3")).expect(1).mount().await;
 
     // Send a message.
@@ -1963,8 +1976,8 @@ async fn test_reactions() {
     let lock_guard = lock.lock().await;
     assert!(watch.is_empty());
 
-    // Abort sending of the second emoji. It was being sent, so it's first cancelled
-    // *then* sent and redacted.
+    // Abort sending of the second emoji. It was being sent, so it's first
+    // cancelled *then* sent and redacted.
     let aborted = emoji_handle2.abort().await.unwrap();
     assert!(aborted);
     assert_update!((global_watch, watch) => cancelled { txn = emoji2_txn });
@@ -1979,7 +1992,8 @@ async fn test_reactions() {
     // The final emoji is sent.
     assert_update!((global_watch, watch) => sent { txn = emoji3_txn, event_id = event_id!("$2") });
 
-    // Cancelling sending of the third emoji fails because it's been sent already.
+    // Cancelling sending of the third emoji fails because it's been sent
+    // already.
     assert!(emoji_handle3.abort().await.unwrap().not());
 
     assert!(watch.is_empty());
@@ -1994,8 +2008,8 @@ async fn test_redaction() {
     client.event_cache().subscribe().unwrap();
 
     let room_id = room_id!("!a:b.c");
-    // Create a non-empty room, so that the Event Cache is not empty, and we can see
-    // the Send Queue injecting events in the Event Cache.
+    // Create a non-empty room, so that the Event Cache is not empty, and we can
+    // see the Send Queue injecting events in the Event Cache.
     let room = server
         .sync_room(
             &client,
@@ -2235,7 +2249,8 @@ async fn test_media_uploads() {
     assert_eq!(tinfo.size, Some(uint!(42)));
     assert_eq!(tinfo.mimetype.as_deref(), Some("image/jpeg"));
 
-    // Check the thumbnail source: it should reference the send queue local storage.
+    // Check the thumbnail source: it should reference the send queue local
+    // storage.
     let local_thumbnail_source = info.thumbnail_source.unwrap();
     assert_let!(MediaSource::Plain(mxc) = &local_thumbnail_source);
     assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
@@ -2341,7 +2356,8 @@ async fn test_media_uploads() {
         .expect("media should be found");
     assert_eq!(thumbnail_media_as_thumbnail, b"thumbnail");
 
-    // The local URI for the thumbnail does not work anymore (it's been renamed).
+    // The local URI for the thumbnail does not work anymore (it's been
+    // renamed).
     client
         .media()
         .get_media_content(
@@ -2557,7 +2573,8 @@ async fn test_gallery_uploads() {
     assert_eq!(tinfo.size, Some(uint!(42)));
     assert_eq!(tinfo.mimetype.as_deref(), Some("image/jpeg"));
 
-    // Check the thumbnail source: it should reference the send queue local storage.
+    // Check the thumbnail source: it should reference the send queue local
+    // storage.
     let local_thumbnail_source1 = info.thumbnail_source.as_ref().unwrap();
     assert_let!(MediaSource::Plain(mxc) = &local_thumbnail_source1);
     assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
@@ -2615,7 +2632,8 @@ async fn test_gallery_uploads() {
     assert_eq!(tinfo.size, Some(uint!(44)));
     assert_eq!(tinfo.mimetype.as_deref(), Some("image/jpeg"));
 
-    // Check the thumbnail source: it should reference the send queue local storage.
+    // Check the thumbnail source: it should reference the send queue local
+    // storage.
     let local_thumbnail_source2 = info.thumbnail_source.as_ref().unwrap();
     assert_let!(MediaSource::Plain(mxc) = &local_thumbnail_source2);
     assert!(mxc.to_string().starts_with("mxc://send-queue.localhost/"), "{mxc}");
@@ -2962,8 +2980,8 @@ async fn test_media_upload_retry_with_520_http_status_code() {
     assert_let!(MessageType::Image(img_content) = content.msgtype);
     assert_eq!(img_content.body, filename);
 
-    // A 520 is a transient (recoverable) server error: let the upload stumble and
-    // the queue disable itself, keeping the request in the queue.
+    // A 520 is a transient (recoverable) server error: let the upload stumble
+    // and the queue disable itself, keeping the request in the queue.
     let error = assert_update!((global_watch, watch) => error { recoverable=true, txn=event_txn });
     let error = error.as_client_api_error().unwrap();
     assert_eq!(error.status_code, 520);
@@ -3017,8 +3035,8 @@ async fn test_unwedging_media_upload() {
     mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
-    // Fail for the first attempt with an error indicating the media's too large,
-    // wedging the upload.
+    // Fail for the first attempt with an error indicating the media's too
+    // large, wedging the upload.
     mock.mock_upload().error_too_large().mock_once().mount().await;
 
     // Send the media.
@@ -3031,8 +3049,8 @@ async fn test_unwedging_media_upload() {
     assert_let!(MessageType::Image(img_content) = content.msgtype);
     assert_eq!(img_content.body, filename);
 
-    // Although the actual error happens on the file upload transaction id, it must
-    // be reported with the *event* transaction id.
+    // Although the actual error happens on the file upload transaction id, it
+    // must be reported with the *event* transaction id.
     let error = assert_update!((global_watch, watch) => error { recoverable=false, txn=event_txn });
     let error = error.as_client_api_error().unwrap();
     assert_eq!(error.status_code, 413);
@@ -3093,7 +3111,8 @@ async fn test_wedged_gallery_upload_error_is_reflected_on_local_echo() {
     mock.mock_authenticated_media_config().ok_default().mount().await;
     mock.mock_room_state_encryption().plain().mount().await;
 
-    // The upload fails with an error indicating the media's too large, wedging it.
+    // The upload fails with an error indicating the media's too large, wedging
+    // it.
     mock.mock_upload().error_too_large().mock_once().mount().await;
 
     // Send a single-item gallery, without a thumbnail.
@@ -3112,14 +3131,15 @@ async fn test_wedged_gallery_upload_error_is_reflected_on_local_echo() {
     let (event_txn, _send_handle, _content) =
         assert_update!((global_watch, watch) => local echo event);
 
-    // Although the actual error happens on the file upload transaction id, it must
-    // be reported with the *event* transaction id.
+    // Although the actual error happens on the file upload transaction id, it
+    // must be reported with the *event* transaction id.
     let error = assert_update!((global_watch, watch) => error { recoverable=false, txn=event_txn });
     assert_eq!(error.as_client_api_error().unwrap().status_code, 413);
     assert!(!q.is_enabled());
 
-    // The wedged upload is reflected on the gallery event's local echo: a client
-    // restarting here must see the gallery as failed, not as still being sent.
+    // The wedged upload is reflected on the gallery event's local echo: a
+    // client restarting here must see the gallery as failed, not as still
+    // being sent.
     let (local_echoes, _) = q.subscribe().await.unwrap();
     assert_eq!(local_echoes.len(), 1);
     assert_let!(LocalEchoContent::Event { send_error, .. } = &local_echoes[0].content);
@@ -3169,8 +3189,8 @@ async fn abort_and_verify(
 
 #[async_test]
 async fn test_media_event_is_sent_in_order() {
-    // Test that despite happening in multiple requests, sending a media maintains
-    // the ordering.
+    // Test that despite happening in multiple requests, sending a media
+    // maintains the ordering.
     let mock = MatrixMockServer::new().await;
 
     // Mark the room as joined.
@@ -3336,8 +3356,9 @@ async fn test_cancel_upload_with_thumbnail_active() {
     mock.mock_room_state_encryption().plain().mount().await;
     mock.mock_room_send().ok(event_id!("$msg")).mock_once().mount().await;
 
-    // Have the thumbnail upload take forever and time out, if continued. This will
-    // be interrupted when aborting, so this will never have to complete.
+    // Have the thumbnail upload take forever and time out, if continued. This
+    // will be interrupted when aborting, so this will never have to
+    // complete.
     mock.mock_upload()
         .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(60)))
         .expect(1)
@@ -3547,8 +3568,8 @@ async fn test_cancel_upload_while_sending_event() {
         .mount()
         .await;
 
-    // Sending of the media event will take 1 second, so we can abort it while it's
-    // happening.
+    // Sending of the media event will take 1 second, so we can abort it while
+    // it's happening.
     mock.mock_room_send()
         .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(1)).set_body_json(
             json!({
@@ -3561,8 +3582,8 @@ async fn test_cancel_upload_while_sending_event() {
         .mount()
         .await;
 
-    // A redaction will happen because the abort happens after the event is getting
-    // sent.
+    // A redaction will happen because the abort happens after the event is
+    // getting sent.
     mock.mock_room_redact().ok(event_id!("$redaction")).mock_once().mount().await;
 
     // Send the media.
@@ -3604,8 +3625,8 @@ async fn test_cancel_upload_while_sending_event() {
         .await
         .unwrap_err();
 
-    // But it does contain the media with the remote URI, which hasn't been removed
-    // from the remote server.
+    // But it does contain the media with the remote URI, which hasn't been
+    // removed from the remote server.
     client
         .media()
         .get_media_content(
@@ -3976,8 +3997,8 @@ async fn test_update_caption_while_sending_media_event() {
         .mount()
         .await;
 
-    // The /event endpoint is used to retrieve the original event, during creation
-    // of the edit event.
+    // The /event endpoint is used to retrieve the original event, during
+    // creation of the edit event.
     mock.mock_room_event()
         .room(room_id)
         .ok(EventFactory::new()
@@ -4042,7 +4063,8 @@ async fn test_update_caption_while_sending_media_event() {
     sleep(Duration::from_secs(1)).await;
     assert_update!((global_watch, watch) => sent { txn = upload_txn, });
 
-    // Then the edit event is set, with another transaction id we don't know about.
+    // Then the edit event is set, with another transaction id we don't know
+    // about.
     assert_update!((global_watch, watch) => sent {});
 
     // That's all, folks!
@@ -4104,8 +4126,8 @@ async fn test_sending_reply_in_thread_auto_subscribe() {
     // Check the endpoints have been correctly called.
     server.server().reset().await;
 
-    // Now, if I send a message in a thread I've already subscribed to, in automatic
-    // mode, this promotes the subscription to manual.
+    // Now, if I send a message in a thread I've already subscribed to, in
+    // automatic mode, this promotes the subscription to manual.
 
     // Subscribed, automatically.
     server
@@ -4225,8 +4247,8 @@ async fn test_sending_event_still_saves_sync_gap() {
     assert_eq!(values.len(), 1);
     assert_eq!(values[0].event_id().unwrap(), event_id!("$msg_now"));
 
-    // Now, assume that a /sync response comes with only this message as part of the
-    // response, and with a previous gap.
+    // Now, assume that a /sync response comes with only this message as part of
+    // the response, and with a previous gap.
     server
         .mock_sync()
         .ok_and_run(&client, |builder| {
@@ -4239,16 +4261,16 @@ async fn test_sending_event_still_saves_sync_gap() {
         })
         .await;
 
-    // After syncing, since a gap was saved, the cache should unload the chunk and
-    // reload the latest one (that includes the remote-echo).
+    // After syncing, since a gap was saved, the cache should unload the chunk
+    // and reload the latest one (that includes the remote-echo).
     assert_let_timeout!(Ok(RoomEventCacheUpdate::UpdateTimelineEvents(update)) = stream.recv());
     assert_eq!(update.diffs.len(), 2);
     assert_let!(VectorDiff::Clear = &update.diffs[0]);
     assert_let!(VectorDiff::Append { values } = &update.diffs[1]);
     assert_eq!(values[0].event_id().unwrap(), event_id!("$msg_now"));
 
-    // When paginating with this previous batch token, we should get new events from
-    // this room.
+    // When paginating with this previous batch token, we should get new events
+    // from this room.
     server
         .mock_room_messages()
         .match_from("prev_batch")

--- a/crates/matrix-sdk/tests/integration/sync.rs
+++ b/crates/matrix-sdk/tests/integration/sync.rs
@@ -176,8 +176,8 @@ async fn test_receive_room_encryption_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -309,8 +309,8 @@ async fn test_receive_room_avatar_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -442,8 +442,8 @@ async fn test_receive_room_name_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -528,8 +528,8 @@ async fn test_receive_room_create_event_via_sync() {
         )
         .await;
 
-    // The room info didn't change because it never changes after being set, and the
-    // invalid state event is in the store.
+    // The room info didn't change because it never changes after being set, and
+    // the invalid state event is in the store.
     assert_eq!(room.create_content().unwrap().room_version, RoomVersionId::V12);
     assert_matches!(
         room.get_state_event_static::<RoomCreateEventContent>().await,
@@ -544,8 +544,8 @@ async fn test_receive_room_create_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_pending!(event_subscriber);
 
-    // We checked that the create content is immutable, now let us try again with a
-    // new room to see if the event would even be accepted.
+    // We checked that the create content is immutable, now let us try again
+    // with a new room to see if the event would even be accepted.
     let room_id = room_id!("!def");
     let room = server.sync_joined_room(&client, room_id).await;
 
@@ -617,8 +617,8 @@ async fn test_receive_room_create_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -752,8 +752,8 @@ async fn test_receive_room_history_visibility_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -838,8 +838,8 @@ async fn test_receive_room_guest_access_event_via_sync() {
         )
         .await;
 
-    // The room info reverted to the default and the invalid state event is in the
-    // store.
+    // The room info reverted to the default and the invalid state event is in
+    // the store.
     assert_eq!(room.guest_access(), GuestAccess::Forbidden);
     assert_matches!(
         room.get_state_event_static::<RoomGuestAccessEventContent>().await,
@@ -885,8 +885,8 @@ async fn test_receive_room_guest_access_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1018,8 +1018,8 @@ async fn test_receive_room_join_rules_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1155,8 +1155,8 @@ async fn test_receive_room_canonical_alias_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1289,8 +1289,8 @@ async fn test_receive_room_topic_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1429,8 +1429,8 @@ async fn test_receive_room_tombstone_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1562,8 +1562,8 @@ async fn test_receive_room_power_levels_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -1696,8 +1696,8 @@ async fn test_receive_room_pinned_events_event_via_sync() {
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_content.json().get());
     assert_matches!(raw_event.deserialize(), Err(_));
 
-    // We receive the raw event because the event handlers only care about the type,
-    // but not the deserialized one since it fails to deserialize.
+    // We receive the raw event because the event handlers only care about the
+    // type, but not the deserialized one since it fails to deserialize.
     let (raw_event, _) = assert_ready!(raw_event_subscriber);
     assert_eq!(raw_event.json().get(), raw_event_with_invalid_state_key.json().get());
     assert_pending!(event_subscriber);
@@ -2437,8 +2437,8 @@ async fn test_update_active_service_members() {
         )
         .await;
 
-    // We check the active human and service members: no service members and 2 human
-    // members
+    // We check the active human and service members: no service members and 2
+    // human members
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 2);
     assert_eq!(room.service_members().unwrap().len(), 2);
@@ -2457,8 +2457,8 @@ async fn test_update_active_service_members() {
         )
         .await;
 
-    // We check the active human and service members: 1 service member and 2 human
-    // members
+    // We check the active human and service members: 1 service member and 2
+    // human members
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);
@@ -2477,8 +2477,8 @@ async fn test_update_active_service_members() {
         )
         .await;
 
-    // We check the active human and service members: 2 service member and 2 human
-    // members The active service members match the member hints
+    // We check the active human and service members: 2 service member and 2
+    // human members The active service members match the member hints
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 4);
     assert_eq!(room.service_members().unwrap().len(), 2);
@@ -2500,8 +2500,8 @@ async fn test_update_active_service_members() {
         )
         .await;
 
-    // We check the active human and service members: 1 service member and 2 human
-    // members again
+    // We check the active human and service members: 1 service member and 2
+    // human members again
     let active_members = room.members_no_sync(RoomMemberships::ACTIVE).await.unwrap();
     assert_eq!(active_members.len(), 3);
     assert_eq!(room.service_members().unwrap().len(), 2);

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -206,9 +206,9 @@ async fn test_negotiate_capabilities_immediately() {
         let request_id = msg["requestId"].as_str().unwrap();
 
         // Let's send a request to get supported versions in the middle
-        // of a capabilities negotiation to ensure that we're not "deadlocked" by
-        // not processing messages while waiting for a reply from a widget to the
-        // the toWidget request.
+        // of a capabilities negotiation to ensure that we're not "deadlocked"
+        // by not processing messages while waiting for a reply from a
+        // widget to the the toWidget request.
         {
             send_request(
                 &driver_handle,
@@ -231,7 +231,8 @@ async fn test_negotiate_capabilities_immediately() {
     }
 
     {
-        // Receive a "request" with the capabilities we were actually granted (wtf?)
+        // Receive a "request" with the capabilities we were actually granted
+        // (wtf?)
         let msg = recv_message(&driver_handle).await;
         assert_eq!(msg["api"], "toWidget");
         assert_eq!(msg["action"], "notify_capabilities");
@@ -543,8 +544,8 @@ async fn test_receive_live_events() {
         })
         .await;
 
-    // The to device and room events are racing -> we dont know the order and just
-    // need to store them separately.
+    // The to device and room events are racing -> we dont know the order and
+    // just need to store them separately.
     let mut to_device: JsonObject = JsonObject::new();
     let mut events = vec![];
     for _ in 0..4 {
@@ -615,8 +616,8 @@ async fn test_block_clear_to_device_in_e2ee_room() {
         })
         .await;
 
-    // The message should be filtered out because it is not encrypted and the room
-    // is encrypted
+    // The message should be filtered out because it is not encrypted and the
+    // room is encrypted
     assert_matches!(recv_message(&driver_handle).now_or_never(), None);
 }
 
@@ -2109,8 +2110,9 @@ async fn test_get_rtc_transports_endpoint_unsupported() {
     )
     .await;
 
-    // The widget receives an error (as opposed to an empty list), so it can tell
-    // the endpoint apart from a homeserver that advertises no transports.
+    // The widget receives an error (as opposed to an empty list), so it can
+    // tell the endpoint apart from a homeserver that advertises no
+    // transports.
     let response = recv_message(&driver_handle).await;
     assert_eq!(response["api"], "fromWidget");
     assert_eq!(response["action"], "org.matrix.msc4515.get_rtc_transports");

--- a/examples/autojoin/src/main.rs
+++ b/examples/autojoin/src/main.rs
@@ -41,8 +41,8 @@ async fn login_and_sync(
     username: &str,
     password: &str,
 ) -> anyhow::Result<()> {
-    // Note that when encryption is enabled, you should use a persistent store to be
-    // able to restore the session with a working encryption setup.
+    // Note that when encryption is enabled, you should use a persistent store
+    // to be able to restore the session with a working encryption setup.
     // See the `persist_session` example.
     let client = Client::builder().homeserver_url(homeserver_url).build().await?;
 

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -33,8 +33,8 @@ async fn login_and_sync(
     username: String,
     password: String,
 ) -> anyhow::Result<()> {
-    // Note that when encryption is enabled, you should use a persistent store to be
-    // able to restore the session with a working encryption setup.
+    // Note that when encryption is enabled, you should use a persistent store
+    // to be able to restore the session with a working encryption setup.
     // See the `persist_session` example.
     let client = Client::builder().homeserver_url(homeserver_url).build().await.unwrap();
     client
@@ -48,8 +48,9 @@ async fn login_and_sync(
     // An initial sync to set up state and so our bot doesn't respond to old
     // messages.
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
-    // add our CommandBot to be notified of incoming messages, we do this after the
-    // initial sync to avoid responding to messages before the bot was running.
+    // add our CommandBot to be notified of incoming messages, we do this after
+    // the initial sync to avoid responding to messages before the bot was
+    // running.
     client.add_event_handler(on_room_message);
 
     // since we called `sync_once` before we entered our sync loop we must pass

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -173,8 +173,8 @@ async fn on_stripped_state_member(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // set up some simple stderr logging. You can configure it by changing the env
-    // var `RUST_LOG`
+    // set up some simple stderr logging. You can configure it by changing the
+    // env var `RUST_LOG`
     tracing_subscriber::fmt::init();
 
     // parse the command line for homeserver, username and password

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -27,8 +27,8 @@ use tokio::time::{Duration, sleep};
 /// an `async` function run.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // set up some simple stderr logging. You can configure it by changing the env
-    // var `RUST_LOG`
+    // set up some simple stderr logging. You can configure it by changing the
+    // env var `RUST_LOG`
     tracing_subscriber::fmt::init();
 
     // parse the command line for homeserver, username and password
@@ -53,8 +53,8 @@ async fn login_and_sync(
 ) -> anyhow::Result<()> {
     // First, we set up the client.
 
-    // Note that when encryption is enabled, you should use a persistent store to be
-    // able to restore the session with a working encryption setup.
+    // Note that when encryption is enabled, you should use a persistent store
+    // to be able to restore the session with a working encryption setup.
     // See the `persist_session` example.
     let client = Client::builder()
         // We use the convenient client builder to set our custom homeserver URL on it.
@@ -72,10 +72,11 @@ async fn login_and_sync(
     // It worked!
     println!("logged in as {username}");
 
-    // Now, we want our client to react to invites. Invites sent us stripped member
-    // state events so we want to react to them. We add the event handler before
-    // the sync, so this happens also for older messages. All rooms we've
-    // already entered won't have stripped states anymore and thus won't fire
+    // Now, we want our client to react to invites. Invites sent us stripped
+    // member state events so we want to react to them. We add the event
+    // handler before the sync, so this happens also for older messages. All
+    // rooms we've already entered won't have stripped states anymore and
+    // thus won't fire
     client.add_event_handler(on_stripped_state_member);
 
     // An initial sync to set up state and so our bot doesn't respond to old
@@ -83,8 +84,8 @@ async fn login_and_sync(
     // initial sync will be skipped in favor of loading state from the store
     let sync_token = client.sync_once(SyncSettings::default()).await.unwrap().next_batch;
 
-    // now that we've synced, let's attach a handler for incoming room messages, so
-    // we can react on it
+    // now that we've synced, let's attach a handler for incoming room messages,
+    // so we can react on it
     client.add_event_handler(on_room_message);
 
     // since we called `sync_once` before we entered our sync loop we must pass
@@ -141,15 +142,16 @@ async fn on_stripped_state_member(
 // rust-sdk to figure out which one to call and only do so, when the parameters
 // are available.
 async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
-    // First, we need to unpack the message: We only want messages from rooms we are
-    // still in and that are regular text messages - ignoring everything else.
+    // First, we need to unpack the message: We only want messages from rooms we
+    // are still in and that are regular text messages - ignoring everything
+    // else.
     if room.state() != RoomState::Joined {
         return;
     }
     let MessageType::Text(text_content) = event.content.msgtype else { return };
 
-    // here comes the actual "logic": when the bot see's a `!party` in the message,
-    // it responds
+    // here comes the actual "logic": when the bot see's a `!party` in the
+    // message, it responds
     if text_content.body.contains("!party") {
         let content = RoomMessageEventContent::text_plain("🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
 

--- a/examples/login/src/main.rs
+++ b/examples/login/src/main.rs
@@ -187,8 +187,8 @@ async fn login_with_sso(client: &Client, idp: Option<&IdentityProvider>) -> anyh
     println!("Logging in with SSO…");
 
     let mut login_builder = client.matrix_auth().login_sso(|url| async move {
-        // Usually we would want to use a library to open the URL in the browser, but
-        // let's keep it simple.
+        // Usually we would want to use a library to open the URL in the
+        // browser, but let's keep it simple.
         println!("\nOpen this URL in your browser: {url}\n");
         println!("Waiting for login token…");
         Ok(())

--- a/examples/oauth_cli/src/main.rs
+++ b/examples/oauth_cli/src/main.rs
@@ -146,8 +146,8 @@ impl OAuthCli {
                 && let OAuthError::ClientRegistration(OAuthClientRegistrationError::NotSupported) =
                     error
             {
-                // This would require to register with the authorization server manually, which
-                // we don't support here.
+                // This would require to register with the authorization server
+                // manually, which we don't support here.
                 bail!(
                     "This server doesn't support dynamic registration.\n\
                      Please select another homeserver."
@@ -158,8 +158,8 @@ impl OAuthCli {
         }
 
         // Persist the session to reuse it later.
-        // This is not very secure, for simplicity. If the system provides a way of
-        // storing secrets securely, it should be used instead.
+        // This is not very secure, for simplicity. If the system provides a way
+        // of storing secrets securely, it should be used instead.
         let full_session =
             cli.client.oauth().full_session().expect("A logged-in client should have a session");
 
@@ -184,9 +184,10 @@ impl OAuthCli {
 
         // We create a loop here so the user can retry if an error happens.
         loop {
-            // Here we spawn a server to listen on the loopback interface. Another option
-            // would be to register a custom URI scheme with the system and handle
-            // the redirect when the custom URI scheme is opened.
+            // Here we spawn a server to listen on the loopback interface.
+            // Another option would be to register a custom URI
+            // scheme with the system and handle the redirect when
+            // the custom URI scheme is opened.
             let (redirect_uri, server_handle) = LocalServerBuilder::new().spawn().await?;
 
             let OAuthAuthorizationData { url, .. } = oauth
@@ -407,9 +408,9 @@ impl OAuthCli {
     async fn watch(&self) -> anyhow::Result<()> {
         let client = &self.client;
 
-        // If this is a new client, ignore previous messages to not fill the logs.
-        // Note that this might not work as intended, the initial sync might have failed
-        // in a previous session.
+        // If this is a new client, ignore previous messages to not fill the
+        // logs. Note that this might not work as intended, the initial
+        // sync might have failed in a previous session.
         if !self.restored {
             client.sync_once(SyncSettings::default()).await.unwrap();
         }
@@ -442,13 +443,15 @@ impl OAuthCli {
 
         let sync_service_clone = sync_service.clone();
         let task = tokio::spawn(async move {
-            // Only fail after getting 5 errors in a row. When we're in an always-refail
-            // scenario, we move from the Error to the Running state for a bit
-            // until we fail again, so we need to track both failure state and
-            // running state, hence `num_errors` and `num_running`:
-            // - if we failed and num_running was 1, then this is a failure following a
-            //   failure.
-            // - otherwise, we recovered from the failure and we can plain continue.
+            // Only fail after getting 5 errors in a row. When we're in an
+            // always-refail scenario, we move from the Error to the
+            // Running state for a bit until we fail again, so we
+            // need to track both failure state and running state,
+            // hence `num_errors` and `num_running`:
+            // - if we failed and num_running was 1, then this is a failure
+            //   following a failure.
+            // - otherwise, we recovered from the failure and we can plain
+            //   continue.
 
             let mut num_errors = 0;
             let mut num_running = 0;
@@ -457,8 +460,8 @@ impl OAuthCli {
             let mut stdin = tokio::io::BufReader::new(tokio::io::stdin());
 
             loop {
-                // Concurrently wait for an update from the sync service OR for the user to
-                // press enter and leave early.
+                // Concurrently wait for an update from the sync service OR for
+                // the user to press enter and leave early.
                 tokio::select! {
                     res = sync_service_state.next() => {
                         if let Some(state) = res {
@@ -562,8 +565,9 @@ impl OAuthCli {
     async fn refresh_token(&self) -> anyhow::Result<()> {
         self.client.oauth().refresh_access_token().await?;
 
-        // The session will automatically be refreshed because of the task persisting
-        // the full session upon refresh in `setup_background_save`.
+        // The session will automatically be refreshed because of the task
+        // persisting the full session upon refresh in
+        // `setup_background_save`.
 
         println!("\nToken refreshed successfully");
 
@@ -641,7 +645,8 @@ async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)
                         } else {
                             println!("Error fetching the OAuth 2.0 server metadata: {error:?}");
                         }
-                        // The client already initialized the store so we need to remove it.
+                        // The client already initialized the store so we need
+                        // to remove it.
                         fs::remove_dir_all(data_dir).await?;
                     }
                 }
@@ -652,7 +657,8 @@ async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)
                 | ClientBuildError::Http(_) => {
                     println!("Error checking the homeserver: {error}");
                     println!("Please try again\n");
-                    // The client already initialized the store so we need to remove it.
+                    // The client already initialized the store so we need to
+                    // remove it.
                     fs::remove_dir_all(data_dir).await?;
                 }
                 ClientBuildError::InvalidServerName => {
@@ -660,7 +666,8 @@ async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)
                     println!("Please try again\n");
                 }
                 _ => {
-                    // Forward other errors, it's unlikely we can retry with a different outcome.
+                    // Forward other errors, it's unlikely we can retry with a
+                    // different outcome.
                     return Err(error.into());
                 }
             },

--- a/examples/persist_session/src/main.rs
+++ b/examples/persist_session/src/main.rs
@@ -151,11 +151,11 @@ async fn login(data_dir: &Path, session_file: &Path) -> anyhow::Result<Client> {
 
     println!("Session persisted in {}", session_file.to_string_lossy());
 
-    // After logging in, you might want to verify this session with another one (see
-    // the `emoji_verification` example), or bootstrap cross-signing if this is your
-    // first session with encryption, or if you need to reset cross-signing because
-    // you don't have access to your old sessions (see the
-    // `cross_signing_bootstrap` example).
+    // After logging in, you might want to verify this session with another one
+    // (see the `emoji_verification` example), or bootstrap cross-signing if
+    // this is your first session with encryption, or if you need to reset
+    // cross-signing because you don't have access to your old sessions (see
+    // the `cross_signing_bootstrap` example).
 
     Ok(client)
 }
@@ -164,9 +164,10 @@ async fn login(data_dir: &Path, session_file: &Path) -> anyhow::Result<Client> {
 async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)> {
     let mut rng = rng();
 
-    // Generating a subfolder for the database is not mandatory, but it is useful if
-    // you allow several clients to run at the same time. Each one must have a
-    // separate database, which is a different folder with the SQLite store.
+    // Generating a subfolder for the database is not mandatory, but it is
+    // useful if you allow several clients to run at the same time. Each one
+    // must have a separate database, which is a different folder with the
+    // SQLite store.
     let db_subfolder: String =
         (&mut rng).sample_iter(Alphanumeric).take(7).map(char::from).collect();
     let db_path = data_dir.join(db_subfolder);
@@ -203,7 +204,8 @@ async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession)
                     println!("Please try again\n");
                 }
                 _ => {
-                    // Forward other errors, it's unlikely we can retry with a different outcome.
+                    // Forward other errors, it's unlikely we can retry with a
+                    // different outcome.
                     return Err(error.into());
                 }
             },
@@ -227,8 +229,8 @@ async fn sync(
     let mut sync_settings = SyncSettings::default().filter(filter.into());
 
     // We restore the sync where we left.
-    // This is not necessary when not using `sync_once`. The other sync methods get
-    // the sync token from the store.
+    // This is not necessary when not using `sync_once`. The other sync methods
+    // get the sync token from the store.
     if let Some(sync_token) = initial_sync_token {
         sync_settings = sync_settings.token(sync_token);
     }
@@ -240,8 +242,8 @@ async fn sync(
     loop {
         match client.sync_once(sync_settings.clone()).await {
             Ok(response) => {
-                // This is the last time we need to provide this token, the sync method after
-                // will handle it on its own.
+                // This is the last time we need to provide this token, the sync
+                // method after will handle it on its own.
                 sync_settings = sync_settings.token(response.next_batch.clone());
                 persist_sync_token(session_file, response.next_batch).await?;
                 break;

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -35,8 +35,8 @@ struct Cli {
 }
 
 async fn login(cli: Cli) -> Result<Client> {
-    // Note that when encryption is enabled, you should use a persistent store to be
-    // able to restore the session with a working encryption setup.
+    // Note that when encryption is enabled, you should use a persistent store
+    // to be able to restore the session with a working encryption setup.
     // See the `persist_session` example.
     let mut builder = Client::builder().homeserver_url(cli.homeserver);
 

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -230,8 +230,8 @@ impl App {
             all_rooms,
         ));
 
-        // This will sync (with encryption) until an error happens or the program is
-        // stopped.
+        // This will sync (with encryption) until an error happens or the
+        // program is stopped.
         sync_service.start().await;
 
         let status = Status::new();
@@ -330,7 +330,8 @@ impl App {
                 let (items, stream) = timeline.subscribe().await;
                 let items = Arc::new(Mutex::new(items));
 
-                // Spawn a timeline task that will listen to all the timeline item changes.
+                // Spawn a timeline task that will listen to all the timeline
+                // item changes.
                 let i = items.clone();
                 let timeline_task = spawn(async move {
                     pin_mut!(stream);
@@ -831,7 +832,8 @@ impl App {
     async fn run(&mut self, terminal: DefaultTerminal) -> Result<()> {
         self.render_loop(terminal).await?;
 
-        // At this point the user has exited the loop, so shut down the application.
+        // At this point the user has exited the loop, so shut down the
+        // application.
         ratatui::restore();
         execute!(stdout(), DisableMouseCapture)?;
 
@@ -847,8 +849,8 @@ impl Widget for &mut App {
             Layout::vertical([Constraint::Length(2), Constraint::Min(0), Constraint::Length(1)]);
         let [header_area, rest_area, status_area] = vertical.areas(area);
 
-        // Create two chunks with equal horizontal screen space. One for the list and
-        // the other for the info block.
+        // Create two chunks with equal horizontal screen space. One for the
+        // list and the other for the info block.
         let horizontal =
             Layout::horizontal([Constraint::Percentage(25), Constraint::Percentage(75)]);
         let [room_list_area, room_view_area] = horizontal.areas(rest_area);

--- a/labs/multiverse/src/widgets/mod.rs
+++ b/labs/multiverse/src/widgets/mod.rs
@@ -31,10 +31,10 @@ impl WidgetRef for Hyperlink<'_> {
         (&self.text).render_ref(area, buffer);
 
         // this is a hacky workaround for https://github.com/ratatui-org/ratatui/issues/902, a bug
-        // in the terminal code that incorrectly calculates the width of ANSI escape
-        // sequences. It works by rendering the hyperlink as a series of
-        // 2-character chunks, which is the calculated width of the hyperlink
-        // text.
+        // in the terminal code that incorrectly calculates the width of ANSI
+        // escape sequences. It works by rendering the hyperlink as a
+        // series of 2-character chunks, which is the calculated width
+        // of the hyperlink text.
         for (i, two_chars) in self.text.to_string().chars().chunks(2).into_iter().enumerate() {
             let text = two_chars.collect::<String>();
             let hyperlink = format!("\x1B]8;;{}\x07{}\x1B]8;;\x07", self.url, text);

--- a/labs/multiverse/src/widgets/recovery/recovering.rs
+++ b/labs/multiverse/src/widgets/recovery/recovering.rs
@@ -241,7 +241,8 @@ impl RecoveringView {
                     }
                     (_, Esc) => Yes,
                     (_, Enter) => {
-                        // We expect a single line since pressing enter gets us here, still, let's
+                        // We expect a single line since pressing enter gets us
+                        // here, still, let's
                         // just join all the lines into a single one.
                         let recovery_key = recovery_text_area.lines().join("");
                         let client = self.client.clone();

--- a/labs/multiverse/src/widgets/room_list.rs
+++ b/labs/multiverse/src/widgets/room_list.rs
@@ -140,8 +140,8 @@ impl Widget for &mut RoomList {
     where
         Self: Sized,
     {
-        // We create two blocks, one is for the header (outer) and the other is for list
-        // (inner).
+        // We create two blocks, one is for the header (outer) and the other is
+        // for list (inner).
         let outer_block = Block::default()
             .borders(Borders::RIGHT)
             .border_set(symbols::border::THICK)
@@ -152,16 +152,16 @@ impl Widget for &mut RoomList {
         let inner_block =
             Block::default().borders(Borders::NONE).fg(TEXT_COLOR).bg(NORMAL_ROW_COLOR);
 
-        // We get the inner area from outer_block. We'll use this area later to render
-        // the table.
+        // We get the inner area from outer_block. We'll use this area later to
+        // render the table.
         let outer_area = area;
         let inner_area = outer_block.inner(outer_area);
 
         // We can render the header in outer_area.
         outer_block.render(outer_area, buf);
 
-        // Don't keep this lock too long by cloning the content. RAM's free these days,
-        // right?
+        // Don't keep this lock too long by cloning the content. RAM's free
+        // these days, right?
         let mut room_info = self.room_infos.lock().clone();
 
         // Iterate through all elements in the `items` and stylize them.
@@ -204,7 +204,8 @@ impl Widget for &mut RoomList {
             })
             .collect();
 
-        // Create a List from all list items and highlight the currently selected one.
+        // Create a List from all list items and highlight the currently
+        // selected one.
         let items = List::new(items)
             .block(inner_block)
             .highlight_style(

--- a/labs/multiverse/src/widgets/room_view/input.rs
+++ b/labs/multiverse/src/widgets/room_view/input.rs
@@ -52,10 +52,11 @@ impl Input {
         if let Some(input) = input.strip_prefix("/") {
             let arguments = input.split_whitespace();
 
-            // Clap expects the first argument to be the binary name, like when a command is
-            // invoked on the command line. Since we aren't a command line, but
-            // still find clap a neat command parser, let's give it what it
-            // expects so we can parse our commands.
+            // Clap expects the first argument to be the binary name, like when
+            // a command is invoked on the command line. Since we
+            // aren't a command line, but still find clap a neat
+            // command parser, let's give it what it expects so we
+            // can parse our commands.
             Cli::try_parse_from(std::iter::once("multiverse").chain(arguments))
                 .map(|cli| MessageOrCommand::Command(cli.command))
         } else {
@@ -89,10 +90,11 @@ impl<'a> StatefulWidget for &'a mut Input {
     where
         Self: Sized,
     {
-        // Set the placeholder text depending on the encryption state of the room.
+        // Set the placeholder text depending on the encryption state of the
+        // room.
         //
-        // We assume that the encryption state is synced because the RoomListService
-        // sets it as required state.
+        // We assume that the encryption state is synced because the
+        // RoomListService sets it as required state.
         if let Some(room) = room.as_deref() {
             let is_encrypted = room.encryption_state().is_encrypted();
 

--- a/labs/multiverse/src/widgets/room_view/timeline.rs
+++ b/labs/multiverse/src/widgets/room_view/timeline.rs
@@ -213,7 +213,8 @@ fn format_text_message(
         }
 
         if !read_receipts.is_empty() {
-            // Read by [5 first users who read it], optionally followed by "and X others".
+            // Read by [5 first users who read it], optionally followed by "and
+            // X others".
             let mut read_by = read_receipts
                 .iter()
                 .take(5)

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -206,7 +206,8 @@ impl TestClientBuilder {
             }
         };
 
-        // safe to assume we have not registered this user yet, but ignore if we did
+        // safe to assume we have not registered this user yet, but ignore if we
+        // did
 
         let auth = client.matrix_auth();
         let mut try_login = true;

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/mod.rs
@@ -154,8 +154,8 @@ async fn test_mutual_sas_verification_with_notification_client_ignores_verificat
         )
         .await;
 
-    // If the ignore_verification_events parameter is true in NotificationClient,
-    // no verification request should have been received
+    // If the ignore_verification_events parameter is true in
+    // NotificationClient, no verification request should have been received
     assert!(verification.is_none());
 
     Ok(())
@@ -729,8 +729,8 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
         assert!(found, "event has not been found for alice");
     }
 
-    // Bob wasn't aware of Carl's presence (no sync() since Carl joined), so Carl
-    // won't see it first.
+    // Bob wasn't aware of Carl's presence (no sync() since Carl joined), so
+    // Carl won't see it first.
     let carl_found_event = Arc::new(Mutex::new(false));
     {
         warn!("carl is looking for the decrypted message");
@@ -801,11 +801,11 @@ async fn test_failed_members_response() -> Result<()> {
 
     bob.sync_once().await?;
 
-    // Although we haven't joined the room yet, logic in `sync_members` looks at the
-    // room's visibility first; since it may be unknown for this room, from the
-    // point of view of Bob, it'll be assumed to be the default, aka shared. As
-    // a result, `sync_members()` doesn't even spawn a network request, and
-    // silently ignores the request.
+    // Although we haven't joined the room yet, logic in `sync_members` looks at
+    // the room's visibility first; since it may be unknown for this room,
+    // from the point of view of Bob, it'll be assumed to be the default,
+    // aka shared. As a result, `sync_members()` doesn't even spawn a
+    // network request, and silently ignores the request.
 
     let result = bob.get_room(alice_room.room_id()).unwrap().sync_members().await;
     assert!(result.is_ok());
@@ -964,8 +964,8 @@ pub(super) async fn assert_can_perform_interactive_verification(
 
     second_client.encryption().wait_for_e2ee_initialization_tasks().await;
 
-    // The second client doesn't have access to the backup, nor is recovery in the
-    // enabled state.
+    // The second client doesn't have access to the backup, nor is recovery in
+    // the enabled state.
     assert_eq!(second_client.encryption().recovery().state(), RecoveryState::Incomplete);
     assert_eq!(second_client.encryption().backups().state(), BackupState::Unknown);
 
@@ -981,10 +981,12 @@ pub(super) async fn assert_can_perform_interactive_verification(
         .await?
         .expect("We should have access to the first device once we have synced");
 
-    // The first client is not verified from the point of view of the second client.
+    // The first client is not verified from the point of view of the second
+    // client.
     assert!(!seconds_first_device.is_verified());
 
-    // Make the first client aware of the device we're requesting verification for
+    // Make the first client aware of the device we're requesting verification
+    // for
     first_client.sync_once().await?;
 
     // Let's send out a request to verify with each other.
@@ -1022,7 +1024,8 @@ pub(super) async fn assert_can_perform_interactive_verification(
 
     seconds_sas.accept().await?;
 
-    // We need to sync a couple of times so the clients exchange the shared secret.
+    // We need to sync a couple of times so the clients exchange the shared
+    // secret.
     first_client.sync_once().await?;
     second_client.sync_once().await?;
     first_client.sync_once().await?;
@@ -1037,8 +1040,8 @@ pub(super) async fn assert_can_perform_interactive_verification(
     firsts_sas.confirm().await?;
     seconds_sas.confirm().await?;
 
-    // After both sides confirm, we need a couple more syncs to exchange the final
-    // verification events.
+    // After both sides confirm, we need a couple more syncs to exchange the
+    // final verification events.
     second_client.sync_once().await?;
     first_client.sync_once().await?;
     second_client.sync_once().await?;
@@ -1066,9 +1069,9 @@ pub(super) async fn assert_can_perform_interactive_verification(
         "The recovery state should be in the Incomplete state, since we have not yet received all secrets"
     );
 
-    // We still need to gossip the secrets from one device to the other, the first
-    // device syncs to receive the gossip requests, then the second device syncs
-    // to receive the secrets.
+    // We still need to gossip the secrets from one device to the other, the
+    // first device syncs to receive the gossip requests, then the second
+    // device syncs to receive the secrets.
     first_client.sync_once().await?;
     warn!("The second client is doing its final sync");
     second_client.sync_once().await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/shared_history.rs
@@ -107,10 +107,10 @@ async fn test_history_share_on_invite_helper(exclude_insecure_devices: bool) -> 
     // Alice invites Bob to the room
     alice_room.invite_user_by_id(bob.user_id().unwrap()).await?;
 
-    // Alice is done. Bob has been invited and the room key bundle should have been
-    // sent out. Let's log her out, so we know that this feature works even when the
-    // sender device has been deleted (and to reduce the amount of noise in the
-    // logs).
+    // Alice is done. Bob has been invited and the room key bundle should have
+    // been sent out. Let's log her out, so we know that this feature works
+    // even when the sender device has been deleted (and to reduce the
+    // amount of noise in the logs).
     alice_sync_service.stop().await;
     alice.logout().instrument(alice_span.clone()).await?;
 
@@ -157,8 +157,8 @@ async fn test_history_share_on_invite_helper(exclude_insecure_devices: bool) -> 
         "The decrypted event should match the message Alice has sent"
     );
 
-    // We should be able to find the event using the high level timeline API, and
-    // inspect who forwarded us the keys to decrypt.
+    // We should be able to find the event using the high level timeline API,
+    // and inspect who forwarded us the keys to decrypt.
 
     let alice_id = alice.user_id().unwrap();
     let alice_display_name =
@@ -218,8 +218,8 @@ async fn test_history_share_on_invite_pin_violation() -> Result<()> {
     alice.encryption().wait_for_e2ee_initialization_tasks().await;
     alice_sync_service.start().await;
 
-    // Bob first creates a room so we can get hold of Alice's identity and verify
-    // it.
+    // Bob first creates a room so we can get hold of Alice's identity and
+    // verify it.
 
     let bob = TestClientBuilder::new("bob")
         .encryption_settings(encryption_settings)
@@ -243,8 +243,8 @@ async fn test_history_share_on_invite_pin_violation() -> Result<()> {
         .await?;
     bob_room.enable_encryption().await?;
 
-    // We invite Alice and try to send a message. This will force a /keys/query to
-    // fetch the identity.
+    // We invite Alice and try to send a message. This will force a /keys/query
+    // to fetch the identity.
     bob_room.invite_user_by_id(alice_user_id).await?;
     bob_room.send(RoomMessageEventContent::text_plain("Hello Alice")).await?;
 
@@ -298,8 +298,8 @@ async fn test_history_share_on_invite_pin_violation() -> Result<()> {
         .await
         .expect("We should be able to get the identity stream");
 
-    // Alice will reset her identity, once Bob sees that a reset happened, Bob will
-    // mark the identity to be in a pin violation.
+    // Alice will reset her identity, once Bob sees that a reset happened, Bob
+    // will mark the identity to be in a pin violation.
     info!("Alice is resetting the identity");
 
     let reset_future = async {
@@ -333,8 +333,8 @@ async fn test_history_share_on_invite_pin_violation() -> Result<()> {
     // Alice invites Bob to the room
     alice_room.invite_user_by_id(bob.user_id().unwrap()).instrument(alice_span.clone()).await?;
 
-    // Alice is done. Bob has been invited and the room key bundle should have been
-    // sent out. Let's stop syncing so the logs contain less noise.
+    // Alice is done. Bob has been invited and the room key bundle should have
+    // been sent out. Let's stop syncing so the logs contain less noise.
     alice_sync_service.stop().await;
 
     // Let's wait for the bundle to arrive.
@@ -555,8 +555,8 @@ async fn test_transitive_history_share_with_withhelds() -> Result<()> {
 
     let derek_timeline = derek_room.timeline().await?;
 
-    // As for Charlie: events 1 and 3 should be decryptable; 2 should be "history
-    // not shared".
+    // As for Charlie: events 1 and 3 should be decryptable; 2 should be
+    // "history not shared".
     derek.sync_once().instrument(derek_span.clone()).await?;
     assert_event_received(&derek_timeline, &event_id_1, "Event 1").await;
     assert_event_received(&derek_timeline, &event_id_3, "Event 3").await;
@@ -680,7 +680,8 @@ async fn test_history_sharing_session_merging() -> Result<()> {
         .expect("Bob should see Charlie in the room");
     let event_id_2 = bob_send_test_event("Event 2").await;
 
-    // 6. Charlie can now decrypt both of Bob's messages, with authenticated sender
+    // 6. Charlie can now decrypt both of Bob's messages, with authenticated
+    //    sender
     let mut charlie_room_stream = charlie.encryption().room_keys_received_stream().await.unwrap();
     charlie.sync_once().instrument(charlie_span.clone()).await?;
 
@@ -804,8 +805,8 @@ async fn test_history_share_on_invite_no_forwarder_info_for_normal_events() -> R
         "The decrypted event should match the message Alice has sent"
     );
 
-    // We should be able to find the event using the high level timeline API, and
-    // inspect who forwarded us the keys to decrypt.
+    // We should be able to find the event using the high level timeline API,
+    // and inspect who forwarded us the keys to decrypt.
 
     let alice_id = alice.user_id().unwrap();
     let alice_display_name =
@@ -833,8 +834,9 @@ async fn test_history_share_on_invite_no_forwarder_info_for_normal_events() -> R
         &alice_display_name
     );
 
-    // Alice sends a second message, which Bob should receive, but have no forwarder
-    // info for as it was sent as part of a session they already have.
+    // Alice sends a second message, which Bob should receive, but have no
+    // forwarder info for as it was sent as part of a session they already
+    // have.
 
     let event_id = alice_room
         .send(RoomMessageEventContent::text_plain("I said Hello, Bob"))
@@ -899,8 +901,8 @@ async fn test_history_share_on_invite_downloads_backup_keys() -> Result<()> {
     alice_a.logout().instrument(alice_a_span.clone()).await?;
     alice_b.sync_once().instrument(alice_b_span.clone()).await?;
 
-    // Alice attempts to decrypt the message on her second device, which should fail
-    // as she has not downloaded the key from her backup.
+    // Alice attempts to decrypt the message on her second device, which should
+    // fail as she has not downloaded the key from her backup.
     let alice_b_room = alice_b
         .get_room(&room_id)
         .expect("We should be able to fetch the room from Alice's second device");
@@ -929,8 +931,8 @@ async fn test_history_share_on_invite_downloads_backup_keys() -> Result<()> {
         .instrument(alice_b_span.clone())
         .await?;
 
-    // ... which should trigger a download from key backup, allowing her to decrypt
-    // the message.
+    // ... which should trigger a download from key backup, allowing her to
+    // decrypt the message.
 
     let alice_b_event = alice_b_room
         .event(&event_id, None)
@@ -1082,8 +1084,8 @@ async fn test_history_share_on_invite_respects_history_visibility() -> Result<()
         "Bob should be aware of the history visibility change before inviting Charlie"
     );
 
-    // Store Charlie's bundle stream before invite so we can check nothing arrives
-    // later.
+    // Store Charlie's bundle stream before invite so we can check nothing
+    // arrives later.
     let charlie_bundle_stream = charlie
         .encryption()
         .historic_room_key_stream()
@@ -1171,8 +1173,8 @@ async fn test_room_key_is_rotated_on_leave() -> Result<()> {
     // rotation.
     bob.sync_once().instrument(bob_span.clone()).await?;
 
-    // 5. Bob sends M2. Because key rotation should have been performed, this should
-    //    be using a fresh session that hasn't been shared with Charlie.
+    // 5. Bob sends M2. Because key rotation should have been performed, this
+    //    should be using a fresh session that hasn't been shared with Charlie.
     let (event_id_b, event_m2_session_id) = send_m2(&bob_room, &bob_span).await?;
 
     assert_ne!(event_m1_session_id, event_m2_session_id, "Session was not rotated");
@@ -1234,8 +1236,8 @@ async fn test_room_key_is_rotated_on_ban() -> Result<()> {
     // rotation.
     bob.sync_once().instrument(bob_span.clone()).await?;
 
-    // 5. Bob sends M2. Because key rotation should have been performed, this should
-    //    be using a fresh session that hasn't been shared with Charlie.
+    // 5. Bob sends M2. Because key rotation should have been performed, this
+    //    should be using a fresh session that hasn't been shared with Charlie.
     let (event_id_b, event_m2_session_id) = send_m2(&bob_room, &bob_span).await?;
 
     assert_ne!(event_m1_session_id, event_m2_session_id, "Session was not rotated");
@@ -1438,8 +1440,8 @@ async fn test_history_share_on_invite_room_key_rotation_with_shutdown() -> Resul
     // 5. Charlie leaves the room.
     charlie_room.leave().instrument(charlie_span.clone()).await?;
 
-    // 6. Bob starts back up, and syncs to learn about Charlie's departure, which
-    //    should trigger key rotation.
+    // 6. Bob starts back up, and syncs to learn about Charlie's departure,
+    //    which should trigger key rotation.
     let bob = SyncTokenAwareClient::new(
         TestClientBuilder::new("bob")
             .use_sqlite_dir(bob_sqlite_dir.path())
@@ -1457,8 +1459,8 @@ async fn test_history_share_on_invite_room_key_rotation_with_shutdown() -> Resul
 
     let bob_room = bob.join_room_by_id(alice_room.room_id()).instrument(bob_span.clone()).await?;
 
-    // 7. Bob sends M2. Because key rotation should have been performed, this should
-    //    be using a fresh session that hasn't been shared with Charlie.
+    // 7. Bob sends M2. Because key rotation should have been performed, this
+    //    should be using a fresh session that hasn't been shared with Charlie.
     let event_id_b = bob_room
         .send(RoomMessageEventContent::text_plain("Charlie is mean!"))
         .into_future()
@@ -1618,8 +1620,8 @@ async fn assert_utd_with_withheld_code(
         MsgLikeContent { kind: MsgLikeKind::UnableToDecrypt(encrypted), .. } = msg_like_content
     );
     assert_let!(EncryptedMessage::MegolmV1AesSha2 { cause, .. } = encrypted);
-    // It should be reported in the UI as a regular "You don't have access to this
-    // event".
+    // It should be reported in the UI as a regular "You don't have access to
+    // this event".
     assert_eq!(UtdCause::SentBeforeWeJoined, *cause);
 
     // The timeline interface doesn't expose the raw withheld code, so call

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/state_events.rs
@@ -89,8 +89,8 @@ async fn test_e2ee_state_events() -> Result<()> {
     // Alice invites Bob to the room
     alice_room.invite_user_by_id(bob.user_id().unwrap()).await?;
 
-    // Alice is done. Bob has been invited and the room key bundle should have been
-    // sent out. Let's stop syncing so the logs contain less noise.
+    // Alice is done. Bob has been invited and the room key bundle should have
+    // been sent out. Let's stop syncing so the logs contain less noise.
     alice_sync_service.stop().await;
 
     let bob_response = bob.sync_once().instrument(bob_span.clone()).await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee/x509.rs
@@ -24,7 +24,8 @@ async fn test_user_is_not_verified_if_their_msk_is_not_signed() -> anyhow::Resul
     // unverified.
     //
     // Alice has no X.509 key pair.
-    // Alice registers on the server. They do not sign the MSK with any X.509 key.
+    // Alice registers on the server. They do not sign the MSK with any X.509
+    // key.
     let alice = create_encryption_enabled_client("alice", None, None)
         .instrument(alice_span.clone())
         .await?;
@@ -33,8 +34,8 @@ async fn test_user_is_not_verified_if_their_msk_is_not_signed() -> anyhow::Resul
     let bob =
         create_encryption_enabled_client("bob", None, None).instrument(bob_span.clone()).await?;
 
-    // Bob sees Alice as untrusted because her MSK is not signed by a valid X.509
-    // key.
+    // Bob sees Alice as untrusted because her MSK is not signed by a valid
+    // X.509 key.
     let bobs_view_of_alice =
         bob.encryption().request_user_identity(alice.user_id().unwrap()).await?.unwrap();
 
@@ -65,8 +66,8 @@ async fn test_user_is_verified_if_their_msk_is_signed() -> anyhow::Result<()> {
             .unwrap(),
     );
 
-    // Alice registers on the server. As part of creating their user identity, they
-    // sign their MSK and upload the signature to the server.
+    // Alice registers on the server. As part of creating their user identity,
+    // they sign their MSK and upload the signature to the server.
     let alice =
         create_encryption_enabled_client(&alice_username, Some(alice_x509_signer.clone()), None)
             .instrument(alice_span.clone())
@@ -116,8 +117,8 @@ async fn test_user_is_not_verified_if_we_dont_trust_their_cert() -> anyhow::Resu
             .unwrap(),
     );
 
-    // Alice registers on the server. As part of creating their user identity, they
-    // sign their MSK and upload the signature to the server.
+    // Alice registers on the server. As part of creating their user identity,
+    // they sign their MSK and upload the signature to the server.
     let alice =
         create_encryption_enabled_client(&alice_username, Some(alice_x509_signer.clone()), None)
             .instrument(alice_span.clone())
@@ -261,9 +262,10 @@ pub(crate) fn subject_key_identifier_extension(
 
     use sha2::{Digest, Sha256};
 
-    // The actual bytes in the SKI don't actually matter that much (and the RFC just
-    // makes a couple of suggestions): they just need to be a reasonably
-    // unique way of referring to the certificate with the right public key.
+    // The actual bytes in the SKI don't actually matter that much (and the RFC
+    // just makes a couple of suggestions): they just need to be a
+    // reasonably unique way of referring to the certificate with the right
+    // public key.
     let spki = signing_key.subject_public_key_info();
     let spki_hash = Sha256::digest(&spki);
     let ski_bytes = &spki_hash.as_slice()[0..20];

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -67,8 +67,8 @@ async fn test_multiple_clients_share_crypto_state() -> Result<()> {
     // And given they are both in an encrypted room together
     let room_id = create_encrypted_room(&alice_main, &bob).await;
 
-    // And given both alices have an Olm session with bob (because they received a
-    // message from him)
+    // And given both alices have an Olm session with bob (because they received
+    // a message from him)
     {
         let _span = span!(Level::INFO, "msg1_from_bob").entered();
 
@@ -90,8 +90,8 @@ async fn test_multiple_clients_share_crypto_state() -> Result<()> {
     }
 
     // Then the NSE process can still receive messages from bob.
-    // (This means that the NSE process must have notice that its Olm machine was
-    // out-of-date and refreshed it from the DB.)
+    // (This means that the NSE process must have notice that its Olm machine
+    // was out-of-date and refreshed it from the DB.)
     {
         let _span = span!(Level::INFO, "msg3_from_bob").entered();
 
@@ -188,12 +188,14 @@ impl ClientWrapper {
         let encrypted_events_clone2 = encrypted_events.clone();
         let events_clone2 = events.clone();
         client.add_event_handler(|_ev: ToDeviceRoomKeyEvent, client: Client| async move {
-            // Whenever we received any room key, attempt to decrypt all existing encrypted
-            // events. This could be more efficient, but it does the job.
+            // Whenever we received any room key, attempt to decrypt all
+            // existing encrypted events. This could be more
+            // efficient, but it does the job.
             let evts = encrypted_events_clone2.lock().unwrap().clone();
             for (event, room_id) in evts.iter() {
                 if let Some((event_id, content)) = decrypt_event(&client, room_id, event).await {
-                    // If we did decrypt an event, remember it in our list of events we've seen
+                    // If we did decrypt an event, remember it in our list of
+                    // events we've seen
                     events_clone2.lock().unwrap().push((event_id, content));
                 }
             }
@@ -230,8 +232,8 @@ impl ClientWrapper {
 
             room.send_state_event(content).await.expect("Failed to send state event");
 
-            // Give the sync loop time to run, to be fairly sure the encryption event is
-            // received
+            // Give the sync loop time to run, to be fairly sure the encryption
+            // event is received
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -29,8 +29,8 @@ async fn test_repeated_join_leave() -> Result<()> {
         is_direct: true,
     });
 
-    // Sync after 1 second to so that create_room receives the event it is waiting
-    // for.
+    // Sync after 1 second to so that create_room receives the event it is
+    // waiting for.
     let peter_clone = peter.clone();
     spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -71,9 +71,10 @@ async fn test_repeated_join_leave() -> Result<()> {
         assert_eq!(*membership.membership(), MembershipState::Join);
         assert_eq!(room.state(), RoomState::Joined);
 
-        // Syncs can overwrite the internal state. If the sync lags behind because we
-        // change so often so fast, we can get errors in the asserts here. So we have to
-        // wait here a bit till the sync happened.
+        // Syncs can overwrite the internal state. If the sync lags behind
+        // because we change so often so fast, we can get errors in the
+        // asserts here. So we have to wait here a bit till the sync
+        // happened.
         room.sync_up().await;
 
         // Leave the room
@@ -96,8 +97,8 @@ async fn test_repeated_join_leave() -> Result<()> {
     // Stop the sync.
     join_handle.abort();
 
-    // Now check the underlying state store that it also has the correct information
-    // (for when the client restarts).
+    // Now check the underlying state store that it also has the correct
+    // information (for when the client restarts).
     let invited = karl.state_store().get_user_ids(room_id, RoomMemberships::INVITE).await?;
     assert_eq!(invited.len(), 1);
     assert_eq!(invited[0], karl_id);

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -284,8 +284,8 @@ async fn test_event_with_context() -> Result<()> {
         assert_event_matches_msg(&next_events[7], "19");
 
         {
-            // Synapse is pranking us here, pretending there might be other events
-            // afterwards.
+            // Synapse is pranking us here, pretending there might be other
+            // events afterwards.
             let next_messages = room
                 .messages(
                     MessagesOptions::forward().from(Some(next_messages.end.unwrap().as_str())),
@@ -462,7 +462,8 @@ async fn test_unread_counts_get_updated_after_decryption() -> TestResult {
         let send_result = bob_room.send(RoomMessageEventContent::text_plain("hi Alyx!")).await?;
         let original_event_id = send_result.response.event_id;
 
-        // Bob edits that message they sent, and adds intentional mentions in the edit.
+        // Bob edits that message they sent, and adds intentional mentions in
+        // the edit.
         let mentions = Mentions::with_user_ids([alice_user_id.to_owned()]);
         let send_edit_result = bob_room
             .send(
@@ -730,8 +731,8 @@ async fn test_latest_event_few_rooms() -> Result<()> {
     debug!("Running check for second client, room1");
     assert_latest_event_is_remote_event(&room1, &mut room1_sub, &room1_msg_event_id).await;
 
-    // Test passes if we uncomment this line, since more events will be fetched from
-    // the server and there will be a latest event update.
+    // Test passes if we uncomment this line, since more events will be fetched
+    // from the server and there will be a latest event update.
     room2.event_cache().await?.0.pagination().run_backwards_until(100).await?;
 
     //warn!("Subscribing to rooms on second client…");

--- a/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_privacy.rs
@@ -53,8 +53,8 @@ async fn test_publishing_room_alias() -> anyhow::Result<()> {
         }
     });
 
-    // The room can only be visible in the public room directory later if its join
-    // rule is one of  [public, knock, knock_restricted] or its history
+    // The room can only be visible in the public room directory later if its
+    // join rule is one of  [public, knock, knock_restricted] or its history
     // visibility is `world_readable`. Let's use this last option.
     let room_history_visibility = InitialRoomHistoryVisibilityEvent::with_empty_state_key(
         RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
@@ -105,7 +105,8 @@ async fn test_publishing_room_alias() -> anyhow::Result<()> {
         room.privacy_settings().publish_room_alias_in_room_directory(&alt_alias).await?;
     assert!(published);
 
-    // Since we only published the room alias, the canonical alias is not set yet
+    // Since we only published the room alias, the canonical alias is not set
+    // yet
     let canonical_alias = room.canonical_alias();
     assert!(canonical_alias.is_none());
 
@@ -149,7 +150,8 @@ async fn test_publishing_room_alias() -> anyhow::Result<()> {
     let room_visibility = room.privacy_settings().get_room_visibility().await?;
     assert_matches!(room_visibility, Visibility::Public);
 
-    // We can check again the public room directory and we should have some results
+    // We can check again the public room directory and we should have some
+    // results
     let results = client.public_rooms_filtered(public_rooms_request).await?.chunk;
     assert_eq!(results.len(), 1);
 
@@ -176,11 +178,11 @@ async fn test_removing_published_room_alias() -> anyhow::Result<()> {
     let raw_room_alias = format!("#{local_part_room_alias}:{server_name}");
     let room_alias = RoomAliasId::parse(raw_room_alias).expect("The room alias should be valid");
 
-    // The room can only be visible in the public room directory later if its join
-    // rule is one of  [public, knock, knock_restricted] or its history
+    // The room can only be visible in the public room directory later if its
+    // join rule is one of  [public, knock, knock_restricted] or its history
     // visibility is `world_readable`. Let's use this last option.
-    // This room will be created with a room alias and being visible in the public
-    // room directory.
+    // This room will be created with a room alias and being visible in the
+    // public room directory.
     let room_history_visibility = InitialRoomHistoryVisibilityEvent::with_empty_state_key(
         RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable),
     )

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -35,8 +35,8 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_notification() -> Result<()> {
-    // Create new users for each test run, to avoid conflicts with invites existing
-    // from previous runs.
+    // Create new users for each test run, to avoid conflicts with invites
+    // existing from previous runs.
     let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
@@ -118,7 +118,8 @@ async fn test_notification() -> Result<()> {
             NotificationClient::new(bob.clone(), process_setup.clone()).await.unwrap();
         let notification =
             notification_client.get_notification_with_context(&room_id, &event_id).await;
-        // We aren't authorized to inspect events from rooms we were not invited to.
+        // We aren't authorized to inspect events from rooms we were not invited
+        // to.
         assert!(matches!(notification.unwrap_err(), Error::SdkError(matrix_sdk::Error::Http(..))));
     } else {
         warn!("Couldn't get the invite event.");
@@ -175,8 +176,9 @@ async fn test_notification() -> Result<()> {
         if is_sliding_sync {
             assert_eq!(notification.joined_members_count, 2);
         } else {
-            // This can't be computed for /context, because we only get a single request,
-            // and not a full sync response that would contain a room summary.
+            // This can't be computed for /context, because we only get a single
+            // request, and not a full sync response that would
+            // contain a room summary.
             warn!("joined member counts: {}", notification.joined_members_count);
         }
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -202,8 +202,8 @@ async fn test_room_avatar_group_conversation() -> Result<()> {
     let alice_room = alice.get_room(alice_room.room_id()).unwrap();
     assert_eq!(alice_room.state(), RoomState::Joined);
 
-    // Here, there should be no avatar (group conversation and no avatar has been
-    // set in the room).
+    // Here, there should be no avatar (group conversation and no avatar has
+    // been set in the room).
     for _ in 0..3 {
         sleep(Duration::from_secs(1)).await;
         assert_eq!(alice_room.avatar_url(), None);
@@ -240,9 +240,9 @@ async fn test_room_avatar_group_conversation() -> Result<()> {
 
 #[tokio::test]
 async fn test_joined_user_can_create_push_context_with_room_list_service() -> Result<()> {
-    // This regression test for #3031 checks that we properly get the logged-in room
-    // member information, when connecting on the first time using the room
-    // list service.
+    // This regression test for #3031 checks that we properly get the logged-in
+    // room member information, when connecting on the first time using the
+    // room list service.
     //
     // Now the conditions to trigger this bug were quite precise:
     // - obviously we shouldn't have had any previous info about the logged-in
@@ -255,9 +255,9 @@ async fn test_joined_user_can_create_push_context_with_room_list_service() -> Re
     // One way to trigger this is to have a room we've joined, but in which we
     // haven't sent the last event.
     //
-    // Set this up, by creating a room, inviting another user, have the other user
-    // send a message, and fake a new "device" by creating another client for
-    // the same user.
+    // Set this up, by creating a room, inviting another user, have the other
+    // user send a message, and fake a new "device" by creating another
+    // client for the same user.
 
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
@@ -479,7 +479,8 @@ async fn test_room_notification_count() -> Result<()> {
     let mut update_observer = UpdateObserver::new(alice_room.subscribe_info());
 
     {
-        // At first, nothing has happened, so we shouldn't have any notifications.
+        // At first, nothing has happened, so we shouldn't have any
+        // notifications.
         assert_eq!(alice_room.num_unread_messages(), 0);
         assert_eq!(alice_room.num_unread_mentions(), 0);
         assert_eq!(alice_room.num_unread_notifications(), 0);
@@ -560,8 +561,9 @@ async fn test_room_notification_count() -> Result<()> {
         assert_eq!(alice_room.num_unread_notifications(), 0);
         assert_eq!(alice_room.num_unread_mentions(), 0);
 
-        // Sometimes the server is slow at realizing that the room has been marked as
-        // read, and zeroing the server-side notification_count.
+        // Sometimes the server is slow at realizing that the room has been
+        // marked as read, and zeroing the server-side
+        // notification_count.
         if alice_room.unread_notification_counts().notification_count == 2 {
             update_observer
                 .next()
@@ -685,9 +687,10 @@ impl wiremock::Respond for &CustomResponder {
             .headers(request.headers.clone())
             .body(request.body.clone());
 
-        // Run await inside of non-async fn by spawning a new thread and creating a new
-        // runtime. We need to do this because the current runtime can't run blocking
-        // tasks (hence can't run `Handle::block_on`).
+        // Run await inside of non-async fn by spawning a new thread and
+        // creating a new runtime. We need to do this because the
+        // current runtime can't run blocking tasks (hence can't run
+        // `Handle::block_on`).
         let drop_todevice = self.drop_todevice.clone();
 
         std::thread::spawn(move || {
@@ -765,8 +768,8 @@ async fn test_delayed_invite_response_and_sent_message_decryption() {
         .unwrap();
     alice_room.enable_encryption().await.unwrap();
 
-    // Initial message to make sure any lazy /members call is performed before the
-    // test actually starts
+    // Initial message to make sure any lazy /members call is performed before
+    // the test actually starts
     alice_room
         .send(RoomMessageEventContent::text_plain("dummy message to make members call"))
         .await
@@ -979,13 +982,13 @@ async fn test_room_preview() -> Result<()> {
     let room_id = room.room_id();
     let private_room_id = private_room.room_id();
 
-    // Wait for Alice's stream to stabilize (stop updating when we haven't received
-    // successful updates for more than 2 seconds).
+    // Wait for Alice's stream to stabilize (stop updating when we haven't
+    // received successful updates for more than 2 seconds).
     let stream = sliding_alice.sync();
     pin_mut!(stream);
 
-    // Wait for updates coming in under than 15 seconds. After that, we consider the
-    // sync as stable.
+    // Wait for updates coming in under than 15 seconds. After that, we consider
+    // the sync as stable.
     loop {
         match timeout(Duration::from_secs(15), stream.next()).await {
             Ok(None) | Err(_) => break,
@@ -999,8 +1002,8 @@ async fn test_room_preview() -> Result<()> {
     get_room_preview_with_room_summary(&alice, &bob, &room_alias, room_id, private_room_id).await;
 
     {
-        // Dummy test for `Client::get_room_preview` which may call one or the other
-        // methods.
+        // Dummy test for `Client::get_room_preview` which may call one or the
+        // other methods.
         info!("Alice gets a preview of the public room using any method");
         let preview = alice.get_room_preview(room_id.into(), Vec::new()).await?;
         assert_room_preview(&preview, &room_alias);
@@ -1138,16 +1141,16 @@ async fn get_room_preview_with_room_state(
     assert_eq!(preview.state, Some(RoomState::Joined));
     assert!(preview.heroes.is_some());
 
-    // Bob definitely doesn't know about the room, but they can get a preview of the
-    // room too.
+    // Bob definitely doesn't know about the room, but they can get a preview of
+    // the room too.
     info!("Bob gets a preview of the public room from state events");
     let preview = RoomPreview::from_state_events(bob, room_id).await.unwrap();
     assert_room_preview(&preview, room_alias);
     assert!(preview.state.is_none());
     assert!(preview.heroes.is_some());
 
-    // Bob can't preview the second room, because its history visibility is neither
-    // world-readable, nor have they joined the room before.
+    // Bob can't preview the second room, because its history visibility is
+    // neither world-readable, nor have they joined the room before.
     info!("Bob gets a preview of the private room from state events");
     let preview_result = RoomPreview::from_state_events(bob, public_no_history_room_id).await;
     assert_eq!(preview_result.unwrap_err().as_client_api_error().unwrap().status_code, 403);
@@ -1187,8 +1190,8 @@ async fn get_room_preview_with_room_summary(
     assert_eq!(preview.state, Some(RoomState::Joined));
     assert!(preview.heroes.is_some());
 
-    // Bob definitely doesn't know about the room, but they can get a preview of the
-    // room too.
+    // Bob definitely doesn't know about the room, but they can get a preview of
+    // the room too.
     info!("Bob gets a preview of the public room from msc3266 using the room id");
     let preview =
         RoomPreview::from_room_summary(bob, room_id.to_owned(), room_id.into(), Vec::new())
@@ -1198,8 +1201,8 @@ async fn get_room_preview_with_room_summary(
     assert!(preview.state.is_none());
     assert!(preview.heroes.is_none());
 
-    // Bob can preview the second room with the room summary (because its join rule
-    // is set to public, or because Alice is a member of that room).
+    // Bob can preview the second room with the room summary (because its join
+    // rule is set to public, or because Alice is a member of that room).
     info!("Bob gets a preview of the private room from msc3266 using the room id");
     let preview = RoomPreview::from_room_summary(
         bob,

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -208,9 +208,10 @@ async fn test_toggling_reaction() -> Result<()> {
             assert_matches!(reaction.status, ReactionStatus::LocalToRemote(..));
         }
 
-        // Remote echo is added twice: one from the Send Queue because the event is sent
-        // and inserted in the Event Cache and one from the Event Cache via the sync.
-        // The difference is it gets a read receipt, that's why we get a second update.
+        // Remote echo is added twice: one from the Send Queue because the event
+        // is sent and inserted in the Event Cache and one from the
+        // Event Cache via the sync. The difference is it gets a read
+        // receipt, that's why we get a second update.
         for timeline_update in timeline_updates.iter().skip(1) {
             let event = assert_event_is_updated!(timeline_update, event_id, message_position);
 
@@ -223,7 +224,8 @@ async fn test_toggling_reaction() -> Result<()> {
 
             // Remote event should have a timestamp <= than now.
             // Note: this can actually be equal because if the timestamp from
-            // server is not available, it might be created with a local call to `now()`
+            // server is not available, it might be created with a local call to
+            // `now()`
             assert!(reaction.timestamp <= MilliSecondsSinceUnixEpoch::now());
         }
 
@@ -295,8 +297,8 @@ async fn test_stale_local_echo_time_abort_edit() {
     let local_echo = assert_matches!(vector_diff, VectorDiff::PushBack { value } => value);
 
     if !local_echo.is_local_echo() {
-        // If the server raced and we've already received the remote echo, then this
-        // test is meaningless, so short-circuit and leave it.
+        // If the server raced and we've already received the remote echo, then
+        // this test is meaningless, so short-circuit and leave it.
         return;
     }
 
@@ -306,13 +308,13 @@ async fn test_stale_local_echo_time_abort_edit() {
 
     // It is then sent. The timeline stream can be racy here:
     //
-    // - either the local echo is marked as sent *before*, and we receive an update
-    //   for this before the remote echo.
+    // - either the local echo is marked as sent *before*, and we receive an
+    //   update for this before the remote echo.
     // - or the remote echo comes up faster.
     //
     // We collect all diffs but we no longer check them. This is tested by unit
-    // tests already, and testing that here is a bit more complex before of the racy
-    // situation.
+    // tests already, and testing that here is a bit more complex before of the
+    // racy situation.
     {
         let mut diffs = Vec::with_capacity(3);
 
@@ -425,8 +427,8 @@ async fn test_enabling_backups_retries_decryption() {
     // We don't need Alice anymore.
     alice_sync.abort();
 
-    // I know that this is Alice again, but it's the Alice's second device which she
-    // named Bob.
+    // I know that this is Alice again, but it's the Alice's second device which
+    // she named Bob.
     let bob = TestClientBuilder::with_exact_username(user_id.localpart().to_owned())
         .use_sqlite()
         .encryption_settings(encryption_settings)
@@ -456,8 +458,8 @@ async fn test_enabling_backups_retries_decryption() {
         .expect("We should be able to paginate the timeline to fetch the history");
 
     // Wait for the event cache and the timeline to do their job.
-    // Timeline triggers a pagination, that inserts events in the event cache, that
-    // then broadcasts new events into the timeline. All this is async.
+    // Timeline triggers a pagination, that inserts events in the event cache,
+    // that then broadcasts new events into the timeline. All this is async.
     sleep(Duration::from_millis(300)).await;
 
     let item =
@@ -466,16 +468,16 @@ async fn test_enabling_backups_retries_decryption() {
     // The event is not decrypted yet.
     assert!(item.content().is_unable_to_decrypt());
 
-    // We now connect to the backup which will not give us the room key right away,
-    // we first need to encounter a UTD to attempt the download.
+    // We now connect to the backup which will not give us the room key right
+    // away, we first need to encounter a UTD to attempt the download.
     bob.encryption()
         .recovery()
         .recover("Bomber's code")
         .await
         .expect("We should be able to recover from Bob's device");
 
-    // Let's subscribe to our timeline so we don't miss the transition from UTD to
-    // decrypted event.
+    // Let's subscribe to our timeline so we don't miss the transition from UTD
+    // to decrypted event.
     let (_, mut stream) = timeline
         .subscribe_filter_map(|item| {
             item.as_event().cloned().filter(|item| item.event_id() == Some(&event_id))
@@ -498,7 +500,8 @@ async fn test_enabling_backups_retries_decryption() {
         .await
         .expect("We should have downloaded the room key from the backup");
 
-    // Alright, we should now receive an update that the event had been decrypted.
+    // Alright, we should now receive an update that the event had been
+    // decrypted.
     let _vector_diff = timeout(Duration::from_secs(5), stream.next()).await.unwrap().unwrap();
 
     // Let's fetch the event again.
@@ -621,7 +624,8 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
         .await
         .expect("We should be able to load the room list");
 
-    // Let's stop the sync so we don't receive the room key using the usual channel.
+    // Let's stop the sync so we don't receive the room key using the usual
+    // channel.
     sync_service.stop().await;
 
     debug!("Alice sends the message");
@@ -653,8 +657,9 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
             .expect("We should be able to paginate the timeline to fetch the history");
 
         // Wait for the event cache and the timeline to do their job.
-        // Timeline triggers a pagination, that inserts events in the event cache, that
-        // then broadcasts new events into the timeline. All this is async.
+        // Timeline triggers a pagination, that inserts events in the event
+        // cache, that then broadcasts new events into the timeline. All
+        // this is async.
         sleep(Duration::from_millis(300)).await;
 
         if let Some(timeline_item) = timeline.item_by_event_id(&event_id).await {
@@ -670,8 +675,8 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
     // The event is not decrypted yet.
     assert!(item.content().is_unable_to_decrypt());
 
-    // Let's subscribe to our timeline so we don't miss the transition from UTD to
-    // decrypted event.
+    // Let's subscribe to our timeline so we don't miss the transition from UTD
+    // to decrypted event.
     let (_, mut stream) = timeline
         .subscribe_filter_map(|item| {
             item.as_event().cloned().filter(|item| item.event_id() == Some(&event_id))
@@ -700,7 +705,8 @@ async fn test_room_keys_received_on_notification_client_trigger_redecryption() {
         .await
         .expect("We should be able toe get a notification item for the given event");
 
-    // Alright, we should now receive an update that the event had been decrypted.
+    // Alright, we should now receive an update that the event had been
+    // decrypted.
     let _vector_diff = timeout(Duration::from_secs(10), stream.next()).await.unwrap().unwrap();
 
     // Let's fetch the event again.
@@ -891,8 +897,8 @@ async fn test_new_users_first_messages_dont_warn_about_insecure_device_if_it_is_
     let update2 = assert_next_with_timeout!(timeline_stream);
 
     {
-        // Then we updated the timeline to reflect the fact that the message is from a
-        // verified device.
+        // Then we updated the timeline to reflect the fact that the message is
+        // from a verified device.
         let messages = timeline_messages(&timeline).await;
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].content().as_message().unwrap().body(), "secret message");
@@ -992,8 +998,8 @@ async fn test_thread_focused_timeline() -> TestResult {
     assert_eq!(items[1].as_event().unwrap().event_id().unwrap(), thread_root);
     assert_eq!(items[2].as_event().unwrap().event_id().unwrap(), thread_reply_event_id);
 
-    // If Alice paginates backwards, nothing happens on the timeline, as we've hit
-    // the start in the /context response.
+    // If Alice paginates backwards, nothing happens on the timeline, as we've
+    // hit the start in the /context response.
     let hit_start = timeline.paginate_backwards(10).await?;
     assert!(hit_start);
 
@@ -1057,8 +1063,8 @@ async fn test_local_echo_to_send_event_has_encryption_info() -> TestResult {
     assert_matches!(local_echo.send_state(), Some(EventSendState::NotSentYet { progress: None }));
     assert_eq!(local_echo.content().as_message().unwrap().body(), "It's a secret to everybody");
 
-    // Now we receive an update from the send queue that the event is in the sent
-    // state.
+    // Now we receive an update from the send queue that the event is in the
+    // sent state.
     let vector_diff = timeout(Duration::from_secs(5), stream.next()).await?;
     let sent_event =
         assert_matches!(vector_diff, Some(VectorDiff::Set { index: 0, value }) => value);
@@ -1121,8 +1127,8 @@ async fn prepare_room_with_pinned_events(
     let timeline = room.timeline().await?;
     timeline.room().pin_event(&event_id).await?;
 
-    // Now send a bunch of normal events, this ensures that our pinned event isn't
-    // in the main timeline when we restore things.
+    // Now send a bunch of normal events, this ensures that our pinned event
+    // isn't in the main timeline when we restore things.
     for i in 0..number_of_normal_events {
         room.send(RoomMessageEventContent::text_plain(format!("Normal event {i}"))).await?;
     }
@@ -1172,8 +1178,8 @@ async fn test_pinned_events_are_decrypted_after_recovering_with_event_count(
     // We need to subscribe to the room, otherwise we won't request the
     // `m.room.pinned_events` state event.
     //
-    // Additionally if we subscribe to the room after we already synced, we won't
-    // receive the event, likely due to a Synapse bug.
+    // Additionally if we subscribe to the room after we already synced, we
+    // won't receive the event, likely due to a Synapse bug.
     sync_service.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service.start().await;
     another_alice.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -1224,8 +1230,8 @@ async fn test_pinned_events_are_decrypted_after_recovering_with_event_count(
     another_alice.encryption().recovery().recover(RECOVERY_PASSPHRASE).await?;
     assert_eq!(another_alice.encryption().recovery().state(), RecoveryState::Enabled);
 
-    // The next update for the timeline should replace the UTD item with a decrypted
-    // value.
+    // The next update for the timeline should replace the UTD item with a
+    // decrypted value.
     let next_item = assert_next_with_timeout!(stream, 5000);
 
     assert_let!(VectorDiff::Set { index: 0, value } = next_item);
@@ -1236,8 +1242,8 @@ async fn test_pinned_events_are_decrypted_after_recovering_with_event_count(
     let message = content.as_message().expect("The pinned event should be a message");
     assert_eq!(message.body(), "It's a secret to everybody");
 
-    // And we check that we don't have any more items in the timeline, the UTD item
-    // was indeed replaced.
+    // And we check that we don't have any more items in the timeline, the UTD
+    // item was indeed replaced.
     let items = pinned_timeline.items().await;
     assert_eq!(items.len(), 2);
 
@@ -1313,8 +1319,8 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
     // We need to subscribe to the room, otherwise we won't request the
     // `m.room.pinned_events` state event.
     //
-    // Additionally if we subscribe to the room after we already synced, we won't
-    // receive the event, likely due to a Synapse bug.
+    // Additionally if we subscribe to the room after we already synced, we
+    // won't receive the event, likely due to a Synapse bug.
     sync_service.room_list_service().set_room_subscriptions(&[&room_id]).await;
     sync_service.start().await;
     another_alice.encryption().wait_for_e2ee_initialization_tasks().await;
@@ -1364,8 +1370,8 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
     another_alice.encryption().recovery().recover(RECOVERY_PASSPHRASE).await?;
     assert_eq!(another_alice.encryption().recovery().state(), RecoveryState::Enabled);
 
-    // The next update for the timeline should replace the UTD item with a decrypted
-    // value.
+    // The next update for the timeline should replace the UTD item with a
+    // decrypted value.
     let next_item = assert_next_with_timeout!(stream, 5000);
 
     assert_let!(VectorDiff::Set { index: 0, value } = next_item);
@@ -1376,8 +1382,8 @@ async fn test_permalink_timelines_redecrypt() -> TestResult {
     let message = content.as_message().expect("The focused event should be a message");
     assert_eq!(message.body(), "It's a secret to everybody");
 
-    // And we check that we don't have any more items in the timeline, the UTD item
-    // was indeed replaced.
+    // And we check that we don't have any more items in the timeline, the UTD
+    // item was indeed replaced.
     let items = permalink_timeline.items().await;
     assert_eq!(items.len(), 3);
 
@@ -1495,8 +1501,8 @@ async fn test_latest_thread_event_is_redecrypted_and_updated() -> TestResult {
     alice2.encryption().recovery().recover(RECOVERY_PASSPHRASE).await?;
     assert_eq!(alice2.encryption().recovery().state(), RecoveryState::Enabled);
 
-    // The next update for the timeline should replace the UTD item with a decrypted
-    // value.
+    // The next update for the timeline should replace the UTD item with a
+    // decrypted value.
     let next_item = assert_next_with_timeout!(stream, 5000);
     assert_let!(VectorDiff::Set { index: 7, value } = next_item);
     assert_eq!(value.event_id(), Some(thread_root_event_id.as_ref()));
@@ -1627,8 +1633,8 @@ async fn test_send_message_updates() -> Result<()> {
     assert_let!(diffs = stream.next().await.unwrap());
     assert_eq!(diffs.len(), 4);
 
-    // FIXME: this is some "bouncing" behavior! The timeline should only trigger a
-    // single `Set` update for the sent event, here, ideally.
+    // FIXME: this is some "bouncing" behavior! The timeline should only trigger
+    // a single `Set` update for the sent event, here, ideally.
     {
         // Removal of the duplicate event.
         assert_let!(VectorDiff::Remove { index: 1 } = &diffs[0]);

--- a/testing/matrix-sdk-test-utils/src/lib.rs
+++ b/testing/matrix-sdk-test-utils/src/lib.rs
@@ -17,13 +17,14 @@ macro_rules! init_tracing_for_tests {
 
             tracing_subscriber::registry()
                 .with(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                    // Output is only printed for failing tests, but still we shouldn't overload
-                    // the output with unnecessary info. When debugging a specific test, it's easy
-                    // to override this default by setting the `RUST_LOG` environment variable.
+                    // Output is only printed for failing tests, but still we shouldn't
+                    // overload the output with unnecessary info. When
+                    // debugging a specific test, it's easy to override this
+                    // default by setting the `RUST_LOG` environment variable.
                     //
-                    // Since tracing_subscriber does prefix matching, the `matrix_sdk=` directive
-                    // takes effect for all the main crates (`matrix_sdk_base`, `matrix_sdk_crypto`
-                    // and so on).
+                    // Since tracing_subscriber does prefix matching, the `matrix_sdk=`
+                    // directive takes effect for all the main crates
+                    // (`matrix_sdk_base`, `matrix_sdk_crypto` and so on).
                     "info,matrix_sdk=debug".into()
                 }))
                 .with(tracing_subscriber::fmt::layer().with_test_writer())

--- a/testing/matrix-sdk-test/src/event_factory.rs
+++ b/testing/matrix-sdk-test/src/event_factory.rs
@@ -344,8 +344,8 @@ where
         let map = json.as_object_mut().unwrap();
 
         if self.format.has_sender() {
-            // Use the `sender` preferably, or resort to the `redacted_because` sender if
-            // none has been set.
+            // Use the `sender` preferably, or resort to the `redacted_because`
+            // sender if none has been set.
             let sender = self
                 .sender
                 .or_else(|| Some(self.unsigned.as_ref()?.redacted_because.as_ref()?.sender.clone())).expect("the sender must be known when building the JSON for a non read-receipt or global event");
@@ -367,10 +367,12 @@ where
 
         if self.format.has_event_id() && !self.no_event_id {
             let event_id = self.event_id.unwrap_or_else(|| {
-                // Compute a hash of the event to use it as the event ID, similar to how a
-                // server would. This is a little bit different since a server would redact the
-                // event before hashing, but at least the event ID construction will be
-                // deterministic and have the same format as in recent room versions.
+                // Compute a hash of the event to use it as the event ID,
+                // similar to how a server would. This is a
+                // little bit different since a server would redact the
+                // event before hashing, but at least the event ID construction
+                // will be deterministic and have the same
+                // format as in recent room versions.
                 let bytes = serde_json::to_vec(&map).unwrap();
                 EventId::new_v2_or_v3(&base64_sha256_hash(&bytes)).unwrap()
             });
@@ -1109,7 +1111,8 @@ impl EventFactory {
         &self,
         service_members: BTreeSet<OwnedUserId>,
     ) -> EventBuilder<MemberHintsEventContent> {
-        // The `m.member_hints` event always has an empty state key, so let's set it.
+        // The `m.member_hints` event always has an empty state key, so let's
+        // set it.
         self.event(MemberHintsEventContent::new(service_members)).state_key("")
     }
 
@@ -1201,7 +1204,8 @@ impl EventFactory {
         poll_question: impl Into<String>,
         answers: Vec<impl Into<String>>,
     ) -> EventBuilder<UnstablePollStartEventContent> {
-        // PollAnswers 'constructor' is not public, so we need to deserialize them
+        // PollAnswers 'constructor' is not public, so we need to deserialize
+        // them
         let answers: Vec<UnstablePollAnswer> = answers
             .into_iter()
             .enumerate()
@@ -1223,7 +1227,8 @@ impl EventFactory {
         poll_question: impl Into<String>,
         answers: Vec<impl Into<String>>,
     ) -> EventBuilder<ReplacementUnstablePollStartEventContent> {
-        // PollAnswers 'constructor' is not public, so we need to deserialize them
+        // PollAnswers 'constructor' is not public, so we need to deserialize
+        // them
         let answers: Vec<UnstablePollAnswer> = answers
             .into_iter()
             .enumerate()

--- a/testing/matrix-sdk-test/src/notification_settings/mod.rs
+++ b/testing/matrix-sdk-test/src/notification_settings/mod.rs
@@ -62,8 +62,8 @@ pub fn build_ruleset(rule_list: Vec<(RuleKind, &RoomId, bool)>) -> Ruleset {
 pub fn server_default_ruleset_with_legacy_mentions() -> Ruleset {
     let mut ruleset = get_server_default_ruleset();
 
-    // In the tests we don't care about the order, so we just add them to the end of
-    // the lists.
+    // In the tests we don't care about the order, so we just add them to the
+    // end of the lists.
     ruleset.content.insert(contains_user_name_push_rule());
     ruleset.override_.insert(contains_display_name_push_rule());
     ruleset.override_.insert(room_notif_push_rule());

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -135,9 +135,9 @@ impl KeyQueryResponseTemplate {
         self.self_signing_key = Some(self_signing_key);
         self.user_signing_key = Some(user_signing_key);
 
-        // For the master key, we build the CrossSigningKey object upfront, so that we
-        // can start to accumulate signatures. For the other keys, we generate
-        // the JSON representation on-demand.
+        // For the master key, we build the CrossSigningKey object upfront, so
+        // that we can start to accumulate signatures. For the other
+        // keys, we generate the JSON representation on-demand.
         self.master_cross_signing_key_json =
             Some(self.signed_cross_signing_key(&master_public_key, KeyUsage::Master));
 

--- a/xtask/src/log/overview.rs
+++ b/xtask/src/log/overview.rs
@@ -138,24 +138,25 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
             let mut tree_node = &mut tree;
 
             for target in full_target.split("::") {
-                tree_node =
-                    match tree_node.entry(target.to_owned()).or_insert_with(|| Target::Node {
+                tree_node = match tree_node.entry(target.to_owned()).or_insert_with(|| {
+                    Target::Node {
                         number_of_errors: 0,
                         number_of_warnings: 0,
                         node: TargetTree::default(),
-                    }) {
-                        Target::Leaf(_) => panic!("Expect a `Node`, not a `Leaf`"),
-                        Target::Node { number_of_errors, number_of_warnings, node } => {
-                            // Adjust number of specific log levels all the targets.
-                            match level {
-                                Level::Error => *number_of_errors += 1,
-                                Level::Warn => *number_of_warnings += 1,
-                                _ => (),
-                            }
-
-                            node
+                    }
+                }) {
+                    Target::Leaf(_) => panic!("Expect a `Node`, not a `Leaf`"),
+                    Target::Node { number_of_errors, number_of_warnings, node } => {
+                        // Adjust number of specific log levels all the targets.
+                        match level {
+                            Level::Error => *number_of_errors += 1,
+                            Level::Warn => *number_of_warnings += 1,
+                            _ => (),
                         }
-                    };
+
+                        node
+                    }
+                };
             }
 
             let span =

--- a/xtask/src/log/timer.rs
+++ b/xtask/src/log/timer.rs
@@ -122,8 +122,8 @@ pub(super) fn run(log_path: path::PathBuf, output_path: path::PathBuf) -> Result
                 .parse()
                 .expect("Failed to parse the `source_line`");
 
-            // Ensure we have parsed the duration correctly (in case Rust stdlib changes
-            // something).
+            // Ensure we have parsed the duration correctly (in case Rust stdlib
+            // changes something).
             assert_eq!(
                 duration_as_str,
                 format!("{duration:?}"),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,7 @@ use release::ReleaseArgs;
 use swift::SwiftArgs;
 use xshell::{Shell, cmd};
 
-const NIGHTLY: &str = "nightly-2026-07-18";
+const NIGHTLY: &str = "nightly-2026-09-07";
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -96,8 +96,8 @@ impl SwiftArgs {
                 watchos_deployment_target,
                 sequentially,
             } => {
-                // The dev profile seems to cause crashes on some platforms so we default to
-                // reldbg (https://github.com/matrix-org/matrix-rust-sdk/issues/4009)
+                // The dev profile seems to cause crashes on some platforms so
+                // we default to reldbg (https://github.com/matrix-org/matrix-rust-sdk/issues/4009)
                 let profile =
                     profile.as_deref().unwrap_or(if release { "small-release" } else { "reldbg" });
                 build_xcframework(
@@ -389,8 +389,9 @@ fn build_targets(
 ) -> Result<HashMap<Platform, Vec<Utf8PathBuf>>> {
     let sh = sh();
 
-    // Note: `push_env` stores environment variables and returns a RAII guard that
-    // will restore the environment variable to its previous value when dropped.
+    // Note: `push_env` stores environment variables and returns a RAII guard
+    // that will restore the environment variable to its previous value when
+    // dropped.
     let _env_guard1 =
         sh.push_env("CARGO_TARGET_AARCH64_APPLE_IOS_RUSTFLAGS", "-Clinker=/usr/bin/clang");
     let _env_guard2 = sh.push_env("AARCH64_APPLE_IOS_CC", "/usr/bin/clang");
@@ -443,8 +444,8 @@ fn build_targets(
         }
     }
 
-    // a hashmap of platform to array, where each array contains all the paths for
-    // that platform.
+    // a hashmap of platform to array, where each array contains all the paths
+    // for that platform.
     let mut platform_build_paths = HashMap::new();
     for target in targets {
         let path = build_path_for_target(target, profile)?;


### PR DESCRIPTION
With https://github.com/rust-lang/rustfmt/pull/6802, `rustfmt` updates many comments in the code. This patch is the result of `rustfmt **/*.rs`.

Reproducible with a nightly version of `rustfmt`.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
