### PR TITLE
fix(media): Ignore the requested format for local medias

### DIFF
--- a/crates/matrix-sdk/changelog.d/xxx.fixed.md
+++ b/crates/matrix-sdk/changelog.d/xxx.fixed.md
@@ -1,0 +1,4 @@
+Local medias (as in attachments pending in the send queue) are always cached 
+with `MediaFormat::File`, be it the file itself or its thumbnail, so requesting 
+one with `MediaFormat::Thumbnail` was failing since the format started being 
+taken into account.

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -436,6 +436,14 @@ impl Media {
         // This is a local media. Force to read the media's content from the store: it
         // cannot exist somewhere else!
         if Self::is_local_uri(&request.source) {
+            // Local medias are always cached with `MediaFormat::File`, be it the file
+            // itself or its thumbnail (see `RoomSendQueue::cache_media`), so ignore the
+            // requested format.
+            let request = &MediaRequestParameters {
+                source: request.source.clone(),
+                format: MediaFormat::File,
+            };
+
             if let Some(content) =
                 self.client.media_store().lock().await?.get_media_content(request).await?
             {

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -2253,6 +2253,23 @@ async fn test_media_uploads() {
         .expect("media should be found");
     assert_eq!(thumbnail_media, b"thumbnail");
 
+    // The format should be ignored when requesting a local media.
+    let thumbnail_media = client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters {
+                source: local_thumbnail_source.clone(),
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    tinfo.width.unwrap(),
+                    tinfo.height.unwrap(),
+                )),
+            },
+            true,
+        )
+        .await
+        .expect("media should be found");
+    assert_eq!(thumbnail_media, b"thumbnail");
+
     // ----------------------
     // Send handle operations.
 
@@ -2575,6 +2592,23 @@ async fn test_gallery_uploads() {
         .expect("media should be found");
     assert_eq!(thumbnail_media, b"thumbnail");
 
+    // The format should be ignored when requesting a local media.
+    let thumbnail_media = client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters {
+                source: local_thumbnail_source1.clone(),
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    tinfo.width.unwrap(),
+                    tinfo.height.unwrap(),
+                )),
+            },
+            true,
+        )
+        .await
+        .expect("media should be found");
+    assert_eq!(thumbnail_media, b"thumbnail");
+
     // ----------------------
     // Media 2.
     assert_let!(GalleryItemType::Image(img_content) = gallery_content.itemtypes.get(1).unwrap());
@@ -2626,6 +2660,23 @@ async fn test_gallery_uploads() {
             &MediaRequestParameters {
                 source: local_thumbnail_source2.clone(),
                 format: MediaFormat::File,
+            },
+            true,
+        )
+        .await
+        .expect("media should be found");
+    assert_eq!(thumbnail_media, b"another thumbnail");
+
+    // The format should be ignored when requesting a local media.
+    let thumbnail_media = client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters {
+                source: local_thumbnail_source2.clone(),
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    tinfo.width.unwrap(),
+                    tinfo.height.unwrap(),
+                )),
             },
             true,
         )


### PR DESCRIPTION
Local medias (as in attachments pending in the send queue) are always cached with `MediaFormat::File`, be it the file itself or its thumbnail, so requesting one with `MediaFormat::Thumbnail` was failing since the format started being taken into account.

Partially reverts fae5eb6ea22515fbaa2dba033b28f56b8c5ececd