### PR TITLE
chore: Lint `Cargo.toml` files

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -58,3 +58,6 @@ harness = false
 [[bench]]
 name = "room_list"
 harness = false
+
+[lints]
+workspace = true

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -79,7 +79,7 @@ if ! ${only_ios}; then
 fi
 
 # Generate uniffi files
-cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
+cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix-sdk-crypto-ffi generate \
   --language swift \
   --library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
   --out-dir ${GENERATED_DIR}

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -16,7 +16,7 @@ release = false
 crate-type = ["cdylib", "staticlib"]
 
 [[bin]]
-name = "matrix_sdk_crypto_ffi"
+name = "matrix-sdk-crypto-ffi"
 path = "uniffi-bindgen.rs"
 
 [features]

--- a/bindings/matrix-sdk-ffi-macros/Cargo.toml
+++ b/bindings/matrix-sdk-ffi-macros/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 description = "Helper macros to write FFI bindings"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "Apache-2.0"
 name = "matrix-sdk-ffi-macros"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.7.0"
@@ -20,8 +18,8 @@ proc-macro2 = { workspace = true , features = ["proc-macro"] }
 quote.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits", "proc-macro"] }
 
-[lints]
-workspace = true
-
 [package.metadata.release]
 release = false
+
+[lints]
+workspace = true

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -2,10 +2,8 @@
 name = "matrix-sdk-ffi"
 version = "0.18.0"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ffi"]
 license = "Apache-2.0"
-readme = "README.md"
 rust-version.workspace = true
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 publish = false

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "The base component to build a Matrix client library."
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 name = "matrix-sdk-base"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "Collection of common types and imports used in the matrix-sdk"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 name = "matrix-sdk-common"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "Matrix encryption library"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 name = "matrix-sdk-crypto"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
 version = "0.18.0"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -6,7 +6,6 @@ description = "Web's IndexedDB Storage backend for matrix-sdk"
 license = "Apache-2.0"
 edition = "2024"
 rust-version.workspace = true
-readme = "README.md"
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"] # Used in the indexed types, by the IndexedMediaContentData (aka media content).

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -4,10 +4,8 @@ description = "Library to encode and decode QR codes for interactive verificatio
 version = "0.18.0"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
-readme = "README.md"
 rust-version.workspace = true
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 

--- a/crates/matrix-sdk-search/Cargo.toml
+++ b/crates/matrix-sdk-search/Cargo.toml
@@ -2,10 +2,8 @@
 authors = ["Shrey Patel <shreyrg14@gmail.com>"]
 description = "The search component to build a Matrix client library."
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"
 name = "matrix-sdk-search"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "A high level Matrix client-server library."
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 name = "matrix-sdk"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -25,3 +25,6 @@ url.workspace = true
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 path = "../../crates/matrix-sdk"
+
+[lints]
+workspace = true

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["stoically <stoically@protonmail.com>"]
 description = "Helper macros to write tests for the Matrix SDK"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "Apache-2.0"
 name = "matrix-sdk-test-macros"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -2,11 +2,9 @@
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 description = "Helpers to write tests for the Matrix SDK"
 edition = "2024"
-homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "Apache-2.0"
 name = "matrix-sdk-test"
-readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version.workspace = true
 version = "0.18.0"

--- a/uniffi-bindgen/Cargo.toml
+++ b/uniffi-bindgen/Cargo.toml
@@ -11,3 +11,6 @@ release = false
 
 [dependencies]
 uniffi = { workspace = true, features = ["cli"] }
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,3 +26,6 @@ serde_json.workspace = true
 uniffi_bindgen.workspace = true
 url.workspace = true
 xshell = "0.2.2"
+
+[lints]
+workspace = true


### PR DESCRIPTION
This patch fixes the following lints:

- `cargo::redundant_homepage`: when the `repository` and `homepage` are the identical, we can have `repository` only,
- `cargo::manual_readme`: when the `readme` is `README.md`, we can skip it,
- `cargo::missing_lints_inheritance`: add `[lints] workspace = true` because it's better,
- `cargo::non_kebab_case_bins`: `-` instead of `_`in `bin.name`.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
