### PR TITLE
Event cache: Skip parsing events that have no bundled relations to strip

### DIFF
--- a/crates/matrix-sdk/changelog.d/7001.changed.md
+++ b/crates/matrix-sdk/changelog.d/7001.changed.md
@@ -1,4 +1,4 @@
 Events written to the event cache store are no longer deserialised in full to
-look for bundled relations to strip. The raw JSON is checked for the
-`m.relations` key first, and only the events that carry it are parsed. The
-stored events are unchanged.
+look for bundled relations to strip. Only the `unsigned` field is inspected
+first, and the event is parsed only when it carries `m.relations`. The stored
+events are unchanged.

--- a/crates/matrix-sdk/changelog.d/7001.changed.md
+++ b/crates/matrix-sdk/changelog.d/7001.changed.md
@@ -1,0 +1,4 @@
+Events written to the event cache store are no longer deserialised in full to
+look for bundled relations to strip. The raw JSON is checked for the
+`m.relations` key first, and only the events that carry it are parsed. The
+stored events are unchanged.

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -256,6 +256,12 @@ fn strip_relations_from_event(ev: &mut Event) {
 ///
 /// Only replaces the present if it contained bundled relations.
 fn strip_relations_if_present<T>(event: &mut Raw<T>) {
+    // Fast path: if the raw JSON does not even contain the key's text, there is
+    // nothing to strip and no need to parse anything.
+    if !event.json().get().contains("\"m.relations\"") {
+        return;
+    }
+
     // We're going to get rid of the `unsigned`/`m.relations` field, if it's
     // present.
     // Use a closure that returns an option so we can quickly short-circuit.

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -256,9 +256,11 @@ fn strip_relations_from_event(ev: &mut Event) {
 ///
 /// Only replaces the present if it contained bundled relations.
 fn strip_relations_if_present<T>(event: &mut Raw<T>) {
-    // Fast path: if the raw JSON does not even contain the key's text, there is
-    // nothing to strip and no need to parse anything.
-    if !event.json().get().contains("\"m.relations\"") {
+    // Most events carry no bundled relations. Look at the `unsigned` field alone
+    // before deserialising the whole event: `Raw::get_field` walks the JSON and
+    // only materialises that one field.
+    let unsigned = event.get_field::<serde_json::Map<String, serde_json::Value>>("unsigned");
+    if !matches!(&unsigned, Ok(Some(unsigned)) if unsigned.contains_key("m.relations")) {
         return;
     }
 

--- a/crates/matrix-sdk/src/event_cache/persistence.rs
+++ b/crates/matrix-sdk/src/event_cache/persistence.rs
@@ -411,3 +411,83 @@ pub async fn find_event_relations(
 
     Ok(related)
 }
+
+#[cfg(test)]
+mod tests {
+    use ruma::{events::AnySyncTimelineEvent, serde::Raw};
+    use serde_json::json;
+
+    use super::strip_relations_if_present;
+
+    #[test]
+    fn test_strip_relations_if_present_removes_only_the_bundled_relations() {
+        let mut event = Raw::<AnySyncTimelineEvent>::from_json_string(
+            json!({
+                "type": "m.room.message",
+                "event_id": "$ev0",
+                "sender": "@alice:example.org",
+                "origin_server_ts": 42,
+                "content": { "msgtype": "m.text", "body": "hey yo" },
+                "unsigned": {
+                    "age": 3,
+                    "m.relations": {
+                        "m.replace": {
+                            "type": "m.room.message",
+                            "event_id": "$ev1",
+                            "sender": "@alice:example.org",
+                            "origin_server_ts": 43,
+                            "content": {
+                                "msgtype": "m.text",
+                                "body": "* hey you",
+                                "m.new_content": { "msgtype": "m.text", "body": "hey you" },
+                                "m.relates_to": { "rel_type": "m.replace", "event_id": "$ev0" }
+                            }
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        strip_relations_if_present(&mut event);
+
+        let unsigned = event
+            .get_field::<serde_json::Map<String, serde_json::Value>>("unsigned")
+            .unwrap()
+            .unwrap();
+        assert_eq!(unsigned.get("age"), Some(&json!(3)));
+        assert!(!unsigned.contains_key("m.relations"));
+    }
+
+    #[test]
+    fn test_strip_relations_if_present_leaves_other_events_untouched() {
+        let without_unsigned = json!({
+            "type": "m.room.message",
+            "event_id": "$ev0",
+            "sender": "@alice:example.org",
+            "origin_server_ts": 42,
+            "content": { "msgtype": "m.text", "body": "hey yo" },
+        });
+
+        let mut with_unsigned = without_unsigned.clone();
+        with_unsigned["unsigned"] = json!({ "age": 3 });
+
+        let mut not_an_object = without_unsigned.clone();
+        not_an_object["unsigned"] = json!("nope");
+
+        // The key's text can show up somewhere else than as an `unsigned` key.
+        let mut mentioned_in_body = without_unsigned.clone();
+        mentioned_in_body["content"]["body"] = json!("look for \"m.relations\" in unsigned");
+
+        for value in [without_unsigned, with_unsigned, not_an_object, mentioned_in_body] {
+            let json = value.to_string();
+            let mut event = Raw::<AnySyncTimelineEvent>::from_json_string(json.clone()).unwrap();
+
+            strip_relations_if_present(&mut event);
+
+            // The raw JSON is left as is, byte for byte.
+            assert_eq!(event.json().get(), json);
+        }
+    }
+}


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Bundled relations are stripped from every event before it is written to the event cache store: consumers must ask for relations explicitly, so a cached bundle would only go stale. `strip_relations_if_present` did this by deserialising every event into a `serde_json::Value`, just to find out, for the vast majority of events, that there was nothing to strip.

This PR looks at the `unsigned` field alone first, with `Raw::get_field`, which walks the JSON and only materialises that one field. The full parse happens only for events that do carry `m.relations`. The stored result is unchanged: the early return covers exactly the cases in which the old code left the event untouched.

The first commit adds direct unit tests for the function. They pass on `main` as well and pin down that the rest of `unsigned` is kept and that events without bundled relations are left byte for byte untouched.

## Measurements

`handle_room_updates` from `benchmarks/benches/event_cache.rs`, memory store, one room with 1000 events per iteration, medians of criterion's 10 samples:

| events | before | after |
|---|---|---|
| stock bench events (no `unsigned`) | 2.81 ms | 2.54 ms |
| every event with an `unsigned` block (`.age(1234)` added locally) | 3.16 ms | 2.77 ms |

`cargo bench -p benchmarks --bench event_cache -- "memory.*room count: 1$"`

The SQLite variant of the same bench stays within noise (about 9 ms per iteration), as the store I/O dominates there.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
