### PR TITLE
chore(sdk): Replace `async-channel` by `tokio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,18 +250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compat"
 version = "0.2.5"
 source = "git+https://github.com/element-hq/async-compat?rev=5a27c8b290f1f1dcfc0c4ec22c464e38528aa591#5a27c8b290f1f1dcfc0c4ec22c464e38528aa591"
@@ -1064,15 +1052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,16 +1817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
  "pin-project-lite",
 ]
 
@@ -3531,7 +3500,6 @@ dependencies = [
  "assert-json-diff",
  "assert_matches",
  "assert_matches2",
- "async-channel",
  "async-stream",
  "async-trait",
  "axum",

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -308,11 +308,11 @@ impl WidgetDriverHandle {
         self.0.recv().await
     }
 
-    //// Send a message from the widget to the widget driver.
+    /// Send a message from the widget to the widget driver.
     ///
     /// Returns `false` if the widget driver is no longer running.
-    pub async fn send(&self, msg: String) -> bool {
-        self.0.send(msg).await
+    pub fn send(&self, msg: String) -> bool {
+        self.0.send(msg)
     }
 }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -82,12 +82,7 @@ federation-api = ["ruma/federation-api-c"]
 
 uniffi = ["dep:uniffi", "matrix-sdk-base/uniffi", "dep:matrix-sdk-ffi-macros"]
 
-experimental-widgets = [
-    "dep:async-channel",
-    "dep:urlencoding",
-    "dep:uuid",
-    "experimental-send-custom-to-device",
-]
+experimental-widgets = ["dep:urlencoding", "dep:uuid", "experimental-send-custom-to-device"]
 
 docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "federation-api"]
 
@@ -108,7 +103,6 @@ anyhow = { workspace = true, optional = true }
 anymap2 = { version = "0.13.0", default-features = false }
 as_variant.workspace = true
 assert_matches2 = { workspace = true, optional = true }
-async-channel = { version = "2.5.0", optional = true }
 async-stream.workspace = true
 async-trait.workspace = true
 axum = { version = "0.8.9", optional = true }

--- a/crates/matrix-sdk/src/widget/README.md
+++ b/crates/matrix-sdk/src/widget/README.md
@@ -206,6 +206,7 @@ To use this module, two structs are needed:
 ```rust
 # async {
 use matrix_sdk::widget::{Capabilities, CapabilitiesProvider, WidgetSettings, WidgetDriver};
+use std::sync::Arc;
 use tokio::spawn;
 use url::Url;
 
@@ -233,6 +234,7 @@ let widget_settings = WidgetSettings::new(
 
 // Create the required structs:
 let (driver, handle) = WidgetDriver::new(widget_settings);
+let handle = Arc::new(handle);
 let cap_provider = CapProv {};
 
 mod my_platform {
@@ -247,7 +249,7 @@ spawn({
     async move {
         loop {
             let message = my_platform::receive_post_message().await;
-            h.send(message).await;
+            h.send(message);
         }
     }
 });

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -17,12 +17,14 @@
 
 use std::{fmt, time::Duration};
 
-use async_channel::{Receiver, Sender};
 use futures_util::StreamExt;
 use matrix_sdk_common::executor::spawn;
 use ruma::api::client::delayed_events::DelayParameters;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
-use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+use tokio::sync::{
+    Mutex,
+    mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::{CancellationToken, DropGuard};
 
@@ -59,13 +61,13 @@ pub struct WidgetDriver {
     /// Raw incoming messages from the widget (normally formatted as JSON).
     ///
     /// These can be both requests and responses.
-    from_widget_rx: Receiver<String>,
+    from_widget_rx: UnboundedReceiver<String>,
 
     /// Raw outgoing messages from the client (SDK) to the widget (normally
     /// formatted as JSON).
     ///
     /// These can be both requests and responses.
-    to_widget_tx: Sender<String>,
+    to_widget_tx: UnboundedSender<String>,
 
     /// Drop guard for an event handler forwarding all events from the Matrix
     /// room to the widget.
@@ -76,7 +78,7 @@ pub struct WidgetDriver {
 
 /// A handle that encapsulates the communication between a widget driver and the
 /// corresponding widget (inside a webview or iframe).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WidgetDriverHandle {
     /// Raw incoming messages from the widget driver to the widget (normally
     /// formatted as JSON).
@@ -84,7 +86,7 @@ pub struct WidgetDriverHandle {
     /// These can be both requests and responses. Users of this API should not
     /// care what's what though because they are only supposed to forward
     /// messages between the webview / iframe, and the SDK's widget driver.
-    to_widget_rx: Receiver<String>,
+    to_widget_rx: Mutex<UnboundedReceiver<String>>,
 
     /// Raw outgoing messages from the widget to the widget driver (normally
     /// formatted as JSON).
@@ -92,7 +94,7 @@ pub struct WidgetDriverHandle {
     /// These can be both requests and responses. Users of this API should not
     /// care what's what though because they are only supposed to forward
     /// messages between the webview / iframe, and the SDK's widget driver.
-    from_widget_tx: Sender<String>,
+    from_widget_tx: UnboundedSender<String>,
 }
 
 impl WidgetDriverHandle {
@@ -101,15 +103,22 @@ impl WidgetDriverHandle {
     /// The message must be passed on to the widget.
     ///
     /// Returns `None` if the widget driver is no longer running.
+    ///
+    /// Despite this method takes a shared reference to `self` with `&self`,
+    /// there is an inner lock around the receiver. They can be only one
+    /// receiver at a time. Be aware if `recv` is waiting in a loop for example.
+    /// This design addresses one particular need where `WidgetDriverHandle`
+    /// lives inside an `Arc` to be cloned and passed in 2 tasks: one calling
+    /// `send`, one calling `recv`. In that case, there is no conflict.
     pub async fn recv(&self) -> Option<String> {
-        self.to_widget_rx.recv().await.ok()
+        self.to_widget_rx.lock().await.recv().await
     }
 
     /// Send a message from the widget to the widget driver.
     ///
     /// Returns `false` if the widget driver is no longer running.
-    pub async fn send(&self, message: String) -> bool {
-        self.from_widget_tx.send(message).await.is_ok()
+    pub fn send(&self, message: String) -> bool {
+        self.from_widget_tx.send(message).is_ok()
     }
 }
 
@@ -117,11 +126,12 @@ impl WidgetDriver {
     /// Creates a new `WidgetDriver` and a corresponding set of channels to let
     /// the widget (inside a webview or iframe) communicate with it.
     pub fn new(settings: WidgetSettings) -> (Self, WidgetDriverHandle) {
-        let (from_widget_tx, from_widget_rx) = async_channel::unbounded();
-        let (to_widget_tx, to_widget_rx) = async_channel::unbounded();
+        let (from_widget_tx, from_widget_rx) = unbounded_channel();
+        let (to_widget_tx, to_widget_rx) = unbounded_channel();
 
         let driver = Self { settings, from_widget_rx, to_widget_tx, event_forwarding_guard: None };
-        let channels = WidgetDriverHandle { from_widget_tx, to_widget_rx };
+        let channels =
+            WidgetDriverHandle { from_widget_tx, to_widget_rx: Mutex::new(to_widget_rx) };
 
         (driver, channels)
     }
@@ -132,7 +142,7 @@ impl WidgetDriver {
     /// error occurs.
     #[expect(clippy::result_unit_err)]
     pub async fn run(
-        mut self,
+        self,
         room: Room,
         capabilities_provider: impl CapabilitiesProvider,
     ) -> Result<(), ()> {
@@ -152,10 +162,10 @@ impl WidgetDriver {
         // the task.
         spawn({
             let incoming_msg_tx = incoming_msg_tx.clone();
-            let from_widget_rx = self.from_widget_rx.clone();
+            let mut from_widget_rx = self.from_widget_rx;
 
             async move {
-                while let Ok(msg) = from_widget_rx.recv().await {
+                while let Some(msg) = from_widget_rx.recv().await {
                     let _ = incoming_msg_tx.send(IncomingMessage::WidgetMessage(msg));
                 }
             }
@@ -179,10 +189,20 @@ impl WidgetDriver {
         // Let's combine our set of initial actions with the stream of received actions.
         let mut combined = tokio_stream::iter(initial_actions).chain(stream);
 
+        let to_widget_tx = self.to_widget_tx;
+        let mut event_forwarding_guard = self.event_forwarding_guard;
+
         // Let's now process all actions we receive forever.
         while let Some(action) = combined.next().await {
-            self.process_action(&matrix_driver, &incoming_msg_tx, &capabilities_provider, action)
-                .await?;
+            Self::process_action(
+                &to_widget_tx,
+                &mut event_forwarding_guard,
+                &matrix_driver,
+                &incoming_msg_tx,
+                &capabilities_provider,
+                action,
+            )
+            .await?;
         }
 
         Ok(())
@@ -190,7 +210,8 @@ impl WidgetDriver {
 
     /// Process a single [`Action`].
     async fn process_action(
-        &mut self,
+        to_widget_tx: &UnboundedSender<String>,
+        event_forwarding_guard: &mut Option<DropGuard>,
         matrix_driver: &MatrixDriver,
         incoming_msg_tx: &UnboundedSender<IncomingMessage>,
         capabilities_provider: &impl CapabilitiesProvider,
@@ -198,7 +219,7 @@ impl WidgetDriver {
     ) -> Result<(), ()> {
         match action {
             Action::SendToWidget(msg) => {
-                self.to_widget_tx.send(msg).await.map_err(|_| ())?;
+                to_widget_tx.send(msg).map_err(|_| ())?;
             }
 
             Action::MatrixDriverRequest { request_id, data } => {
@@ -276,7 +297,7 @@ impl WidgetDriver {
 
             Action::Subscribe => {
                 // Only subscribe if we are not already subscribed.
-                if self.event_forwarding_guard.is_some() {
+                if event_forwarding_guard.is_some() {
                     return Ok(());
                 }
 
@@ -285,7 +306,7 @@ impl WidgetDriver {
                     (token.child_token(), token.drop_guard())
                 };
 
-                self.event_forwarding_guard = Some(guard);
+                event_forwarding_guard.replace(guard);
 
                 let mut events = matrix_driver.events();
                 let mut state_updates = matrix_driver.state_updates();
@@ -320,7 +341,7 @@ impl WidgetDriver {
             }
 
             Action::Unsubscribe => {
-                self.event_forwarding_guard = None;
+                event_forwarding_guard.take();
             }
         }
 

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -153,7 +153,7 @@ async fn recv_message(driver_handle: &WidgetDriverHandle) -> JsonObject {
     serde_json::from_str(&msg.unwrap()).unwrap()
 }
 
-async fn send_request(
+fn send_request(
     driver_handle: &WidgetDriverHandle,
     request_id: &str,
     action: &str,
@@ -167,27 +167,25 @@ async fn send_request(
         "data": data,
     });
     println!("Json string sent from the widget {json_string}");
-    let sent = driver_handle.send(json_string).await;
+    let sent = driver_handle.send(json_string);
     assert!(sent);
 }
 
-async fn send_response(
+fn send_response(
     driver_handle: &WidgetDriverHandle,
     request_id: &str,
     action: &str,
     request_data: impl Serialize,
     response_data: impl Serialize,
 ) {
-    let sent = driver_handle
-        .send(json_string!({
-            "api": "toWidget",
-            "widgetId": WIDGET_ID,
-            "requestId": request_id,
-            "action": action,
-            "data": request_data,
-            "response": response_data,
-        }))
-        .await;
+    let sent = driver_handle.send(json_string!({
+        "api": "toWidget",
+        "widgetId": WIDGET_ID,
+        "requestId": request_id,
+        "action": action,
+        "data": request_data,
+        "response": response_data,
+    }));
     assert!(sent);
 }
 
@@ -215,8 +213,7 @@ async fn test_negotiate_capabilities_immediately() {
                 "get-supported-api-versions",
                 "supported_api_versions",
                 json!({}),
-            )
-            .await;
+            );
 
             let msg = recv_message(&driver_handle).await;
             assert_eq!(msg["api"], "fromWidget");
@@ -227,7 +224,7 @@ async fn test_negotiate_capabilities_immediately() {
 
         // Answer with caps we want
         let response = json!({ "capabilities": caps });
-        send_response(&driver_handle, request_id, "capabilities", data, &response).await;
+        send_response(&driver_handle, request_id, "capabilities", data, &response);
     }
 
     {
@@ -239,7 +236,7 @@ async fn test_negotiate_capabilities_immediately() {
         let request_id = msg["requestId"].as_str().unwrap();
 
         // ACK the request
-        send_response(&driver_handle, request_id, "notify_capabilities", caps, json!({})).await;
+        send_response(&driver_handle, request_id, "notify_capabilities", caps, json!({}));
     }
 
     assert_matches!(driver_handle.recv().now_or_never(), None);
@@ -280,7 +277,7 @@ async fn test_read_messages() {
 
     {
         // Tell the driver that we're ready for communication
-        send_request(&driver_handle, "1-content-loaded", "content_loaded", json!({})).await;
+        send_request(&driver_handle, "1-content-loaded", "content_loaded", json!({}));
 
         // Receive the response
         let msg = recv_message(&driver_handle).await;
@@ -320,8 +317,7 @@ async fn test_read_messages() {
             "type": "m.room.message",
             "limit": 2,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -340,7 +336,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
 
     {
         // Tell the driver that we're ready for communication
-        send_request(&driver_handle, "1-content-loaded", "content_loaded", json!({})).await;
+        send_request(&driver_handle, "1-content-loaded", "content_loaded", json!({}));
 
         // Receive the response
         let msg = recv_message(&driver_handle).await;
@@ -383,8 +379,7 @@ async fn test_read_messages_with_msgtype_capabilities() {
             "type": "m.room.message",
             "limit": 3,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -455,8 +450,7 @@ async fn test_read_room_members() {
             "state_key": true,
             "limit": 3,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -962,8 +956,7 @@ async fn test_send_room_message() {
                 "body": "Message from a widget!",
             },
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1002,8 +995,7 @@ async fn test_send_room_name() {
                 "name": "Room Name set by Widget",
             },
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1048,8 +1040,7 @@ async fn test_send_delayed_message_event() {
             },
             "delay":1000,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1095,8 +1086,7 @@ async fn test_send_delayed_state_event() {
             },
             "delay":1000,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1141,8 +1131,7 @@ async fn test_fail_sending_delay_rate_limit() {
             },
             "delay":1000,
         }),
-    )
-    .await;
+    );
 
     let msg = recv_message(&driver_handle).await;
     assert_eq!(msg["api"], "fromWidget");
@@ -1187,8 +1176,7 @@ async fn test_try_send_delayed_state_event_without_permission() {
             },
             "delay":1000,
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1223,8 +1211,8 @@ async fn test_update_delayed_event() {
             "action":"refresh",
             "delay_id": "1234",
         }),
-    )
-    .await;
+    );
+
     // Receive the response
     let response = recv_message(&driver_handle).await;
     print!("{response:?}");
@@ -1248,8 +1236,8 @@ async fn test_try_update_delayed_event_without_permission() {
             "action":"refresh",
             "delay_id": "1234",
         }),
-    )
-    .await;
+    );
+
     // Receive the response
     let response = recv_message(&driver_handle).await;
     print!("{response:?}");
@@ -1274,8 +1262,8 @@ async fn test_try_update_delayed_event_without_permission_negotiate() {
             "action":"refresh",
             "delay_id": "1234",
         }),
-    )
-    .await;
+    );
+
     // Wait for the corresponding response.
     loop {
         let response = recv_message(&driver_handle).await;
@@ -1316,8 +1304,7 @@ async fn test_send_redaction() {
                 "redacts": "$1234"
             },
         }),
-    )
-    .await;
+    );
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1349,7 +1336,7 @@ async fn send_to_device_test_helper(
 
     mock_server.mock_send_to_device().ok().expect(calls).mount().await;
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1463,7 +1450,7 @@ async fn test_send_encrypted_to_device_event() {
         }
     });
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1559,7 +1546,7 @@ async fn test_send_encrypted_to_device_event_wildcard() {
         .mount(mock_server.server())
         .await;
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1644,7 +1631,7 @@ async fn test_send_encrypted_to_device_event_wildcard_edge_cases() {
         .mount(mock_server.server())
         .await;
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1678,7 +1665,7 @@ async fn test_send_encrypted_to_device_event_unknown_device() {
         }
     });
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1745,7 +1732,7 @@ async fn test_send_internal_to_device_event() {
             }
         });
 
-        send_request(&driver_handle, request_id, "send_to_device", data).await;
+        send_request(&driver_handle, request_id, "send_to_device", data);
 
         // Receive the response
         let msg = recv_message(&driver_handle).await;
@@ -1791,7 +1778,7 @@ async fn test_send_encrypted_to_device_event_partial_error() {
     let (guard, event_as_sent_by_alice) =
         mock_server.mock_capture_put_to_device(alice.user_id().unwrap()).await;
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // It was sent to bob even though other recipients failed
     let event_as_sent_by_alice = event_as_sent_by_alice.await.deserialize().unwrap();
@@ -1841,7 +1828,7 @@ async fn test_send_encrypted_to_device_event_server_error() {
 
     mock_server.mock_send_to_device().error500().mount().await;
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1920,7 +1907,7 @@ async fn test_send_encrypted_to_device_different_content() {
         }
     });
 
-    send_request(&driver_handle, request_id, "send_to_device", data).await;
+    send_request(&driver_handle, request_id, "send_to_device", data);
 
     // Receive the response
     let msg = recv_message(&driver_handle).await;
@@ -1969,8 +1956,7 @@ async fn test_try_download_file_without_permission() {
         json!({
             "content_uri":"mxc://example.org/profile.jpg",
         }),
-    )
-    .await;
+    );
 
     let response = recv_message(&driver_handle).await;
     if response["api"] == "fromWidget" && response["action"] == "org.matrix.msc4039.download_file" {
@@ -1995,8 +1981,7 @@ async fn test_download_non_mxc_uri_should_fail() {
         json!({
             "content_uri":"https://example.org/profile.jpg",
         }),
-    )
-    .await;
+    );
 
     let response = recv_message(&driver_handle).await;
     if response["api"] == "fromWidget" && response["action"] == "org.matrix.msc4039.download_file" {
@@ -2018,8 +2003,7 @@ async fn test_try_download_file() {
         json!({
             "content_uri":"mxc://example.org/xJbofAzMprfEWsmWWqGsMuEY",
         }),
-    )
-    .await;
+    );
 
     let bundle = vec![1, 2, 3, 4, 5];
 
@@ -2067,8 +2051,7 @@ async fn test_get_rtc_transports() {
         "get-rtc-transports",
         "org.matrix.msc4515.get_rtc_transports",
         json!({}),
-    )
-    .await;
+    );
 
     let response = recv_message(&driver_handle).await;
     assert_eq!(response["api"], "fromWidget");
@@ -2106,8 +2089,7 @@ async fn test_get_rtc_transports_endpoint_unsupported() {
         "get-rtc-transports",
         "org.matrix.msc4515.get_rtc_transports",
         json!({}),
-    )
-    .await;
+    );
 
     // The widget receives an error (as opposed to an empty list), so it can tell
     // the endpoint apart from a homeserver that advertises no transports.
@@ -2142,8 +2124,7 @@ async fn test_get_rtc_transports_falls_back_to_well_known() {
         "get-rtc-transports",
         "org.matrix.msc4515.get_rtc_transports",
         json!({}),
-    )
-    .await;
+    );
 
     let response = recv_message(&driver_handle).await;
     assert_eq!(response["api"], "fromWidget");
@@ -2169,8 +2150,7 @@ async fn test_get_rtc_transports_without_permission() {
         "get-rtc-transports",
         "org.matrix.msc4515.get_rtc_transports",
         json!({}),
-    )
-    .await;
+    );
 
     let response = recv_message(&driver_handle).await;
     assert_eq!(response["api"], "fromWidget");
@@ -2192,7 +2172,7 @@ async fn negotiate_capabilities(driver_handle: &WidgetDriverHandle, caps: JsonVa
 
         // Answer with caps we want
         let response = json!({ "capabilities": caps });
-        send_response(driver_handle, request_id, "capabilities", data, &response).await;
+        send_response(driver_handle, request_id, "capabilities", data, &response);
     }
 
     {
@@ -2204,6 +2184,6 @@ async fn negotiate_capabilities(driver_handle: &WidgetDriverHandle, caps: JsonVa
         let request_id = msg["requestId"].as_str().unwrap();
 
         // ACK the notification
-        send_response(driver_handle, request_id, "notify_capabilities", caps, json!({})).await;
+        send_response(driver_handle, request_id, "notify_capabilities", caps, json!({}));
     }
 }


### PR DESCRIPTION
This adventure has started with a lint saying `async-channel` is unused. It appears to be true, but only if the `experimental-widgets` feature is enabled. However, I noticed that `async-channel` is used in a single place: the `matrix_sdk::widget` module.

We already have `tokio` in our dependency tree. Let's replace `async-channel` by `tokio` for the sake of smaller binary.

`async-channel` is a MPMC, whilst `tokio::sync` has a MPSC. Why do we need multiple-consumers in the original code? The only reason is that one field is used in a task: the field was cloned. We can change the code a little bit to move the value instead of cloning it.

This is what this code does. The code is refactored to move values instead of cloning them. That way, we can use a MPSC channel.

Small changes:

- `WidgetDriverHandle` no longer implements `Clone`,
- `WidgetDriverHandle::send` no longer is `async`.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
