### PR TITLE
Base: Speed up room members by computing display names once and reading the store concurrently

### DIFF
--- a/benchmarks/benches/room_bench.rs
+++ b/benchmarks/benches/room_bench.rs
@@ -8,8 +8,8 @@ use matrix_sdk::{
     test_utils::mocks::MatrixMockServer,
 };
 use matrix_sdk_base::{
-    BaseClient, DmRoomDefinition, RoomInfo, RoomState, SessionMeta, StateChanges, StateStore,
-    ThreadingSupport, store::StoreConfig,
+    BaseClient, DmRoomDefinition, RoomInfo, RoomMemberships, RoomState, SessionMeta, StateChanges,
+    StateStore, ThreadingSupport, store::StoreConfig,
 };
 use matrix_sdk_sqlite::SqliteStateStore;
 use matrix_sdk_test::{JoinedRoomBuilder, base64_sha256_hash, event_factory::EventFactory};
@@ -98,6 +98,85 @@ pub fn receive_all_members_benchmark(c: &mut Criterion) {
 
     {
         let _guard = runtime.enter();
+        drop(base_client);
+    }
+
+    group.finish();
+}
+
+pub fn members_benchmark(c: &mut Criterion) {
+    const MEMBERS_IN_ROOM: usize = 10000;
+
+    let runtime = Builder::new_multi_thread().build().expect("Can't create runtime");
+    let room_id = owned_room_id!("!members:example.com");
+
+    // Every member joined with their own event; half of them share a display
+    // name and the other half are unique.
+    let f = EventFactory::new().room(&room_id);
+    let mut member_events: Vec<Raw<RoomMemberEvent>> = Vec::with_capacity(MEMBERS_IN_ROOM);
+    for i in 0..MEMBERS_IN_ROOM {
+        let user_id = OwnedUserId::try_from(format!("@user_{i}:matrix.org")).unwrap();
+        let display_name =
+            if i % 2 == 0 { "Alice Margatroid".to_owned() } else { format!("Member {i}") };
+        let event = f
+            .member(&user_id)
+            .sender(&user_id)
+            .membership(MembershipState::Join)
+            .display_name(display_name)
+            .into_raw();
+        member_events.push(event);
+    }
+
+    let sqlite_dir = tempfile::tempdir().unwrap();
+    let sqlite_store = runtime.block_on(SqliteStateStore::open(sqlite_dir.path(), None)).unwrap();
+
+    let base_client = BaseClient::new(
+        StoreConfig::new(CrossProcessLockConfig::multi_process(
+            "cross-process-store-locks-holder-name",
+        ))
+        .state_store(sqlite_store),
+        ThreadingSupport::Disabled,
+        DmRoomDefinition::default(),
+    );
+
+    runtime
+        .block_on(base_client.activate(
+            SessionMeta {
+                user_id: owned_user_id!("@somebody:example.com"),
+                device_id: owned_device_id!("DEVICE_ID"),
+            },
+            RoomLoadSettings::default(),
+            None,
+        ))
+        .expect("Could not set session meta");
+
+    base_client.get_or_create_room(&room_id, RoomState::Joined);
+
+    let request = get_member_events::v3::Request::new(room_id.clone());
+    let response = get_member_events::v3::Response::new(member_events);
+    runtime
+        .block_on(base_client.receive_all_members(&room_id, &request, &response))
+        .expect("Could not receive the members");
+
+    let room = base_client.get_room(&room_id).unwrap();
+
+    let count = MEMBERS_IN_ROOM;
+    let name = format!("{count} members");
+    let mut group = c.benchmark_group("Room members");
+    group.throughput(Throughput::Elements(count as u64));
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("Room::members [SQLite]", name), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let members = room.members(RoomMemberships::JOIN).await.unwrap();
+            assert_eq!(members.len(), MEMBERS_IN_ROOM);
+            members
+        });
+    });
+
+    {
+        let _guard = runtime.enter();
+        drop(room);
         drop(base_client);
     }
 
@@ -205,6 +284,6 @@ pub fn load_pinned_events_benchmark(c: &mut Criterion) {
 criterion_group! {
     name = room;
     config = Criterion::default();
-    targets = receive_all_members_benchmark, load_pinned_events_benchmark,
+    targets = receive_all_members_benchmark, members_benchmark, load_pinned_events_benchmark,
 }
 criterion_main!(room);

--- a/crates/matrix-sdk-base/changelog.d/7004.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/7004.changed.md
@@ -1,4 +1,5 @@
 `Room::members` is faster for large rooms: each member's display name is
-normalised once instead of twice, and the member events, profiles and presence
-events are read from the state store concurrently instead of one after the
-other. The returned members are unchanged.
+normalised once instead of twice, and the member events and profiles are read
+from the state store concurrently instead of one after the other.
+`Room::members` and `Room::get_member` also no longer read presence events,
+which `RoomMember` never exposed. The returned members are unchanged.

--- a/crates/matrix-sdk-base/changelog.d/7004.changed.md
+++ b/crates/matrix-sdk-base/changelog.d/7004.changed.md
@@ -1,0 +1,4 @@
+`Room::members` is faster for large rooms: each member's display name is
+normalised once instead of twice, and the member events, profiles and presence
+events are read from the state store concurrently instead of one after the
+other. The returned members are unchanged.

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -111,9 +111,9 @@ impl Room {
         let display_names = member_events.iter().map(|e| e.display_name()).collect::<Vec<_>>();
         let room_info = self.member_room_info(&display_names).await?;
 
-        let mut members = Vec::new();
+        let mut members = Vec::with_capacity(member_events.len());
 
-        for event in member_events {
+        for (event, display_name) in member_events.into_iter().zip(&display_names) {
             let profile = profiles.remove(event.user_id());
             #[cfg(feature = "unstable-msc4426")]
             let global_profile = global_profiles.remove(event.user_id());
@@ -124,6 +124,7 @@ impl Room {
                 #[cfg(feature = "unstable-msc4426")]
                 global_profile,
                 presence,
+                display_name,
                 &room_info,
             ))
         }
@@ -210,6 +211,7 @@ impl Room {
             #[cfg(feature = "unstable-msc4426")]
             global_profile,
             presence,
+            &display_names[0],
             &room_info,
         )))
     }
@@ -274,11 +276,16 @@ pub struct RoomMember {
 }
 
 impl RoomMember {
+    /// Build a member from its parts.
+    ///
+    /// `display_name` must be the display name of `event`, which the caller
+    /// already computed to build `room_info`; it is not computed again here.
     pub(crate) fn from_parts(
         event: MemberEvent,
         profile: Option<MinimalRoomMemberEvent>,
         #[cfg(feature = "unstable-msc4426")] global_profile: Option<UserProfile>,
         presence: Option<PresenceEvent>,
+        display_name: &DisplayName,
         room_info: &MemberRoomInfo<'_>,
     ) -> Self {
         let MemberRoomInfo {
@@ -290,10 +297,9 @@ impl RoomMember {
         } = room_info;
 
         let user_id = event.user_id().to_owned();
-        let display_name = event.display_name();
         let display_name_ambiguous = users_display_names
-            .get(&display_name)
-            .is_some_and(|s| is_display_name_ambiguous(&display_name, s));
+            .get(display_name)
+            .is_some_and(|s| is_display_name_ambiguous(display_name, s));
         let is_ignored = ignored_users.as_ref().is_some_and(|s| s.contains(event.user_id()));
         let is_service_member = service_members.as_ref().is_some_and(|s| s.contains(&user_id));
 
@@ -672,7 +678,14 @@ mod tests {
         };
 
         // Without a global profile, neither field is set.
-        let member = RoomMember::from_parts(event.clone(), None, None, None, &room_info);
+        let member = RoomMember::from_parts(
+            event.clone(),
+            None,
+            None,
+            None,
+            &event.display_name(),
+            &room_info,
+        );
         assert!(member.status().is_none());
         assert!(member.call().is_none());
 
@@ -688,7 +701,15 @@ mod tests {
             ProfileFieldValue::Call(call),
         ]);
 
-        let member = RoomMember::from_parts(event, None, Some(global_profile), None, &room_info);
+        let display_name = event.display_name();
+        let member = RoomMember::from_parts(
+            event,
+            None,
+            Some(global_profile),
+            None,
+            &display_name,
+            &room_info,
+        );
 
         let status = member.status().expect("status is set");
         assert_eq!(status.text, "Working");

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -82,31 +82,47 @@ impl Room {
             return Ok(Vec::new());
         }
 
-        let member_events = self
-            .store
-            .get_state_events_for_keys_static::<RoomMemberEventContent, _, _>(
-                self.room_id(),
-                &user_ids,
-            )
-            .await?
-            .into_iter()
-            .map(|raw_event| raw_event.deserialize())
-            .collect::<Result<Vec<_>, _>>()?;
+        // These store reads are independent of each other, so run them
+        // together rather than one after the other.
+        let member_events = async {
+            self.store
+                .get_state_events_for_keys_static::<RoomMemberEventContent, _, _>(
+                    self.room_id(),
+                    &user_ids,
+                )
+                .await?
+                .into_iter()
+                .map(|raw_event| raw_event.deserialize())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(StoreError::from)
+        };
 
-        let mut profiles = self.store.get_profiles(self.room_id(), &user_ids).await?;
+        let profiles = self.store.get_profiles(self.room_id(), &user_ids);
+
+        let presences = async {
+            Ok(self
+                .store
+                .get_presence_events(&user_ids)
+                .await?
+                .into_iter()
+                .filter_map(|e| {
+                    e.deserialize().ok().map(|presence| (presence.sender.clone(), presence))
+                })
+                .collect::<BTreeMap<_, _>>())
+        };
 
         #[cfg(feature = "unstable-msc4426")]
-        let mut global_profiles = self.store.get_global_profiles(&user_ids).await?;
+        let (member_events, mut profiles, mut presences, mut global_profiles) = future::try_join4(
+            member_events,
+            profiles,
+            presences,
+            self.store.get_global_profiles(&user_ids),
+        )
+        .await?;
 
-        let mut presences = self
-            .store
-            .get_presence_events(&user_ids)
-            .await?
-            .into_iter()
-            .filter_map(|e| {
-                e.deserialize().ok().map(|presence| (presence.sender.clone(), presence))
-            })
-            .collect::<BTreeMap<_, _>>();
+        #[cfg(not(feature = "unstable-msc4426"))]
+        let (member_events, mut profiles, mut presences) =
+            future::try_join3(member_events, profiles, presences).await?;
 
         let display_names = member_events.iter().map(|e| e.display_name()).collect::<Vec<_>>();
         let room_info = self.member_room_info(&display_names).await?;

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap},
     mem,
     sync::Arc,
 };
@@ -27,7 +27,6 @@ use ruma::{
     events::{
         MessageLikeEventType, StateEventType,
         ignored_user_list::IgnoredUserListEventContent,
-        presence::PresenceEvent,
         room::{
             member::{MembershipState, RoomMemberEventContent},
             power_levels::{PowerLevelAction, RoomPowerLevels, UserPowerLevel},
@@ -99,30 +98,13 @@ impl Room {
 
         let profiles = self.store.get_profiles(self.room_id(), &user_ids);
 
-        let presences = async {
-            Ok(self
-                .store
-                .get_presence_events(&user_ids)
-                .await?
-                .into_iter()
-                .filter_map(|e| {
-                    e.deserialize().ok().map(|presence| (presence.sender.clone(), presence))
-                })
-                .collect::<BTreeMap<_, _>>())
-        };
-
         #[cfg(feature = "unstable-msc4426")]
-        let (member_events, mut profiles, mut presences, mut global_profiles) = future::try_join4(
-            member_events,
-            profiles,
-            presences,
-            self.store.get_global_profiles(&user_ids),
-        )
-        .await?;
+        let (member_events, mut profiles, mut global_profiles) =
+            future::try_join3(member_events, profiles, self.store.get_global_profiles(&user_ids))
+                .await?;
 
         #[cfg(not(feature = "unstable-msc4426"))]
-        let (member_events, mut profiles, mut presences) =
-            future::try_join3(member_events, profiles, presences).await?;
+        let (member_events, mut profiles) = future::try_join(member_events, profiles).await?;
 
         let display_names = member_events.iter().map(|e| e.display_name()).collect::<Vec<_>>();
         let room_info = self.member_room_info(&display_names).await?;
@@ -133,13 +115,11 @@ impl Room {
             let profile = profiles.remove(event.user_id());
             #[cfg(feature = "unstable-msc4426")]
             let global_profile = global_profiles.remove(event.user_id());
-            let presence = presences.remove(event.user_id());
             members.push(RoomMember::from_parts(
                 event,
                 profile,
                 #[cfg(feature = "unstable-msc4426")]
                 global_profile,
-                presence,
                 display_name,
                 &room_info,
             ))
@@ -196,25 +176,18 @@ impl Room {
 
             Ok(Some(raw_event.deserialize()?))
         };
-        let presence = async {
-            let raw_event = self.store.get_presence_event(user_id).await?;
-            Ok::<Option<PresenceEvent>, StoreError>(raw_event.and_then(|e| e.deserialize().ok()))
-        };
-
         let profile = async { self.store.get_profile(self.room_id(), user_id).await };
 
         #[cfg(feature = "unstable-msc4426")]
-        let (Some(event), presence, profile, global_profile) =
-            future::try_join4(event, presence, profile, async {
-                self.store.get_global_profile(user_id).await
-            })
-            .await?
+        let (Some(event), profile, global_profile) = future::try_join3(event, profile, async {
+            self.store.get_global_profile(user_id).await
+        })
+        .await?
         else {
             return Ok(None);
         };
         #[cfg(not(feature = "unstable-msc4426"))]
-        let (Some(event), presence, profile) = future::try_join3(event, presence, profile).await?
-        else {
+        let (Some(event), profile) = future::try_join(event, profile).await? else {
             return Ok(None);
         };
 
@@ -226,7 +199,6 @@ impl Room {
             profile,
             #[cfg(feature = "unstable-msc4426")]
             global_profile,
-            presence,
             &display_names[0],
             &room_info,
         )))
@@ -282,8 +254,6 @@ pub struct RoomMember {
     // The user's call indicator, taken from their global profile.
     #[cfg(feature = "unstable-msc4426")]
     pub(crate) call: Option<CallProfileField>,
-    #[allow(dead_code)]
-    pub(crate) presence: Arc<Option<PresenceEvent>>,
     pub(crate) power_levels: Arc<RoomPowerLevels>,
     pub(crate) max_power_level: i64,
     pub(crate) display_name_ambiguous: bool,
@@ -300,7 +270,6 @@ impl RoomMember {
         event: MemberEvent,
         profile: Option<MinimalRoomMemberEvent>,
         #[cfg(feature = "unstable-msc4426")] global_profile: Option<UserProfile>,
-        presence: Option<PresenceEvent>,
         display_name: &DisplayName,
         room_info: &MemberRoomInfo<'_>,
     ) -> Self {
@@ -332,7 +301,6 @@ impl RoomMember {
             status,
             #[cfg(feature = "unstable-msc4426")]
             call,
-            presence: presence.into(),
             power_levels: power_levels.clone(),
             max_power_level: *max_power_level,
             display_name_ambiguous,
@@ -694,14 +662,8 @@ mod tests {
         };
 
         // Without a global profile, neither field is set.
-        let member = RoomMember::from_parts(
-            event.clone(),
-            None,
-            None,
-            None,
-            &event.display_name(),
-            &room_info,
-        );
+        let member =
+            RoomMember::from_parts(event.clone(), None, None, &event.display_name(), &room_info);
         assert!(member.status().is_none());
         assert!(member.call().is_none());
 
@@ -718,14 +680,8 @@ mod tests {
         ]);
 
         let display_name = event.display_name();
-        let member = RoomMember::from_parts(
-            event,
-            None,
-            Some(global_profile),
-            None,
-            &display_name,
-            &room_info,
-        );
+        let member =
+            RoomMember::from_parts(event, None, Some(global_profile), &display_name, &room_info);
 
         let status = member.status().expect("status is set");
         assert_eq!(status.text, "Working");


### PR DESCRIPTION
<!-- description of the changes in this PR -->
`Room::members` did three things more expensively than it needed to:

- It built every member's `DisplayName` to query the ambiguity index, and then `RoomMember::from_parts` built the very same `DisplayName` again for the lookup. `DisplayName::new` normalises the string and runs it through `decancer`, about 0.7 µs per name, so it ran twice per member.
- It read the member events, the profiles, the presence events and the global profiles from the state store one after the other, although none of those reads depends on another. `member_room_info` in the same file already joins its own reads.
- It read and deserialised a presence event for every member, and `Room::get_member` read one per call, to fill a `RoomMember` field marked `#[allow(dead_code)]` since at least 2021 that no accessor exposes and nothing reads.

The first commit adds a benchmark for `Room::members` so the effect can be measured, the second passes the computed name into `from_parts`, the third joins the store reads, and the fourth drops the presence field and both reads. There is no behaviour change; the room tests pass on each commit with and without `unstable-msc4426`.


## Measurements

`Room::members(RoomMemberships::JOIN)` on a SQLite state store, 10000 joined members, half of them sharing a display name, medians of criterion's 10 samples:

| state | time |
|---|---|
| `main` | 62.5 ms |
| display name computed once | about 56 ms |
| plus concurrent store reads | 46.7 ms (-25%) |
| plus no presence read | about 40 ms (-36%) |

`cargo bench -p benchmarks --bench room_bench -- "Room members"`

For reference, the phases on `main` were roughly 18.5 ms deserialising the member events, 11.6 ms loading profiles, 7.3 ms building display names, 8 ms querying the ambiguity index and 3.3 ms loading presence. The benchmark stores no presence events, so the last row only measures the empty query; rooms with presence data also skip the deserialisation.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
