### PR TITLE
Timeline: Load the read receipts of new events in one store batch

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/7007.added.md
+++ b/crates/matrix-sdk-base/changelog.d/7007.added.md
@@ -1,0 +1,1 @@
+Add `StateStore::get_event_room_receipt_events_batch` to read the receipts of several events in one call, keyed by event id, and `Room::load_event_receipts_batch` on top of it. The default implementation reads the events one by one; the IndexedDB store overrides it to serve the whole batch from a single transaction.

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -577,6 +577,27 @@ impl Room {
             .await
     }
 
+    /// Load from storage the receipts of several events in this room, for the
+    /// given `receipt_type` and `receipt_thread`.
+    ///
+    /// The receipts are keyed by event id, as a list of `OwnedUserId` and
+    /// `Receipt` tuples. Events without receipts are absent from the map.
+    pub async fn load_event_receipts_batch<'a>(
+        &self,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> StoreResult<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>> {
+        self.store
+            .get_event_room_receipt_events_batch(
+                self.room_id(),
+                receipt_type,
+                receipt_thread,
+                event_ids,
+            )
+            .await
+    }
+
     /// Returns a boolean indicating if this room has been manually marked as
     /// unread
     pub fn is_marked_unread(&self) -> bool {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -90,6 +90,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_power_level_saving(&self) -> TestResult;
     /// Test user receipts saving.
     async fn test_receipts_saving(&self) -> TestResult;
+    /// Test loading the receipts of several events at once.
+    async fn test_receipts_bulk_loading(&self) -> TestResult;
     /// Test custom storage.
     async fn test_custom_storage(&self) -> TestResult;
     /// Test stripped and non-stripped room member saving.
@@ -1042,6 +1044,100 @@ impl StateStoreIntegrationTests for DynStateStore {
         );
         assert_eq!(second_event_threaded_receipts[0].0, user_id());
         assert_eq!(second_event_threaded_receipts[0].1.ts.unwrap().0, third_receipt_ts);
+
+        Ok(())
+    }
+
+    async fn test_receipts_bulk_loading(&self) -> TestResult {
+        let room_id = room_id!("!test_receipts_bulk_loading:localhost");
+
+        let first_event_id = event_id!("$1435641916114394fHBLK:matrix.org");
+        let second_event_id = event_id!("$fHBLK1435641916114394:matrix.org");
+        let third_event_id = event_id!("$4394fHBLK143564191611:matrix.org");
+
+        let first_receipt_ts = uint!(1436451550);
+        let second_receipt_ts = uint!(1436451653);
+        let third_receipt_ts = uint!(1436474532);
+
+        let receipt_event = serde_json::from_value(json!({
+            first_event_id: {
+                "m.read": {
+                    user_id(): {
+                        "ts": first_receipt_ts,
+                    }
+                }
+            },
+            second_event_id: {
+                "m.read": {
+                    invited_user_id(): {
+                        "ts": second_receipt_ts,
+                    },
+                    user_id(): {
+                        "ts": third_receipt_ts,
+                        "thread_id": "main",
+                    }
+                }
+            }
+        }))?;
+
+        let mut changes = StateChanges::default();
+        changes.add_receipts(room_id, receipt_event);
+        self.save_changes(&changes).await?;
+
+        let requested =
+            [first_event_id.to_owned(), second_event_id.to_owned(), third_event_id.to_owned()];
+
+        // Events without receipts are absent from the map.
+        let unthreaded_receipts = self
+            .get_event_room_receipt_events_batch(
+                room_id,
+                ReceiptType::Read,
+                &ReceiptThread::Unthreaded,
+                &requested,
+            )
+            .await
+            .expect("failed to read the unthreaded receipts of the batch");
+        assert_eq!(unthreaded_receipts.len(), 2);
+        assert!(!unthreaded_receipts.contains_key(third_event_id));
+
+        let first_event_receipts = &unthreaded_receipts[first_event_id];
+        assert_eq!(first_event_receipts.len(), 1);
+        assert_eq!(first_event_receipts[0].0, user_id());
+        assert_eq!(first_event_receipts[0].1.ts.unwrap().0, first_receipt_ts);
+
+        let second_event_receipts = &unthreaded_receipts[second_event_id];
+        assert_eq!(second_event_receipts.len(), 1);
+        assert_eq!(second_event_receipts[0].0, invited_user_id());
+        assert_eq!(second_event_receipts[0].1.ts.unwrap().0, second_receipt_ts);
+
+        // Only the receipts of the requested thread are returned.
+        let threaded_receipts = self
+            .get_event_room_receipt_events_batch(
+                room_id,
+                ReceiptType::Read,
+                &ReceiptThread::Main,
+                &requested,
+            )
+            .await
+            .expect("failed to read the threaded receipts of the batch");
+        assert_eq!(threaded_receipts.len(), 1);
+
+        let second_event_receipts = &threaded_receipts[second_event_id];
+        assert_eq!(second_event_receipts.len(), 1);
+        assert_eq!(second_event_receipts[0].0, user_id());
+        assert_eq!(second_event_receipts[0].1.ts.unwrap().0, third_receipt_ts);
+
+        // An empty batch is an empty map.
+        let no_receipts = self
+            .get_event_room_receipt_events_batch(
+                room_id,
+                ReceiptType::Read,
+                &ReceiptThread::Unthreaded,
+                &[],
+            )
+            .await
+            .expect("failed to read the receipts of an empty batch");
+        assert!(no_receipts.is_empty());
 
         Ok(())
     }
@@ -2348,6 +2444,12 @@ macro_rules! statestore_integration_tests {
             async fn test_receipts_saving() -> TestResult {
                 let store = get_store().await?.into_state_store();
                 store.test_receipts_saving().await
+            }
+
+            #[async_test]
+            async fn test_receipts_bulk_loading() -> TestResult {
+                let store = get_store().await?.into_state_store();
+                store.test_receipts_bulk_loading().await
             }
 
             #[async_test]

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -306,6 +306,53 @@ pub trait StateStore: AsyncTraitDeps {
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error>;
 
+    /// Get the read receipts of several events for a given room, receipt type,
+    /// and thread.
+    ///
+    /// Events without receipts are absent from the returned map.
+    ///
+    /// The default implementation reads the events one at a time. Backends
+    /// where each read has a fixed cost, such as opening a transaction, should
+    /// override it to serve the whole batch at once.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the receipts should be
+    ///   fetched.
+    ///
+    /// * `receipt_type` - The type of the receipts.
+    ///
+    /// * `receipt_thread` - The thread a receipt applies to.
+    ///
+    /// * `event_ids` - The ids of the events for which the receipts should be
+    ///   fetched.
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>, Self::Error> {
+        let mut receipts = BTreeMap::new();
+
+        for event_id in event_ids {
+            let event_receipts = self
+                .get_event_room_receipt_events(
+                    room_id,
+                    receipt_type.clone(),
+                    receipt_thread,
+                    event_id,
+                )
+                .await?;
+
+            if !event_receipts.is_empty() {
+                receipts.insert(event_id.as_ref(), event_receipts);
+            }
+        }
+
+        Ok(receipts)
+    }
+
     /// Get arbitrary data from the custom store
     ///
     /// # Arguments
@@ -714,6 +761,18 @@ impl<T: StateStore> StateStore for &T {
         (*self).get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id).await
     }
 
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>, Self::Error> {
+        (*self)
+            .get_event_room_receipt_events_batch(room_id, receipt_type, receipt_thread, event_ids)
+            .await
+    }
+
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         (*self).get_custom_value(key).await
     }
@@ -1037,6 +1096,18 @@ impl<T: StateStore + ?Sized> StateStore for Arc<T> {
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
         self.deref()
             .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
+            .await
+    }
+
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>, Self::Error> {
+        self.deref()
+            .get_event_room_receipt_events_batch(room_id, receipt_type, receipt_thread, event_ids)
             .await
     }
 
@@ -1374,6 +1445,19 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
         self.0
             .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>, Self::Error> {
+        self.0
+            .get_event_room_receipt_events_batch(room_id, receipt_type, receipt_thread, event_ids)
             .await
             .map_err(Into::into)
     }
@@ -1777,6 +1861,18 @@ impl<T: StateStore> StateStore for SaveLockedStateStore<T> {
     ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
         self.store
             .get_event_room_receipt_events(room_id, receipt_type, receipt_thread, event_id)
+            .await
+    }
+
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>, Self::Error> {
+        self.store
+            .get_event_room_receipt_events_batch(room_id, receipt_type, receipt_thread, event_ids)
             .await
     }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use futures_util::future::try_join_all;
 use gloo_utils::format::JsValueSerdeExt;
 use growable_bloom_filter::GrowableBloom;
 use indexed_db_futures::{
@@ -1504,6 +1505,59 @@ impl_state_store!({
             .filter_map(Result::ok)
             .filter_map(|f| self.deserialize_value(&f).ok())
             .collect::<Vec<_>>())
+    }
+
+    async fn get_event_room_receipt_events_batch<'a>(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>> {
+        if event_ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+
+        // Opening a transaction is the expensive part of a read, so the whole
+        // batch goes through a single one. The requests are issued together and
+        // resolved by the transaction in order.
+        let tx = self
+            .inner
+            .transaction(keys::ROOM_EVENT_RECEIPTS)
+            .with_mode(TransactionMode::Readonly)
+            .build()?;
+        let store = tx.object_store(keys::ROOM_EVENT_RECEIPTS)?;
+
+        let requests = event_ids.iter().map(|event_id| {
+            let event_id: &EventId = event_id;
+            let range = match receipt_thread.as_str() {
+                Some(thread_id) => self.encode_to_range(
+                    keys::ROOM_EVENT_RECEIPTS,
+                    (room_id, &receipt_type, thread_id, event_id),
+                ),
+                None => self
+                    .encode_to_range(keys::ROOM_EVENT_RECEIPTS, (room_id, &receipt_type, event_id)),
+            };
+            let store = &store;
+
+            async move {
+                let receipts = store
+                    .get_all()
+                    .with_query(&range)
+                    .await?
+                    .filter_map(Result::ok)
+                    .filter_map(|f| self.deserialize_value(&f).ok())
+                    .collect::<Vec<_>>();
+
+                Ok::<_, IndexeddbStateStoreError>((event_id, receipts))
+            }
+        });
+
+        Ok(try_join_all(requests)
+            .await?
+            .into_iter()
+            .filter(|(_, receipts)| !receipts.is_empty())
+            .collect())
     }
 
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/crates/matrix-sdk-ui/changelog.d/7007.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/7007.changed.md
@@ -1,0 +1,1 @@
+The timeline now loads the read receipts of the events it adds in one batch instead of one store call per event, which removes hundreds of IndexedDB transactions from a room open on web.

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -585,7 +585,8 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
     /// Every requested event has an entry in the returned map, even when it
     /// has no receipts, so that
     /// [`Self::load_read_receipts_for_event`] can tell an event without
-    /// receipts from one that wasn't prefetched.
+    /// receipts from one that wasn't prefetched. If the batch read fails, the
+    /// map is empty and every event is read on its own instead.
     pub(super) async fn prefetch_read_receipts(
         &self,
         event_ids: &[OwnedEventId],
@@ -603,12 +604,19 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
             if matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main) {
                 // Same as in `load_read_receipts_for_event`: accept both the main and the
                 // unthreaded receipts, for compatibility with clients using either.
-                let (mut main_receipts, unthreaded_receipts) = join(
+                let (main_receipts, unthreaded_receipts) = join(
                     room_data_provider.load_event_receipts_batch(event_ids, &ReceiptThread::Main),
                     room_data_provider
                         .load_event_receipts_batch(event_ids, &ReceiptThread::Unthreaded),
                 )
                 .await;
+
+                // An entry is only complete with both halves.
+                let (Some(mut main_receipts), Some(unthreaded_receipts)) =
+                    (main_receipts, unthreaded_receipts)
+                else {
+                    return HashMap::new();
+                };
 
                 for (event_id, event_receipts) in unthreaded_receipts {
                     main_receipts.entry(event_id).or_default().extend(event_receipts);
@@ -616,7 +624,13 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
 
                 main_receipts
             } else {
-                room_data_provider.load_event_receipts_batch(event_ids, &receipt_thread).await
+                let Some(receipts) =
+                    room_data_provider.load_event_receipts_batch(event_ids, &receipt_thread).await
+                else {
+                    return HashMap::new();
+                };
+
+                receipts
             };
 
         for event_id in event_ids {

--- a/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/read_receipts.rs
@@ -15,6 +15,7 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use futures_core::Stream;
+use futures_util::future::join;
 use indexmap::IndexMap;
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
@@ -579,20 +580,72 @@ impl<P: RoomDataProvider> TimelineStateTransaction<'_, P> {
         }
     }
 
+    /// Load the read receipts of several events from the store, in one batch.
+    ///
+    /// Every requested event has an entry in the returned map, even when it
+    /// has no receipts, so that
+    /// [`Self::load_read_receipts_for_event`] can tell an event without
+    /// receipts from one that wasn't prefetched.
+    pub(super) async fn prefetch_read_receipts(
+        &self,
+        event_ids: &[OwnedEventId],
+        room_data_provider: &P,
+    ) -> HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>> {
+        if event_ids.is_empty() {
+            return HashMap::new();
+        }
+
+        trace!(num_events = event_ids.len(), "prefetching the initial receipts of events");
+
+        let receipt_thread = self.focus.receipt_thread();
+
+        let mut receipts =
+            if matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main) {
+                // Same as in `load_read_receipts_for_event`: accept both the main and the
+                // unthreaded receipts, for compatibility with clients using either.
+                let (mut main_receipts, unthreaded_receipts) = join(
+                    room_data_provider.load_event_receipts_batch(event_ids, &ReceiptThread::Main),
+                    room_data_provider
+                        .load_event_receipts_batch(event_ids, &ReceiptThread::Unthreaded),
+                )
+                .await;
+
+                for (event_id, event_receipts) in unthreaded_receipts {
+                    main_receipts.entry(event_id).or_default().extend(event_receipts);
+                }
+
+                main_receipts
+            } else {
+                room_data_provider.load_event_receipts_batch(event_ids, &receipt_thread).await
+            };
+
+        for event_id in event_ids {
+            receipts.entry(event_id.clone()).or_default();
+        }
+
+        receipts
+    }
+
     /// Load the read receipts from the store for the given event ID.
     ///
     /// Populates the read receipts in-memory caches.
+    ///
+    /// The receipts are taken from `prefetched` when the event is part of it
+    /// (see [`Self::prefetch_read_receipts`]), and loaded from the store
+    /// otherwise.
     pub(super) async fn load_read_receipts_for_event(
         &mut self,
         event_id: &EventId,
         room_data_provider: &P,
+        prefetched: &mut HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>,
     ) {
         trace!(%event_id, "loading initial receipts for an event");
 
         let receipt_thread = self.focus.receipt_thread();
 
-        let receipts = if matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main)
-        {
+        let receipts = if let Some(receipts) = prefetched.remove(event_id) {
+            receipts
+        } else if matches!(receipt_thread, ReceiptThread::Unthreaded | ReceiptThread::Main) {
             // If the requested receipt thread is unthreaded or main, we maintain maximal
             // compatibility with clients using either unthreaded or main-thread read
             // receipts by allowing both here.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -15,13 +15,16 @@
 use std::collections::{HashMap, HashSet};
 
 use eyeball_im::VectorDiff;
+use indexmap::IndexMap;
 use itertools::Itertools as _;
 use matrix_sdk::deserialized_responses::{
     ThreadSummaryStatus, TimelineEvent, TimelineEventKind, UnsignedEventLocation,
 };
 use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
-    events::AnySyncTimelineEvent, push::Action, serde::Raw,
+    events::{AnySyncTimelineEvent, receipt::Receipt},
+    push::Action,
+    serde::Raw,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -100,6 +103,26 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
         let mut cached_profiles: HashMap<OwnedUserId, Option<Profile>> = HashMap::new();
 
+        // Read receipts are loaded for every added event. Load them in one batch
+        // rather than one store read per event.
+        let mut cached_receipts = if settings.track_read_receipts.is_enabled() {
+            let event_ids = diffs
+                .iter()
+                .flat_map(|diff| match diff {
+                    VectorDiff::Append { values } => values.iter().collect(),
+                    VectorDiff::PushFront { value }
+                    | VectorDiff::PushBack { value }
+                    | VectorDiff::Insert { value, .. } => vec![value],
+                    _ => Vec::new(),
+                })
+                .filter_map(|event| event.event_id().map(ToOwned::to_owned))
+                .collect::<Vec<_>>();
+
+            self.prefetch_read_receipts(&event_ids, room_data_provider).await
+        } else {
+            HashMap::new()
+        };
+
         let mut recycled_timeline_ids = HashMap::new();
 
         for diff in diffs {
@@ -116,6 +139,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                             settings,
                             &mut date_divider_adjuster,
                             &mut cached_profiles,
+                            &mut cached_receipts,
                             recycled_timeline_id,
                         )
                         .await;
@@ -133,6 +157,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                         settings,
                         &mut date_divider_adjuster,
                         &mut cached_profiles,
+                        &mut cached_receipts,
                         recycled_timeline_id,
                     )
                     .await;
@@ -149,6 +174,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                         settings,
                         &mut date_divider_adjuster,
                         &mut cached_profiles,
+                        &mut cached_receipts,
                         recycled_timeline_id,
                     )
                     .await;
@@ -165,6 +191,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                         settings,
                         &mut date_divider_adjuster,
                         &mut cached_profiles,
+                        &mut cached_receipts,
                         recycled_timeline_id,
                     )
                     .await;
@@ -184,6 +211,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                             settings,
                             &mut date_divider_adjuster,
                             &mut cached_profiles,
+                            &mut cached_receipts,
                             None,
                         )
                         .await;
@@ -576,6 +604,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         raw: &Raw<AnySyncTimelineEvent>,
         deserialization_error: serde_json::Error,
         settings: &TimelineSettings,
+        receipts: &mut HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>,
     ) -> Option<(
         OwnedEventId,
         OwnedUserId,
@@ -666,6 +695,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     position,
                     room_data_provider,
                     settings,
+                    receipts,
                 )
                 .await;
                 None
@@ -710,6 +740,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         settings: &TimelineSettings,
         date_divider_adjuster: &mut DateDividerAdjuster,
         profiles: &mut HashMap<OwnedUserId, Option<Profile>>,
+        receipts: &mut HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>,
         recycled_timeline_id: Option<TimelineUniqueId>,
     ) -> RemovedItem {
         let is_highlighted =
@@ -797,8 +828,9 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
 
             // The event seems invalid…
             Err(e) => {
-                if let Some(tuple) =
-                    self.maybe_add_error_item(position, room_data_provider, &raw, e, settings).await
+                if let Some(tuple) = self
+                    .maybe_add_error_item(position, room_data_provider, &raw, e, settings, receipts)
+                    .await
                 {
                     tuple
                 } else {
@@ -822,6 +854,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             position,
             room_data_provider,
             settings,
+            receipts,
         )
         .await;
 
@@ -1013,6 +1046,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     /// [`ObservableItems::all_remote_events`] collection.
     ///
     /// This method also adjusts read receipt if needed.
+    #[allow(clippy::too_many_arguments)]
     async fn add_or_update_remote_event(
         &mut self,
         event_meta: EventMeta,
@@ -1021,6 +1055,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
         position: TimelineItemPosition,
         room_data_provider: &P,
         settings: &TimelineSettings,
+        receipts: &mut HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>,
     ) {
         let event_id = event_meta.event_id.clone();
 
@@ -1061,7 +1096,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
                     | TimelineItemPosition::At { .. }
             )
         {
-            self.load_read_receipts_for_event(&event_id, room_data_provider).await;
+            self.load_read_receipts_for_event(&event_id, room_data_provider, receipts).await;
 
             self.maybe_add_implicit_read_receipt(&event_id, sender, timestamp);
         }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -399,6 +399,23 @@ impl RoomDataProvider for TestRoomDataProvider {
         map
     }
 
+    async fn load_event_receipts_batch<'a>(
+        &'a self,
+        event_ids: &'a [OwnedEventId],
+        receipt_thread: &'a ReceiptThread,
+    ) -> HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>> {
+        let mut receipts = HashMap::new();
+
+        for event_id in event_ids {
+            let event_receipts = self.load_event_receipts(event_id, receipt_thread).await;
+            if !event_receipts.is_empty() {
+                receipts.insert(event_id.clone(), event_receipts);
+            }
+        }
+
+        receipts
+    }
+
     async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {
         self.fully_read_marker.clone()
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -285,6 +285,11 @@ struct TestRoomDataProvider {
     /// Configurable at construction, static for the lifetime of the provider.
     fully_read_marker: Option<OwnedEventId>,
 
+    /// Whether batched receipt reads fail, to exercise the per-event fallback.
+    ///
+    /// Configurable at construction, static for the lifetime of the provider.
+    fail_receipt_batch_reads: bool,
+
     /// Events sent with that room data provider.
     pub sent_events: Arc<RwLock<Vec<AnyMessageLikeEventContent>>>,
 
@@ -303,6 +308,11 @@ impl TestRoomDataProvider {
 
     fn with_fully_read_marker(mut self, event_id: OwnedEventId) -> Self {
         self.fully_read_marker = Some(event_id);
+        self
+    }
+
+    fn with_failing_receipt_batch_reads(mut self) -> Self {
+        self.fail_receipt_batch_reads = true;
         self
     }
 }
@@ -403,7 +413,11 @@ impl RoomDataProvider for TestRoomDataProvider {
         &'a self,
         event_ids: &'a [OwnedEventId],
         receipt_thread: &'a ReceiptThread,
-    ) -> HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>> {
+    ) -> Option<HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>> {
+        if self.fail_receipt_batch_reads {
+            return None;
+        }
+
         let mut receipts = HashMap::new();
 
         for event_id in event_ids {
@@ -413,7 +427,7 @@ impl RoomDataProvider for TestRoomDataProvider {
             }
         }
 
-        receipts
+        Some(receipts)
     }
 
     async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -242,6 +242,73 @@ async fn test_read_receipts_updates_on_filtered_events() {
 }
 
 #[async_test]
+async fn test_stored_receipts_survive_a_failed_batch_read() {
+    // Same expectations as
+    // `test_read_receipts_updates_on_filtered_events_with_stored`,
+    // with the batched receipt read failing: the events must fall back to their own
+    // reads, not be treated as having no receipts.
+    let event_with_bob_receipt_id = event_id!("$event_with_bob_receipt");
+
+    // Add initial unthreaded private receipt.
+    let mut initial_user_receipts = ReadReceiptMap::new();
+    initial_user_receipts
+        .entry(ReceiptType::Read)
+        .or_default()
+        .entry(ReceiptThread::Unthreaded)
+        .or_default()
+        .insert(
+            BOB.to_owned(),
+            (
+                event_with_bob_receipt_id.to_owned(),
+                Receipt::new(ruma::MilliSecondsSinceUnixEpoch(uint!(5))),
+            ),
+        );
+
+    let timeline = TestTimelineBuilder::new()
+        .provider(
+            TestRoomDataProvider::default()
+                .with_initial_user_receipts(initial_user_receipts)
+                .with_failing_receipt_batch_reads(),
+        )
+        .settings(TimelineSettings {
+            track_read_receipts: TimelineReadReceiptTracking::AllEvents,
+            event_filter: Arc::new(filter_notice),
+            ..Default::default()
+        })
+        .build()
+        .await;
+    let f = &timeline.factory;
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_event(f.text_msg("A").sender(*ALICE)).await;
+    timeline
+        .handle_live_event(f.notice("B").sender(*CAROL).event_id(event_with_bob_receipt_id))
+        .await;
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    let _date_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
+
+    // Stored read receipt of Bob.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // Implicit read receipt of Carol.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 2);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+    assert!(event_a.read_receipts().get(*CAROL).is_some());
+
+    assert_pending!(stream);
+}
+
+#[async_test]
 async fn test_read_receipts_updates_on_filtered_events_with_stored() {
     let event_with_bob_receipt_id = event_id!("$event_with_bob_receipt");
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -128,12 +128,17 @@ pub(super) trait RoomDataProvider:
 
     /// Loads the read receipts of several events from the storage backend.
     ///
-    /// Events without receipts are absent from the returned map.
+    /// Events without receipts are absent from the returned map. Returns
+    /// `None` if the read failed: unlike the single-event read, an empty
+    /// result means the events have no stored receipts, so a failure must be
+    /// told apart from it.
     fn load_event_receipts_batch<'a>(
         &'a self,
         event_ids: &'a [OwnedEventId],
         receipt_thread: &'a ReceiptThread,
-    ) -> impl Future<Output = HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>> + SendOutsideWasm + 'a;
+    ) -> impl Future<Output = Option<HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>>>
+    + SendOutsideWasm
+    + 'a;
 
     /// Load the current fully-read event id, from storage.
     fn load_fully_read_marker(&self) -> impl Future<Output = Option<OwnedEventId>> + '_;
@@ -229,15 +234,19 @@ impl RoomDataProvider for Room {
         &'a self,
         event_ids: &'a [OwnedEventId],
         receipt_thread: &'a ReceiptThread,
-    ) -> HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>> {
+    ) -> Option<HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>> {
         match self.load_event_receipts_batch(ReceiptType::Read, receipt_thread, event_ids).await {
-            Ok(receipts) => receipts
-                .into_iter()
-                .map(|(event_id, receipts)| (event_id.to_owned(), receipts.into_iter().collect()))
-                .collect(),
+            Ok(receipts) => Some(
+                receipts
+                    .into_iter()
+                    .map(|(event_id, receipts)| {
+                        (event_id.to_owned(), receipts.into_iter().collect())
+                    })
+                    .collect(),
+            ),
             Err(e) => {
                 error!(?receipt_thread, "Failed to get read receipts for events: {e}");
-                HashMap::new()
+                None
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::future::Future;
+use std::{collections::HashMap, future::Future};
 
 use eyeball::Subscriber;
 use indexmap::IndexMap;
@@ -126,6 +126,15 @@ pub(super) trait RoomDataProvider:
         receipt_thread: &'a ReceiptThread,
     ) -> impl Future<Output = IndexMap<OwnedUserId, Receipt>> + SendOutsideWasm + 'a;
 
+    /// Loads the read receipts of several events from the storage backend.
+    ///
+    /// Events without receipts are absent from the returned map.
+    fn load_event_receipts_batch<'a>(
+        &'a self,
+        event_ids: &'a [OwnedEventId],
+        receipt_thread: &'a ReceiptThread,
+    ) -> impl Future<Output = HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>> + SendOutsideWasm + 'a;
+
     /// Load the current fully-read event id, from storage.
     fn load_fully_read_marker(&self) -> impl Future<Output = Option<OwnedEventId>> + '_;
 
@@ -212,6 +221,23 @@ impl RoomDataProvider for Room {
             Err(e) => {
                 error!(?event_id, ?receipt_thread, "Failed to get read receipts for event: {e}");
                 IndexMap::new()
+            }
+        }
+    }
+
+    async fn load_event_receipts_batch<'a>(
+        &'a self,
+        event_ids: &'a [OwnedEventId],
+        receipt_thread: &'a ReceiptThread,
+    ) -> HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>> {
+        match self.load_event_receipts_batch(ReceiptType::Read, receipt_thread, event_ids).await {
+            Ok(receipts) => receipts
+                .into_iter()
+                .map(|(event_id, receipts)| (event_id.to_owned(), receipts.into_iter().collect()))
+                .collect(),
+            Err(e) => {
+                error!(?receipt_thread, "Failed to get read receipts for events: {e}");
+                HashMap::new()
             }
         }
     }

--- a/crates/matrix-sdk/changelog.d/7007.added.md
+++ b/crates/matrix-sdk/changelog.d/7007.added.md
@@ -1,0 +1,1 @@
+Add `Room::load_event_receipts_batch` to load the read receipts of several events in one store call.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -3608,6 +3608,30 @@ impl Room {
             .map_err(Into::into)
     }
 
+    /// Load from storage the receipts of several events in this room.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_type` - The type of receipt to get.
+    ///
+    /// * `receipt_thread` - The thread a receipt applies to.
+    ///
+    /// * `event_ids` - The IDs of the events.
+    ///
+    /// Returns, for each event with receipts, a list of IDs of users who have
+    /// sent a receipt for the event and the corresponding receipts.
+    pub async fn load_event_receipts_batch<'a>(
+        &self,
+        receipt_type: ReceiptType,
+        receipt_thread: &ReceiptThread,
+        event_ids: &'a [OwnedEventId],
+    ) -> Result<BTreeMap<&'a EventId, Vec<(OwnedUserId, Receipt)>>> {
+        self.inner
+            .load_event_receipts_batch(receipt_type, receipt_thread, event_ids)
+            .await
+            .map_err(Into::into)
+    }
+
     /// Get the push-condition context for this room.
     ///
     /// Returns `None` if some data couldn't be found. This should only happen


### PR DESCRIPTION
<!-- description of the changes in this PR -->
The timeline loads the stored read receipts of every added event with one store call per event, two when the receipt thread is main or unthreaded. On IndexedDB each call opens its own transaction: opening a room on web made 942 such calls for 154 ms under the timeline lock. Running them concurrently with `join_all` changed nothing, since the transactions queue against each other. With this change the same open makes 8 calls for 29.6 ms, with no single-event fallbacks.

This adds `StateStore::get_event_room_receipt_events_batch`, keyed by event id like `get_profiles`, with a default that loops over the single-event method, so the memory and SQLite stores are unchanged. IndexedDB overrides it to serve the batch from one read-only transaction. The timeline prefetches the receipts of all added events before handling the diffs, falling back to the single-event read for anything not in the batch. A failed batch read leaves the prefetch empty, so every event of the batch falls back to its own read; a test covers it. `Room::load_event_receipts_batch` is exposed on the base and SDK rooms.

The wrapper stores (`&T`, `Arc<T>`, `EraseStateStoreError<T>`, `SaveLockedStateStore<T>`) forward the new method explicitly. Left to the default, a call through `EraseStateStoreError<IndexeddbStateStore>` would silently run the per-event loop and never reach the override.

Covered by a new store integration test that runs against every store, IndexedDB under wasm included, and by the existing timeline read receipt tests.


- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
