### PR TITLE
Event cache: Save an event fetched from the homeserver so the next lookup is served from the cache

### DIFF
--- a/crates/matrix-sdk/changelog.d/7008.added.md
+++ b/crates/matrix-sdk/changelog.d/7008.added.md
@@ -1,0 +1,1 @@
+Add `RoomEventCache::save_events` to save events into the event cache out-of-band, so that later lookups with `find_event`, `find_event_with_relations` and `find_event_relations` find them.

--- a/crates/matrix-sdk/changelog.d/7008.fixed.md
+++ b/crates/matrix-sdk/changelog.d/7008.fixed.md
@@ -1,0 +1,1 @@
+`Room::load_or_fetch_event` and `Room::load_or_fetch_event_with_relations` now save an event fetched from the homeserver into the event cache, so a cache miss is no longer repeated by every later lookup of the same event.

--- a/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/room/mod.rs
@@ -24,6 +24,7 @@ use matrix_sdk_base::{
     event_cache::Event,
     sync::Timeline,
 };
+use matrix_sdk_common::executor::spawn;
 use ruma::{
     EventId, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId,
     events::{AnyRoomAccountDataEvent, relation::RelationType},
@@ -225,6 +226,28 @@ impl RoomEventCache {
     ) -> Result<Vec<Event>> {
         // Search in all loaded or stored events.
         self.inner.state.read().await?.find_event_relations(event_id, filter.clone()).await
+    }
+
+    /// Save events into the store, out-of-band: they don't become part of any
+    /// linked chunk, but later lookups with [`Self::find_event`],
+    /// [`Self::find_event_with_relations`] and [`Self::find_event_relations`]
+    /// will find them.
+    pub async fn save_events(&self, events: impl IntoIterator<Item = Event>) -> Result<()> {
+        // Only the store handle is needed here, not the in-memory state: take it and
+        // release the state lock before writing.
+        let store = self.inner.state.read().await?.store;
+        let room_id = self.room_id().to_owned();
+        let events = events.into_iter().collect::<Vec<_>>();
+
+        // Spawn a task so the save is uninterrupted by task cancellation.
+        spawn(async move {
+            for event in events {
+                store.save_event(&room_id, event).await?;
+            }
+            Result::Ok(())
+        })
+        .await
+        .expect("joining failed")
     }
 
     /// Return a reference to the state.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -820,6 +820,9 @@ impl Room {
     /// Try to load the event from the [`EventCache`][crate::event_cache], if
     /// it's enabled, or fetch it from the homeserver.
     ///
+    /// An event fetched from the homeserver is saved into the event cache, so
+    /// that the next lookup finds it there.
+    ///
     /// When running the request against the homeserver, it uses the given
     /// [`RequestConfig`] if provided, or the client's default one
     /// otherwise.
@@ -833,13 +836,35 @@ impl Room {
                 if let Some(event) = event_cache.find_event(event_id).await? {
                     return Ok(event);
                 }
-                // Fallthrough: try with a request.
+
+                // Not in the event cache: fetch it, and remember it for next time.
+                self.fetch_event_and_save(&event_cache, event_id, request_config).await
             }
             Err(err) => {
                 debug!("error when getting the event cache: {err}");
+                self.event(event_id, request_config).await
             }
         }
-        self.event(event_id, request_config).await
+    }
+
+    /// Fetch an event from the homeserver and save it into the event cache, so
+    /// that later lookups are served from the cache instead of a new request.
+    ///
+    /// A failure to save the event is logged and otherwise ignored, since the
+    /// caller has the event it asked for.
+    async fn fetch_event_and_save(
+        &self,
+        event_cache: &RoomEventCache,
+        event_id: &EventId,
+        request_config: Option<RequestConfig>,
+    ) -> Result<TimelineEvent> {
+        let event = self.event(event_id, request_config).await?;
+
+        if let Err(err) = event_cache.save_events([event.clone()]).await {
+            debug!("couldn't save the fetched event into the event cache: {err}");
+        }
+
+        Ok(event)
     }
 
     /// Try to load the event and its relations from the
@@ -852,6 +877,9 @@ impl Room {
     /// If the event is found in the event cache, but we can't find any
     /// relations for it there, then we will still attempt to fetch the
     /// relations from the homeserver.
+    ///
+    /// An event fetched from the homeserver is saved into the event cache, so
+    /// that the next lookup finds it there. Its relations are not.
     ///
     /// When running any request against the homeserver, it uses the given
     /// [`RequestConfig`] if provided, or the client's default one
@@ -949,7 +977,12 @@ impl Room {
 
         // Fetch the event from the server. A failure here is fatal, as we must return
         // the target event.
-        let event = self.event(event_id, request_config).await?;
+        let event = match &event_cache {
+            Some((event_cache, _drop_handles)) => {
+                self.fetch_event_and_save(event_cache, event_id, request_config).await?
+            }
+            None => self.event(event_id, request_config).await?,
+        };
 
         // Try to get the relations from the event cache (if we have one).
         if let Some((event_cache, _drop_handles)) = event_cache

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
     RoomDisplayName, RoomMemberships,
     config::{SyncSettings, SyncToken},
     room::RoomMember,
-    test_utils::mocks::{AnyRoomBuilder, MatrixMockServer},
+    test_utils::mocks::{AnyRoomBuilder, MatrixMockServer, RoomRelationsResponseTemplate},
 };
 use matrix_sdk_base::DmRoomDefinition;
 use matrix_sdk_test::{
@@ -655,6 +655,66 @@ async fn test_event() {
     let push_actions = timeline_event.push_actions().unwrap();
     assert!(push_actions.iter().any(|a| a.is_highlight()));
     assert!(push_actions.iter().any(|a| a.should_notify()));
+
+    // The fetched event has been saved into the event cache, so loading it again is
+    // served from there: the `/event` mock above only accepts one request.
+    let cached_event = room.load_or_fetch_event(event_id, None).await.unwrap();
+    assert_eq!(cached_event.event_id(), Some(event_id));
+
+    let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
+    assert!(room_event_cache.find_event(event_id).await.unwrap().is_some());
+}
+
+#[async_test]
+async fn test_load_or_fetch_event_with_relations_saves_the_fetched_event() {
+    let event_id = event_id!("$target");
+
+    let server = MatrixMockServer::new().await;
+    let client = server.client_builder().build().await;
+    client.event_cache().subscribe().unwrap();
+
+    let f = EventFactory::new().sender(user_id!("@example:localhost"));
+    let room = server
+        .sync_room(
+            &client,
+            // We need the member event and power levels locally so the push rules processor
+            // works.
+            JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)
+                .add_state_event(f.member(user_id!("@example:localhost")).display_name("example"))
+                .add_state_event(f.default_power_levels()),
+        )
+        .await;
+
+    // The event itself is fetched once.
+    server
+        .mock_room_event()
+        .ok(f.text_msg("hello").event_id(event_id).room(*DEFAULT_TEST_ROOM_ID).into())
+        .named("/event")
+        .mock_once()
+        .mount()
+        .await;
+
+    // The event cache never learns of any relation for this event, so they are
+    // requested from the server on both calls.
+    server
+        .mock_room_relations()
+        .match_target_event(event_id.to_owned())
+        .ok(RoomRelationsResponseTemplate::default())
+        .expect(2)
+        .mount()
+        .await;
+
+    let (event, relations) =
+        room.load_or_fetch_event_with_relations(event_id, None, None).await.unwrap();
+    assert_eq!(event.event_id(), Some(event_id));
+    assert!(relations.is_empty());
+
+    // The second lookup finds the event in the event cache and only fetches the
+    // relations.
+    let (event, relations) =
+        room.load_or_fetch_event_with_relations(event_id, None, None).await.unwrap();
+    assert_eq!(event.event_id(), Some(event_id));
+    assert!(relations.is_empty());
 }
 
 #[async_test]


### PR DESCRIPTION
<!-- description of the changes in this PR -->
`Room::load_or_fetch_event` and `load_or_fetch_event_with_relations` fell back to `/event` when the event cache had no copy and returned the result without saving it, so a cache miss was permanent. Every later lookup and every timeline rebuild repeated the request; on a room with many thread roots whose latest replies are outside the loaded window, that was ~150 `/event` requests on every open.

This adds `RoomEventCache::save_events`, which the docs on `find_event_relations` already referred to, and saves the fetched event through it in both lookups. Undecryptable events are saved as well, since the redecryptor finds them in the store by session id and fixes them when the key arrives. Relations are not saved, because the cache treats a non-empty cached set as complete.

`save_events` takes the store handle from a read guard and releases the state lock before writing, since it doesn't touch the in-memory state, and writes from a spawned task like the state's own `save_events`.

Both lookups are covered: `test_event` now loads the event a second time against a `/event` mock that accepts one request, and a new test does the same for the variant with relations. Both fail without the fix.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
