### PR TITLE
Timeline: Use a thread root's bundled latest reply instead of loading it

### DIFF
--- a/crates/matrix-sdk-ui/changelog.d/7009.changed.md
+++ b/crates/matrix-sdk-ui/changelog.d/7009.changed.md
@@ -1,0 +1,1 @@
+The timeline now builds a thread root's summary from the latest reply bundled with the event, instead of loading it from the event cache or the homeserver. This removes a `/event` request per thread root from event-focused timelines.

--- a/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/state_transaction.rs
@@ -677,7 +677,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     // using the event cache or the storage.
     #[instrument(skip(self, room_data_provider))]
     async fn fetch_latest_thread_reply(
-        &mut self,
+        &self,
         event_id: &EventId,
         room_data_provider: &P,
     ) -> Option<Box<EmbeddedEvent>> {
@@ -688,6 +688,15 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             })
             .ok()?;
 
+        self.embed_latest_thread_reply(event, room_data_provider).await
+    }
+
+    // Attempt to turn a thread's latest reply into an embedded timeline item.
+    async fn embed_latest_thread_reply(
+        &self,
+        event: TimelineEvent,
+        room_data_provider: &P,
+    ) -> Option<Box<EmbeddedEvent>> {
         EmbeddedEvent::try_from_timeline_event(event, room_data_provider, &self.meta)
             .await
             .inspect_err(|err| {
@@ -704,7 +713,7 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn handle_remote_event(
         &mut self,
-        event: TimelineEvent,
+        mut event: TimelineEvent,
         position: TimelineItemPosition,
         room_data_provider: &P,
         settings: &TimelineSettings,
@@ -716,11 +725,17 @@ impl<'a, P: RoomDataProvider> TimelineStateTransaction<'a, P> {
             event.push_actions().is_some_and(|actions| actions.iter().any(Action::is_highlight));
 
         let thread_summary = if let ThreadSummaryStatus::Some(ref summary) = event.thread_summary {
-            let latest_reply_item = if let Some(ref latest_reply) = summary.latest_reply {
-                self.fetch_latest_thread_reply(latest_reply, room_data_provider).await
-            } else {
-                None
-            };
+            // The latest reply usually comes bundled with the event. Loading it instead
+            // means a store lookup at best, and a request when the event cache doesn't
+            // have it, as in an event-focused timeline.
+            let latest_reply_item =
+                if let Some(latest_reply) = event.bundled_latest_thread_event.take() {
+                    self.embed_latest_thread_reply(*latest_reply, room_data_provider).await
+                } else if let Some(ref latest_reply) = summary.latest_reply {
+                    self.fetch_latest_thread_reply(latest_reply, room_data_provider).await
+                } else {
+                    None
+                };
 
             Some(ThreadSummary {
                 latest_event: TimelineDetails::from_initial_value(latest_reply_item),

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -71,6 +71,7 @@ mod read_receipts;
 mod redaction;
 mod rtc;
 mod shields;
+mod thread;
 mod virt;
 
 /// A timeline instance used only for testing purposes in unit tests.

--- a/crates/matrix-sdk-ui/src/timeline/tests/thread.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/thread.rs
@@ -1,0 +1,66 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use assert_matches2::assert_let;
+use eyeball_im::VectorDiff;
+use imbl::vector;
+use matrix_sdk_test::{ALICE, BOB, async_test};
+use ruma::event_id;
+use stream_assert::assert_next_matches;
+
+use super::TestTimeline;
+use crate::timeline::{TimelineDetails, TimelineEventItemId, event_item::RemoteEventOrigin};
+
+#[async_test]
+async fn test_thread_root_uses_its_bundled_latest_reply() {
+    // `TestRoomDataProvider::load_event` is not implemented, so this only passes
+    // if the latest reply is taken from the bundle, not loaded.
+    let timeline = TestTimeline::new().await;
+    let mut stream = timeline.subscribe().await;
+
+    let f = &timeline.factory;
+    let thread_root_id = event_id!("$thread_root");
+    let latest_reply_id = event_id!("$latest_reply");
+
+    let thread_root = f
+        .text_msg("thread root")
+        .sender(*ALICE)
+        .event_id(thread_root_id)
+        .with_bundled_thread_summary(
+            f.text_msg("the last one!").sender(*BOB).event_id(latest_reply_id).into(),
+            3,
+            false,
+        )
+        .into_event();
+
+    timeline
+        .controller
+        .handle_remote_events_with_diffs(
+            vec![VectorDiff::Append { values: vector![thread_root] }],
+            RemoteEventOrigin::Sync,
+        )
+        .await;
+
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_item = item.as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), thread_root_id);
+
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    assert_eq!(summary.num_replies, 3);
+
+    assert_let!(TimelineDetails::Ready(latest_reply) = summary.latest_event);
+    assert_eq!(latest_reply.identifier, TimelineEventItemId::EventId(latest_reply_id.to_owned()));
+    assert_eq!(latest_reply.content.as_message().unwrap().body(), "the last one!");
+    assert_eq!(latest_reply.sender, *BOB);
+}

--- a/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/thread.rs
@@ -304,6 +304,68 @@ async fn test_extract_bundled_thread_summary() {
 }
 
 #[async_test]
+async fn test_focused_timeline_uses_the_bundled_latest_reply() {
+    // The events of an event-focused timeline are not in the event cache, so
+    // loading a thread root's latest reply would be a request. It isn't needed:
+    // the reply comes bundled with the thread root.
+
+    let server = MatrixMockServer::new().await;
+    let client = client_with_threading_support(&server).await;
+
+    let room_id = room_id!("!a:b.c");
+    let f = EventFactory::new().room(room_id).sender(&ALICE);
+    let thread_root_id = event_id!("$thread_root");
+    let latest_event_id = event_id!("$latest_event");
+
+    let thread_root = f
+        .text_msg("thready thread mcthreadface")
+        .with_bundled_thread_summary(
+            f.text_msg("the last one!").event_id(latest_event_id).into(),
+            42,
+            false,
+        )
+        .event_id(thread_root_id)
+        .into_event();
+
+    // No `/event` endpoint is mocked: a request for the latest reply would fail,
+    // and the summary would have no latest event.
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(thread_root))
+        .mock_once()
+        .mount()
+        .await;
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    let timeline = TimelineBuilder::new(&room)
+        .with_focus(TimelineFocus::Event {
+            target: thread_root_id.to_owned(),
+            num_context_events: 20,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: false },
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let (items, _stream) = timeline.subscribe().await;
+
+    // A date divider and the thread root.
+    assert_eq!(items.len(), 2);
+    let event_item = items[1].as_event().unwrap();
+    assert_eq!(event_item.event_id().unwrap(), thread_root_id);
+
+    assert_let!(Some(summary) = event_item.content().thread_summary());
+    assert_eq!(summary.num_replies, 42);
+
+    assert_let!(TimelineDetails::Ready(latest_event) = summary.latest_event);
+    assert_eq!(latest_event.identifier, TimelineEventItemId::EventId(latest_event_id.to_owned()));
+    assert_eq!(latest_event.content.as_message().unwrap().body(), "the last one!");
+    assert_eq!(latest_event.sender, *ALICE);
+}
+
+#[async_test]
 async fn test_redact_thread_root_keeps_thread_summary() {
     // Redacting the thread root must not hide the thread: the thread summary
     // is preserved on the redacted item.


### PR DESCRIPTION
<!-- description of the changes in this PR -->
When the timeline builds a thread root's summary it loads the latest reply through `RoomDataProvider::load_event`, although a freshly received thread root already carries it in `bundled_latest_thread_event`. In a live timeline that is a store lookup per thread root. In an event-focused timeline it is worse: its events are not in the event cache, so every thread root costs a `/event` request, sequentially, on every open. That is the ~150-request train behind #7008, which only made the second open cheap.

The summary now embeds the bundled reply when the event has one and loads it only otherwise, the same way `ThreadListService` already does. Events reloaded from the store have no bundle, but the room cache saved the reply out of band when it first saw the root, so the fallback is a store hit.

Two tests, both failing without the change: a unit test that relies on the test provider's unimplemented `load_event` to show no load happens, and an integration test that builds a focused timeline on a thread root with no `/event` mock.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
