### PR TITLE
Base: Look up display name ambiguity under the name a member is shown with

### DIFF
--- a/crates/matrix-sdk-base/changelog.d/7010.fixed.md
+++ b/crates/matrix-sdk-base/changelog.d/7010.fixed.md
@@ -1,0 +1,5 @@
+Look up display name ambiguity under the name a member is shown with, which is
+the name they set themselves, instead of under the latest member event's name.
+A kicked member keeps their own profile but their kick event carries no display
+name, so `RoomMember::name_ambiguous()` reported `false` for them even when the
+remaining members still shared the name they are rendered with.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1375,14 +1375,14 @@ mod tests {
     use serde_json::{json, value::to_raw_value};
 
     use super::{BaseClient, RequestedRequiredStates};
+    #[cfg(feature = "unstable-msc4426")]
+    use crate::store::StateChanges;
     use crate::{
-        DmRoomDefinition, RoomDisplayName, RoomState, SessionMeta,
+        DmRoomDefinition, RoomDisplayName, RoomMemberships, RoomState, SessionMeta,
         client::ThreadingSupport,
         store::{RoomLoadSettings, StateStoreExt, StoreConfig},
         test_utils::logged_in_base_client,
     };
-    #[cfg(feature = "unstable-msc4426")]
-    use crate::{RoomMemberships, store::StateChanges};
 
     #[test]
     fn test_requested_required_states() {
@@ -1928,6 +1928,54 @@ mod tests {
 
         let invited = room.get_member(invited_user_id).await.expect("ok").expect("exists");
         assert!(invited.name_ambiguous());
+    }
+
+    #[async_test]
+    async fn test_a_kicked_member_is_ambiguous_under_the_name_it_is_shown_with() {
+        let admin_user_id = user_id!("@admin:example.org");
+        let kicked_user_id = user_id!("@bob:example.org");
+        let other_user_ids = [user_id!("@carol:example.org"), user_id!("@dave:example.org")];
+        let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
+
+        let client = logged_in_base_client(Some(user_id!("@alice:example.org"))).await;
+
+        // Three joined members share a display name.
+        let f = EventFactory::new().room(room_id);
+        let mut sync_builder = SyncResponseBuilder::new();
+        let mut room_builder = matrix_sdk_test::JoinedRoomBuilder::new(room_id);
+        for user_id in [kicked_user_id].into_iter().chain(other_user_ids) {
+            room_builder = room_builder.add_state_event(f.member(user_id).display_name("Amandine"));
+        }
+        let response = sync_builder.add_joined_room(room_builder).build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        // An admin kicks one of them. The kick event carries no display name,
+        // but the kicked member's own profile, and with it the name they are
+        // still shown with, is kept.
+        let response = sync_builder
+            .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id).add_state_event(
+                f.member(kicked_user_id).sender(admin_user_id).kicked(kicked_user_id),
+            ))
+            .build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        let room = client.get_room(room_id).unwrap();
+
+        // The kicked member is shown under the shared name, which the two
+        // remaining members still make ambiguous.
+        let kicked = room.get_member(kicked_user_id).await.expect("ok").expect("exists");
+        assert_eq!(kicked.name(), "Amandine");
+        assert!(kicked.name_ambiguous());
+
+        let left_members = room.members(RoomMemberships::LEAVE).await.expect("ok");
+        assert_eq!(left_members.len(), 1);
+        assert_eq!(left_members[0].user_id(), kicked_user_id);
+        assert!(left_members[0].name_ambiguous());
+
+        for user_id in other_user_ids {
+            let member = room.get_member(user_id).await.expect("ok").expect("exists");
+            assert!(member.name_ambiguous());
+        }
     }
 
     #[cfg(feature = "unstable-msc4426")]

--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -43,6 +43,32 @@ use crate::{
     store::{Result as StoreResult, StateStoreExt, ambiguity_map::is_display_name_ambiguous},
 };
 
+/// The display name of a member, as [`RoomMember::display_name`] resolves it:
+/// the one from the profile the member set themselves, falling back to the
+/// latest member event's.
+fn display_name_value<'a>(
+    event: &'a MemberEvent,
+    profile: Option<&'a MinimalRoomMemberEvent>,
+) -> Option<&'a str> {
+    match profile {
+        Some(profile) => profile.content.displayname.as_deref(),
+        None => event.displayname_value(),
+    }
+}
+
+/// The name a member is shown under, as [`RoomMember::name`] renders it: their
+/// display name, falling back to the localpart of their user ID.
+///
+/// The ambiguity index must be looked up under this name, not under the latest
+/// member event's. The two differ for a kicked member: the kick event carries
+/// no display name, but the member's own profile is kept and its name is still
+/// rendered for them.
+fn displayed_name(event: &MemberEvent, profile: Option<&MinimalRoomMemberEvent>) -> DisplayName {
+    DisplayName::new(
+        display_name_value(event, profile).unwrap_or_else(|| event.user_id().localpart()),
+    )
+}
+
 impl Room {
     /// Check if the room has its members fully synced.
     ///
@@ -108,7 +134,10 @@ impl Room {
             })
             .collect::<BTreeMap<_, _>>();
 
-        let display_names = member_events.iter().map(|e| e.display_name()).collect::<Vec<_>>();
+        let display_names = member_events
+            .iter()
+            .map(|event| displayed_name(event, profiles.get(event.user_id())))
+            .collect::<Vec<_>>();
         let room_info = self.member_room_info(&display_names).await?;
 
         let mut members = Vec::new();
@@ -201,7 +230,7 @@ impl Room {
             return Ok(None);
         };
 
-        let display_names = [event.display_name()];
+        let display_names = [displayed_name(&event, profile.as_ref())];
         let room_info = self.member_room_info(&display_names).await?;
 
         Ok(Some(RoomMember::from_parts(
@@ -290,7 +319,7 @@ impl RoomMember {
         } = room_info;
 
         let user_id = event.user_id().to_owned();
-        let display_name = event.display_name();
+        let display_name = displayed_name(&event, profile.as_ref());
         let display_name_ambiguous = users_display_names
             .get(&display_name)
             .is_some_and(|s| is_display_name_ambiguous(&display_name, s));
@@ -331,11 +360,7 @@ impl RoomMember {
 
     /// Get the display name of the member if there is one.
     pub fn display_name(&self) -> Option<&str> {
-        if let Some(p) = self.profile.as_ref() {
-            p.content.displayname.as_deref()
-        } else {
-            self.event.displayname_value()
-        }
+        display_name_value(&self.event, (*self.profile).as_ref())
     }
 
     /// Get the name of the member.


### PR DESCRIPTION
<!-- description of the changes in this PR -->
The ambiguity index is keyed by the name a member set themselves, which is also what `RoomMember::name` renders: own profile, then the latest member event, then the localpart. But the lookup behind `RoomMember::name_ambiguous` used the latest member event's name. The two differ for a kicked member: the kick event carries no display name, and the profile writer deliberately keeps the member's own profile, so the member is still shown under their old name while the lookup asked about their localpart and always came back unambiguous.

Concretely, with three members sharing a display name and one of them kicked, the kicked member's messages render under the shared name without disambiguation while the two remaining members are disambiguated.

The fix resolves the name once, through a helper that `RoomMember::display_name` now shares so the two cannot drift, and uses it for the lookup in `members`, `get_member` and `from_parts`. No public API changes. The new test drives the scenario through sync and the real profile writer; it fails on `name_ambiguous()` without the fix.

This touches the same lines as #7004, whichever merges second rebases trivially.

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Šimun Kordiš <kordis.simun@gmail.com>
