### PR TITLE
chore(base): Simplify a future by removing an `async` block

### DIFF
--- a/crates/matrix-sdk-base/src/room/members.rs
+++ b/crates/matrix-sdk-base/src/room/members.rs
@@ -184,7 +184,7 @@ impl Room {
             Ok::<Option<PresenceEvent>, StoreError>(raw_event.and_then(|e| e.deserialize().ok()))
         };
 
-        let profile = async { self.store.get_profile(self.room_id(), user_id).await };
+        let profile = self.store.get_profile(self.room_id(), user_id);
 
         #[cfg(feature = "unstable-msc4426")]
         let (Some(event), presence, profile, global_profile) =


### PR DESCRIPTION
`get_profile` already returns a future. No need to wrap this future inside another future.

I've noticed that while doing a review for another PR.

---

- [ ] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
