### PR TITLE
feat(sticky events): add MSC4354 sticky events over the MSC4480 sliding sync extension

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = [
 ]
 
 [features]
-default = ["bundled-sqlite", "unstable-msc4274", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
+default = ["bundled-sqlite", "unstable-msc4274", "unstable-msc4354", "experimental-element-recent-emojis", "experimental-push-secrets", "experimental-search", "rustls-aws-lc-rs"]
 experimental-search = ["matrix-sdk/experimental-search", "matrix-sdk-ui/experimental-search"]
 # Use SQLite for the session storage.
 sqlite = ["matrix-sdk/sqlite"]
@@ -33,6 +33,9 @@ bundled-sqlite = ["sqlite", "matrix-sdk/bundled-sqlite"]
 # Use IndexedDB for the session storage.
 indexeddb = ["matrix-sdk/indexeddb"]
 unstable-msc4274 = ["matrix-sdk-ui/unstable-msc4274"]
+# Add support for sticky events (MSC4354), delivered over sliding sync via the
+# MSC4480 extension.
+unstable-msc4354 = ["matrix-sdk-ui/unstable-msc4354"]
 # Required when targeting a Javascript environment, like Wasm in a browser.
 js = ["matrix-sdk-ui/js"]
 # Enable sentry error monitoring, not compatible with Wasm platforms.

--- a/bindings/matrix-sdk-ffi/changelog.d/7014.added.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/7014.added.md
@@ -1,0 +1,2 @@
+Sticky events ([MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354)) are
+now enabled by default: the room list sync requests the [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480) extension and the SDK tracks the sticky events of each room. No FFI API exposes them yet.

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -72,6 +72,10 @@ testing = [
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = []
 
+# Add support for sticky events (MSC4354), delivered over sliding sync via the
+# MSC4480 extension.
+unstable-msc4354 = ["ruma/unstable-msc4480"]
+
 # Add support for user status profile fields (m.status, m.call).
 unstable-msc4426 = ["ruma/unstable-msc4426"]
 

--- a/crates/matrix-sdk-base/changelog.d/7014.added.md
+++ b/crates/matrix-sdk-base/changelog.d/7014.added.md
@@ -1,0 +1,4 @@
+Add support for sticky events ([MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354))
+behind the `unstable-msc4354` feature. The sticky events of a room are folded into an in-memory
+map, available through `Room::sticky_events()` with `StickyEvents::live()` and
+`StickyEvents::subscribe()`.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -15,6 +15,8 @@
 
 #[cfg(feature = "e2e-encryption")]
 use std::sync::Arc;
+#[cfg(all(feature = "e2e-encryption", feature = "unstable-msc4354"))]
+use std::sync::Mutex as StdMutex;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
@@ -24,6 +26,8 @@ use std::{
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::Stream;
+#[cfg(all(feature = "e2e-encryption", feature = "unstable-msc4354"))]
+use matrix_sdk_common::executor::AbortOnDrop;
 use matrix_sdk_common::{cross_process_lock::CrossProcessLockConfig, timer};
 #[cfg(feature = "experimental-x509-identity-verification")]
 use matrix_sdk_crypto::x509::{RawX509Signer, RawX509Verifier};
@@ -140,6 +144,12 @@ pub struct BaseClient {
     #[cfg(feature = "e2e-encryption")]
     pub handle_verification_events: bool,
 
+    /// The task retrying to decrypt encrypted sticky events (MSC4354) as room
+    /// keys arrive. Bound to the room keys stream of the current `OlmMachine`,
+    /// so it is replaced whenever the machine is.
+    #[cfg(all(feature = "e2e-encryption", feature = "unstable-msc4354"))]
+    sticky_redecryptor: Arc<StdMutex<Option<AbortOnDrop<()>>>>,
+
     /// Whether the client supports threads or not.
     pub threading_support: ThreadingSupport,
 
@@ -225,6 +235,8 @@ impl BaseClient {
             },
             #[cfg(feature = "e2e-encryption")]
             handle_verification_events: true,
+            #[cfg(all(feature = "e2e-encryption", feature = "unstable-msc4354"))]
+            sticky_redecryptor: Default::default(),
             threading_support,
             #[cfg(feature = "experimental-x509-identity-verification")]
             x509_signer: None,
@@ -262,6 +274,8 @@ impl BaseClient {
             room_key_recipient_strategy: self.room_key_recipient_strategy.clone(),
             decryption_settings: self.decryption_settings.clone(),
             handle_verification_events,
+            #[cfg(feature = "unstable-msc4354")]
+            sticky_redecryptor: Default::default(),
             threading_support: self.threading_support,
             #[cfg(feature = "experimental-x509-identity-verification")]
             x509_signer: self.x509_signer.clone(),
@@ -432,7 +446,25 @@ impl BaseClient {
 
         let olm_machine = builder.build().await.map_err(OlmError::from)?;
 
+        // Subscribe before the machine is shared, so that no room key is missed.
+        #[cfg(feature = "unstable-msc4354")]
+        let room_keys_stream = olm_machine.store().room_keys_received_stream();
+
         *self.olm_machine.write().await = Some(olm_machine);
+
+        // Retry pending encrypted sticky events as this machine receives room
+        // keys; the task bound to the previous machine, if any, is dropped.
+        #[cfg(feature = "unstable-msc4354")]
+        {
+            let redecryptor = crate::sticky::spawn_redecryptor(
+                room_keys_stream,
+                self.olm_machine.clone(),
+                self.decryption_settings.clone(),
+                self.state_store.clone(),
+            );
+            *self.sticky_redecryptor.lock().unwrap() = Some(redecryptor);
+        }
+
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -39,6 +39,9 @@ mod room;
 
 pub mod sliding_sync;
 
+#[cfg(feature = "unstable-msc4354")]
+pub mod sticky;
+
 pub mod store;
 pub mod sync;
 #[cfg(any(test, feature = "testing"))]

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -13,17 +13,31 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+#[cfg(feature = "unstable-msc4354")]
+use std::collections::BTreeSet;
 
+#[cfg(feature = "unstable-msc4354")]
+use matrix_sdk_common::deserialized_responses::{TimelineEvent, TimelineEventKind};
+#[cfg(feature = "unstable-msc4354")]
+use ruma::events::AnySyncTimelineEvent;
 use ruma::{
     OwnedRoomId, RoomId,
     api::client::sync::sync_events::v5 as http,
     events::{AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent, receipt::ReceiptEventContent},
     serde::Raw,
 };
+#[cfg(feature = "unstable-msc4354")]
+use tracing::trace;
 
+#[cfg(all(feature = "unstable-msc4354", feature = "e2e-encryption"))]
+use super::super::super::e2ee;
 use super::super::super::{
     Context, account_data::for_room as account_data_for_room, ephemeral_events::dispatch_receipt,
 };
+#[cfg(feature = "unstable-msc4354")]
+use crate::sticky::{Candidate, Payload, PendingEvent, classify, now_ms, resolve};
+#[cfg(all(feature = "unstable-msc4354", feature = "e2e-encryption"))]
+use crate::sticky::{Decryption, decrypt};
 use crate::{
     RoomState,
     store::BaseStateStore,
@@ -82,6 +96,160 @@ pub fn room_account_data(
                     .append(&mut raw.to_vec()),
                 RoomState::Invited | RoomState::Knocked => {}
             }
+        }
+    }
+}
+
+/// Feed the sticky events (MSC4354) of the response into the map of each room.
+///
+/// Sticky events arrive in the `extensions.sticky_events` part of the
+/// response, and in the timeline of the rooms (the server leaves out of the
+/// extension the ones that are in a timeline). The timeline events were already
+/// decrypted when the rooms were processed, so they are taken from
+/// `joined_room_updates` rather than decrypted again; only the events of the
+/// extension are decrypted here.
+///
+/// This must run once the rooms are saved, so that the state of each room is
+/// up to date.
+#[cfg(feature = "unstable-msc4354")]
+pub async fn sticky_events(
+    sticky_events: &http::response::StickyEvents,
+    rooms: &BTreeMap<OwnedRoomId, http::response::Room>,
+    joined_room_updates: &BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
+    state_store: &BaseStateStore,
+    #[cfg(feature = "e2e-encryption")] e2ee: &e2ee::E2EE<'_>,
+) {
+    let room_ids: BTreeSet<&RoomId> =
+        sticky_events.rooms.keys().chain(rooms.keys()).map(AsRef::as_ref).collect();
+
+    for room_id in room_ids {
+        let Some(room) = state_store.room(room_id) else {
+            trace!(?room_id, "Ignoring sticky events for an unknown room");
+            continue;
+        };
+
+        // Sticky events are only meaningful to joined members. Forget what we
+        // know about a room we are not in anymore.
+        if room.state() != RoomState::Joined {
+            if let Some(sticky) = room.sticky_events_if_any() {
+                sticky.clear();
+            }
+            continue;
+        }
+
+        let mut collector = StickyEventsCollector {
+            now: now_ms(),
+            room_id,
+            #[cfg(feature = "e2e-encryption")]
+            e2ee,
+            candidates: Vec::new(),
+            pending: Vec::new(),
+        };
+
+        // The sticky events of the timeline, paired with their processed (i.e.
+        // decrypted) counterparts.
+        if let Some(room_response) = rooms.get(room_id) {
+            // The processed timeline has one event per raw event, in order. Not
+            // having it (or, defensively, having a different number of events)
+            // means decrypting the encrypted ones here.
+            let processed_events = joined_room_updates
+                .get(room_id)
+                .map(|update| update.timeline.events.as_slice())
+                .filter(|events| events.len() == room_response.timeline.len())
+                .unwrap_or_default();
+
+            for (index, raw) in room_response.timeline.iter().enumerate() {
+                collector.collect(raw, processed_events.get(index)).await;
+            }
+        }
+
+        // The sticky events of the extension.
+        if let Some(sticky_room) = sticky_events.rooms.get(room_id) {
+            for raw in &sticky_room.events {
+                collector.collect(raw, None).await;
+            }
+        }
+
+        let StickyEventsCollector { now, candidates, pending, .. } = collector;
+
+        if candidates.is_empty() && pending.is_empty() {
+            continue;
+        }
+
+        let sticky = room.sticky_events();
+        sticky.ingest(now, candidates);
+        sticky.park(pending);
+    }
+}
+
+/// Gathers the sticky events of a single room out of raw sync events, as map
+/// candidates and, for the encrypted ones that can't be decrypted, pending
+/// events.
+#[cfg(feature = "unstable-msc4354")]
+struct StickyEventsCollector<'a> {
+    now: u64,
+    room_id: &'a RoomId,
+    #[cfg(feature = "e2e-encryption")]
+    e2ee: &'a e2ee::E2EE<'a>,
+    candidates: Vec<Candidate>,
+    pending: Vec<PendingEvent>,
+}
+
+#[cfg(feature = "unstable-msc4354")]
+impl StickyEventsCollector<'_> {
+    /// Collect `raw`, if it is a sticky event. `processed` is its already
+    /// processed (thus decrypted) form, when it went through the timeline
+    /// processing.
+    #[cfg_attr(not(feature = "e2e-encryption"), allow(clippy::unused_async))]
+    async fn collect(
+        &mut self,
+        raw: &Raw<AnySyncTimelineEvent>,
+        processed: Option<&TimelineEvent>,
+    ) {
+        let Some(meta) = classify(self.now, raw) else { return };
+
+        match &meta.payload {
+            Payload::Plain { .. } => {
+                let kind = match processed {
+                    Some(processed) => processed.kind.clone(),
+                    None => TimelineEventKind::PlainText { event: raw.clone() },
+                };
+                self.candidates.extend(resolve(meta, kind));
+            }
+
+            Payload::Encrypted { .. } => match processed.map(|processed| &processed.kind) {
+                // Already decrypted by the timeline processing.
+                Some(kind @ TimelineEventKind::Decrypted(_)) => {
+                    self.candidates.extend(resolve(meta, kind.clone()));
+                }
+
+                // The timeline processing couldn't decrypt it, no point in
+                // trying again right away.
+                Some(_) => self.pending.push(PendingEvent { meta, event: raw.clone() }),
+
+                // Not processed yet: try to decrypt it.
+                None => {
+                    let event = PendingEvent { meta, event: raw.clone() };
+
+                    #[cfg(feature = "e2e-encryption")]
+                    match decrypt(self.e2ee, self.room_id, event).await {
+                        Decryption::Resolved(candidate) => self.candidates.push(candidate),
+                        Decryption::Pending(event) => self.pending.push(event),
+                        Decryption::Dropped => {}
+                    }
+
+                    #[cfg(not(feature = "e2e-encryption"))]
+                    {
+                        trace!(
+                            room_id = %self.room_id,
+                            event_id = %event.meta.event_id,
+                            "Keeping an encrypted sticky event aside, it can't be decrypted \
+                             without encryption support"
+                        );
+                        self.pending.push(event);
+                    }
+                }
+            },
         }
     }
 }

--- a/crates/matrix-sdk-base/src/room/mod.rs
+++ b/crates/matrix-sdk-base/src/room/mod.rs
@@ -27,6 +27,8 @@ mod tags;
 mod tombstone;
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+#[cfg(feature = "unstable-msc4354")]
+use std::sync::{Arc, OnceLock};
 
 pub use call::CallIntentConsensus;
 pub use create::*;
@@ -105,6 +107,13 @@ pub struct Room {
 
     /// A sender that will notify receivers when room member updates happen.
     pub room_member_updates_sender: broadcast::Sender<RoomMembersUpdate>,
+
+    /// The sticky events (MSC4354) of this room.
+    ///
+    /// Created on first use, so that rooms that never see a sticky
+    /// event don't pay for a map and its maintenance task.
+    #[cfg(feature = "unstable-msc4354")]
+    pub(super) sticky_events: Arc<OnceLock<crate::sticky::StickyEvents>>,
 }
 
 impl Room {
@@ -134,12 +143,31 @@ impl Room {
             room_info_notable_update_sender,
             seen_knock_request_ids_map: SharedObservable::new_async(None),
             room_member_updates_sender,
+            #[cfg(feature = "unstable-msc4354")]
+            sticky_events: Default::default(),
         }
     }
 
     /// Get the unique room id of the room.
     pub fn room_id(&self) -> &RoomId {
         &self.room_id
+    }
+
+    /// The sticky events ([MSC4354]) of this room.
+    ///
+    /// [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+    #[cfg(feature = "unstable-msc4354")]
+    pub fn sticky_events(&self) -> &crate::sticky::StickyEvents {
+        self.sticky_events.get_or_init(|| crate::sticky::StickyEvents::new(self.room_id.clone()))
+    }
+
+    /// The sticky events of this room, if it ever had any.
+    ///
+    /// Unlike [`Room::sticky_events`], this doesn't create the map of a room
+    /// that has never seen a sticky event.
+    #[cfg(feature = "unstable-msc4354")]
+    pub(crate) fn sticky_events_if_any(&self) -> Option<&crate::sticky::StickyEvents> {
+        self.sticky_events.get()
     }
 
     /// Get a copy of the room creators.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -226,6 +226,28 @@ impl BaseClient {
             state_store_guard,
         )?;
 
+        // Handle sticky events, now that the rooms are saved and their state is
+        // up to date.
+        #[cfg(feature = "unstable-msc4354")]
+        {
+            #[cfg(feature = "e2e-encryption")]
+            let olm_machine = self.olm_machine().await;
+
+            processors::room::msc4186::extensions::sticky_events(
+                &extensions.sticky_events,
+                rooms,
+                &room_updates.joined,
+                &self.state_store,
+                #[cfg(feature = "e2e-encryption")]
+                &processors::e2ee::E2EE::new(
+                    olm_machine.as_ref(),
+                    &self.decryption_settings,
+                    false,
+                ),
+            )
+            .await;
+        }
+
         let mut context = processors::Context::default();
 
         // Now that all the rooms information have been saved, update the display name
@@ -292,6 +314,8 @@ mod tests {
 
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
+    #[cfg(feature = "unstable-msc4354")]
+    use ruma::events::AnySyncTimelineEvent;
     use ruma::{
         JsOption, MxcUri, OwnedRoomId, OwnedUserId, RoomAliasId, RoomId, UserId,
         api::client::sync::sync_events::UnreadNotificationsCount,
@@ -445,6 +469,202 @@ mod tests {
             )
             .await
             .expect("Failed to process sync");
+    }
+
+    /// A sticky `m.rtc.member` event sent by Alice, sticky for 10 minutes from
+    /// now according to the server.
+    #[cfg(feature = "unstable-msc4354")]
+    fn sticky_event(event_id: &str, content: serde_json::Value) -> Raw<AnySyncTimelineEvent> {
+        serde_json::from_value(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:example.org",
+            "event_id": event_id,
+            "origin_server_ts": 1,
+            "content": content,
+            "msc4354_sticky": { "duration_ms": 600_000 },
+            "unsigned": { "msc4354_sticky_duration_ttl_ms": 600_000 },
+        }))
+        .unwrap()
+    }
+
+    #[cfg(feature = "unstable-msc4354")]
+    #[async_test]
+    async fn test_sticky_events_are_ingested_from_the_timeline() {
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!room:example.org");
+
+        let mut room = http::response::Room::new();
+        room.timeline.push(sticky_event(
+            "$a:example.org",
+            json!({ "msc4354_sticky_key": "slot", "application": "m.call" }),
+        ));
+
+        client
+            .process_sliding_sync(
+                &response_with_room(room_id, room),
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        let room = client.get_room(room_id).expect("found room");
+        let live = room.sticky_events().live();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].key.sender, "@alice:example.org");
+        assert_eq!(live[0].key.sticky_key, "slot");
+        assert_eq!(live[0].event_id, "$a:example.org");
+        assert!(live[0].encryption_info().is_none());
+    }
+
+    #[cfg(feature = "unstable-msc4354")]
+    #[async_test]
+    async fn test_sticky_events_are_ingested_from_the_extension() {
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!room:example.org");
+
+        // The room must be known for its sticky events to be tracked.
+        let mut response = response_with_room(room_id, http::response::Room::new());
+
+        let mut sticky_room = http::response::StickyEventsRoom::default();
+        sticky_room.events = vec![
+            sticky_event(
+                "$a:example.org",
+                json!({ "msc4354_sticky_key": "laptop", "application": "m.call" }),
+            ),
+            sticky_event(
+                "$b:example.org",
+                json!({ "msc4354_sticky_key": "phone", "application": "m.call" }),
+            ),
+        ];
+        response.extensions.sticky_events.rooms.insert(room_id.to_owned(), sticky_room);
+
+        // Sticky events for a room we don't know about are ignored.
+        let mut unknown_room = http::response::StickyEventsRoom::default();
+        unknown_room.events = vec![sticky_event(
+            "$c:example.org",
+            json!({ "msc4354_sticky_key": "slot", "application": "m.call" }),
+        )];
+        response
+            .extensions
+            .sticky_events
+            .rooms
+            .insert(room_id!("!unknown:example.org").to_owned(), unknown_room);
+
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        let room = client.get_room(room_id).expect("found room");
+        let mut live = room.sticky_events().live();
+        live.sort_by(|a, b| a.key.sticky_key.cmp(&b.key.sticky_key));
+        assert_eq!(live.len(), 2);
+        assert_eq!(live[0].key.sticky_key, "laptop");
+        assert_eq!(live[1].key.sticky_key, "phone");
+
+        assert!(client.get_room(room_id!("!unknown:example.org")).is_none());
+    }
+
+    #[cfg(feature = "unstable-msc4354")]
+    #[async_test]
+    async fn test_sticky_events_are_forgotten_when_leaving_the_room() {
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!room:example.org");
+        let user_id = client.session_meta().unwrap().user_id.to_owned();
+
+        let mut room = http::response::Room::new();
+        set_room_joined(&mut room, &user_id);
+        room.timeline.push(sticky_event(
+            "$a:example.org",
+            json!({ "msc4354_sticky_key": "slot", "application": "m.call" }),
+        ));
+
+        client
+            .process_sliding_sync(
+                &response_with_room(room_id, room),
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        let room = client.get_room(room_id).expect("found room");
+        let mut subscriber = room.sticky_events().subscribe();
+        assert_eq!(room.sticky_events().live().len(), 1);
+
+        // We leave the room.
+        let mut room_response = http::response::Room::new();
+        set_room_left(&mut room_response, &user_id);
+
+        client
+            .process_sliding_sync(
+                &response_with_room(room_id, room_response),
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        assert_eq!(room.state(), RoomState::Left);
+        assert!(room.sticky_events().live().is_empty());
+
+        let update = subscriber.try_recv().unwrap();
+        assert_matches!(update.removed.as_slice(), [(key, crate::sticky::RemovalReason::RoomLeft)] => {
+            assert_eq!(key.sticky_key, "slot");
+        });
+    }
+
+    #[cfg(all(feature = "unstable-msc4354", feature = "e2e-encryption"))]
+    #[async_test]
+    async fn test_undecryptable_sticky_event_is_kept_aside_not_mapped() {
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!room:example.org");
+
+        // An encrypted sticky event for which we have no room key.
+        let encrypted: Raw<AnySyncTimelineEvent> = serde_json::from_value(json!({
+            "type": "m.room.encrypted",
+            "sender": "@alice:example.org",
+            "event_id": "$enc:example.org",
+            "origin_server_ts": 1,
+            "content": {
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "AAAA",
+                "sender_key": "senderkey",
+                "session_id": "session",
+                "device_id": "DEV",
+            },
+            "msc4354_sticky": { "duration_ms": 600_000 },
+            "unsigned": { "msc4354_sticky_duration_ttl_ms": 600_000 },
+        }))
+        .unwrap();
+
+        let mut room = http::response::Room::new();
+        room.timeline.push(encrypted.clone());
+        let mut response = response_with_room(room_id, room);
+
+        // Once in the timeline, once in the extension: neither may end up in the
+        // map as an `m.room.encrypted` entry, its real type and key are unknown.
+        let mut sticky_room = http::response::StickyEventsRoom::default();
+        sticky_room.events = vec![encrypted];
+        response.extensions.sticky_events.rooms.insert(room_id.to_owned(), sticky_room);
+
+        client
+            .process_sliding_sync(
+                &response,
+                &RequestedRequiredStates::default(),
+                &client.state_store_lock().lock().await,
+            )
+            .await
+            .expect("Failed to process sync");
+
+        let room = client.get_room(room_id).expect("found room");
+        assert!(room.sticky_events().live().is_empty());
+        assert!(room.sticky_events().has_pending());
     }
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/sticky/decrypt.rs
+++ b/crates/matrix-sdk-base/src/sticky/decrypt.rs
@@ -1,0 +1,176 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Decryption of encrypted sticky events.
+//!
+//! The key of an encrypted sticky event (its type and `content.sticky_key`)
+//! lives in the encrypted content, so the event can only enter the map once it
+//! is decrypted. Until then it is kept aside in its room's [`StickyEvents`],
+//! and retried by the redecryptor when a room key for it arrives.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use futures_util::{Stream, StreamExt as _};
+use matrix_sdk_common::{
+    deserialized_responses::TimelineEvent,
+    executor::{AbortOnDrop, JoinHandleExt as _, spawn},
+};
+use matrix_sdk_crypto::{DecryptionSettings, OlmMachine, store::types::RoomKeyInfo};
+use ruma::{OwnedRoomId, RoomId};
+use tokio::sync::RwLock;
+use tracing::{debug, trace, warn};
+
+use super::{Candidate, PendingEvent, StickyEvents, now_ms, resolve};
+use crate::{response_processors::e2ee, store::BaseStateStore};
+
+/// The outcome of trying to decrypt an encrypted sticky event.
+pub(crate) enum Decryption {
+    /// The event was decrypted and is ready for the map.
+    Resolved(Candidate),
+    /// The event couldn't be decrypted (yet).
+    Pending(PendingEvent),
+    /// The event was decrypted but has no sticky key: it is not tracked.
+    Dropped,
+}
+
+/// Try to decrypt `pending`, an encrypted sticky event of `room_id`.
+pub(crate) async fn decrypt(
+    e2ee: &e2ee::E2EE<'_>,
+    room_id: &RoomId,
+    pending: PendingEvent,
+) -> Decryption {
+    let event = TimelineEvent::from_plaintext(pending.event.clone());
+
+    match e2ee::decrypt::sync_timeline_event(e2ee, &event, room_id).await {
+        Ok(Some(decrypted)) if !decrypted.kind.is_utd() => {
+            match resolve(pending.meta, decrypted.kind) {
+                Some(candidate) => Decryption::Resolved(candidate),
+                None => Decryption::Dropped,
+            }
+        }
+        // Unable to decrypt, or no `OlmMachine` at all.
+        Ok(_) => Decryption::Pending(pending),
+        Err(error) => {
+            warn!(?error, event_id = %pending.meta.event_id, "Failed to decrypt a sticky event");
+            Decryption::Pending(pending)
+        }
+    }
+}
+
+/// Retry decrypting the pending sticky events of a room that were encrypted
+/// with one of `session_ids`, or all of them if `None`.
+pub(crate) async fn retry_pending(
+    sticky: &StickyEvents,
+    e2ee: &e2ee::E2EE<'_>,
+    session_ids: Option<&BTreeSet<String>>,
+) {
+    let pending = sticky.take_pending(session_ids);
+
+    if pending.is_empty() {
+        return;
+    }
+
+    trace!(room_id = %sticky.room_id(), count = pending.len(), "Retrying to decrypt sticky events");
+
+    let mut resolved = Vec::new();
+    let mut still_pending = Vec::new();
+
+    for event in pending {
+        match decrypt(e2ee, sticky.room_id(), event).await {
+            Decryption::Resolved(candidate) => resolved.push(candidate),
+            Decryption::Pending(event) => still_pending.push(event),
+            Decryption::Dropped => {}
+        }
+    }
+
+    sticky.ingest(now_ms(), resolved);
+    sticky.park(still_pending);
+}
+
+/// Spawn the task that retries pending sticky events as room keys arrive on
+/// `room_keys_stream` (the [`room_keys_received_stream`] of the `OlmMachine`
+/// behind `olm_machine`).
+///
+/// [`room_keys_received_stream`]: matrix_sdk_crypto::store::CryptoStoreWrapper::room_keys_received_stream
+pub(crate) fn spawn_redecryptor<S, E>(
+    room_keys_stream: S,
+    olm_machine: Arc<RwLock<Option<OlmMachine>>>,
+    decryption_settings: DecryptionSettings,
+    state_store: BaseStateStore,
+) -> AbortOnDrop<()>
+where
+    S: Stream<Item = Result<Vec<RoomKeyInfo>, E>> + Send + 'static,
+    E: Send + 'static,
+{
+    spawn(run_redecryptor(room_keys_stream, olm_machine, decryption_settings, state_store))
+        .abort_on_drop()
+}
+
+async fn run_redecryptor<S, E>(
+    room_keys_stream: S,
+    olm_machine: Arc<RwLock<Option<OlmMachine>>>,
+    decryption_settings: DecryptionSettings,
+    state_store: BaseStateStore,
+) where
+    S: Stream<Item = Result<Vec<RoomKeyInfo>, E>>,
+{
+    let mut room_keys_stream = std::pin::pin!(room_keys_stream);
+
+    while let Some(item) = room_keys_stream.next().await {
+        // Which pending events to retry, per room: those encrypted with the
+        // sessions we just received keys for, or, if we missed some keys, every
+        // pending event of every room.
+        let rooms: Vec<(OwnedRoomId, Option<BTreeSet<String>>)> = match item {
+            Ok(room_keys) => {
+                let mut sessions_per_room: BTreeMap<OwnedRoomId, BTreeSet<String>> =
+                    BTreeMap::new();
+
+                for key in room_keys {
+                    sessions_per_room.entry(key.room_id).or_default().insert(key.session_id);
+                }
+
+                sessions_per_room
+                    .into_iter()
+                    .map(|(room_id, session_ids)| (room_id, Some(session_ids)))
+                    .collect()
+            }
+            Err(_) => {
+                debug!("The room keys stream lagged, retrying every pending sticky event");
+
+                state_store
+                    .rooms()
+                    .into_iter()
+                    .map(|room| (room.room_id().to_owned(), None))
+                    .collect()
+            }
+        };
+
+        for (room_id, session_ids) in rooms {
+            let Some(room) = state_store.room(&room_id) else { continue };
+            let Some(sticky) = room.sticky_events_if_any() else { continue };
+
+            if !sticky.has_pending() {
+                continue;
+            }
+
+            let olm_machine = olm_machine.read().await;
+            let e2ee = e2ee::E2EE::new(olm_machine.as_ref(), &decryption_settings, false);
+
+            retry_pending(sticky, &e2ee, session_ids.as_ref()).await;
+        }
+    }
+}

--- a/crates/matrix-sdk-base/src/sticky/extract.rs
+++ b/crates/matrix-sdk-base/src/sticky/extract.rs
@@ -1,0 +1,442 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Reading the sticky metadata out of raw sync events.
+//!
+//! Sticky events reach us both through the dedicated sliding sync extension
+//! and, deduplicated out of it, through room timelines. Either way they are
+//! `Raw<AnySyncTimelineEvent>`s that carry the MSC4354 `sticky` object at the
+//! top level, next to the usual `sender`, `event_id` and `origin_server_ts`.
+//!
+//! The *key* of a sticky event, on the other hand, lives in its content
+//! (`type` and `content.sticky_key`), which for an encrypted event is only
+//! available after decryption. [`classify`] therefore only reads the outer
+//! metadata, and [`resolve`] combines it with the (decrypted) content.
+
+use std::collections::BTreeMap;
+
+use matrix_sdk_common::deserialized_responses::TimelineEventKind;
+use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId,
+    events::{
+        AnySyncTimelineEvent, TimelineEventType,
+        sticky::{StickyDurationMs, StickyObject},
+    },
+    serde::Raw,
+};
+use serde::Deserialize;
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{StickyKey, map::Candidate};
+
+/// The sticky metadata of an event, read from the outer (possibly encrypted)
+/// event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StickyMeta {
+    /// The sender of the event.
+    pub sender: OwnedUserId,
+    /// The event ID.
+    pub event_id: OwnedEventId,
+    /// `origin_server_ts + sticky.duration_ms`, the MSC4354 conflict-resolution
+    /// value.
+    pub order_ts: u64,
+    /// When the event stops being sticky, in milliseconds since the Unix epoch.
+    pub expires_at: u64,
+    /// The part of the event that depends on its content.
+    pub payload: Payload,
+}
+
+/// What we know about a sticky event's content from the outer event alone.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Payload {
+    /// The event is in the clear, so its key is known.
+    Plain {
+        /// The event type.
+        event_type: TimelineEventType,
+        /// The `content.sticky_key`.
+        sticky_key: String,
+        /// Whether the content carries nothing but the sticky key, i.e. this
+        /// event removes the entry.
+        is_tombstone: bool,
+    },
+    /// The event is encrypted: its type and sticky key are only known once it
+    /// is decrypted.
+    Encrypted {
+        /// The Megolm session the event was encrypted with, if the content is
+        /// well-formed.
+        session_id: Option<String>,
+    },
+}
+
+/// The top-level fields of a sync event we need to tell whether, and until
+/// when, it is sticky.
+///
+/// The field names mirror Ruma's `OriginalSyncMessageLikeEvent::sticky` and
+/// `MessageLikeUnsigned::sticky_duration_ttl_ms`; those are only reachable via
+/// a typed event content, which we don't have (nor want to deserialize) here.
+///
+/// A malformed `sticky` object (e.g. an out-of-range duration, which Ruma
+/// rejects) fails the whole probe, and the event is then simply not sticky;
+/// that is also what Ruma does with `default_on_error`.
+#[derive(Deserialize)]
+struct EventProbe<'a> {
+    sender: OwnedUserId,
+    event_id: OwnedEventId,
+    origin_server_ts: MilliSecondsSinceUnixEpoch,
+    #[serde(rename = "type")]
+    event_type: TimelineEventType,
+    #[serde(rename = "msc4354_sticky")]
+    sticky: Option<StickyObject>,
+    #[serde(default)]
+    unsigned: UnsignedProbe,
+    #[serde(borrow)]
+    content: &'a RawJsonValue,
+}
+
+#[derive(Default, Deserialize)]
+struct UnsignedProbe {
+    #[serde(rename = "msc4354_sticky_duration_ttl_ms")]
+    sticky_duration_ttl_ms: Option<u64>,
+}
+
+/// The unstable name of `content.sticky_key`, as defined by MSC4354.
+const UNSTABLE_STICKY_KEY: &str = "msc4354_sticky_key";
+
+/// The stable name of `content.sticky_key`.
+const STICKY_KEY: &str = "sticky_key";
+
+/// Read the sticky metadata of a raw sync event, or `None` if it is not
+/// sticky, is already expired at `now`, or is in the clear without a sticky
+/// key (such events are not tracked in the map).
+///
+/// `now` is the local time the event was received, in milliseconds since the
+/// Unix epoch.
+pub(crate) fn classify(now: u64, raw: &Raw<AnySyncTimelineEvent>) -> Option<StickyMeta> {
+    let probe: EventProbe<'_> = serde_json::from_str(raw.json().get()).ok()?;
+
+    // Ruma guarantees this is within the range MSC4354 allows.
+    let duration_ms = u64::from(probe.sticky?.duration_ms.get());
+    let origin_server_ts = u64::from(probe.origin_server_ts.0);
+
+    // MSC4354: the start time is `min(received_ts, origin_server_ts)`, so that
+    // an `origin_server_ts` in the future can't extend stickiness, and the end
+    // time is `start + duration`. When the server tells us how long the event
+    // has left, use that instead, as it removes the clock skew between us and
+    // the server.
+    let expires_at = match probe.unsigned.sticky_duration_ttl_ms {
+        Some(ttl_ms) => now.saturating_add(ttl_ms.min(u64::from(StickyDurationMs::MAX))),
+        None => origin_server_ts.min(now).saturating_add(duration_ms),
+    };
+
+    if expires_at <= now {
+        return None;
+    }
+
+    let payload = if probe.event_type == TimelineEventType::RoomEncrypted {
+        Payload::Encrypted { session_id: read_session_id(probe.content) }
+    } else {
+        let (sticky_key, is_tombstone) = read_content(probe.content)?;
+        Payload::Plain { event_type: probe.event_type, sticky_key, is_tombstone }
+    };
+
+    Some(StickyMeta {
+        sender: probe.sender,
+        event_id: probe.event_id,
+        order_ts: origin_server_ts.saturating_add(duration_ms),
+        expires_at,
+        payload,
+    })
+}
+
+/// Turn a sticky event into a map candidate, using the content of `kind` (the
+/// event itself if it was in the clear, its decrypted form otherwise).
+///
+/// Returns `None` if the content carries no sticky key.
+pub(crate) fn resolve(meta: StickyMeta, kind: TimelineEventKind) -> Option<Candidate> {
+    let (event_type, sticky_key, is_tombstone) = match meta.payload {
+        Payload::Plain { event_type, sticky_key, is_tombstone } => {
+            (event_type, sticky_key, is_tombstone)
+        }
+        Payload::Encrypted { .. } => {
+            let probe: DecryptedProbe<'_> = serde_json::from_str(kind.raw().json().get()).ok()?;
+            let (sticky_key, is_tombstone) = read_content(probe.content)?;
+            (probe.event_type, sticky_key, is_tombstone)
+        }
+    };
+
+    Some(Candidate {
+        key: StickyKey { sender: meta.sender, event_type, sticky_key },
+        event_id: meta.event_id,
+        order_ts: meta.order_ts,
+        expires_at: meta.expires_at,
+        is_tombstone,
+        kind,
+    })
+}
+
+/// The fields of a decrypted event we need to key it.
+#[derive(Deserialize)]
+struct DecryptedProbe<'a> {
+    #[serde(rename = "type")]
+    event_type: TimelineEventType,
+    #[serde(borrow)]
+    content: &'a RawJsonValue,
+}
+
+/// Read `(sticky_key, is_tombstone)` from an event content, or `None` if it
+/// has no sticky key.
+fn read_content(content: &RawJsonValue) -> Option<(String, bool)> {
+    // Only the keys are inspected, the values stay as raw JSON.
+    let content: BTreeMap<&str, &RawJsonValue> = serde_json::from_str(content.get()).ok()?;
+
+    let sticky_key = content
+        .get(UNSTABLE_STICKY_KEY)
+        .or_else(|| content.get(STICKY_KEY))
+        .and_then(|value| serde_json::from_str::<String>(value.get()).ok())?;
+
+    // MSC4354: to remove an entry, send an event "with just `content.sticky_key`
+    // set, with all the other application-specific fields omitted".
+    let is_tombstone = content.keys().all(|key| *key == UNSTABLE_STICKY_KEY || *key == STICKY_KEY);
+
+    Some((sticky_key, is_tombstone))
+}
+
+/// Read the Megolm session ID out of an `m.room.encrypted` content.
+fn read_session_id(content: &RawJsonValue) -> Option<String> {
+    #[derive(Deserialize)]
+    struct EncryptedContentProbe {
+        session_id: Option<String>,
+    }
+
+    serde_json::from_str::<EncryptedContentProbe>(content.get()).ok()?.session_id
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use matrix_sdk_common::deserialized_responses::TimelineEventKind;
+    use ruma::{
+        events::{AnySyncTimelineEvent, TimelineEventType},
+        serde::Raw,
+    };
+    use serde_json::{Value, json};
+
+    use super::{Payload, classify, resolve};
+
+    const NOW: u64 = 10_000;
+
+    fn raw(value: Value) -> Raw<AnySyncTimelineEvent> {
+        serde_json::from_value(value).unwrap()
+    }
+
+    /// A sticky event sent 100ms ago, sticky for 500ms.
+    fn sticky_event(content: Value) -> Raw<AnySyncTimelineEvent> {
+        raw(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW - 100,
+            "content": content,
+            "msc4354_sticky": { "duration_ms": 500 },
+        }))
+    }
+
+    #[test]
+    fn test_plaintext_event_is_classified_and_resolved() {
+        let event = sticky_event(json!({ "msc4354_sticky_key": "slot", "application": "m.call" }));
+
+        let meta = classify(NOW, &event).unwrap();
+        assert_eq!(meta.sender, "@alice:localhost");
+        assert_eq!(meta.event_id, "$a:localhost");
+        // The start time is `min(origin_server_ts, now)`, i.e. the origin.
+        assert_eq!(meta.expires_at, NOW + 400);
+        assert_eq!(meta.order_ts, NOW + 400);
+        assert_matches!(&meta.payload, Payload::Plain { event_type, sticky_key, is_tombstone });
+        assert_eq!(*event_type, TimelineEventType::from("m.rtc.member"));
+        assert_eq!(sticky_key, "slot");
+        assert!(!is_tombstone);
+
+        let candidate = resolve(meta, TimelineEventKind::PlainText { event }).unwrap();
+        assert_eq!(candidate.key.sticky_key, "slot");
+        assert!(!candidate.is_tombstone);
+    }
+
+    #[test]
+    fn test_future_origin_server_ts_does_not_extend_stickiness() {
+        let event = raw(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW + 5000,
+            "content": { "msc4354_sticky_key": "slot" },
+            "msc4354_sticky": { "duration_ms": 500 },
+        }));
+
+        let meta = classify(NOW, &event).unwrap();
+        assert_eq!(meta.expires_at, NOW + 500);
+        // The ordering value is taken from the event as is, though.
+        assert_eq!(meta.order_ts, NOW + 5500);
+    }
+
+    #[test]
+    fn test_server_ttl_takes_precedence_for_expiry_but_not_for_ordering() {
+        let event = raw(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": 1000,
+            "content": { "msc4354_sticky_key": "slot" },
+            "msc4354_sticky": { "duration_ms": 500 },
+            "unsigned": { "msc4354_sticky_duration_ttl_ms": 300 },
+        }));
+
+        let meta = classify(NOW, &event).unwrap();
+        assert_eq!(meta.expires_at, NOW + 300);
+        assert_eq!(meta.order_ts, 1500);
+    }
+
+    #[test]
+    fn test_expired_event_is_not_sticky() {
+        let event = sticky_event(json!({ "msc4354_sticky_key": "slot" }));
+
+        // It expires at `NOW + 400`.
+        assert!(classify(NOW + 400, &event).is_none());
+    }
+
+    #[test]
+    fn test_out_of_range_duration_is_not_sticky() {
+        let event = raw(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW,
+            "content": { "msc4354_sticky_key": "slot" },
+            "msc4354_sticky": { "duration_ms": 3_600_001 },
+        }));
+
+        assert!(classify(NOW, &event).is_none());
+    }
+
+    #[test]
+    fn test_event_without_sticky_key_is_not_tracked() {
+        let event = raw(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW,
+            "content": { "application": "m.call" },
+            "msc4354_sticky": { "duration_ms": 500 },
+        }));
+
+        assert!(classify(NOW, &event).is_none());
+    }
+
+    #[test]
+    fn test_non_sticky_event_is_ignored() {
+        let event = raw(json!({
+            "type": "m.room.message",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW,
+            "content": { "body": "hello", "msgtype": "m.text" },
+        }));
+
+        assert!(classify(NOW, &event).is_none());
+    }
+
+    #[test]
+    fn test_content_with_only_the_sticky_key_is_a_tombstone() {
+        for content in [
+            json!({ "msc4354_sticky_key": "slot" }),
+            json!({ "sticky_key": "slot" }),
+            json!({ "msc4354_sticky_key": "slot", "sticky_key": "slot" }),
+        ] {
+            let event = raw(json!({
+                "type": "m.rtc.member",
+                "sender": "@alice:localhost",
+                "event_id": "$a:localhost",
+                "origin_server_ts": NOW,
+                "content": content,
+                "msc4354_sticky": { "duration_ms": 500 },
+            }));
+
+            let meta = classify(NOW, &event).unwrap();
+            assert_matches!(meta.payload, Payload::Plain { sticky_key, is_tombstone, .. });
+            assert_eq!(sticky_key, "slot");
+            assert!(is_tombstone);
+        }
+    }
+
+    #[test]
+    fn test_encrypted_event_is_resolved_from_its_decrypted_form() {
+        let event = raw(json!({
+            "type": "m.room.encrypted",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW,
+            "content": {
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "AAAA",
+                "session_id": "session",
+            },
+            "msc4354_sticky": { "duration_ms": 500 },
+        }));
+
+        let meta = classify(NOW, &event).unwrap();
+        assert_matches!(&meta.payload, Payload::Encrypted { session_id });
+        assert_eq!(session_id.as_deref(), Some("session"));
+
+        // Pretend we decrypted it.
+        let decrypted = TimelineEventKind::PlainText {
+            event: raw(json!({
+                "type": "m.rtc.member",
+                "sender": "@alice:localhost",
+                "event_id": "$a:localhost",
+                "origin_server_ts": NOW,
+                "content": { "msc4354_sticky_key": "slot", "application": "m.call" },
+            })),
+        };
+
+        let candidate = resolve(meta, decrypted).unwrap();
+        assert_eq!(candidate.key.event_type, TimelineEventType::from("m.rtc.member"));
+        assert_eq!(candidate.key.sticky_key, "slot");
+        assert!(!candidate.is_tombstone);
+    }
+
+    #[test]
+    fn test_decrypted_event_without_sticky_key_is_not_tracked() {
+        let event = raw(json!({
+            "type": "m.room.encrypted",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": NOW,
+            "content": { "algorithm": "m.megolm.v1.aes-sha2", "ciphertext": "AAAA" },
+            "msc4354_sticky": { "duration_ms": 500 },
+        }));
+
+        let meta = classify(NOW, &event).unwrap();
+
+        let decrypted = TimelineEventKind::PlainText {
+            event: raw(json!({
+                "type": "m.room.message",
+                "sender": "@alice:localhost",
+                "event_id": "$a:localhost",
+                "origin_server_ts": NOW,
+                "content": { "body": "hello", "msgtype": "m.text" },
+            })),
+        };
+
+        assert!(resolve(meta, decrypted).is_none());
+    }
+}

--- a/crates/matrix-sdk-base/src/sticky/map.rs
+++ b/crates/matrix-sdk-base/src/sticky/map.rs
@@ -1,0 +1,560 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The in-memory, per-room map of sticky events (the "ephemeral map" of
+//! [MSC4354]).
+//!
+//! [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::{BinaryHeap, HashMap},
+};
+
+use matrix_sdk_common::deserialized_responses::TimelineEventKind;
+use ruma::{MilliSecondsSinceUnixEpoch, OwnedEventId, UInt};
+use tracing::warn;
+
+use super::{RemovalReason, StickyEvent, StickyEventsUpdate, StickyKey};
+
+/// The maximum number of entries (live values and tombstones alike) a single
+/// room's map holds.
+///
+/// Servers are expected to rate limit sticky events, but nothing stops a room
+/// member from sending a stream of events with distinct sticky keys. Beyond
+/// this many entries, events for *new* keys are dropped; updates to existing
+/// keys are still applied. Entries expire after at most one hour, so the map
+/// recovers on its own.
+pub(super) const MAX_ENTRIES: usize = 500;
+
+/// A sticky event that has been fully resolved (decrypted if needed) and is
+/// ready to be applied to the map.
+#[derive(Debug)]
+pub(crate) struct Candidate {
+    /// The map key of the event.
+    pub key: StickyKey,
+    /// The event ID, used as the tie-breaker of last resort.
+    pub event_id: OwnedEventId,
+    /// `origin_server_ts + sticky.duration_ms`: the value MSC4354 orders
+    /// competing events for the same key by ("last to expire wins"). It is
+    /// derived from the event alone, so every client agrees on it.
+    pub order_ts: u64,
+    /// When this event stops being sticky, in milliseconds since the Unix
+    /// epoch, according to our clock and the server's TTL hint.
+    pub expires_at: u64,
+    /// Whether the content carries nothing but the sticky key, which is how
+    /// MSC4354 expresses the removal of a map entry.
+    pub is_tombstone: bool,
+    /// The event, decrypted if it was encrypted, along with its encryption
+    /// info.
+    pub kind: TimelineEventKind,
+}
+
+/// An entry of the map.
+#[derive(Debug)]
+struct Entry {
+    event_id: OwnedEventId,
+    order_ts: u64,
+    expires_at: u64,
+    is_tombstone: bool,
+    kind: TimelineEventKind,
+    /// Identifies the insertion this entry stems from, so that stale nodes in
+    /// the expiry heap can be told apart from the current one.
+    seq: u64,
+}
+
+impl Entry {
+    /// The conflict-resolution rank of this entry: higher wins.
+    fn rank(&self) -> (u64, &OwnedEventId) {
+        (self.order_ts, &self.event_id)
+    }
+
+    /// Whether this entry is a live value at `now`, i.e. neither expired nor a
+    /// tombstone.
+    fn is_live(&self, now: u64) -> bool {
+        !self.is_tombstone && self.expires_at > now
+    }
+}
+
+/// A node of the expiry min-heap. Ordered by `expires_at`, then insertion
+/// sequence number, so that keys never need to be compared.
+#[derive(Debug)]
+struct ExpiryNode {
+    expires_at: u64,
+    seq: u64,
+    key: StickyKey,
+}
+
+impl PartialEq for ExpiryNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for ExpiryNode {}
+
+impl PartialOrd for ExpiryNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ExpiryNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.expires_at, self.seq).cmp(&(other.expires_at, other.seq))
+    }
+}
+
+/// The per-room map of sticky events.
+///
+/// Each key holds the winning event according to the MSC4354 tie-break: the
+/// highest `origin_server_ts + duration_ms` wins, then the highest event ID.
+/// A removal (an event whose content only carries the sticky key) is kept as a
+/// *tombstone* rather than deleting the key, so that a superseded event that
+/// arrives late (which MSC4354 explicitly allows) doesn't resurrect the value.
+/// Tombstones are invisible to readers and disappear when they expire.
+///
+/// Expiry is evaluated against a `now` passed in by the caller, so the map has
+/// no notion of time of its own and is trivially testable.
+#[derive(Debug, Default)]
+pub(crate) struct EphemeralMap {
+    entries: HashMap<StickyKey, Entry>,
+    /// Min-heap over the expiry of every insertion. Replaced entries leave a
+    /// stale node behind, recognised by its `seq` and skipped on pop.
+    expiry_heap: BinaryHeap<Reverse<ExpiryNode>>,
+    next_seq: u64,
+}
+
+impl EphemeralMap {
+    /// Apply a batch of candidates, returning what visibly changed.
+    pub fn apply(
+        &mut self,
+        now: u64,
+        candidates: impl IntoIterator<Item = Candidate>,
+    ) -> StickyEventsUpdate {
+        let mut update = StickyEventsUpdate::default();
+
+        for candidate in candidates {
+            match self.insert(now, candidate) {
+                Some(Change::Added(event)) => update.added.push(event),
+                Some(Change::Updated(event)) => update.updated.push(event),
+                Some(Change::Removed(key)) => update.removed.push((key, RemovalReason::Replaced)),
+                None => {}
+            }
+        }
+
+        update
+    }
+
+    /// Insert a single candidate, returning the visible change, if any.
+    fn insert(&mut self, now: u64, candidate: Candidate) -> Option<Change> {
+        if candidate.expires_at <= now {
+            return None;
+        }
+
+        let Candidate { key, event_id, order_ts, expires_at, is_tombstone, kind } = candidate;
+
+        let was_live = match self.entries.get(&key) {
+            Some(current) => {
+                // The very same event, delivered again (e.g. both in the
+                // timeline and in the sticky section, or after the connection
+                // restarted).
+                if current.event_id == event_id {
+                    return None;
+                }
+
+                // Last to expire wins, then the highest event ID.
+                if (order_ts, &event_id) <= current.rank() {
+                    return None;
+                }
+
+                current.is_live(now)
+            }
+
+            None => {
+                if self.entries.len() >= MAX_ENTRIES {
+                    // Make room by dropping what has expired before giving up.
+                    self.evict_expired(now);
+
+                    if self.entries.len() >= MAX_ENTRIES {
+                        warn!(
+                            ?key,
+                            %event_id,
+                            "Dropping a sticky event: the room holds too many sticky events already"
+                        );
+                        return None;
+                    }
+                }
+
+                false
+            }
+        };
+
+        let seq = self.next_seq;
+        self.next_seq += 1;
+
+        self.entries
+            .insert(key.clone(), Entry { event_id, order_ts, expires_at, is_tombstone, kind, seq });
+        self.expiry_heap.push(Reverse(ExpiryNode { expires_at, seq, key: key.clone() }));
+
+        match (was_live, is_tombstone) {
+            (true, true) => Some(Change::Removed(key)),
+            (true, false) => Some(Change::Updated(self.event(&key)?)),
+            (false, false) => Some(Change::Added(self.event(&key)?)),
+            // A tombstone replacing nothing visible: nothing to report.
+            (false, true) => None,
+        }
+    }
+
+    /// The live events at `now`, in no particular order.
+    pub fn live(&self, now: u64) -> impl Iterator<Item = StickyEvent> + '_ {
+        self.entries
+            .iter()
+            .filter(move |(_, entry)| entry.is_live(now))
+            .map(|(key, entry)| Self::event_from_entry(key, entry))
+    }
+
+    /// The number of entries, including tombstones and not-yet-evicted expired
+    /// ones.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// The earliest time an entry may need evicting, if any.
+    pub fn next_expiry(&self) -> Option<u64> {
+        self.expiry_heap.peek().map(|Reverse(node)| node.expires_at)
+    }
+
+    /// Drop every entry that has expired at `now`, returning the keys whose
+    /// live value disappeared as a result (expired tombstones are not
+    /// reported, they were never visible).
+    pub fn evict_expired(&mut self, now: u64) -> Vec<StickyKey> {
+        let mut removed = Vec::new();
+
+        while let Some(Reverse(node)) = self.expiry_heap.peek() {
+            if node.expires_at > now {
+                break;
+            }
+
+            let Reverse(node) = self.expiry_heap.pop().expect("the heap was just peeked");
+
+            // Skip stale nodes: the entry has since been replaced by a newer
+            // insertion, which has its own node.
+            let is_current = self.entries.get(&node.key).is_some_and(|entry| entry.seq == node.seq);
+
+            if is_current
+                && let Some(entry) = self.entries.remove(&node.key)
+                && !entry.is_tombstone
+            {
+                removed.push(node.key);
+            }
+        }
+
+        removed
+    }
+
+    /// Drop every entry, returning the keys whose live value disappeared.
+    pub fn clear(&mut self, now: u64) -> Vec<StickyKey> {
+        self.expiry_heap.clear();
+        self.next_seq = 0;
+
+        self.entries.drain().filter(|(_, entry)| entry.is_live(now)).map(|(key, _)| key).collect()
+    }
+
+    fn event(&self, key: &StickyKey) -> Option<StickyEvent> {
+        self.entries.get(key).map(|entry| Self::event_from_entry(key, entry))
+    }
+
+    fn event_from_entry(key: &StickyKey, entry: &Entry) -> StickyEvent {
+        StickyEvent {
+            key: key.clone(),
+            event_id: entry.event_id.clone(),
+            kind: entry.kind.clone(),
+            expires_at: MilliSecondsSinceUnixEpoch(UInt::new_saturating(entry.expires_at)),
+        }
+    }
+}
+
+/// A single visible change to the map.
+enum Change {
+    Added(StickyEvent),
+    Updated(StickyEvent),
+    Removed(StickyKey),
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use matrix_sdk_common::deserialized_responses::TimelineEventKind;
+    use ruma::{
+        EventId, MilliSecondsSinceUnixEpoch, events::TimelineEventType, owned_event_id,
+        owned_user_id, uint,
+    };
+    use serde_json::json;
+
+    use super::{Candidate, EphemeralMap, MAX_ENTRIES};
+    use crate::sticky::{RemovalReason, StickyKey};
+
+    fn key(sticky_key: &str) -> StickyKey {
+        StickyKey {
+            sender: owned_user_id!("@alice:localhost"),
+            event_type: TimelineEventType::from("m.rtc.member"),
+            sticky_key: sticky_key.to_owned(),
+        }
+    }
+
+    fn kind() -> TimelineEventKind {
+        TimelineEventKind::PlainText {
+            event: serde_json::from_value(json!({
+                "type": "m.rtc.member",
+                "sender": "@alice:localhost",
+                "event_id": "$event:localhost",
+                "origin_server_ts": 1,
+                "content": {},
+            }))
+            .unwrap(),
+        }
+    }
+
+    fn candidate(key: StickyKey, event_id: &EventId, order_ts: u64, expires_at: u64) -> Candidate {
+        Candidate {
+            key,
+            event_id: event_id.to_owned(),
+            order_ts,
+            expires_at,
+            is_tombstone: false,
+            kind: kind(),
+        }
+    }
+
+    fn tombstone(key: StickyKey, event_id: &EventId, order_ts: u64, expires_at: u64) -> Candidate {
+        Candidate { is_tombstone: true, ..candidate(key, event_id, order_ts, expires_at) }
+    }
+
+    #[test]
+    fn test_added_entries_are_live_until_they_expire() {
+        let mut map = EphemeralMap::default();
+
+        let update =
+            map.apply(0, [candidate(key("slot"), &owned_event_id!("$a:localhost"), 100, 100)]);
+        assert_eq!(update.added.len(), 1);
+        assert_eq!(update.added[0].key, key("slot"));
+        assert_eq!(update.added[0].expires_at, MilliSecondsSinceUnixEpoch(uint!(100)));
+
+        assert_eq!(map.live(99).count(), 1);
+        assert_eq!(map.live(100).count(), 0, "an entry is no longer live at its expiry");
+    }
+
+    #[test]
+    fn test_already_expired_candidates_are_ignored() {
+        let mut map = EphemeralMap::default();
+
+        let update =
+            map.apply(100, [candidate(key("slot"), &owned_event_id!("$a:localhost"), 100, 100)]);
+        assert!(update.is_empty());
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn test_last_to_expire_wins() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 1000)]);
+
+        // A later `origin_server_ts + duration_ms` wins…
+        let update =
+            map.apply(0, [candidate(k.clone(), &owned_event_id!("$b:localhost"), 200, 1000)]);
+        assert_eq!(update.updated.len(), 1);
+        assert_eq!(update.updated[0].event_id, "$b:localhost");
+
+        // …and an earlier one loses, whatever its local expiry is.
+        let update = map.apply(0, [candidate(k, &owned_event_id!("$c:localhost"), 150, 5000)]);
+        assert!(update.is_empty());
+
+        let live: Vec<_> = map.live(0).collect();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].event_id, "$b:localhost");
+    }
+
+    #[test]
+    fn test_ties_are_broken_by_the_highest_event_id() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$b:localhost"), 100, 1000)]);
+
+        assert!(
+            map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 1000)])
+                .is_empty()
+        );
+        assert_eq!(
+            map.apply(0, [candidate(k, &owned_event_id!("$c:localhost"), 100, 1000)]).updated.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_redelivering_the_same_event_is_a_no_op() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 1000)]);
+
+        // The same event, received again a bit later, with a slightly different
+        // local expiry: neither an update nor a change of expiry.
+        let update = map.apply(0, [candidate(k, &owned_event_id!("$a:localhost"), 100, 1010)]);
+        assert!(update.is_empty());
+
+        let live: Vec<_> = map.live(0).collect();
+        assert_eq!(live[0].expires_at, MilliSecondsSinceUnixEpoch(uint!(1000)));
+    }
+
+    #[test]
+    fn test_tombstone_removes_the_live_value() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 1000)]);
+
+        let update =
+            map.apply(0, [tombstone(k.clone(), &owned_event_id!("$b:localhost"), 200, 1000)]);
+        assert_eq!(update.removed, vec![(k, RemovalReason::Replaced)]);
+        assert_eq!(map.live(0).count(), 0);
+
+        // The tombstone stays in the map until it expires, though.
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_late_superseded_event_does_not_resurrect_a_removed_key() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        // The removal arrives first…
+        let update =
+            map.apply(0, [tombstone(k.clone(), &owned_event_id!("$b:localhost"), 200, 1000)]);
+        assert!(update.is_empty(), "removing nothing visible reports nothing");
+
+        // …then the event it superseded arrives late: it must lose.
+        let update =
+            map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 1000)]);
+        assert!(update.is_empty());
+        assert_eq!(map.live(0).count(), 0);
+
+        // A genuinely newer event does win against the tombstone, and shows up
+        // as an addition since nothing was visible before.
+        let update = map.apply(0, [candidate(k, &owned_event_id!("$c:localhost"), 300, 1000)]);
+        assert_eq!(update.added.len(), 1);
+        assert_eq!(map.live(0).count(), 1);
+    }
+
+    #[test]
+    fn test_stale_tombstone_does_not_remove_a_newer_value() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$b:localhost"), 200, 1000)]);
+
+        let update = map.apply(0, [tombstone(k, &owned_event_id!("$a:localhost"), 100, 1000)]);
+        assert!(update.is_empty());
+        assert_eq!(map.live(0).count(), 1);
+    }
+
+    #[test]
+    fn test_evict_expired_reports_live_values_only() {
+        let mut map = EphemeralMap::default();
+
+        map.apply(
+            0,
+            [
+                candidate(key("1"), &owned_event_id!("$a:localhost"), 100, 100),
+                candidate(key("2"), &owned_event_id!("$b:localhost"), 200, 200),
+                tombstone(key("3"), &owned_event_id!("$c:localhost"), 200, 200),
+                candidate(key("4"), &owned_event_id!("$d:localhost"), 300, 300),
+            ],
+        );
+
+        let mut removed = map.evict_expired(250);
+        removed.sort_by(|a, b| a.sticky_key.cmp(&b.sticky_key));
+        assert_eq!(removed, vec![key("1"), key("2")]);
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.next_expiry(), Some(300));
+    }
+
+    #[test]
+    fn test_evict_expired_skips_stale_heap_nodes() {
+        let mut map = EphemeralMap::default();
+        let k = key("slot");
+
+        // A short-lived entry, then a replacement that lives much longer.
+        map.apply(0, [candidate(k.clone(), &owned_event_id!("$a:localhost"), 100, 100)]);
+        map.apply(0, [candidate(k, &owned_event_id!("$b:localhost"), 500, 500)]);
+
+        // The node of the first insertion is stale and must not evict the
+        // replacement.
+        assert!(map.evict_expired(150).is_empty());
+        assert_eq!(map.live(150).count(), 1);
+        assert_eq!(map.next_expiry(), Some(500));
+    }
+
+    #[test]
+    fn test_clear_reports_live_values_only() {
+        let mut map = EphemeralMap::default();
+
+        map.apply(
+            0,
+            [
+                candidate(key("1"), &owned_event_id!("$a:localhost"), 100, 100),
+                tombstone(key("2"), &owned_event_id!("$b:localhost"), 100, 100),
+            ],
+        );
+
+        assert_eq!(map.clear(0), vec![key("1")]);
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.next_expiry(), None);
+    }
+
+    #[test]
+    fn test_new_keys_are_dropped_beyond_the_cap_but_updates_still_apply() {
+        let mut map = EphemeralMap::default();
+
+        map.apply(
+            0,
+            (0..MAX_ENTRIES).map(|i| {
+                candidate(key(&i.to_string()), &owned_event_id!("$a:localhost"), 100, 1000)
+            }),
+        );
+        assert_eq!(map.len(), MAX_ENTRIES);
+
+        // One more key is dropped…
+        let update =
+            map.apply(0, [candidate(key("extra"), &owned_event_id!("$a:localhost"), 100, 1000)]);
+        assert!(update.is_empty());
+        assert_eq!(map.len(), MAX_ENTRIES);
+
+        // …but an update to an existing key goes through.
+        let update =
+            map.apply(0, [candidate(key("0"), &owned_event_id!("$b:localhost"), 200, 1000)]);
+        assert_matches!(update.updated.as_slice(), [event]);
+        assert_eq!(event.event_id, "$b:localhost");
+
+        // And once entries expire, new keys are accepted again.
+        let update = map
+            .apply(1000, [candidate(key("extra"), &owned_event_id!("$c:localhost"), 2000, 2000)]);
+        assert_eq!(update.added.len(), 1);
+    }
+}

--- a/crates/matrix-sdk-base/src/sticky/mod.rs
+++ b/crates/matrix-sdk-base/src/sticky/mod.rs
@@ -1,0 +1,561 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sticky events ([MSC4354]), received over sliding sync through the
+//! [MSC4480] extension.
+//!
+//! A sticky event is a message-like event that the server keeps delivering to
+//! clients for a bounded duration (at most one hour), regardless of the
+//! timeline limit. Clients fold the sticky events of a room into a map keyed by
+//! `(sender, type, content.sticky_key)`, in which the event that is last to
+//! expire wins, and from which entries disappear once they expire. MatrixRTC
+//! uses this to track who is in a call.
+//!
+//! The map of a room is reachable through [`Room::sticky_events`]. It is fed
+//! from the sync response, expires its entries in the background, and
+//! broadcasts every visible change to its subscribers. Encrypted sticky events
+//! that cannot be decrypted yet are kept aside and retried when their room key
+//! arrives. Nothing is persisted: the server re-sends every sticky event that
+//! is still live when the sliding sync connection starts over.
+//!
+//! [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
+//! [MSC4480]: https://github.com/matrix-org/matrix-spec-proposals/pull/4480
+//! [`Room::sticky_events`]: crate::Room::sticky_events
+
+#[cfg(feature = "e2e-encryption")]
+mod decrypt;
+mod extract;
+mod map;
+mod task;
+
+#[cfg(feature = "e2e-encryption")]
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use matrix_sdk_common::{
+    deserialized_responses::{EncryptionInfo, TimelineEventKind},
+    executor::AbortOnDrop,
+};
+use ruma::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
+    events::{AnySyncTimelineEvent, TimelineEventType},
+    serde::Raw,
+};
+use tokio::sync::{Notify, broadcast};
+use tracing::{debug, warn};
+
+#[cfg(feature = "e2e-encryption")]
+pub(crate) use self::decrypt::{Decryption, decrypt, spawn_redecryptor};
+use self::map::EphemeralMap;
+pub(crate) use self::{
+    extract::{Payload, StickyMeta, classify, resolve},
+    map::Candidate,
+};
+
+/// The maximum number of encrypted sticky events kept aside per room while
+/// waiting for their room keys. Beyond that, the oldest (which are the closest
+/// to expiring) make way for new ones.
+const MAX_PENDING: usize = 100;
+
+/// The capacity of the broadcast channel behind [`StickyEvents::subscribe`].
+const UPDATES_CHANNEL_CAPACITY: usize = 16;
+
+/// The key of a sticky event in the map of a room.
+///
+/// MSC4354 keys the map by `(room_id, sender, type, content.sticky_key)`; the
+/// room is implied by the map this key belongs to.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StickyKey {
+    /// The sender of the event.
+    pub sender: OwnedUserId,
+    /// The type of the event, e.g. `m.rtc.member`.
+    pub event_type: TimelineEventType,
+    /// The `content.sticky_key` of the event.
+    pub sticky_key: String,
+}
+
+/// A sticky event that is currently live in the map of a room.
+#[derive(Clone, Debug)]
+pub struct StickyEvent {
+    /// The key of the event in the map.
+    pub key: StickyKey,
+    /// The event ID.
+    pub event_id: OwnedEventId,
+    /// The event, decrypted if it was encrypted, along with its encryption
+    /// info.
+    pub kind: TimelineEventKind,
+    /// When the event stops being sticky.
+    pub expires_at: MilliSecondsSinceUnixEpoch,
+}
+
+impl StickyEvent {
+    /// The event, decrypted if it was encrypted.
+    pub fn raw(&self) -> &Raw<AnySyncTimelineEvent> {
+        self.kind.raw()
+    }
+
+    /// The encryption info of the event, if it was encrypted.
+    pub fn encryption_info(&self) -> Option<&Arc<EncryptionInfo>> {
+        self.kind.encryption_info()
+    }
+}
+
+/// Why a sticky event disappeared from the map of a room.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RemovalReason {
+    /// The event stopped being sticky.
+    Expired,
+    /// A newer event with the same key and an empty content (a removal, in
+    /// MSC4354 terms) replaced it.
+    Replaced,
+    /// We left the room.
+    RoomLeft,
+}
+
+/// A batch of visible changes to the map of a room.
+///
+/// One update is broadcast per processed sync response, and one per expiry
+/// pass, so that subscribers see the net effect of each at once.
+#[derive(Clone, Debug, Default)]
+pub struct StickyEventsUpdate {
+    /// The events that appeared under a key that had no live event.
+    pub added: Vec<StickyEvent>,
+    /// The events that replaced the live event of their key.
+    pub updated: Vec<StickyEvent>,
+    /// The keys whose live event disappeared, and why.
+    pub removed: Vec<(StickyKey, RemovalReason)>,
+}
+
+impl StickyEventsUpdate {
+    /// Whether this update carries no change at all.
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.updated.is_empty() && self.removed.is_empty()
+    }
+}
+
+/// An encrypted sticky event that couldn't be decrypted yet.
+///
+/// Without encryption support nothing ever reads the event back: it is kept
+/// until it expires, like any other, for the sake of a single code path.
+#[derive(Debug)]
+pub(crate) struct PendingEvent {
+    /// The sticky metadata of the event, with a [`Payload::Encrypted`].
+    pub meta: StickyMeta,
+    /// The encrypted event.
+    #[cfg_attr(not(feature = "e2e-encryption"), allow(dead_code))]
+    pub event: Raw<AnySyncTimelineEvent>,
+}
+
+impl PendingEvent {
+    /// Return the Megolm session the event was encrypted with (if any).
+    fn session_id(&self) -> Option<&str> {
+        match &self.meta.payload {
+            Payload::Encrypted { session_id } => session_id.as_deref(),
+            Payload::Plain { .. } => None,
+        }
+    }
+}
+
+/// The sticky events of a room.
+///
+/// This is a cheap-to-clone handle over the map of a room, which every clone
+/// (and every clone of the [`Room`](crate::Room) it belongs to) shares.
+#[derive(Clone, Debug)]
+pub struct StickyEvents {
+    inner: Arc<StickyEventsInner>,
+}
+
+#[derive(Debug)]
+struct StickyEventsInner {
+    /// The ID of the room these sticky events belong to.
+    room_id: OwnedRoomId,
+    /// The mutable state of the room's sticky events.
+    state: Mutex<State>,
+    /// Broadcasts the visible changes of the map to subscribers.
+    updates: broadcast::Sender<StickyEventsUpdate>,
+    /// Notified whenever the state changed in a way that may require the
+    /// maintenance task to wake up earlier than planned.
+    changed: Arc<Notify>,
+    /// The background task expiring entries and pending events. Spawned the
+    /// first time there is something to expire, so that a room without sticky
+    /// events costs nothing, and aborted when the last handle is dropped.
+    task: OnceLock<AbortOnDrop<()>>,
+}
+
+/// The mutable state of a room's sticky events.
+#[derive(Debug, Default)]
+struct State {
+    /// The map of live (and tombstoned) sticky events.
+    map: EphemeralMap,
+    /// Encrypted sticky events awaiting their room key, oldest first.
+    pending: Vec<PendingEvent>,
+}
+
+impl StickyEvents {
+    pub(crate) fn new(room_id: OwnedRoomId) -> Self {
+        let (updates, _) = broadcast::channel(UPDATES_CHANNEL_CAPACITY);
+
+        Self {
+            inner: Arc::new(StickyEventsInner {
+                room_id,
+                state: Default::default(),
+                updates,
+                changed: Default::default(),
+                task: OnceLock::new(),
+            }),
+        }
+    }
+
+    /// The room these sticky events belong to.
+    pub fn room_id(&self) -> &RoomId {
+        &self.inner.room_id
+    }
+
+    /// The sticky events that are currently live, in no particular order.
+    pub fn live(&self) -> Vec<StickyEvent> {
+        self.inner.state.lock().unwrap().map.live(now_ms()).collect()
+    }
+
+    /// Subscribe to the changes of the map.
+    ///
+    /// A subscriber that falls behind receives a
+    /// [`Lagged`](broadcast::error::RecvError::Lagged) error, after which it
+    /// should reconcile with [`live`](Self::live).
+    pub fn subscribe(&self) -> broadcast::Receiver<StickyEventsUpdate> {
+        self.inner.updates.subscribe()
+    }
+
+    /// Apply resolved sticky events received at `now` to the map.
+    pub(crate) fn ingest(&self, now: u64, candidates: Vec<Candidate>) {
+        if candidates.is_empty() {
+            return;
+        }
+
+        self.ensure_task();
+
+        let update = self.inner.state.lock().unwrap().map.apply(now, candidates);
+        self.inner.changed.notify_one();
+        self.publish(update);
+    }
+
+    /// Keep encrypted sticky events aside until their room key arrives.
+    pub(crate) fn park(&self, pending: Vec<PendingEvent>) {
+        if pending.is_empty() {
+            return;
+        }
+
+        self.ensure_task();
+
+        {
+            let mut state = self.inner.state.lock().unwrap();
+
+            for event in pending {
+                if event.session_id().is_none() {
+                    debug!(
+                        room_id = %self.inner.room_id,
+                        event_id = %event.meta.event_id,
+                        "Dropping an encrypted sticky event without a session ID"
+                    );
+                    continue;
+                }
+
+                state.pending.push(event);
+            }
+
+            if state.pending.len() > MAX_PENDING {
+                warn!(
+                    room_id = %self.inner.room_id,
+                    "Too many encrypted sticky events await their room key, dropping the oldest"
+                );
+                let excess = state.pending.len() - MAX_PENDING;
+                state.pending.drain(..excess);
+            }
+        }
+
+        self.inner.changed.notify_one();
+    }
+
+    /// Take the pending encrypted sticky events that were encrypted with one of
+    /// `session_ids`, or all of them if `None`.
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) fn take_pending(&self, session_ids: Option<&BTreeSet<String>>) -> Vec<PendingEvent> {
+        let mut state = self.inner.state.lock().unwrap();
+
+        match session_ids {
+            None => std::mem::take(&mut state.pending),
+            Some(session_ids) => {
+                let (taken, kept) =
+                    std::mem::take(&mut state.pending).into_iter().partition(|event| {
+                        event.session_id().is_some_and(|id| session_ids.contains(id))
+                    });
+                state.pending = kept;
+                taken
+            }
+        }
+    }
+
+    /// Whether any encrypted sticky event awaits its room key.
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) fn has_pending(&self) -> bool {
+        !self.inner.state.lock().unwrap().pending.is_empty()
+    }
+
+    /// Forget every sticky event, e.g. because we left the room.
+    pub(crate) fn clear(&self) {
+        let removed = {
+            let mut state = self.inner.state.lock().unwrap();
+            state.pending.clear();
+            state.map.clear(now_ms())
+        };
+
+        self.publish(StickyEventsUpdate {
+            removed: removed.into_iter().map(|key| (key, RemovalReason::RoomLeft)).collect(),
+            ..Default::default()
+        });
+    }
+
+    fn publish(&self, update: StickyEventsUpdate) {
+        if !update.is_empty() {
+            // Failing to send only means there is no subscriber.
+            let _ = self.inner.updates.send(update);
+        }
+    }
+
+    fn ensure_task(&self) {
+        self.inner
+            .task
+            .get_or_init(|| task::spawn(Arc::downgrade(&self.inner), self.inner.changed.clone()));
+    }
+}
+
+impl StickyEventsInner {
+    /// Drop what has expired at `now`, broadcast the visible removals, and
+    /// return when the next entry is due to expire, if any.
+    fn expire(&self, now: u64) -> Option<u64> {
+        let (removed, next) = {
+            let mut state = self.state.lock().unwrap();
+
+            let removed = state.map.evict_expired(now);
+            state.pending.retain(|event| event.meta.expires_at > now);
+
+            let next_pending = state.pending.iter().map(|event| event.meta.expires_at).min();
+            let next = match (state.map.next_expiry(), next_pending) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            };
+
+            (removed, next)
+        };
+
+        if !removed.is_empty() {
+            let _ = self.updates.send(StickyEventsUpdate {
+                removed: removed.into_iter().map(|key| (key, RemovalReason::Expired)).collect(),
+                ..Default::default()
+            });
+        }
+
+        next
+    }
+}
+
+/// The current time, in milliseconds since the Unix epoch.
+pub(crate) fn now_ms() -> u64 {
+    MilliSecondsSinceUnixEpoch::now().get().into()
+}
+
+/// A weak handle to the state of a room's sticky events, for background
+/// tasks.
+type WeakStickyEvents = Weak<StickyEventsInner>;
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use assert_matches2::assert_matches;
+    use matrix_sdk_common::deserialized_responses::TimelineEventKind;
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        events::{AnySyncTimelineEvent, TimelineEventType},
+        owned_event_id, owned_user_id, room_id,
+        serde::Raw,
+    };
+    use serde_json::json;
+    use tokio::sync::broadcast::error::TryRecvError;
+
+    use super::{
+        Candidate, PendingEvent, RemovalReason, StickyEvents, StickyKey, StickyMeta, now_ms,
+    };
+    use crate::sticky::Payload;
+
+    fn raw_event() -> Raw<AnySyncTimelineEvent> {
+        serde_json::from_value(json!({
+            "type": "m.rtc.member",
+            "sender": "@alice:localhost",
+            "event_id": "$a:localhost",
+            "origin_server_ts": 1,
+            "content": { "msc4354_sticky_key": "slot" },
+        }))
+        .unwrap()
+    }
+
+    fn candidate(sticky_key: &str, expires_at: u64) -> Candidate {
+        Candidate {
+            key: StickyKey {
+                sender: owned_user_id!("@alice:localhost"),
+                event_type: TimelineEventType::from("m.rtc.member"),
+                sticky_key: sticky_key.to_owned(),
+            },
+            event_id: owned_event_id!("$a:localhost"),
+            order_ts: expires_at,
+            expires_at,
+            is_tombstone: false,
+            kind: TimelineEventKind::PlainText { event: raw_event() },
+        }
+    }
+
+    fn pending(session_id: Option<&str>, expires_at: u64) -> PendingEvent {
+        PendingEvent {
+            meta: StickyMeta {
+                sender: owned_user_id!("@alice:localhost"),
+                event_id: owned_event_id!("$a:localhost"),
+                order_ts: expires_at,
+                expires_at,
+                payload: Payload::Encrypted { session_id: session_id.map(ToOwned::to_owned) },
+            },
+            event: raw_event(),
+        }
+    }
+
+    #[async_test]
+    async fn test_ingest_broadcasts_and_exposes_live_events() {
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+        let mut subscriber = sticky.subscribe();
+
+        let now = now_ms();
+        sticky.ingest(now, vec![candidate("slot", now + 60_000)]);
+
+        let live = sticky.live();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].key.sticky_key, "slot");
+        assert!(live[0].encryption_info().is_none());
+
+        let update = subscriber.try_recv().unwrap();
+        assert_eq!(update.added.len(), 1);
+        assert_eq!(update.added[0].key.sticky_key, "slot");
+    }
+
+    #[async_test]
+    async fn test_expired_events_are_evicted_in_the_background() {
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+        let mut subscriber = sticky.subscribe();
+
+        let now = now_ms();
+        sticky.ingest(now, vec![candidate("slot", now + 50)]);
+        assert_matches!(subscriber.try_recv(), Ok(update));
+        assert_eq!(update.added.len(), 1);
+
+        // No further action on our side: the maintenance task must notice the
+        // expiry and tell us.
+        let update = tokio::time::timeout(Duration::from_secs(5), subscriber.recv())
+            .await
+            .expect("the expiry should be broadcast in time")
+            .unwrap();
+        assert_matches!(update.removed.as_slice(), [(key, RemovalReason::Expired)]);
+        assert_eq!(key.sticky_key, "slot");
+
+        assert!(sticky.live().is_empty());
+    }
+
+    #[async_test]
+    async fn test_clear_broadcasts_removals() {
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+        let mut subscriber = sticky.subscribe();
+
+        let now = now_ms();
+        sticky.ingest(now, vec![candidate("slot", now + 60_000)]);
+        sticky.park(vec![pending(Some("session"), now + 60_000)]);
+        let _ = subscriber.try_recv().unwrap();
+
+        sticky.clear();
+
+        let update = subscriber.try_recv().unwrap();
+        assert_matches!(update.removed.as_slice(), [(key, RemovalReason::RoomLeft)]);
+        assert_eq!(key.sticky_key, "slot");
+        assert!(sticky.live().is_empty());
+        assert_matches!(subscriber.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[async_test]
+    async fn test_pending_events_are_taken_by_session_id() {
+        use std::collections::BTreeSet;
+
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+
+        let now = now_ms();
+        sticky.park(vec![
+            pending(Some("session1"), now + 60_000),
+            pending(Some("session2"), now + 60_000),
+            // Nothing could ever decrypt this one: it isn't kept.
+            pending(None, now + 60_000),
+        ]);
+
+        let taken = sticky.take_pending(Some(&BTreeSet::from(["session2".to_owned()])));
+        assert_eq!(taken.len(), 1);
+        assert_matches!(&taken[0].meta.payload, Payload::Encrypted { session_id });
+        assert_eq!(session_id.as_deref(), Some("session2"));
+
+        assert!(sticky.has_pending());
+        let taken = sticky.take_pending(None);
+        assert_eq!(taken.len(), 1);
+        assert!(!sticky.has_pending());
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[async_test]
+    async fn test_pending_events_are_capped() {
+        use std::collections::BTreeSet;
+
+        use super::MAX_PENDING;
+
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+
+        let now = now_ms();
+        // One more than the cap, the oldest first.
+        let mut events = vec![pending(Some("oldest"), now + 60_000)];
+        events.extend((0..MAX_PENDING).map(|_| pending(Some("newer"), now + 60_000)));
+        sticky.park(events);
+
+        // The oldest made way.
+        assert!(sticky.take_pending(Some(&BTreeSet::from(["oldest".to_owned()]))).is_empty());
+        assert_eq!(sticky.take_pending(None).len(), MAX_PENDING);
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[async_test]
+    async fn test_expired_pending_events_are_pruned_in_the_background() {
+        let sticky = StickyEvents::new(room_id!("!room:localhost").to_owned());
+
+        sticky.park(vec![pending(Some("session"), now_ms() + 50)]);
+        assert!(sticky.has_pending());
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while sticky.has_pending() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the pending event should be pruned in time");
+    }
+}

--- a/crates/matrix-sdk-base/src/sticky/task.rs
+++ b/crates/matrix-sdk-base/src/sticky/task.rs
@@ -1,0 +1,71 @@
+// Copyright 2025 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The background task expiring the sticky events of a room.
+//!
+//! Readers of the map filter out expired entries themselves, so this task is
+//! only there to broadcast expiries to subscribers as they happen (rather than
+//! at the next sync), and to keep the map from holding onto dead entries.
+
+use std::{pin::pin, sync::Arc, time::Duration};
+
+use futures_util::future::select;
+use matrix_sdk_common::{
+    executor::{self, AbortOnDrop, JoinHandleExt as _},
+    sleep::sleep,
+};
+use tokio::sync::Notify;
+
+use super::{WeakStickyEvents, now_ms};
+
+/// The longest the task sleeps before re-evaluating the expiries.
+///
+/// The sleep is measured by a monotonic clock while expiries are wall-clock
+/// times; the two drift apart when the device sleeps. Capping the sleep bounds
+/// how late an expiry can be noticed after the device wakes up.
+const MAX_SLEEP: Duration = Duration::from_secs(60);
+
+/// Spawn the task for the sticky events behind `inner`.
+///
+/// The task holds a weak reference only, and stops as soon as the sticky
+/// events are dropped; the returned guard aborts it right away in that case.
+pub(super) fn spawn(inner: WeakStickyEvents, changed: Arc<Notify>) -> AbortOnDrop<()> {
+    executor::spawn(run(inner, changed)).abort_on_drop()
+}
+
+async fn run(inner: WeakStickyEvents, changed: Arc<Notify>) {
+    loop {
+        let Some(sticky) = inner.upgrade() else {
+            break;
+        };
+
+        let now = now_ms();
+        let next_expiry = sticky.expire(now);
+
+        // Don't keep the sticky events alive while waiting.
+        drop(sticky);
+
+        let notified = pin!(changed.notified());
+
+        match next_expiry {
+            // Nothing to expire: wait for something to be added.
+            None => notified.await,
+            // Sleep until the next expiry, unless something changes before.
+            Some(next_expiry) => {
+                let until_expiry = Duration::from_millis(next_expiry.saturating_sub(now));
+                let _ = select(pin!(sleep(until_expiry.min(MAX_SLEEP))), notified).await;
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -23,6 +23,10 @@ unstable-msc3956 = ["ruma/unstable-msc3956"]
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["matrix-sdk/unstable-msc4274"]
 
+# Add support for sticky events (MSC4354), delivered over sliding sync via the
+# MSC4480 extension.
+unstable-msc4354 = ["matrix-sdk/unstable-msc4354"]
+
 # Add support for user status profile fields (m.status, m.call).
 unstable-msc4426 = ["matrix-sdk/unstable-msc4426"]
 

--- a/crates/matrix-sdk-ui/changelog.d/7014.added.md
+++ b/crates/matrix-sdk-ui/changelog.d/7014.added.md
@@ -1,0 +1,2 @@
+`RoomListService` enables the sticky events sliding sync extension ([MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480))
+when built with the `unstable-msc4354` feature.

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -178,6 +178,14 @@ impl RoomListService {
                 enabled: Some(true),
             }));
 
+        #[cfg(feature = "unstable-msc4354")]
+        {
+            builder = builder.with_sticky_events_extension(assign!(
+                http::request::StickyEvents::default(),
+                { enabled: Some(true) }
+            ));
+        }
+
         match client.enabled_thread_subscriptions().await {
             Ok(true) => {
                 debug!("Client requested thread subscriptions extension");

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -23,6 +23,7 @@ use ruma::{
     owned_mxc_uri, room_id,
     time::{Duration, Instant},
 };
+use serde_json::{Value, json};
 use stream_assert::{assert_next_matches, assert_pending};
 use tempfile::TempDir;
 use tokio::{spawn, sync::Barrier, task::yield_now, time::sleep};
@@ -51,6 +52,33 @@ async fn new_persistent_room_list_service(
 
 // Same macro as in the main, with additional checking that the state
 // before/after the sync loop match those we expect.
+/// The extensions the room list service enables on every request.
+fn expected_extensions() -> Value {
+    expected_extensions_with(json!({}))
+}
+
+/// The extensions the room list service enables on every request, plus `extra`
+/// ones (those depending on what the server advertises).
+fn expected_extensions_with(extra: Value) -> Value {
+    let mut extensions = json!({
+        "account_data": { "enabled": true },
+        "receipts": { "enabled": true, "rooms": ["*"] },
+        "typing": { "enabled": true },
+        "org.matrix.msc4262.profiles": { "enabled": true },
+    });
+
+    #[cfg(feature = "unstable-msc4354")]
+    {
+        extensions["org.matrix.msc4354.sticky_events"] = json!({ "enabled": true });
+    }
+
+    if let Value::Object(extra) = extra {
+        extensions.as_object_mut().unwrap().extend(extra);
+    }
+
+    extensions
+}
+
 macro_rules! sync_then_assert_request_and_fake_response {
     (
         [$server:ident, $room_list:ident, $stream:ident]
@@ -369,21 +397,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                     "timeline_limit": 1,
                 },
             },
-            "extensions": {
-                "account_data": {
-                    "enabled": true
-                },
-                "receipts": {
-                    "enabled": true,
-                    "rooms": ["*"]
-                },
-                "typing": {
-                    "enabled": true,
-                },
-                "org.matrix.msc4262.profiles": {
-                    "enabled": true,
-                },
-            },
+            "extensions": expected_extensions(),
         },
         respond with = {
             "pos": "0",
@@ -2406,12 +2420,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                     "timeline_limit": 20,
                 },
             },
-            "extensions": {
-                "account_data": { "enabled": true },
-                "receipts": { "enabled": true, "rooms": [ "*" ] },
-                "typing": { "enabled": true },
-                "org.matrix.msc4262.profiles": { "enabled": true },
-            },
+            "extensions": expected_extensions(),
         },
         respond with = {
             "pos": "2",
@@ -2506,12 +2515,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                     "timeline_limit": 20,
                 },
             },
-            "extensions": {
-                "account_data": { "enabled": true },
-                "receipts": { "enabled": true, "rooms": [ "*" ] },
-                "typing": { "enabled": true },
-                "org.matrix.msc4262.profiles": { "enabled": true },
-            },
+            "extensions": expected_extensions(),
         },
         respond with = {
             "pos": "3",
@@ -2642,12 +2646,7 @@ async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
                     "timeline_limit": 20,
                 },
             },
-            "extensions": {
-                "account_data": { "enabled": true },
-                "receipts": { "enabled": true, "rooms": [ "*" ] },
-                "typing": { "enabled": true },
-                "org.matrix.msc4262.profiles": { "enabled": true },
-            },
+            "extensions": expected_extensions(),
         },
         respond with = {
             "pos": "2",
@@ -2749,12 +2748,7 @@ async fn test_remove_and_reset_room_subscriptions() -> Result<(), Error> {
                     "timeline_limit": 20,
                 },
             },
-            "extensions": {
-                "account_data": { "enabled": true },
-                "receipts": { "enabled": true, "rooms": [ "*" ] },
-                "typing": { "enabled": true },
-                "org.matrix.msc4262.profiles": { "enabled": true },
-            },
+            "extensions": expected_extensions(),
         },
         respond with = {
             "pos": "3",
@@ -3296,21 +3290,7 @@ async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_i
             [mock_server, room_list, sync]
             assert request = {
                 "conn_id": "room-list",
-                "extensions": {
-                    "account_data": {
-                        "enabled": true,
-                    },
-                    "receipts": {
-                        "enabled": true,
-                        "rooms": ["*"],
-                    },
-                    "typing": {
-                        "enabled": true,
-                    },
-                    "org.matrix.msc4262.profiles": {
-                        "enabled": true,
-                    },
-                },
+                "extensions": expected_extensions(),
                 "lists": {
                     "all_rooms": {
                         "filters": {},
@@ -3394,25 +3374,9 @@ async fn test_thread_subscriptions_extension_enabled_only_if_server_advertises_i
         [mock_server, room_list, sync]
         assert request = {
             "conn_id": "room-list",
-            "extensions": {
-                "account_data": {
-                    "enabled": true,
-                },
-                "receipts": {
-                    "enabled": true,
-                    "rooms": ["*"],
-                },
-                "typing": {
-                    "enabled": true,
-                },
-                "io.element.msc4308.thread_subscriptions": {
-                    "enabled": true,
-                    "limit": 10,
-                },
-                "org.matrix.msc4262.profiles": {
-                    "enabled": true,
-                },
-            },
+            "extensions": expected_extensions_with(json!({
+                "io.element.msc4308.thread_subscriptions": { "enabled": true, "limit": 10 },
+            })),
             "lists": {
                 "all_rooms": {
                     "filters": {},

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -91,6 +91,10 @@ docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "feder
 # Add support for inline media galleries via msgtypes
 unstable-msc4274 = ["ruma/unstable-msc4274", "matrix-sdk-base/unstable-msc4274"]
 
+# Add support for sticky events (MSC4354), delivered over sliding sync via the
+# MSC4480 extension.
+unstable-msc4354 = ["matrix-sdk-base/unstable-msc4354"]
+
 # Add support for user status profile fields (m.status, m.call).
 unstable-msc4426 = ["matrix-sdk-base/unstable-msc4426"]
 

--- a/crates/matrix-sdk/changelog.d/7014.added.md
+++ b/crates/matrix-sdk/changelog.d/7014.added.md
@@ -1,0 +1,2 @@
+Add support for the sticky events sliding sync extension ([MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480))
+behind the `unstable-msc4354` feature, enabled with `SlidingSyncBuilder::with_sticky_events_extension()`.

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -88,8 +88,8 @@ impl SlidingSyncBuilder {
         Ok(self.add_list(list))
     }
 
-    /// Activate e2ee, to-device-message, account data, typing and receipt
-    /// extensions if not yet configured.
+    /// Activate e2ee, to-device-message, account data, typing, receipt and
+    /// (if compiled in) sticky events extensions if not yet configured.
     ///
     /// Will leave any extension configuration found untouched, so the order
     /// does not matter.
@@ -114,6 +114,11 @@ impl SlidingSyncBuilder {
 
             if cfg.typing.enabled.is_none() {
                 cfg.typing.enabled = Some(true);
+            }
+
+            #[cfg(feature = "unstable-msc4354")]
+            if cfg.sticky_events.enabled.is_none() {
+                cfg.sticky_events.enabled = Some(true);
             }
         }
         self
@@ -212,6 +217,26 @@ impl SlidingSyncBuilder {
         self
     }
 
+    /// Set the sticky events (MSC4480) extension configuration.
+    ///
+    /// The `since` token of the extension is managed by the sliding sync
+    /// itself, any value set here is ignored.
+    #[cfg(feature = "unstable-msc4354")]
+    pub fn with_sticky_events_extension(
+        mut self,
+        sticky_events: http::request::StickyEvents,
+    ) -> Self {
+        self.extensions.get_or_insert_with(Default::default).sticky_events = sticky_events;
+        self
+    }
+
+    /// Unset the sticky events (MSC4480) extension configuration.
+    #[cfg(feature = "unstable-msc4354")]
+    pub fn without_sticky_events_extension(mut self) -> Self {
+        self.extensions.get_or_insert_with(Default::default).sticky_events = Default::default();
+        self
+    }
+
     /// Sets a custom timeout duration for the sliding sync polling endpoint.
     ///
     /// This is the maximum time to wait before the sliding sync server returns
@@ -298,7 +323,11 @@ impl SlidingSyncBuilder {
 
             lists,
 
-            position: Arc::new(AsyncMutex::new(SlidingSyncPositionMarkers { pos })),
+            position: Arc::new(AsyncMutex::new(SlidingSyncPositionMarkers {
+                pos,
+                #[cfg(feature = "unstable-msc4354")]
+                sticky_events_since: None,
+            })),
 
             room_subscriptions: StdRwLock::new(self.room_subscriptions),
             extensions: self.extensions.unwrap_or_default(),

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -455,6 +455,13 @@ impl SlidingSync {
 
         position.pos = pos;
 
+        // The sticky events extension only sends a `next_batch` when it has
+        // something new; keep the previous one otherwise.
+        #[cfg(feature = "unstable-msc4354")]
+        if let Some(next_batch) = sliding_sync_response.extensions.sticky_events.next_batch.take() {
+            position.sticky_events_since = Some(next_batch);
+        }
+
         Ok(update_summary)
     }
 
@@ -573,6 +580,12 @@ impl SlidingSync {
         if to_device_enabled {
             request.extensions.to_device.since =
                 restored_fields.and_then(|fields| fields.to_device_token);
+        }
+
+        // Same for the sticky events token, which lives in memory only.
+        #[cfg(feature = "unstable-msc4354")]
+        if self.is_sticky_events_enabled() {
+            request.extensions.sticky_events.since = position_guard.sticky_events_since.clone();
         }
 
         Ok((
@@ -718,6 +731,12 @@ impl SlidingSync {
         self.inner.extensions.thread_subscriptions.enabled == Some(true)
     }
 
+    /// Is the sticky events extension enabled for this sliding sync instance?
+    #[cfg(feature = "unstable-msc4354")]
+    fn is_sticky_events_enabled(&self) -> bool {
+        self.inner.extensions.sticky_events.enabled == Some(true)
+    }
+
     #[cfg(not(feature = "e2e-encryption"))]
     fn is_e2ee_enabled(&self) -> bool {
         false
@@ -855,6 +874,13 @@ impl SlidingSync {
             // Invalidate in memory.
             position.pos = None;
 
+            // Start the stream of sticky events over too: the server will
+            // re-send those that are still live.
+            #[cfg(feature = "unstable-msc4354")]
+            {
+                position.sticky_events_since = None;
+            }
+
             // Propagate to disk.
             // Note: this propagates both the sliding sync state and the cached lists'
             // state to disk.
@@ -971,6 +997,16 @@ pub(super) struct SlidingSyncPositionMarkers {
     /// An ephemeral position in the current stream, as received from the
     /// previous `/sync` response, or `None` for the first request.
     pos: Option<String>,
+
+    /// The position in the stream of sticky events (MSC4480), as received in
+    /// the `next_batch` of the extension in the previous response, or `None`
+    /// for the first request.
+    ///
+    /// This is deliberately not persisted: without it, the server sends every
+    /// sticky event that is still live, which is exactly what a fresh client
+    /// needs.
+    #[cfg(feature = "unstable-msc4354")]
+    sticky_events_since: Option<String>,
 }
 
 /// A summary of the updates received after a sync (like in
@@ -1815,6 +1851,99 @@ mod tests {
             assert_eq!(to_device.enabled, Some(true));
             assert_eq!(to_device.since, Some(since_token));
         }
+    }
+
+    #[cfg(feature = "unstable-msc4354")]
+    #[async_test]
+    async fn test_extensions_sticky_events_since_is_set() -> Result<()> {
+        let server = MockServer::start().await;
+
+        #[derive(Deserialize)]
+        struct PartialRequest {
+            txn_id: Option<String>,
+        }
+
+        // The server answers with a sticky events `next_batch` on the first two
+        // responses, then without.
+        let response_count = Arc::new(Mutex::new(0));
+        let _mock_guard = Mock::given(SlidingSyncMatcher)
+            .respond_with(move |request: &Request| {
+                let request: PartialRequest = request.body_json().unwrap();
+                let count = {
+                    let mut count = response_count.lock().unwrap();
+                    *count += 1;
+                    *count
+                };
+
+                let mut response = json!({
+                    "txn_id": request.txn_id,
+                    "pos": count.to_string(),
+                });
+
+                if count <= 2 {
+                    response["extensions"] = json!({
+                        "org.matrix.msc4354.sticky_events": {
+                            "next_batch": format!("sticky_{count}"),
+                        }
+                    });
+                }
+
+                ResponseTemplate::new(200).set_body_json(response)
+            })
+            .mount_as_scoped(&server)
+            .await;
+
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let sliding_sync = client
+            .sliding_sync("sticky")?
+            .with_sticky_events_extension(assign!(
+                http::request::StickyEvents::default(),
+                { enabled: Some(true) }
+            ))
+            .build()
+            .await?;
+
+        // No `since` to start with.
+        {
+            let (request, _, _) = sliding_sync.generate_sync_request().await?;
+            assert_eq!(request.extensions.sticky_events.enabled, Some(true));
+            assert!(request.extensions.sticky_events.since.is_none());
+        }
+
+        // The `next_batch` of a response is the `since` of the next request.
+        sliding_sync.sync_once().await?;
+
+        {
+            let (request, _, _) = sliding_sync.generate_sync_request().await?;
+            assert_eq!(request.extensions.sticky_events.since.as_deref(), Some("sticky_1"));
+        }
+
+        sliding_sync.sync_once().await?;
+
+        {
+            let (request, _, _) = sliding_sync.generate_sync_request().await?;
+            assert_eq!(request.extensions.sticky_events.since.as_deref(), Some("sticky_2"));
+        }
+
+        // A response without `next_batch` leaves the `since` untouched.
+        sliding_sync.sync_once().await?;
+
+        {
+            let (request, _, _) = sliding_sync.generate_sync_request().await?;
+            assert_eq!(request.extensions.sticky_events.since.as_deref(), Some("sticky_2"));
+        }
+
+        // Expiring the session starts the stream of sticky events over.
+        sliding_sync.expire_session().await;
+
+        {
+            let (request, _, _) = sliding_sync.generate_sync_request().await?;
+            assert!(request.pos.is_none());
+            assert!(request.extensions.sticky_events.since.is_none());
+        }
+
+        Ok(())
     }
 
     // With MSC4186, with the `e2ee` extension enabled, if a request has no `pos`,


### PR DESCRIPTION
This adds the following behind the `unstable-msc4354` feature flag:

- Per-room in-memory map of sticky events on `Room::sticky_events()`, keyed by `(sender, type, sticky_key)`, with the MSC4354 tie-break (`origin_server_ts + duration_ms`, then event ID), removals kept as tombstones until they expire so that late-arriving superseded events can't resurrect a key, and a background task broadcasting expiries.
- Ingestion as an MSC4186 extension processor, reusing the already-decrypted timeline events and decrypting only the extension's; undecryptable events are kept aside and retried when their room key arrives.

This is, unfortunately, very large but it did seem like the most reasonable split to me. Most of the logic resides in the new sticky crate, so that's probably a good place to start the review.

Left for follow-up PRs:

- Exposing sticky events over FFI
- Sending sticky events

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries