### PR TITLE
fix(sqlite): Clear the `pos` sliding sync value in the crypto store

### DIFF
--- a/crates/matrix-sdk-sqlite/changelog.d/7016.changed.md
+++ b/crates/matrix-sdk-sqlite/changelog.d/7016.changed.md
@@ -1,0 +1,4 @@
+Cleared the Sliding Sync `pos` value from the crypto store after [this PR](https://github.com/matrix-org/matrix-rust-sdk/pull/6872) 
+emptied the event cache. With this, the initial sync should at least return the most recent events for the rooms in 
+the room list, which would be missing with he previous `pos` value and would force the clients to paginate to load 
+*any* events for *any* timeline, not even the room's latest event would be present. 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -249,7 +249,7 @@ impl SqliteCryptoStore {
     }
 }
 
-const DATABASE_VERSION: u8 = 15;
+const DATABASE_VERSION: u8 = 19;
 
 /// key for the dehydrated device pickle key in the key/value table.
 const DEHYDRATED_DEVICE_PICKLE_KEY: &str = "dehydrated_device_pickle_key";
@@ -524,6 +524,22 @@ pub(crate) async fn run_migrations(
                 update_query.execute((info, row.get::<_, Vec<u8>>(0)?))?;
             }
             txn.set_db_version(18)
+        })
+        .await?;
+    }
+
+    if version < 19 {
+        debug!("Upgrading database to version 19");
+        // Remove the sliding sync `pos` value stored in the crypto store.
+        // There was recently an event cache migration that emptied the cache but never
+        // reset the `pos` value, this fixes it.
+        let user_id = store.load_account().await?.map(|account| account.user_id.clone());
+
+        conn.with_transaction(move |txn| {
+            if let Some(user_id) = user_id {
+                txn.clear_kv(&format!("sliding_sync_store::room-list::{user_id}::instance"))?;
+            }
+            txn.set_db_version(19)
         })
         .await?;
     }


### PR DESCRIPTION
We recently added [a PR](https://github.com/matrix-org/matrix-rust-sdk/pull/6872) that cleared all the linked chunks in the event cache, meaning the events there are no longer present. However, when doing so we never reset the `pos` value to receive those events again, so clients would have a working and updated room list but opening any timeline gave you an empty one that was only filled by paginating it, since the sync never returned any of the missing events.

<!-- description of the changes in this PR -->

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [ ] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by:
