### PR TITLE
feat(ffi): Make `WidgetCapabilitiesProvider::acquire_capabilities` async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,6 +3786,7 @@ version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-compat",
+ "async-trait",
  "chrono",
  "console_error_panic_hook",
  "extension-trait",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -48,6 +48,7 @@ rustls-aws-lc-rs = ["matrix-sdk/rustls-aws-lc-rs", "matrix-sdk-ui/rustls-aws-lc-
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 chrono.workspace = true
 extension-trait = "1.0.2"
 eyeball-im.workspace = true

--- a/bindings/matrix-sdk-ffi/changelog.d/7017.changed.md
+++ b/bindings/matrix-sdk-ffi/changelog.d/7017.changed.md
@@ -1,0 +1,3 @@
+[**breaking**] `WidgetCapabilitiesProvider::acquire_capabilities` is now an async callback
+(`suspend fun` in Kotlin, `async` in Swift). The SDK awaits it directly instead of running it
+on a tokio blocking thread.

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::{SendOutsideWasm, SyncOutsideWasm};
 use ruma::events::MessageLikeEventType;
 use tracing::error;
 
-use crate::{room::Room, runtime::get_runtime_handle};
+use crate::room::Room;
 
 #[derive(uniffi::Record)]
 pub struct WidgetDriverAndHandle {
@@ -430,8 +430,10 @@ impl From<matrix_sdk::widget::Filter> for WidgetEventFilter {
 }
 
 #[matrix_sdk_ffi_macros::export(callback_interface)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub trait WidgetCapabilitiesProvider: SendOutsideWasm + SyncOutsideWasm {
-    fn acquire_capabilities(&self, capabilities: WidgetCapabilities) -> WidgetCapabilities;
+    async fn acquire_capabilities(&self, capabilities: WidgetCapabilities) -> WidgetCapabilities;
 }
 
 struct CapabilitiesProviderWrap(Arc<dyn WidgetCapabilitiesProvider>);
@@ -441,15 +443,9 @@ impl matrix_sdk::widget::CapabilitiesProvider for CapabilitiesProviderWrap {
         &self,
         capabilities: matrix_sdk::widget::Capabilities,
     ) -> matrix_sdk::widget::Capabilities {
-        let this = self.0.clone();
-        // This could require a prompt to the user. Ideally the callback
-        // interface would just be async, but that's not supported yet so use
-        // one of tokio's blocking task threads instead.
-        get_runtime_handle()
-            .spawn_blocking(move || this.acquire_capabilities(capabilities.into()).into())
-            .await
-            // propagate panics from the blocking task
-            .unwrap()
+        // This could require a prompt to the user; the callback interface is
+        // async, so just await it.
+        self.0.acquire_capabilities(capabilities.into()).await.into()
     }
 }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

### What

`WidgetCapabilitiesProvider::acquire_capabilities` is now `async` on the FFI (`suspend fun` in
Kotlin, `async` in Swift). The SDK awaits it directly instead of using a tokio blocking thread.

### Why

The code had this comment since 2023:

> Ideally the callback interface would just be async, but that's not supported yet so use one of
> tokio's blocking task threads instead.

uniffi supports async callback interface methods now, so the workaround can go. Benefits:

- no blocking-pool thread is held while the user answers a capabilities prompt,
- async hosts (for example a React Native app showing a dialog) can await the user directly,
- no more `unwrap()` on the `JoinHandle`, so a panic in the callback does not kill the widget task.

We found this while making all callback interfaces in our React Native bindings async. This is the
only place where upstream already marked the sync signature as a limitation.

### Breaking change

Foreign implementations must change the method to `suspend fun` / `async`. Changelog fragment
included.

### Notes

- The trait has explicit `async_trait` attributes (`?Send` on wasm) because `async fn` in a `dyn`
  trait is not object-safe. This follows uniffi's docs. It is the first async callback interface in
  `matrix-sdk-ffi`; if you prefer the `matrix_sdk_ffi_macros::export` macro to add the attribute
  automatically, I can do a follow-up.
- `async-trait` was already a workspace dependency.
- Verified by generating the bindings with `uniffi-bindgen`: Kotlin emits
  `suspend fun acquireCapabilities`, Swift emits
  `func acquireCapabilities(capabilities: WidgetCapabilities) async -> WidgetCapabilities`.


- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->

