### PR TITLE
doc(sdk): Document all crate feature flags in the README

### DIFF
--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -56,20 +56,38 @@ More examples can be found in the [examples] directory.
 
 The following crate feature flags are available:
 
-| Feature          | Default | Description                                                                                                                                     |
-| ---------------- | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `anyhow`         |   No    | Better logging for event handlers that return `anyhow::Result`                                                                                  |
-| `e2e-encryption` |   Yes   | End-to-end encryption (E2EE) support                                                                                                            |
-| `eyre`           |   No    | Better logging for event handlers that return `eyre::Result`                                                                                    |
-| `js`             |   No    | Enables JavaScript API usage on WASM (does nothing on other targets)                                                                            |
-| `markdown`       |   No    | Support for sending Markdown-formatted messages                                                                                                 |
-| `qrcode`         |   Yes   | QR code verification support                                                                                                                    |
-| `sqlite`         |   Yes   | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite available on system                  |
-| `bundled-sqlite` |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite compiled and bundled with the binary |
-| `indexeddb`      |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled) for browsers, via IndexedDB                      |
-| `socks`          |   No    | SOCKS support in the default HTTP client, [`reqwest`]                                                                                           |
-| `sso-login`      |   No    | Support for SSO login with a local HTTP server                                                                                                  |
+| Feature                                   | Default | Description                                                                                                                                                                  |
+| ----------------------------------------- | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `anyhow`                                  |   No    | Better logging for event handlers that return `anyhow::Result`                                                                                                               |
+| `e2e-encryption`                          |   Yes   | End-to-end encryption (E2EE) support                                                                                                                                         |
+| `automatic-room-key-forwarding`           |   Yes   | Request missing room keys from other devices, and answer such requests (enables `e2e-encryption`)                                                                            |
+| `eyre`                                    |   No    | Better logging for event handlers that return `eyre::Result`                                                                                                                 |
+| `js`                                      |   No    | Enables JavaScript API usage on WASM (does nothing on other targets)                                                                                                         |
+| `markdown`                                |   No    | Support for sending Markdown-formatted messages                                                                                                                              |
+| `qrcode`                                  |   No    | QR code verification support (enables `e2e-encryption`)                                                                                                                      |
+| `sqlite`                                  |   Yes   | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite available on system                                               |
+| `bundled-sqlite`                          |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled), via SQLite compiled and bundled with the binary                              |
+| `indexeddb`                               |   No    | Persistent storage of state and E2EE data (optionally, if feature `e2e-encryption` is enabled) for browsers, via IndexedDB                                                   |
+| `rustls-aws-lc-rs`                        |   Yes   | Install `aws-lc-rs` as the default crypto provider for `rustls`, the TLS backend of [`reqwest`]; if disabled, the application must install a `rustls` crypto provider itself |
+| `socks`                                   |   No    | SOCKS support in the default HTTP client, [`reqwest`]                                                                                                                        |
+| `local-server`                            |   No    | `LocalServerBuilder`, to spawn a server on localhost when the end-user needs to be redirected there, e.g. during OAuth 2.0 login                                             |
+| `sso-login`                               |   No    | Support for SSO login with a local HTTP server (enables `local-server`)                                                                                                      |
+| `federation-api`                          |   No    | Methods that make calls to the federation API, like `Client::server_vendor_info()`                                                                                           |
+| `uniffi`                                  |   No    | Support for the UniFFI-based bindings                                                                                                                                        |
+| `testing`                                 |   No    | Helpers for tests, like a mocked homeserver. Do not use outside of tests, there are no stability guarantees                                                                  |
+| `unstable-msc4274`                        |   No    | Sending media galleries via the send queue ([MSC4274])                                                                                                                       |
+| `unstable-msc4426`                        |   No    | User status profile fields, `m.status` and `m.call` ([MSC4426])                                                                                                              |
+| `experimental-widgets`                    |   No    | Widget driver, giving widgets access to Matrix via a `postMessage` API (experimental)                                                                                        |
+| `experimental-search`                     |   No    | Local full-text search index of messages, via the `matrix-sdk-search` crate (experimental)                                                                                   |
+| `experimental-send-custom-to-device`      |   No    | `Encryption::encrypt_and_send_raw_to_device`, to send custom encrypted to-device events (experimental)                                                                       |
+| `experimental-encrypted-state-events`     |   No    | Encryption of state events (experimental)                                                                                                                                    |
+| `experimental-push-secrets`               |   No    | Pushing secrets to other devices ([MSC4385], experimental)                                                                                                                   |
+| `experimental-element-recent-emojis`      |   No    | Reading and updating the `io.element.recent_emoji` account data (experimental)                                                                                               |
+| `experimental-x509-identity-verification` |   No    | Verification of user identities via X.509 certificates (experimental)                                                                                                        |
 
+[MSC4274]: https://github.com/matrix-org/matrix-spec-proposals/pull/4274
+[MSC4385]: https://github.com/matrix-org/matrix-spec-proposals/pull/4385
+[MSC4426]: https://github.com/matrix-org/matrix-spec-proposals/pull/4426
 [`reqwest`]: https://docs.rs/reqwest/0.11.5/reqwest/index.html
 
 ## Enabling logging


### PR DESCRIPTION
Fixes #2994

The "Crate feature flags" table in `crates/matrix-sdk/README.md` (which is also the crate-level rustdoc / crates.io page via `#![doc = include_str!("../README.md")]`) listed only 11 of the 26 features declared in `Cargo.toml`. The issue hit `native-tls`/`rustls-tls` back then; those are gone since #6409, but the same gap exists today with `rustls-aws-lc-rs` — a default feature that users turning off `default-features` have to know about to get a crypto provider — plus `local-server`, `federation-api`, `automatic-room-key-forwarding` and the `unstable-*`/`experimental-*` flags.

This PR:

- adds a row for every feature in `[features]` (except the private `docsrs` one), with a one-line description taken from the gating doc comments / CHANGELOG entries;
- marks `automatic-room-key-forwarding` and `rustls-aws-lc-rs` as defaults, and fixes `qrcode`, which the table showed as a default but isn't in `default = [...]`;
- links the MSC numbers for the `unstable-msc*` / `experimental-push-secrets` flags.

No code changes, so no changelog fragment — happy to add one if you'd like it.

### Validation

- `rumdl check crates/matrix-sdk/README.md` (repo's `.rumdl.toml`) — no issues (table re-aligned with `rumdl fmt`)
- `typos crates/matrix-sdk/README.md` — clean
- `cargo doc -p matrix-sdk --no-deps` — builds; the table and the new MSC links render in `target/doc/matrix_sdk/index.html`. The only warning (`unresolved link to QrVerification`) is pre-existing and unrelated.
