### PR TITLE
fix(sdk): Refresh thread summaries on event-focused copies of a threa…

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -20,7 +20,7 @@ use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::{
-    assert_let_timeout,
+    ThreadingSupport, assert_let_timeout,
     test_utils::mocks::{
         MatrixMockServer, RoomContextResponseTemplate, RoomMessagesResponseTemplate,
         RoomRelationsResponseTemplate,
@@ -242,6 +242,180 @@ async fn test_live_aggregations_are_reflected_on_focused_timelines() {
     let reactions = event_item.content().reactions().cloned().unwrap_or_default();
     assert_eq!(reactions.len(), 1);
     let _ = reactions["👍"][*BOB];
+}
+
+#[async_test]
+async fn test_focused_timeline_updates_thread_summary_on_root() {
+    // A timeline focused on a thread root reflects thread summary updates on
+    // its copy of the root.
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: false })
+        })
+        .build()
+        .await;
+
+    let f = EventFactory::new().room(room_id);
+    let thread_root = event_id!("$thread_root");
+
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(
+            f.text_msg("root of the thread").event_id(thread_root).sender(*BOB).into_event(),
+        ))
+        .mock_once()
+        .mount()
+        .await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    let timeline = TimelineBuilder::new(&room)
+        .with_focus(TimelineFocus::Event {
+            target: thread_root.to_owned(),
+            num_context_events: 20,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: true },
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert_eq!(items.len(), 1 + 1); // the root event and a date divider
+    assert!(items[0].is_date_divider());
+
+    let event_item = items[1].as_event().unwrap();
+    assert_eq!(event_item.content().as_message().unwrap().body(), "root of the thread");
+    assert!(event_item.content().thread_summary().is_none());
+
+    assert_pending!(timeline_stream);
+
+    // A threaded reply arrives via sync.
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(room_id).add_timeline_bulk([f
+                    .text_msg("a threaded reply")
+                    .sender(*ALICE)
+                    .in_thread(thread_root, thread_root)
+                    .event_id(event_id!("$reply"))
+                    .into()]),
+            );
+        })
+        .await;
+
+    // The root's copy receives the new summary; the reply itself stays hidden.
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+
+    let mut saw_summary = false;
+    for update in &timeline_updates {
+        assert_let!(VectorDiff::Set { index: 1, value: item } = update);
+        let event_item = item.as_event().unwrap();
+        assert_eq!(event_item.content().as_message().unwrap().body(), "root of the thread");
+        if let Some(summary) = event_item.content().thread_summary() {
+            assert_eq!(summary.num_replies, 1);
+            saw_summary = true;
+        }
+    }
+    assert!(saw_summary, "the root's copy never received the thread summary");
+}
+
+#[async_test]
+async fn test_focused_timeline_updates_thread_summary_on_root_in_context() {
+    // Same as above, but the thread root is only part of another focused
+    // event's /context window.
+
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let server = MatrixMockServer::new().await;
+    let client = server
+        .client_builder()
+        .on_builder(|builder| {
+            builder.with_threading_support(ThreadingSupport::Enabled { with_subscriptions: false })
+        })
+        .build()
+        .await;
+
+    let f = EventFactory::new().room(room_id);
+    let thread_root = event_id!("$thread_root");
+    let focus_target = event_id!("$focus_target");
+
+    server
+        .mock_room_event_context()
+        .room(room_id)
+        .ok(RoomContextResponseTemplate::new(
+            f.text_msg("the focused event").event_id(focus_target).sender(*BOB).into_event(),
+        )
+        .events_before(vec![
+            f.text_msg("root of the thread").event_id(thread_root).sender(*ALICE).into_event(),
+        ]))
+        .mock_once()
+        .mount()
+        .await;
+
+    server.mock_room_state_encryption().plain().mount().await;
+
+    let room = server.sync_joined_room(&client, room_id).await;
+    let timeline = TimelineBuilder::new(&room)
+        .with_focus(TimelineFocus::Event {
+            target: focus_target.to_owned(),
+            num_context_events: 20,
+            thread_mode: TimelineEventFocusThreadMode::Automatic { hide_threaded_events: true },
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert_eq!(items.len(), 2 + 1); // the root, the focused event, and a date divider
+    assert!(items[0].is_date_divider());
+
+    let root_item = items[1].as_event().unwrap();
+    assert_eq!(root_item.content().as_message().unwrap().body(), "root of the thread");
+    assert!(root_item.content().thread_summary().is_none());
+    assert_eq!(
+        items[2].as_event().unwrap().content().as_message().unwrap().body(),
+        "the focused event"
+    );
+
+    assert_pending!(timeline_stream);
+
+    // A threaded reply arrives via sync.
+    server
+        .mock_sync()
+        .ok_and_run(&client, |builder| {
+            builder.add_joined_room(
+                JoinedRoomBuilder::new(room_id).add_timeline_bulk([f
+                    .text_msg("a threaded reply")
+                    .sender(*ALICE)
+                    .in_thread(thread_root, thread_root)
+                    .event_id(event_id!("$reply"))
+                    .into()]),
+            );
+        })
+        .await;
+
+    // The root's copy receives the new summary.
+    assert_let_timeout!(Some(timeline_updates) = timeline_stream.next());
+
+    let mut saw_summary = false;
+    for update in &timeline_updates {
+        assert_let!(VectorDiff::Set { index: 1, value: item } = update);
+        let event_item = item.as_event().unwrap();
+        assert_eq!(event_item.content().as_message().unwrap().body(), "root of the thread");
+        if let Some(summary) = event_item.content().thread_summary() {
+            assert_eq!(summary.num_replies, 1);
+            saw_summary = true;
+        }
+    }
+    assert!(saw_summary, "the root's copy never received the thread summary");
 }
 
 #[async_test]

--- a/crates/matrix-sdk/changelog.d/7021.fixed.md
+++ b/crates/matrix-sdk/changelog.d/7021.fixed.md
@@ -1,0 +1,7 @@
+When a thread summary is recomputed (new reply, redaction, edit, or
+redecryption), event-focused caches that contain their own copy of the thread
+root event now have that copy's summary updated too, and the change is
+propagated to their subscribers. Previously an event-focused timeline showing a
+thread root kept a stale thread summary (e.g. an outdated replies count) while
+it was open, and the stale in-memory cache was re-served to later timelines
+focused on the same event.

--- a/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/event_focused/mod.rs
@@ -33,12 +33,12 @@ use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
 use matrix_sdk_base::{
-    deserialized_responses::TimelineEvent,
+    deserialized_responses::{ThreadSummary, ThreadSummaryStatus, TimelineEvent},
     event_cache::{Event, Gap},
     linked_chunk::OwnedLinkedChunkId,
 };
 use matrix_sdk_common::{linked_chunk::ChunkIdentifier, serde_helpers::extract_thread_root};
-use ruma::{OwnedEventId, UInt, api::Direction};
+use ruma::{EventId, OwnedEventId, UInt, api::Direction};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tracing::{instrument, trace};
 
@@ -656,6 +656,37 @@ impl EventFocusedCache {
             EventFocusedPaginationMode::Thread { thread_root } => Some(thread_root.clone()),
             _ => None,
         })
+    }
+
+    /// Update the thread summary on this cache's copy of the given thread
+    /// root event, if present, notifying observers.
+    pub(in super::super) async fn update_thread_summary(
+        &self,
+        thread_id: &EventId,
+        new_thread_summary: Option<ThreadSummary>,
+    ) -> Result<()> {
+        let mut state = self.inner.write().await?;
+
+        let Some((position, mut thread_root_event)) = state
+            .chunk
+            .events()
+            .find(|(_position, event)| event.event_id() == Some(thread_id))
+            .map(|(position, event)| (position, event.clone()))
+        else {
+            return Ok(());
+        };
+
+        trace!(%thread_id, "updating thread summary on the event-focused copy of the root");
+        thread_root_event.thread_summary = ThreadSummaryStatus::from_opt(new_thread_summary);
+        state
+            .chunk
+            .replace_event_at(position, thread_root_event)
+            .expect("should have been a valid position of an item");
+
+        state.propagate_changes();
+        state.notify_subscribers(EventsOrigin::Sync);
+
+        Ok(())
     }
 
     /// Try to locate the events in the linked chunk corresponding to the given

--- a/crates/matrix-sdk/src/event_cache/caches/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/caches/mod.rs
@@ -369,7 +369,14 @@ impl Caches {
                     let new_thread_summary =
                         thread.state().read().await?.compute_thread_summary().await?;
 
-                    room.update_thread_summary(thread.thread_id(), new_thread_summary).await?;
+                    room.update_thread_summary(thread.thread_id(), new_thread_summary.clone())
+                        .await?;
+
+                    for event_focused in self.event_focused.read().await.values() {
+                        event_focused
+                            .update_thread_summary(thread.thread_id(), new_thread_summary.clone())
+                            .await?;
+                    }
                 }
             }
         }

--- a/crates/matrix-sdk/src/event_cache/redecryptor.rs
+++ b/crates/matrix-sdk/src/event_cache/redecryptor.rs
@@ -562,7 +562,16 @@ impl EventCache {
                 let new_thread_summary =
                     thread_cache.state().read().await?.compute_thread_summary().await?;
 
-                all_caches.room.update_thread_summary(&thread_id, new_thread_summary).await?;
+                all_caches
+                    .room
+                    .update_thread_summary(&thread_id, new_thread_summary.clone())
+                    .await?;
+
+                for event_focused in all_caches.event_focused.read().await.values() {
+                    event_focused
+                        .update_thread_summary(&thread_id, new_thread_summary.clone())
+                        .await?;
+                }
             }
         }
 


### PR DESCRIPTION
A thread root event can live in an event-focused cache's linked chunk (e.g. a timeline focused on the root, as used for permalinks). When a thread summary was recomputed, only the room linked chunk's copy of the root was updated, so an event-focused timeline kept a stale summary (e.g. an outdated replies count) while open — and since the cache is in-memory and keyed, later timelines focused on the same event were served the stale copy too.

Add EventFocusedCache::update_thread_summary, which patches the root's bundled summary on the cache's copy (no-op when absent) and notifies its subscribers, and call it wherever the room's copy is updated: the joined-room update handler and the redecryptor.

A [previous attempt](https://github.com/matrix-org/matrix-rust-sdk/pull/7015) to update them in thread focused timelines, but because of the stored-cache system, this change was much more involved as a result, while the event focused caches are in-memory only. I believe this version is much simpler and therefore more land-able.  Unsure the best way to document that that thread-summaries in thread-focused timelines are not trustworthy, but open to suggestions.  

<!-- description of the changes in this PR -->

- [X] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [X] This PR was made with the help of AI.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Daniel Salinas
