### PR TITLE
feat(indexeddb): add previous for quick loading of chunks from oldest

### DIFF
--- a/crates/matrix-sdk-indexeddb/changelog.d/7022.added.md
+++ b/crates/matrix-sdk-indexeddb/changelog.d/7022.added.md
@@ -1,0 +1,1 @@
+Added `previous` index to the IndexedDB `linked_chunks` store (V9 migration), enabling forward traversal from the oldest chunk.

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/migrations.rs
@@ -21,10 +21,10 @@ use thiserror::Error;
 
 /// The current version and keys used in the database.
 pub mod current {
-    use super::{Version, v8};
+    use super::{Version, v9};
 
-    pub const VERSION: Version = Version::V8;
-    pub use v8::keys;
+    pub const VERSION: Version = Version::V9;
+    pub use v9::keys;
 }
 
 /// Opens a connection to the IndexedDB database and takes care of upgrading it
@@ -68,6 +68,8 @@ pub enum Version {
     V7 = 7,
     /// Version 8 of the database, for details see [`v8`].
     V8 = 8,
+    /// Version 9 of the database, for details see [`v9`].
+    V9 = 9,
 }
 
 impl Version {
@@ -82,7 +84,8 @@ impl Version {
             Self::V5 => v5::upgrade(transaction).map(Some),
             Self::V6 => v6::upgrade(transaction).map(Some),
             Self::V7 => v7::upgrade(transaction).map(Some),
-            Self::V8 => Ok(None),
+            Self::V8 => v8::upgrade(transaction).map(Some),
+            Self::V9 => Ok(None),
         }
     }
 }
@@ -105,6 +108,7 @@ impl TryFrom<u32> for Version {
             6 => Ok(Version::V6),
             7 => Ok(Version::V7),
             8 => Ok(Version::V8),
+            9 => Ok(Version::V9),
             v => Err(UnknownVersionError(v)),
         }
     }
@@ -505,6 +509,71 @@ pub mod v8 {
         let threads = transaction.object_store(keys::THREADS)?;
         threads.clear()?;
 
+        Ok(())
+    }
+
+    /// Upgrade database from `v8` to `v9`
+    pub fn upgrade(transaction: &Transaction<'_>) -> Result<Version, Error> {
+        v9::add_previous_chunk_index(transaction)?;
+        Ok(Version::V9)
+    }
+}
+
+mod v9 {
+    use indexed_db_futures::Build;
+
+    pub mod keys {
+        // Re-use all the same keys from `v8`.
+        pub use super::super::v8::keys::*;
+
+        // Add new keys.
+        pub const LINKED_CHUNKS_PREVIOUS: &str = "linked_chunks_previous";
+        pub const LINKED_CHUNKS_PREVIOUS_KEY_PATH: &str = "previous";
+    }
+    use super::*;
+
+    /// Adds a `previous` index to the linked chunks object store, enabling
+    /// efficient lookup of the first chunk in a room's timeline.
+    ///
+    /// This requires clearing and recreating the linked chunks store, as well
+    /// as clearing all dependent stores (events, gaps, threads), following the
+    /// same approach as earlier migrations.
+    pub fn add_previous_chunk_index(transaction: &Transaction<'_>) -> Result<(), Error> {
+        // Recreate the linked chunks store with the new index.
+        let linked_chunks = transaction.object_store(keys::LINKED_CHUNKS)?;
+        // Via v3 migration, clear before deleting for Firefox performance
+        linked_chunks.clear()?;
+        transaction.db().delete_object_store(keys::LINKED_CHUNKS)?;
+        create_linked_chunks_object_store(transaction.db())?;
+
+        // Clear dependent stores.
+        transaction.object_store(keys::GAPS)?.clear()?;
+        transaction.object_store(keys::EVENTS)?.clear()?;
+        transaction.object_store(keys::THREADS)?.clear()?;
+
+        Ok(())
+    }
+
+    /// Create an object store for tracking information about linked chunks.
+    ///
+    /// * Primary Key - `id`
+    /// * Index - `next` - tracks the next chunk in linked chunks
+    /// * Index - `previous` - tracks the previous chunk in linked chunks,
+    ///   enabling efficient lookup of the first chunk
+    fn create_linked_chunks_object_store(db: &Database) -> Result<(), Error> {
+        let linked_chunks = db
+            .create_object_store(keys::LINKED_CHUNKS)
+            .with_key_path(keys::LINKED_CHUNKS_KEY_PATH.into())
+            .build()?;
+        let _ = linked_chunks
+            .create_index(keys::LINKED_CHUNKS_NEXT, keys::LINKED_CHUNKS_NEXT_KEY_PATH.into())
+            .build()?;
+        let _ = linked_chunks
+            .create_index(
+                keys::LINKED_CHUNKS_PREVIOUS,
+                keys::LINKED_CHUNKS_PREVIOUS_KEY_PATH.into(),
+            )
+            .build()?;
         Ok(())
     }
 }

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/serializer/indexed_types.rs
@@ -162,11 +162,15 @@ impl IndexedKeyComponentBounds<Lease> for IndexedLeaseIdKey {
 
 /// Represents the [`LINKED_CHUNKS`][1] object store.
 ///
-/// [1]: crate::event_cache_store::migrations::v1::create_linked_chunks_object_store
+/// [1]: crate::event_cache_store::migrations::v9::create_linked_chunks_object_store
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexedChunk {
     /// The primary key of the object store.
     pub id: IndexedChunkIdKey,
+    /// An indexed key on the object store, which represents the
+    /// [`IndexedChunkIdKey`] of the previous chunk in the linked list, if it
+    /// exists.
+    pub previous: IndexedPreviousChunkIdKey,
     /// An indexed key on the object store, which represents the
     /// [`IndexedChunkIdKey`] of the next chunk in the linked list, if it
     /// exists.
@@ -188,6 +192,10 @@ impl Indexed for Chunk {
         Ok(IndexedChunk {
             id: <IndexedChunkIdKey as IndexedKey<Chunk>>::encode(
                 (self.linked_chunk_id.as_ref(), ChunkIdentifier::new(self.identifier)),
+                serializer,
+            ),
+            previous: IndexedPreviousChunkIdKey::encode(
+                (self.linked_chunk_id.as_ref(), self.previous.map(ChunkIdentifier::new)),
                 serializer,
             ),
             next: IndexedNextChunkIdKey::encode(
@@ -299,6 +307,76 @@ impl IndexedKey<Chunk> for IndexedNextChunkIdKey {
 }
 
 impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, LinkedChunkId<'a>> for IndexedNextChunkIdKey {
+    fn lower_key_components_with_prefix(
+        linked_chunk_id: LinkedChunkId<'a>,
+    ) -> Self::KeyComponents<'a> {
+        (linked_chunk_id, None)
+    }
+
+    fn upper_key_components_with_prefix(
+        linked_chunk_id: LinkedChunkId<'a>,
+    ) -> Self::KeyComponents<'a> {
+        (linked_chunk_id, Some(*INDEXED_KEY_UPPER_CHUNK_IDENTIFIER))
+    }
+}
+
+/// The value associated with the [`previous`](IndexedChunk::previous) index of
+/// the [`LINKED_CHUNKS`][1] object store, which is constructed from:
+///
+/// - The (possibly) hashed Linked Chunk ID
+/// - The Chunk ID, if there is a previous chunk in the list.
+///
+/// Note: it would be more convenient to represent this type with an optional
+/// Chunk ID, but unfortunately, this creates an issue when querying for objects
+/// that don't have a `previous` value, because `None` serializes to `null`
+/// which is an invalid value in any part of an IndexedDB query.
+///
+/// Furthermore, each variant must serialize to the same type, so the `None`
+/// variant must contain a non-empty tuple.
+///
+/// [1]: crate::event_cache_store::migrations::v9::create_linked_chunks_object_store
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum IndexedPreviousChunkIdKey {
+    /// There is no previous chunk.
+    None((IndexedLinkedChunkId,)),
+    /// The identifier of the previous chunk in the list.
+    Some(IndexedChunkIdKey),
+}
+
+impl IndexedPreviousChunkIdKey {
+    pub fn none(linked_chunk_id: IndexedLinkedChunkId) -> Self {
+        Self::None((linked_chunk_id,))
+    }
+}
+
+impl IndexedKey<Chunk> for IndexedPreviousChunkIdKey {
+    const INDEX: Option<&'static str> = Some(keys::LINKED_CHUNKS_PREVIOUS);
+
+    type KeyComponents<'a> = (LinkedChunkId<'a>, Option<ChunkIdentifier>);
+
+    fn encode(
+        (linked_chunk_id, previous_chunk_id): Self::KeyComponents<'_>,
+        serializer: &SafeEncodeSerializer,
+    ) -> Self {
+        previous_chunk_id
+            .map(|id| {
+                Self::Some(<IndexedChunkIdKey as IndexedKey<Chunk>>::encode(
+                    (linked_chunk_id, id),
+                    serializer,
+                ))
+            })
+            .unwrap_or_else(|| {
+                let room_id =
+                    serializer.hash_key(keys::LINKED_CHUNK_IDS, linked_chunk_id.storage_key());
+                Self::none(room_id)
+            })
+    }
+}
+
+impl<'a> IndexedPrefixKeyComponentBounds<'a, Chunk, LinkedChunkId<'a>>
+    for IndexedPreviousChunkIdKey
+{
     fn lower_key_components_with_prefix(
         linked_chunk_id: LinkedChunkId<'a>,
     ) -> Self::KeyComponents<'a> {

--- a/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
+++ b/crates/matrix-sdk-indexeddb/src/event_cache_store/transaction.rs
@@ -29,7 +29,8 @@ use crate::{
             IndexedChunk, IndexedChunkIdKey, IndexedEvent, IndexedEventError,
             IndexedEventEventIdKey, IndexedEventIdKey, IndexedEventPositionKey,
             IndexedEventRelationKey, IndexedEventRoomKey, IndexedGapIdKey, IndexedLease,
-            IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedThread, IndexedThreadIdKey,
+            IndexedLeaseIdKey, IndexedNextChunkIdKey, IndexedPreviousChunkIdKey, IndexedThread,
+            IndexedThreadIdKey,
         },
         types::{Chunk, ChunkType, Event, Gap, Lease, Position, Thread},
     },
@@ -163,6 +164,21 @@ impl<'a> IndexeddbEventCacheStoreTransaction<'a> {
     ) -> Result<Option<Chunk>, TransactionError> {
         self.get_item_by_key_components::<Chunk, IndexedChunkIdKey>((linked_chunk_id, chunk_id))
             .await
+    }
+
+    /// Query IndexedDB for chunks such that the previous chunk matches the
+    /// given chunk identifier and the given linked chunk id. If more than one
+    /// item is found, an error is returned.
+    pub async fn get_chunk_by_previous_chunk_id(
+        &self,
+        linked_chunk_id: LinkedChunkId<'_>,
+        previous_chunk_id: Option<ChunkIdentifier>,
+    ) -> Result<Option<Chunk>, TransactionError> {
+        self.get_item_by_key_components::<Chunk, IndexedPreviousChunkIdKey>((
+            linked_chunk_id,
+            previous_chunk_id,
+        ))
+        .await
     }
 
     /// Query IndexedDB for chunks such that the next chunk matches the given


### PR DESCRIPTION
Added previous to IndexxedDB linked chunks store, such that we can load chunks from oldest to newest for #6965

- [x] I've documented the public API changes in the appropriate changelog files (see [Writing changelog entries][pull-request-template-changelog]).
- [x] This PR was made with the help of AI.

[pull-request-template-changelog]: https://github.com/matrix-org/matrix-rust-sdk/blob/main/CONTRIBUTING.md#writing-changelog-entries
